### PR TITLE
Define version Tango in the config file

### DIFF
--- a/ldc_install.conf.in
+++ b/ldc_install.conf.in
@@ -11,6 +11,7 @@ default:
         "-I@INCLUDE_INSTALL_DIR@/@RUNTIME_AIO@",
         "-I@INCLUDE_INSTALL_DIR@/ldc",
         "-L-L@CMAKE_INSTALL_LIBDIR@",
+        "-d-version=Tango",
         "-defaultlib=@RUNTIME_AIO@",
         "-debuglib=@RUNTIME_AIO@"
     ];


### PR DESCRIPTION
This is defined in ldc.conf but wasn't in ldc_install.conf
