### PR TITLE
Module ldc.gccbuiltins_x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,15 @@ set_target_properties(
 )
 target_link_libraries(${LDC_EXE} ${LDC_LIB} ${LIBCONFIG++_LIBRARY})
 
+add_executable(GEN_GCCBUILTINS utils/gen_gccbuiltins.cpp)
+set_target_properties(
+    GEN_GCCBUILTINS PROPERTIES
+    OUTPUT_NAME gen_gccbuiltins
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+    COMPILE_FLAGS "${LLVM_CXXFLAGS}"
+)
+target_link_libraries(GEN_GCCBUILTINS "-lLLVMTableGen -lLLVMSupport -ldl ${LLVM_LDFLAGS}" ${LLVM_LIBRARIES})
+
 # For use by the druntime/Phobos build system.
 get_target_property(LDC_LOC ${LDC_EXE} LOCATION)
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -265,6 +265,12 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix)
     endforeach(f)
 
     if(EXISTS ${RUNTIME_DIR})
+        set(GCCBUILTINS "${PROJECT_BINARY_DIR}/gccbuiltins_x86.di") 
+        add_custom_command(
+            OUTPUT ${GCCBUILTINS} 
+            COMMAND ${PROJECT_PARENT_DIR}/bin/gen_gccbuiltins ${GCCBUILTINS} "x86"
+            DEPENDS ${PROJECT_PARENT_DIR}/bin/gen_gccbuiltins 
+        )
         if(BUILD_SINGLE_LIB)
             add_library(${RUNTIME_AIO}${target_suffix}
                         ${D_LIBRARY_TYPE}
@@ -273,11 +279,12 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix)
                         ${GC_O}
                         ${DCRT_O}
                         ${DCRT_C}
+                        ${GCCBUILTINS}
             )
             set(LIBS ${RUNTIME_AIO}${target_suffix})
             set_target_properties(${RUNTIME_AIO}${target_suffix} PROPERTIES OUTPUT_NAME ${RUNTIME_AIO}${lib_suffix})
         else(BUILD_SINGLE_LIB)
-            add_library(${RUNTIME_CC}${target_suffix} ${D_LIBRARY_TYPE} ${CORE_O} ${CORE_C})
+            add_library(${RUNTIME_CC}${target_suffix} ${D_LIBRARY_TYPE} ${CORE_O} ${CORE_C} ${GCCBUILTINS})
             add_library(${RUNTIME_GC}${target_suffix} ${D_LIBRARY_TYPE} ${GC_O})
             add_library(${RUNTIME_DC}${target_suffix} ${D_LIBRARY_TYPE} ${DCRT_O} ${DCRT_C})
             set_target_properties(${RUNTIME_CC}${target_suffix} PROPERTIES OUTPUT_NAME ${RUNTIME_CC}${lib_suffix})
