### PR TITLE
Simplify CMakeLists.txt by taking advantage of LLVM 3.1 features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 # Locate LLVM.
 #
 
-# This would actually better be named named EXTRA_LLVM_TARGETS, as it allows
-# additional targets (beside the native one) to be specified. It affects the
-# LLVM libraries linked and is converted to a preprocessor define used in
-# gen/main.cpp.
-set(EXTRA_LLVM_MODULES "" CACHE STRING
-    "Extra LLVM targets to link in (see llvm-config --targets-built)")
-separate_arguments(EXTRA_LLVM_MODULES)
-
 # We need to find exactly the right LLVM version, our code usually does not
 # work across LLVM »minor« releases.
 find_package(LLVM 3.1 EXACT REQUIRED
-    bitwriter linker ipo instrumentation native ${EXTRA_LLVM_MODULES})
+    all-targets bitwriter linker ipo instrumentation native)
 
 #
 # Locate libconfig++.
@@ -121,68 +113,6 @@ set(LDC_GENERATED
     ${PROJECT_BINARY_DIR}/${DMDFE_PATH}/id.c
     ${PROJECT_BINARY_DIR}/${DMDFE_PATH}/id.h
     ${PROJECT_BINARY_DIR}/${DMDFE_PATH}/impcnvtab.c
-)
-
-#
-# Set up target defines.
-#
-
-set(DEFAULT_TARGET ${LLVM_HOST_TARGET} CACHE STRING "default target")
-add_definitions(-DDEFAULT_TARGET_TRIPLE="${DEFAULT_TARGET}")
-
-# Generate the alternate target triple (x86 on x86_64 and vice versa.)
-if(LLVM_HOST_TARGET MATCHES "i[3-9]86-")
-    string(REGEX REPLACE "^i[3-9]86-(.*)" "x86_64-\\1" HOST_ALT_TARGET ${LLVM_HOST_TARGET})
-elseif(LLVM_HOST_TARGET MATCHES "^x86_64-.*")
-    string(REGEX REPLACE "^x86_64-(.*)" "i686-\\1" HOST_ALT_TARGET ${LLVM_HOST_TARGET})
-endif()
-set(DEFAULT_ALT_TARGET ${HOST_ALT_TARGET} CACHE STRING "default alt target")
-add_definitions(-DDEFAULT_ALT_TARGET_TRIPLE="${DEFAULT_ALT_TARGET}")
-
-#
-# Detect host architecture.
-# The code borrowed from llvm's config-x.cmake.
-#
-# This is only needed to initialize the llvm native target which is
-# exactly the purpose of llvm::InitializeNativeTarget* functions.
-# Unfortunately, there is a bug in llvm's cmake script that prevents
-# the asm parser from being initialized when the functions are used.
-# So we have to do the dirty work ourselves.
-string(REGEX MATCH "^[^-]*" HOST_ARCH ${LLVM_HOST_TARGET})
-if(HOST_ARCH MATCHES "i[2-6]86")
-  set(HOST_ARCH X86)
-elseif(HOST_ARCH STREQUAL "x86")
-  set(HOST_ARCH X86)
-elseif(HOST_ARCH STREQUAL "amd64")
-  set(HOST_ARCH X86)
-elseif(HOST_ARCH STREQUAL "x86_64")
-  set(HOST_ARCH X86)
-elseif(HOST_ARCH MATCHES "sparc")
-  set(HOST_ARCH Sparc)
-elseif(HOST_ARCH MATCHES "powerpc")
-  set(HOST_ARCH PowerPC)
-elseif(HOST_ARCH MATCHES "alpha")
-  set(HOST_ARCH Alpha)
-elseif(HOST_ARCH MATCHES "arm")
-  set(HOST_ARCH ARM)
-elseif(HOST_ARCH MATCHES "mips")
-  set(HOST_ARCH Mips)
-elseif(HOST_ARCH MATCHES "xcore")
-  set(HOST_ARCH XCore)
-elseif(HOST_ARCH MATCHES "msp430")
-  set(HOST_ARCH MSP430)
-else(HOST_ARCH MATCHES "i[2-6]86")
-  message(FATAL_ERROR "Unknown architecture ${HOST_ARCH}")
-endif(HOST_ARCH MATCHES "i[2-6]86")
-
-# Pass the list of LLVM targets as preprocessor constants.
-foreach(TARGET ${HOST_ARCH} ${EXTRA_LLVM_MODULES})
-    set(LLVM_MODULES_DEFINE "${LLVM_MODULES_DEFINE} LLVM_TARGET(${TARGET})")
-endforeach(TARGET)
-
-set_source_files_properties(
-    ${PROJECT_SOURCE_DIR}/driver/main.cpp PROPERTIES
-    COMPILE_DEFINITIONS LDC_TARGETS=${LLVM_MODULES_DEFINE}
 )
 
 #

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -219,18 +219,14 @@ int main(int argc, char** argv)
 
     // Initialize LLVM.
     // Initialize targets first, so that --version shows registered targets.
