### PR TITLE
Define ARM even in Thumb mode.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -568,6 +568,7 @@ LDC_TARGETS
         global.params.cpu = ARCHarm;
     }
     else if (strcmp(global.params.llvmArch,"thumb")==0) {
+        VersionCondition::addPredefinedGlobalIdent("ARM");
         VersionCondition::addPredefinedGlobalIdent("Thumb");
         global.params.isLE = true;
         global.params.is64bit = false;


### PR DESCRIPTION
Needed for things to work properly in Thumb mode.
