### PR TITLE
Fix Issue 8675 - Nothrow can't throw Errors

### DIFF
--- a/dmd2/statement.c
+++ b/dmd2/statement.c
@@ -5112,8 +5112,17 @@ Statement *ThrowStatement::semantic(Scope *sc)
 int ThrowStatement::blockExit(bool mustNotThrow)
 {
     if (mustNotThrow)
-        error("%s is thrown but not caught", exp->type->toChars());
-    return BEthrow;  // obviously
+    {
+        ClassDeclaration *cd = exp->type->toBasetype()->isClassHandle();
+        assert(cd);
+
+        // Bugzilla 8675
+        // Throwing Errors is allowed even if mustNotThrow
+        if (cd != ClassDeclaration::errorException &&
+            !ClassDeclaration::errorException->isBaseOf(cd, NULL))
+            error("%s is thrown but not caught", exp->type->toChars());
+    }
+    return BEthrow;
 }
 
 


### PR DESCRIPTION
This is a fix from current DMD master branch.

"Fix Issue 8675 - Nothrow can't throw Errors

Fixed by checking whether the thrown exception is derived from Error before complaining about uncaught throws."

I like to have this applied early because it fixes the only 2 compile errors in the ldc-latest branch (which works really well for Win64).
