### PR TITLE
MinGW32 version identifier.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -603,7 +603,8 @@ LDC_TARGETS
         global.params.os = OSWindows;
         VersionCondition::addPredefinedGlobalIdent("Windows");
         VersionCondition::addPredefinedGlobalIdent("Win32");
-        VersionCondition::addPredefinedGlobalIdent("mingw32");
+        VersionCondition::addPredefinedGlobalIdent("mingw32"); // backwards compatibility
+        VersionCondition::addPredefinedGlobalIdent("MinGW32");
         VersionCondition::addPredefinedGlobalIdent("MinGW");
     }
     // FIXME: cygwin


### PR DESCRIPTION
Define `MinGW32` (rather than `mingw32`) like GDC when compiling under 32-bit MinGW. Keeping `mingw32` around for backwards compatibility, though.
