### PR TITLE
Near to be a perfect completion

### DIFF
--- a/bash_completion.d/ldc
+++ b/bash_completion.d/ldc
@@ -125,7 +125,7 @@ have ldc2 &&{
             '-Dd='*|'-Hd='*|'-I='*|'-J='*|'-od='*)                                                                                                              # add an =<dir>
                 prev="${cur%%=*}="
                 cur=${cur#*=}
-                COMPREPLY=( ${prev}$(compgen -d "${cur}") )
+                COMPREPLY=( ${prev}$(compgen -S '/' -d "${cur}") )
                 return 0
                 ;;
             -'Df='*|'-Hf='*|'-deps='*|'-internalize-public-api-file='*|'-of='*|'-Xf='*)                                                                         # add an =<file>


### PR DESCRIPTION
bash completion enhancement
Now it complete to .d .o or .di file. This it is useffull by example foo.c and foo.d exist ldc2 foo[TAB] will choose foo.d 
complete a dir path when is expected like -od=
complete enumerable var lile -code-model= default kernel ...

use it :)
