### PR TITLE
Added pure, @safe and nothrow to gccbuiltins.

### DIFF
--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -57,6 +57,17 @@ string dtype(Record* rec)
         return "";
 }
 
+string attributes(ListInit* propertyList)
+{
+    string prop = propertyList->getSize() ? 
+        propertyList->getElementAsRecord(0)->getName() : "";
+
+    return
+        prop == "IntrNoMem" ? "nothrow pure @safe" :
+        prop == "IntrReadArgMem" ? "nothrow pure" :
+        prop == "IntrReadWriteArgMem" ? "nothrow pure" : "nothrow";
+}
+
 void processRecord(raw_ostream& os, Record& rec, string arch)
 {
     if(!rec.getValue("GCCBuiltinName"))
@@ -105,7 +116,7 @@ void processRecord(raw_ostream& os, Record& rec, string arch)
     for(int i = 1; i < params.size(); i++)
         os << ", " << params[i];
 
-    os << ");\n\n";
+    os << ")" + attributes(rec.getValueAsListInit("Properties")) + ";\n\n";
 }
 
 std::string arch;


### PR DESCRIPTION
This adds pure, @safe and nothrow attributes to declarations in ldc.gccbuiltins_x86. All the intrinsics are marked with nothrow, the ones that only read or write to memory through their parameters and don't have other side effects are marked as pure, and the ones that don't access memory at all are also marked as @safe. 