-#define LLVM_TARGET(A) \
-    LLVMInitialize##A##TargetInfo(); \
-    LLVMInitialize##A##Target(); \
-    LLVMInitialize##A##AsmPrinter(); \
-    LLVMInitialize##A##AsmParser(); \
-    LLVMInitialize##A##TargetMC();
-LDC_TARGETS
-#undef LLVM_TARGET
+    llvm::InitializeAllTargets();
+    llvm::InitializeAllTargetMCs();
+    llvm::InitializeAllAsmPrinters();
+    llvm::InitializeAllAsmParsers();
 
     // Handle fixed-up arguments!
     cl::SetVersionPrinter(&printVersion);
-    cl::ParseCommandLineOptions(final_args.size(), (char**)&final_args[0], "LLVM-based D Compiler\n", true);
+    cl::ParseCommandLineOptions(final_args.size(), const_cast<char**>(&final_args[0]), "LLVM-based D Compiler\n", true);
 
     // Print config file path if -v was passed
     if (global.params.verbose) {
@@ -455,11 +451,16 @@ LDC_TARGETS
         fatal();
 
     // override triple if needed
-    const char* defaultTriple = DEFAULT_TARGET_TRIPLE;
-    if ((sizeof(void*) == 4 && m64bits) || (sizeof(void*) == 8 && m32bits))
+    std::string defaultTriple = llvm::sys::getDefaultTargetTriple();
+    if (sizeof(void*) == 4 && m64bits)
     {
-        defaultTriple = DEFAULT_ALT_TARGET_TRIPLE;
+        defaultTriple = llvm::Triple(defaultTriple).get64BitArchVariant().str();
     }
+    else if (sizeof(void*) == 8 && m32bits)
+    {
+        defaultTriple = llvm::Triple(defaultTriple).get32BitArchVariant().str();
+    }
+
 
     // did the user override the target triple?
     if (mTargetTriple.empty())
@@ -469,7 +470,7 @@ LDC_TARGETS
             error("you must specify a target triple as well with -mtriple when using the -march option");
             fatal();
         }
