### PR TITLE
Use LDC_intrinsic in ldc.gccbuiltins_x86

### DIFF
--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -107,7 +107,7 @@ void processRecord(raw_ostream& os, Record& rec, string arch)
     else
         return;
 
-    os << "pragma(intrinsic, \"" + name + "\")\n    ";
+    os << "pragma(LDC_intrinsic, \"" + name + "\")\n    ";
     os << ret + " " + builtinName + "(";
 
     if(params.size())


### PR DESCRIPTION
Pragma intrinsic is deprecated, so ldc.gccbuiltins_x86 needs to use LDC_intrinsic instead.
