### PR TITLE
Split Travis test execution into debug and release tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ install:
   - sudo apt-get install -qq $LLVM_PACKAGE libconfig++8-dev
 env:
   - DVER=1 LLVM_PACKAGE=llvm-3.1 LLVM_VERSION=3.1
-  - DVER=2 LLVM_PACKAGE=llvm-3.0-dev LLVM_VERSION=3.0
-  - DVER=2 LLVM_PACKAGE=llvm-3.1 LLVM_VERSION=3.1
+  - DVER=2 LLVM_PACKAGE=llvm-3.0-dev LLVM_VERSION=3.0 TESTSUITE_FILTER=debug
+  - DVER=2 LLVM_PACKAGE=llvm-3.0-dev LLVM_VERSION=3.0 TESTSUITE_FILTER=release
+  - DVER=2 LLVM_PACKAGE=llvm-3.1 LLVM_VERSION=3.1 TESTSUITE_FILTER=debug
+  - DVER=2 LLVM_PACKAGE=llvm-3.1 LLVM_VERSION=3.1 TESTSUITE_FILTER=release
 script:
   - cmake -DD_VERSION=$DVER -DLLVM_CONFIG=/usr/bin/llvm-config-$LLVM_VERSION
   - make
-  - ctest --output-on-failure
+  - ctest --output-on-failure -R $TESTSUITE_FILTER
 
 notifications:
   # Temporarily disabled due to time limit problems.


### PR DESCRIPTION
Hopefully enough to reliably make it below the time limit,
even if the load distribution is not quite symmetric.
