### PR TITLE
Return 0 immediately after printing -version/--version.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -83,6 +83,8 @@ void printVersion() {
     global.ldc_version, global.version, global.llvm_version, global.copyright, global.written);
     printf("D Language Documentation: http://d-programming-language.org/index.html\n"
            "LDC Homepage: https://github.com/ldc-developers/ldc\n");
+
+    exit(EXIT_SUCCESS);
 }
 
 // Helper function to handle -d-debug=* and -d-version=*


### PR DESCRIPTION
Currently, LDC returns a non-zero exit code on a simple invocation like `ldc2 -version` which is absolute nonsense. Several build systems (Waf in particular) use heuristics (this being one of them) to detect whether the found compiler is LDC2, but this currently fails because such an invocation returns an exit code indicating failure.

So, instead of this, I've made `printVersion` exit the process immediately with a zero exit code. I believe this is sensible behavior, as you normally don't invoke a tool with its version argument to do actual work.