-        global.params.targetTriple = defaultTriple;
+        global.params.targetTriple = defaultTriple.c_str();
     }
     else
     {
@@ -615,79 +616,61 @@ LDC_TARGETS
     // parse the OS out of the target triple
     // see http://gcc.gnu.org/install/specific.html for details
     // also llvm's different SubTargets have useful information
-    size_t npos = std::string::npos;
-
-    // windows
-    if (triple.find("win32") != npos)
+    switch (llvm::Triple(triple).getOS())
     {
-        global.params.os = OSWindows;
-        VersionCondition::addPredefinedGlobalIdent("Windows");
-        VersionCondition::addPredefinedGlobalIdent("Win32");
-        if (global.params.is64bit) {
-            VersionCondition::addPredefinedGlobalIdent("Win64");
-        }
-    }
-    // FIXME: mingw
-    else if (triple.find("mingw") != npos)
-    {
-        global.params.os = OSWindows;
-        VersionCondition::addPredefinedGlobalIdent("Windows");
-        VersionCondition::addPredefinedGlobalIdent("Win32");
-        VersionCondition::addPredefinedGlobalIdent("mingw32");
-        VersionCondition::addPredefinedGlobalIdent("MinGW");
-        if (global.params.is64bit) {
-            VersionCondition::addPredefinedGlobalIdent("Win64");
-        }
-    }
-    // FIXME: cygwin
-    else if (triple.find("cygwin") != npos)
-    {
-        error("CygWin is not yet supported");
-        fatal();
-    }
-    // linux
-    else if (triple.find("linux") != npos)
-    {
-        global.params.os = OSLinux;
-        VersionCondition::addPredefinedGlobalIdent("linux");
-        VersionCondition::addPredefinedGlobalIdent("Posix");
-    }
-    // haiku
-    else if (triple.find("haiku") != npos)
-    {
-        global.params.os = OSHaiku;
-        VersionCondition::addPredefinedGlobalIdent("Haiku");
-        VersionCondition::addPredefinedGlobalIdent("Posix");
-    }
-    // darwin
-    else if (triple.find("-darwin") != npos)
-    {
-        global.params.os = OSMacOSX;
-        VersionCondition::addPredefinedGlobalIdent("OSX");
-        VersionCondition::addPredefinedGlobalIdent("darwin");
-        VersionCondition::addPredefinedGlobalIdent("Posix");
-    }
-    // freebsd
-    else if (triple.find("-freebsd") != npos)
-    {
-        global.params.os = OSFreeBSD;
-        VersionCondition::addPredefinedGlobalIdent("freebsd");
-        VersionCondition::addPredefinedGlobalIdent("FreeBSD");
-        VersionCondition::addPredefinedGlobalIdent("Posix");
-    }
-    // solaris
-    else if (triple.find("-solaris") != npos)
-    {
-        global.params.os = OSSolaris;
-        VersionCondition::addPredefinedGlobalIdent("solaris");
-        VersionCondition::addPredefinedGlobalIdent("Solaris");
-        VersionCondition::addPredefinedGlobalIdent("Posix");
-    }
-    // unsupported
-    else
-    {
-        error("target '%s' is not yet supported", global.params.targetTriple);
-        fatal();
+        case llvm::Triple::Win32:
+            global.params.os = OSWindows;
+            VersionCondition::addPredefinedGlobalIdent("Windows");
+            VersionCondition::addPredefinedGlobalIdent("Win32");
+            if (global.params.is64bit) {
+                VersionCondition::addPredefinedGlobalIdent("Win64");
+            }
+            break;
+        case llvm::Triple::MinGW32:
+            global.params.os = OSWindows;
+            VersionCondition::addPredefinedGlobalIdent("Windows");
+            VersionCondition::addPredefinedGlobalIdent("Win32");
+            VersionCondition::addPredefinedGlobalIdent("mingw32");
+            VersionCondition::addPredefinedGlobalIdent("MinGW");
+            if (global.params.is64bit) {
+                VersionCondition::addPredefinedGlobalIdent("Win64");
+            }
+            break;
+        case llvm::Triple::Cygwin:
+            error("CygWin is not yet supported");
+            fatal();
+            break;
+        case llvm::Triple::Linux:
+            global.params.os = OSLinux;
+            VersionCondition::addPredefinedGlobalIdent("linux");
+            VersionCondition::addPredefinedGlobalIdent("Posix");
+            break;
+        case llvm::Triple::Haiku:
+            global.params.os = OSHaiku;
+            VersionCondition::addPredefinedGlobalIdent("Haiku");
+            VersionCondition::addPredefinedGlobalIdent("Posix");
+            break;
+        case llvm::Triple::Darwin:
+            global.params.os = OSMacOSX;
+            VersionCondition::addPredefinedGlobalIdent("OSX");
+            VersionCondition::addPredefinedGlobalIdent("darwin");
+            VersionCondition::addPredefinedGlobalIdent("Posix");
+            break;
+        case llvm::Triple::FreeBSD:
+            global.params.os = OSFreeBSD;
+            VersionCondition::addPredefinedGlobalIdent("freebsd");
+            VersionCondition::addPredefinedGlobalIdent("FreeBSD");
+            VersionCondition::addPredefinedGlobalIdent("Posix");
+            break;
+        case llvm::Triple::Solaris:
+            global.params.os = OSSolaris;
+            VersionCondition::addPredefinedGlobalIdent("solaris");
+            VersionCondition::addPredefinedGlobalIdent("Solaris");
+            VersionCondition::addPredefinedGlobalIdent("Posix");
+            break;
+        default:
+            error("target '%s' is not yet supported", global.params.targetTriple);
+            fatal();
     }
 
     if (global.params.os == OSWindows) {


### PR DESCRIPTION
Lot of code in CMakeLists.txt deals with configuration of LLVM.

This can really be simplified by initializing all targets and using LLVM 3.1 features:
- `llvm::sys::getDefaultTargetTriple()` returns the default target triple
- `llvm::Triple` provides parsing of triple strings
- methods `get64BitArchVariant()` and `get32BitArchVariant()` of `llvm::Triple` can be used to implement -m32 and -m64. This also works with other architectures, e.g. ppc/ppc64 and mips/mips64.

I think more simplifications are possible by using llvm::Triple as type for global.params.llvmArch and global.params.os (e.g. using Triple.isOSWindows())

IMHO this is an argument against merging the 3.0 and 3.1 branch (see #107). It looks really complicated to me to create conditional compiled code to achieve this result.
