### PR TITLE
Add pragma to install function as global ctor or dtor.

### DIFF
--- a/dmd/declaration.h
+++ b/dmd/declaration.h
@@ -853,6 +853,7 @@ struct FuncDeclaration : Declaration
     std::set<VarDeclaration*> nestedVars;
 
     std::string intrinsicName;
+    uint32_t priority;
 
     bool isIntrinsic();
     bool isVaIntrinsic();

--- a/dmd/idgen.c
+++ b/dmd/idgen.c
@@ -241,6 +241,8 @@ Msgtable msgtable[] =
     { "LDC_atomic_store" },
     { "LDC_atomic_cmp_xchg" },
     { "LDC_atomic_rmw" },
+    { "LDC_global_crt_ctor" },
+    { "LDC_global_crt_dtor" },
 
     // Deprecated LDC pragmas lacking the vendor prefix.
     { "intrinsic" },

--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -907,6 +907,7 @@ struct FuncDeclaration : Declaration
     std::set<VarDeclaration*> nestedVars;
 
     std::string intrinsicName;
+    uint32_t priority;
 
     bool isIntrinsic();
     bool isVaIntrinsic();

--- a/dmd2/idgen.c
+++ b/dmd2/idgen.c
@@ -285,6 +285,8 @@ Msgtable msgtable[] =
     { "LDC_atomic_store" },
     { "LDC_atomic_cmp_xchg" },
     { "LDC_atomic_rmw" },
+    { "LDC_global_crt_ctor" },
+    { "LDC_global_crt_dtor" },
 
     // Deprecated LDC pragmas lacking the vendor prefix.
     { "intrinsic" },

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -767,6 +767,11 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
         }
     }
 
+    if (fdecl->llvmInternal == LLVMglobal_crt_ctor || fdecl->llvmInternal == LLVMglobal_crt_dtor)
+    {
+        AppendFunctionToLLVMGlobalCtorsDtors(func, fdecl->priority, fdecl->llvmInternal == LLVMglobal_crt_ctor);
+    }
+
     // we never reference parameters of function prototypes
     std::string str;
    // if (!declareOnly)

--- a/gen/pragma.h
+++ b/gen/pragma.h
@@ -25,6 +25,8 @@ enum Pragma
     LLVMnone, // Not an LDC pragma.
     LLVMignore, // Pragma has already been processed in DtoGetPragma, ignore.
     LLVMintrinsic,
+    LLVMglobal_crt_ctor,
+    LLVMglobal_crt_dtor,
     LLVMno_typeinfo,
     LLVMno_moduleinfo,
     LLVMalloca,


### PR DESCRIPTION
DMD has the obscure functionality to install functions starting with `_STI_` as global ctors and funtions starting with `_STD_` as global dtors. IMHO a pragma is a better way to specify the behaviour.

This commit adds pragma(ctor) and pragma(dtor). If the pragma is specified on a function or static method then an entry is made in the corresponding list. E.g. in `monitor_.d`:

```
extern (C) {
    #pragma(ctor)
    void _STI_monitor_staticctor()
    {
        // ...
    }
}
```

This works on Linux without problems. On Windows with MS C Runtime only ctors works due to a bug in LLVM.
