### PR TITLE
Fix #162 - contracts for member functions with out parameters.

### DIFF
--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -740,8 +740,12 @@ struct FuncDeclaration : Declaration
     FuncDeclaration *fdrequire;         // function that does the in contract
     FuncDeclaration *fdensure;          // function that does the out contract
 
+#if IN_LLVM
+    // Argument lists for the __require/__ensure calls. NULL if not a virtual
+    // function with contracts.
     Expressions *fdrequireParams;
     Expressions *fdensureParams;
+#endif
 
     Identifier *outId;                  // identifier for out statement
     VarDeclaration *vresult;            // variable corresponding to outId


### PR DESCRIPTION
Also documented the code and changed it to explicitly use IN_LLVM
or the LDC specific parts in order to make debugging/frontend
merging easier.

Submitted as a pull request to test Travis CI pull request testing.
