### PR TITLE
Fix some warnings arising in some compilers

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -554,7 +554,7 @@ LLConstant* DtoConstArrayInitializer(ArrayInitializer* arrinit)
 
     LLConstant* idxs[2] = { DtoConstUint(0), DtoConstUint(0) };
 
-    LLConstant* gep = llvm::ConstantExpr::getGetElementPtr(gvar,idxs,2);
+    LLConstant* gep = llvm::ConstantExpr::getGetElementPtr(gvar, idxs, true);
     gep = llvm::ConstantExpr::getBitCast(gvar, getPtrToType(llelemty));
 
     return DtoConstSlice(DtoConstSize_t(arrlen), gep, arrty);

--- a/gen/asm-x86-32.h
+++ b/gen/asm-x86-32.h
@@ -2088,7 +2088,7 @@ namespace AsmParserx8632
                             Logger::cout() << "baseReg: " << operand->baseReg << '\n';
                             Logger::cout() << "segmentPrefix: " << operand->segmentPrefix << '\n';
                             Logger::cout() << "constDisplacement: " << operand->constDisplacement << '\n';
-                            for (int i = 0; i < operand->symbolDisplacement.dim; i++) {
+                            for (unsigned i = 0; i < operand->symbolDisplacement.dim; i++) {
                                 Expression* expr = (Expression*) operand->symbolDisplacement.data[i];
                                 Logger::cout() << "symbolDisplacement[" << i << "] = " << expr->toChars() << '\n';
                             }

--- a/gen/asm-x86-64.h
+++ b/gen/asm-x86-64.h
@@ -2243,7 +2243,7 @@ namespace AsmParserx8664
                             Logger::cout() << "baseReg: " << operand->baseReg << '\n';
                             Logger::cout() << "segmentPrefix: " << operand->segmentPrefix << '\n';
                             Logger::cout() << "constDisplacement: " << operand->constDisplacement << '\n';
-                            for (int i = 0; i < operand->symbolDisplacement.dim; i++) {
+                            for (unsigned i = 0; i < operand->symbolDisplacement.dim; i++) {
                                 Expression* expr = (Expression*) operand->symbolDisplacement.data[i];
                                 Logger::cout() << "symbolDisplacement[" << i << "] = " << expr->toChars() << '\n';
                             }

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -534,7 +534,7 @@ void AsmBlockStatement::toIR(IRState* p)
     p->asmBlock = asmblock;
 
     // do asm statements
-    for (int i=0; i<statements->dim; i++)
+    for (unsigned i=0; i<statements->dim; i++)
     {
         Statement* s = (Statement*)statements->data[i];
         if (s) {

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -221,7 +221,7 @@ void TemplateInstance::codegen(Ir* p)
 #endif
     if (!errors && members)
     {
-        for (int i = 0; i < members->dim; i++)
+        for (unsigned i = 0; i < members->dim; i++)
         {
             Dsymbol *s = (Dsymbol *)members->data[i];
             s->codegen(p);
@@ -235,7 +235,7 @@ void TemplateMixin::codegen(Ir* p)
 {
     if (!errors && members)
     {
-        for (int i = 0; i < members->dim; i++)
+        for (unsigned i = 0; i < members->dim; i++)
         {
             Dsymbol *s = (Dsymbol *)members->data[i];
             if (s->isVarDeclaration())

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1134,7 +1134,7 @@ DValue* DtoDeclarationExp(Dsymbol* declaration)
         // choose the right set in case this is a conditional declaration
         Array *d = a->include(NULL, NULL);
         if (d)
-            for (int i=0; i < d->dim; ++i)
+            for (unsigned i=0; i < d->dim; ++i)
             {
                 DtoDeclarationExp((Dsymbol*)d->data[i]);
             }
@@ -1143,7 +1143,7 @@ DValue* DtoDeclarationExp(Dsymbol* declaration)
     else if (TemplateMixin* m = declaration->isTemplateMixin())
     {
         Logger::println("TemplateMixin");
-        for (int i=0; i < m->members->dim; ++i)
+        for (unsigned i=0; i < m->members->dim; ++i)
         {
             Dsymbol* mdsym = (Dsymbol*)m->members->data[i];
             DtoDeclarationExp(mdsym);
@@ -1159,7 +1159,7 @@ DValue* DtoDeclarationExp(Dsymbol* declaration)
         }
 
         assert(tupled->objects);
-        for (int i=0; i < tupled->objects->dim; ++i)
+        for (unsigned i=0; i < tupled->objects->dim; ++i)
         {
             DsymbolExp* exp = (DsymbolExp*)tupled->objects->data[i];
             DtoDeclarationExp(exp->s);
@@ -1637,7 +1637,7 @@ bool hasUnalignedFields(Type* t)
 
     // go through all the fields and try to find something unaligned
     ts->unaligned = 2;
-    for (int i = 0; i < sym->fields.dim; i++)
+    for (unsigned i = 0; i < sym->fields.dim; i++)
     {
         VarDeclaration* f = (VarDeclaration*)sym->fields.data[i];
         unsigned a = f->type->alignsize() - 1;

--- a/gen/main.cpp
+++ b/gen/main.cpp
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
     {
         if (libs)
         {
-            for (int i = 0; i < libs->dim; i++)
+            for (unsigned i = 0; i < libs->dim; i++)
             {
                 char* lib = (char *)libs->data[i];
                 char *arg = (char *)mem.malloc(strlen(lib) + 3);
@@ -649,7 +649,7 @@ int main(int argc, char** argv)
     // Build import search path
     if (global.params.imppath)
     {
-        for (int i = 0; i < global.params.imppath->dim; i++)
+        for (unsigned i = 0; i < global.params.imppath->dim; i++)
         {
             char *path = (char *)global.params.imppath->data[i];
             Strings *a = FileName::splitPath(path);
@@ -666,7 +666,7 @@ int main(int argc, char** argv)
     // Build string import search path
     if (global.params.fileImppath)
     {
-        for (int i = 0; i < global.params.fileImppath->dim; i++)
+        for (unsigned i = 0; i < global.params.fileImppath->dim; i++)
         {
             char *path = (char *)global.params.fileImppath->data[i];
             Strings *a = FileName::splitPath(path);
@@ -683,7 +683,7 @@ int main(int argc, char** argv)
     // Create Modules
     Modules modules;
     modules.reserve(files.dim);
-    for (int i = 0; i < files.dim; i++)
+    for (unsigned i = 0; i < files.dim; i++)
     {   Identifier *id;
         char *ext;
         char *name;
@@ -790,7 +790,7 @@ int main(int argc, char** argv)
     }
 
     // Read files, parse them
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
         m = (Module *)modules.data[i];
         if (global.params.verbose)
@@ -825,7 +825,7 @@ int main(int argc, char** argv)
          * line switches and what else is imported, they are generated
          * before any semantic analysis.
          */
-        for (int i = 0; i < modules.dim; i++)
+        for (unsigned i = 0; i < modules.dim; i++)
         {
             m = (Module *)modules.data[i];
             if (global.params.verbose)
@@ -838,7 +838,7 @@ int main(int argc, char** argv)
 #endif
 
     // load all unconditional imports for better symbol resolving
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
        m = (Module *)modules.data[i];
        if (global.params.verbose)
@@ -849,7 +849,7 @@ int main(int argc, char** argv)
        fatal();
 
     // Do semantic analysis
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
         m = (Module *)modules.data[i];
         if (global.params.verbose)
@@ -863,7 +863,7 @@ int main(int argc, char** argv)
     Module::runDeferredSemantic();
 
     // Do pass 2 semantic analysis
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
         m = (Module *)modules.data[i];
         if (global.params.verbose)
@@ -874,7 +874,7 @@ int main(int argc, char** argv)
         fatal();
 
     // Do pass 3 semantic analysis
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
         m = (Module *)modules.data[i];
         if (global.params.verbose)
@@ -904,7 +904,7 @@ int main(int argc, char** argv)
         {
             // Do pass 3 semantic analysis on all imported modules,
             // since otherwise functions in them cannot be inlined
-            for (int i = 0; i < Module::amodules.dim; i++)
+            for (unsigned i = 0; i < Module::amodules.dim; i++)
             {
                 m = (Module *)Module::amodules.data[i];
                 if (global.params.verbose)
@@ -944,7 +944,7 @@ int main(int argc, char** argv)
     llvm::LLVMContext& context = llvm::getGlobalContext();
 
     // Generate output files
-    for (int i = 0; i < modules.dim; i++)
+    for (unsigned i = 0; i < modules.dim; i++)
     {
         m = (Module *)modules.data[i];
         if (global.params.verbose)
@@ -1019,7 +1019,7 @@ int main(int argc, char** argv)
 
                 /* Delete .obj files and .exe file
                  */
-                for (int i = 0; i < modules.dim; i++)
+                for (unsigned i = 0; i < modules.dim; i++)
                 {
                     m = (Module *)modules.data[i];
                     m->deleteObjFile();

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -36,7 +36,7 @@ void CompoundStatement::toIR(IRState* p)
     Logger::println("CompoundStatement::toIR(): %s", loc.toChars());
     LOG_SCOPE;
 
-    for (int i=0; i<statements->dim; i++)
+    for (unsigned i=0; i<statements->dim; i++)
     {
         Statement* s = (Statement*)statements->data[i];
         if (s) {
@@ -741,7 +741,7 @@ void TryCatchStatement::toIR(IRState* p)
     gIR->scope() = IRScope(landingpadbb, endbb);
 
     IRLandingPad& pad = gIR->func()->gen->landingPadInfo;
-    for (int i = 0; i < catches->dim; i++)
+    for (unsigned i = 0; i < catches->dim; i++)
     {
         Catch *c = (Catch *)catches->data[i];
         pad.addCatch(c, endbb);
@@ -870,7 +870,7 @@ void SwitchStatement::toIR(IRState* p)
     llvm::BasicBlock* oldend = gIR->scopeend();
 
     // clear data from previous passes... :/
-    for (int i=0; i<cases->dim; ++i)
+    for (unsigned i=0; i<cases->dim; ++i)
     {
         CaseStatement* cs = (CaseStatement*)cases->data[i];
         cs->bodyBB = NULL;
@@ -881,7 +881,7 @@ void SwitchStatement::toIR(IRState* p)
     // 'switch' instruction (that can happen because D2 allows to
     // initialize a global variable in a static constructor).
     bool useSwitchInst = true;
-    for (int i=0; i<cases->dim; ++i)
+    for (unsigned i=0; i<cases->dim; ++i)
     {
         CaseStatement* cs = (CaseStatement*)cases->data[i];
         VarDeclaration* vd = 0;
@@ -928,7 +928,7 @@ void SwitchStatement::toIR(IRState* p)
             Logger::println("is string switch");
             // build array of the stringexpS
             caseArray.reserve(cases->dim);
-            for (int i=0; i<cases->dim; ++i)
+            for (unsigned i=0; i<cases->dim; ++i)
             {
                 CaseStatement* cs = (CaseStatement*)cases->data[i];
 
@@ -980,7 +980,7 @@ void SwitchStatement::toIR(IRState* p)
 
         // create switch and add the cases
         llvm::SwitchInst* si = llvm::SwitchInst::Create(condVal, defbb ? defbb : endbb, cases->dim, p->scopebb());
-        for (int i=0; i<cases->dim; ++i)
+        for (unsigned i=0; i<cases->dim; ++i)
         {
             CaseStatement* cs = (CaseStatement*)cases->data[i];
             si->addCase(isaConstantInt(cs->llvmIdx), cs->bodyBB);
@@ -995,7 +995,7 @@ void SwitchStatement::toIR(IRState* p)
         llvm::BranchInst::Create(nextbb, p->scopebb());
 
         p->scope() = IRScope(nextbb, endbb);
-        for (int i=0; i<cases->dim; ++i)
+        for (unsigned i=0; i<cases->dim; ++i)
         {
             CaseStatement* cs = (CaseStatement*)cases->data[i];
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -478,7 +478,7 @@ DValue* StringExp::toElem(IRState* p)
 
     llvm::ConstantInt* zero = LLConstantInt::get(LLType::getInt32Ty(gIR->context()), 0, false);
     LLConstant* idxs[2] = { zero, zero };
-    LLConstant* arrptr = llvm::ConstantExpr::getGetElementPtr(gvar,idxs,2);
+    LLConstant* arrptr = llvm::ConstantExpr::getGetElementPtr(gvar, idxs, true);
 
     if (dtype->ty == Tarray) {
         LLConstant* clen = LLConstantInt::get(DtoSize_t(),len,false);
@@ -554,7 +554,7 @@ LLConstant* StringExp::toConstElem(IRState* p)
 
     llvm::ConstantInt* zero = LLConstantInt::get(LLType::getInt32Ty(gIR->context()), 0, false);
     LLConstant* idxs[2] = { zero, zero };
-    LLConstant* arrptr = llvm::ConstantExpr::getGetElementPtr(gvar,idxs,2);
+    LLConstant* arrptr = llvm::ConstantExpr::getGetElementPtr(gvar, idxs, true);
 
     if (t->ty == Tpointer) {
         return arrptr;
@@ -1074,7 +1074,7 @@ LLConstant* CastExp::toConstElem(IRState* p)
         Type *type = vd->type->toBasetype();
         if (type->ty == Tarray || type->ty == Tdelegate) {
             LLConstant* idxs[2] = { DtoConstSize_t(0), DtoConstSize_t(1) };
-            value = llvm::ConstantExpr::getGetElementPtr(value, idxs, 2);
+            value = llvm::ConstantExpr::getGetElementPtr(value, idxs, true);
         }
         return DtoBitCast(value, DtoType(tb));
     }
@@ -1206,7 +1206,7 @@ LLConstant* AddrExp::toConstElem(IRState* p)
         LLConstant* idxs[2] = { DtoConstSize_t(0), index };
         LLConstant *val = isaConstant(vd->ir.irGlobal->value);
         val = DtoBitCast(val, DtoType(vd->type->pointerTo()));
-        LLConstant* gep = llvm::ConstantExpr::getGetElementPtr(val, idxs, 2);
+        LLConstant* gep = llvm::ConstantExpr::getGetElementPtr(val, idxs, true);
 
         // bitcast to requested type
         assert(type->toBasetype()->ty == Tpointer);
@@ -2751,7 +2751,7 @@ LLConstant* ArrayLiteralExp::toConstElem(IRState* p)
 
     // build a constant dynamic array reference with the .ptr field pointing into globalstore
     LLConstant* idxs[2] = { DtoConstUint(0), DtoConstUint(0) };
-    LLConstant* globalstorePtr = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, 2);
+    LLConstant* globalstorePtr = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, true);
 
     return DtoConstSlice(DtoConstSize_t(elements->dim), globalstorePtr);
 }
@@ -2975,14 +2975,14 @@ DValue* AssocArrayLiteralExp::toElem(IRState* p)
         LLArrayType* arrtype = LLArrayType::get(DtoType(indexType), keys->dim);
         LLConstant* initval = LLConstantArray::get(arrtype, keysInits);
         LLConstant* globalstore = new LLGlobalVariable(*gIR->module, arrtype, false, LLGlobalValue::InternalLinkage, initval, ".aaKeysStorage");
-        LLConstant* slice = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, 2);
+        LLConstant* slice = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, true);
         slice = DtoConstSlice(DtoConstSize_t(keys->dim), slice);
         LLValue* keysArray = DtoAggrPaint(slice, funcTy->getParamType(1));
 
         arrtype = LLArrayType::get(DtoType(vtype), values->dim);
         initval = LLConstantArray::get(arrtype, valuesInits);
         globalstore = new LLGlobalVariable(*gIR->module, arrtype, false, LLGlobalValue::InternalLinkage, initval, ".aaValuesStorage");
-        slice = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, 2);
+        slice = llvm::ConstantExpr::getGetElementPtr(globalstore, idxs, true);
         slice = DtoConstSlice(DtoConstSize_t(keys->dim), slice);
         LLValue* valuesArray = DtoAggrPaint(slice, funcTy->getParamType(2));
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -447,7 +447,7 @@ LLValue* DtoGEPi(LLValue* ptr, unsigned i0, unsigned i1, const char* var, llvm::
 LLConstant* DtoGEPi(LLConstant* ptr, unsigned i0, unsigned i1)
 {
     LLValue* v[2] = { DtoConstUint(i0), DtoConstUint(i1) };
-    return llvm::ConstantExpr::getGetElementPtr(ptr, v, 2);
+    return llvm::ConstantExpr::getGetElementPtr(ptr, v, true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -596,7 +596,7 @@ LLConstant* DtoConstString(const char* str)
     LLConstant* idxs[2] = { DtoConstUint(0), DtoConstUint(0) };
     return DtoConstSlice(
         DtoConstSize_t(s.size()),
-        llvm::ConstantExpr::getGetElementPtr(gvar,idxs,2),
+        llvm::ConstantExpr::getGetElementPtr(gvar, idxs, true),
         Type::tchar->arrayOf()
     );
 }
@@ -608,7 +608,7 @@ LLConstant* DtoConstStringPtr(const char* str, const char* section)
         *gIR->module, init->getType(), true,llvm::GlobalValue::InternalLinkage, init, ".str");
     if (section) gvar->setSection(section);
     LLConstant* idxs[2] = { DtoConstUint(0), DtoConstUint(0) };
-    return llvm::ConstantExpr::getGetElementPtr(gvar,idxs,2);
+    return llvm::ConstantExpr::getGetElementPtr(gvar, idxs, true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gen/toobj.cpp
+++ b/gen/toobj.cpp
@@ -134,7 +134,7 @@ llvm::Module* Module::genLLVMModule(llvm::LLVMContext& context, Ir* sir)
     LLVM_D_InitRuntime();
 
     // process module members
-    for (int k=0; k < members->dim; k++) {
+    for (unsigned k=0; k < members->dim; k++) {
         Dsymbol* dsym = (Dsymbol*)(members->data[k]);
         assert(dsym);
         dsym->codegen(sir);

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -711,7 +711,7 @@ void TypeInfoStructDeclaration::llvmDefine()
     {
         TypeTuple *tup = tc->toArgTypes();
         assert(tup->arguments->dim <= 2);
-        for (int i = 0; i < 2; i++)
+        for (unsigned i = 0; i < 2; i++)
         {
             if (i < tup->arguments->dim)
             {

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -377,7 +377,7 @@ llvm::GlobalVariable * IrStruct::getInterfaceVtbl(BaseClass * b, bool new_instan
     };
 
     llvm::Constant* c = llvm::ConstantExpr::getGetElementPtr(
-        getInterfaceArraySymbol(), idxs, 2);
+        getInterfaceArraySymbol(), idxs, true);
 
     constants.push_back(c);
 
@@ -533,7 +533,7 @@ LLConstant * IrStruct::getClassInfoInterfaces()
     };
 
     LLConstant* ptr = llvm::ConstantExpr::getGetElementPtr(
-        classInterfacesArray, idxs, 2);
+        classInterfacesArray, idxs, true);
 
     // return as a slice
     return DtoConstSlice( DtoConstSize_t(cd->vtblInterfaces->dim), ptr );


### PR DESCRIPTION
This pull request fixes 2 issues:

1) The last parameter of getGetElementPtr() has type bool. In some instances, a 2 is used as parameter. This is converted to true.
2) Several loops use int instead of unsigned. This causes warning about signed/unsigned mismatch. Therefore I replaced int with unsigned. (I love the auto type of D :-))

Curiously, only Visual C++ complains about this. (I tried ggc and the static analyzer from clang.) Nevertheless I think that the warnings should be fixed - it looks much cleaner for me.
