### PR TITLE
Added a link to wiki

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@ For build instructions see the wiki:
 
 https://github.com/ldc-developers/ldc/wiki
 
-For more information, visit the LDC website:
+For more information, visit the LDC website (note that the site relates to
+an old version of LDC, so some of the information there is outdated):
 
 http://www.dsource.org/projects/ldc


### PR DESCRIPTION
The readme.txt was suggesting people to follow the build instructions
at dsource.org. Those build instructions are outdated and don't work
any more. 
