### PR TITLE
Add pragma shufflevector

### DIFF
--- a/dmd2/idgen.c
+++ b/dmd2/idgen.c
@@ -272,6 +272,7 @@ Msgtable msgtable[] =
     { "no_typeinfo" },
     { "no_moduleinfo" },
     { "Alloca", "alloca" },
+    { "Shufflevector", "shufflevector" },
     { "vastart", "va_start" },
     { "vacopy", "va_copy" },
     { "vaend", "va_end" },

--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -106,6 +106,17 @@ Pragma DtoGetPragma(Scope *sc, PragmaDeclaration *decl, std::string &arg1str)
         return LLVMalloca;
     }
 
+    // pragma(shufflevector) { funcdecl(s) }
+    else if (ident == Id::Shufflevector)
+    {
+        if (args && args->dim > 0)
+        {
+             error("takes no parameters");
+             fatal();
+        }
+        return LLVMshufflevector;
+    }
+
     // pragma(va_start) { templdecl(s) }
     else if (ident == Id::vastart)
     {
@@ -352,6 +363,18 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
         else
         {
             error("the '%s' pragma must only be used on function declarations of type 'void* function(uint nbytes)'", ident->toChars());
+            fatal();
+        }
+        break;
+
+    case LLVMshufflevector:
+        if (FuncDeclaration* fd = s->isFuncDeclaration())
+        {
+            fd->llvmInternal = llvm_internal;
+        }
+        else
+        {
+            error("the '%s' pragma must only be used on function declarations.", ident->toChars());
             fatal();
         }
         break;

--- a/gen/pragma.h
+++ b/gen/pragma.h
@@ -14,6 +14,7 @@ enum Pragma
     LLVMno_typeinfo,
     LLVMno_moduleinfo,
     LLVMalloca,
+    LLVMshufflevector,
     LLVMva_start,
     LLVMva_copy,
     LLVMva_end,


### PR DESCRIPTION
This adds pragma shufflevector to support shuffling elements in SIMD vectors. It is used like that:

```
pragma(shufflevector) 
        float4 shufflevector(float4, float4, int, int, int, int);

// This will compile to shufps instruction when using SSE
static auto shufps(int m0, int m1, int m2, int m3)(float4 a, float4 b)
{
    return shufflevector(a, b, m3, m2, m1 + 4, m0 + 4);
}
```

Without support for LLVM shufflevector instruction there is no clean way to support some SIMD instructions in LDC. AFAIK LLVM only defines intrinsics for operations that can't be achieved through other means such as shufflevector or vector addition, subtraction etc. Shufflevector is also what Clang uses to implement SIMD intrinsics, as you can see [here](http://llvm.org/svn/llvm-project/cfe/trunk/lib/Headers/xmmintrin.h), for example.

I am new to LDC, the DMD frontend and LLVM, so it would probably be a good idea to carefully review this code before merging. I have, however, tried it on my code [here](https://github.com/jerro/pfft/tree/ldc-shufflevector) (files pfft/sse_float.d and pfft/sse_double.d use shufflevector) and it seems to work fine.
