### PR TITLE
Fix #49: Static arrays should be passed using byval

### DIFF
--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -428,7 +428,8 @@ bool X86_64TargetABI::returnInArg(TypeFunction* tf) {
 bool X86_64TargetABI::passByVal(Type* t) {
     t = t->toBasetype();
     if (linkage() == LINKd) {
-        return t->toBasetype()->ty == Tstruct;
+        // static arrays are also passed byval
+        return t->ty == Tstruct || t->ty == Tsarray;
     } else {
         // This implements the C calling convention for x86-64.
         // It might not be correct for other calling conventions.
@@ -598,6 +599,11 @@ void X86_64TargetABI::rewriteFunctionType(TypeFunction* tf) {
                 else
                 {
                     Logger::println("Putting static array in register");
+                    // need to make sure type is not pointer
+                    arg.ltype = DtoType(arg.type);
+                    arg.byref = false;
+                    // erase previous attributes
+                    arg.attrs = 0;
                 }
                 arg.attrs |= llvm::Attribute::InReg;
                 --regcount;

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -108,7 +108,7 @@ struct X86TargetABI : TargetABI
 
     bool passByVal(Type* t)
     {
-        return t->toBasetype()->ty == Tstruct;
+        return t->toBasetype()->ty == Tstruct || t->toBasetype()->ty == Tsarray;
     }
 
     void rewriteFunctionType(TypeFunction* tf)

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -162,6 +162,7 @@ llvm::FunctionType* DtoFunctionType(Type* type, Type* thistype, Type* nesttype, 
         else if (abi->passByVal(byref ? argtype->pointerTo() : argtype))
         {
             if (!byref) a |= llvm::Attribute::ByVal;
+            // set byref, because byval requires a pointed LLVM type
             byref = true;
         }
         // sext/zext

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -13,9 +13,8 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-IrFuncTyArg::IrFuncTyArg(Type* t, bool bref, unsigned a)
+IrFuncTyArg::IrFuncTyArg(Type* t, bool bref, unsigned a) : type(t)
 {
-    type = t;
     ltype = t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t);
     attrs = a;
     byref = bref;

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -20,7 +20,7 @@ struct IrFuncTyArg : IrBase
 {
     /** This is the original D type as the frontend knows it
      *  May NOT be rewritten!!! */
-    Type* type;
+    Type* const type;
 
     /// This is the final LLVM Type used for the parameter/return value type
     llvm::Type* ltype;
@@ -92,7 +92,7 @@ struct IrFuncTy : IrBase
     {}
 
 #if defined(_MSC_VER)
-    // Copy constructor and operator= seems to be requreid for MSC
+    // Copy constructor and operator= seems to be required for MSC
 
     IrFuncTy(const IrFuncTy& rhs)
     :   ret(rhs.ret),


### PR DESCRIPTION
... instead of as chunks of data.

This [example](https://github.com/ldc-developers/ldc/issues/49#issuecomment-6099754) in #49 makes it apparent that compilation of such LLVM assembly into native (tested on x86-64) code 1) takes a really long time and 2) produces a lot of useless mov instructions.

Thus, when a static array is too big to fit into a register (only in the case of x86-64), it should get passed to a function as `[4096 x i8]* byval` (if the array were `char[4096]` in this example).

Phobos unit tests pass, and I've noticed a huge performance boon in some druntime benchmarks (`aabench/string` is now more than 10 times faster).

Haven't tested on anything else than `OS X x86-64 / LLVM 3.0`.