@@ -396,5 +403,6 @@ if(PHOBOS2_DIR)
     install(DIRECTORY ${PHOBOS2_DIR}/etc                               DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.d")
     install(FILES     ${PHOBOS2_DIR}/crc32.d                           DESTINATION ${INCLUDE_INSTALL_DIR})
 endif(PHOBOS2_DIR)
-install(FILES         ${RUNTIME_DIR}/src/object.di                  DESTINATION ${INCLUDE_INSTALL_DIR}/ldc)
+install(FILES         ${RUNTIME_DIR}/src/object.di                     DESTINATION ${INCLUDE_INSTALL_DIR}/ldc)
 install(DIRECTORY     ${RUNTIME_DIR}/import/ldc                        DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.di")
+install(FILES         ${GCCBUILTINS}                                   DESTINATION ${INCLUDE_INSTALL_DIR}/ldc)

--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -1,0 +1,159 @@
+#include <map>
+#include <string>
+#include <algorithm>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include <llvm/Config/llvm-config.h>
+#include <llvm/TableGen/Main.h>
+#include <llvm/TableGen/TableGenAction.h>
+#include <llvm/TableGen/Record.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/PathV1.h>
+#include <llvm/ADT/StringRef.h>
+
+using namespace std;
+using namespace llvm;
+
+string dtype(Record* rec)
+{
+    Init* typeInit = rec->getValueInit("VT");
+    if(!typeInit) 
+        return "";
+
+    string type = typeInit->getAsString();
+
+    if(type == "iPTR")
+        return "void*";
+    
+    string vec = "";
+
+    if(type[0] == 'v')
+    {
+        size_t i = 1;
+        while(i != type.size() && type[i] <= '9' && type[i] >= '0')
+            i++;
+        
+        vec = type.substr(1, i - 1);
+        type = type.substr(i);
+    }
+
+    if(type == "i8")
+        return "byte" + vec;
+    else if(type == "i16")
+        return "short" + vec;
+    else if(type == "i32")
+        return "int" + vec;
+    else if(type == "i64")
+        return "long" + vec;
+    else if(type == "f32")
+        return "float" + vec;
+    else if(type == "f64")
+        return "double" + vec;
+    else
+        return "";
+}
+
+void processRecord(raw_ostream& os, Record& rec, string arch)
+{
+    if(!rec.getValue("GCCBuiltinName"))
+        return; 
+
+    string builtinName = rec.getValueAsString("GCCBuiltinName");
+    string name =  rec.getName();
+
+    if(name.substr(0, 4) != "int_" || name.find(arch) == string::npos)
+        return;
+
+    name = name.substr(4);
+    replace(name.begin(), name.end(), '_', '.');
+    name = string("llvm.") + name;
+
+    ListInit* paramsList = rec.getValueAsListInit("ParamTypes"); 
+    vector<string> params;
+    for(int i = 0; i < paramsList->getSize(); i++)
+    {
+        string t = dtype(paramsList->getElementAsRecord(i));
+        if(t == "") 
+            return; 
+        
+        params.push_back(t);
+    }
+
+    ListInit* retList = rec.getValueAsListInit("RetTypes");
+    string ret;
+    if(retList->getSize() == 0)
+        ret = "void";
+    else if(retList->getSize() == 1)
+    {
+        ret = dtype(retList->getElementAsRecord(0));
+        if(ret == "")
+            return;
+    }
+    else
+        return; 
+
+    os << "pragma(intrinsic, \"" + name + "\")\n    ";
+    os << ret + " " + builtinName + "(";
+   
+    if(params.size())
+        os << params[0];
+ 
+    for(int i = 1; i < params.size(); i++)
+        os << ", " << params[i];
+
+    os << ");\n\n";
+}
+
+struct ActionImpl : TableGenAction 
+{
+    string arch;
+    ActionImpl(string arch_): arch(arch_) {}
+
+    bool operator()(raw_ostream& os, RecordKeeper& records)
+    {
+        os << "module llvm.gccbuiltins_";
+        os << arch; 
+        os << "; \n\nimport core.simd;\n\n";
+
+        map<string, Record*> defs = records.getDefs();
+        
+        for(
+            map<string, Record* >::iterator it = defs.begin(); 
+            it != defs.end(); 
+            it++)
+        {
+            processRecord(os, *(*it).second, arch);
+        } 
+
+        return false;
+    }
+};
+
+int main(int argc, char** argv)
+{
+    if(argc != 3)
+    {
+        fprintf(stderr, "There must be exactly two command line arguments\n");
+        return 1;
+    }
+
+    sys::Path file(LLVM_INCLUDEDIR);
+    file.appendComponent("llvm");
+    file.appendComponent("Intrinsics.td");
+
+    string iStr = string("-I=") + string(LLVM_INCLUDEDIR); 
+    string oStr = string("-o=") + argv[1];
+
+    vector<char*> args2(argv, argv + 1);
+    args2.push_back(const_cast<char*>(file.c_str()));
+    args2.push_back(const_cast<char*>(iStr.c_str()));
+    args2.push_back(const_cast<char*>(oStr.c_str()));
+
+    cl::ParseCommandLineOptions(args2.size(), &args2[0]);
+    ActionImpl act(argv[2]);
+    return TableGenMain(argv[0], act); 
+}
+


### PR DESCRIPTION
This generates ldc.gccbuiltins_x86  when LDC is built. The  ldc.gccbuiltins_x86 module contains declarations for gcc builtins for x86 that LLVM supports and that have parameters and return types that correspond to D's integral, floating point and vector types,  and type void*. void return type is also supported. 
