### PR TITLE
when creating an executable, always set global.params.objname = NULL

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -444,8 +444,7 @@ int main(int argc, char** argv)
     if (global.params.link && !createSharedLib)
     {
         global.params.exefile = global.params.objname;
-        if (files.dim > 1)
-            global.params.objname = NULL;
+        global.params.objname = NULL;
     }
     else if (global.params.run)
     {


### PR DESCRIPTION
In that case, -of is just not supposed to name the object file.
This makes ldmd2 work with rdmd.

Disclaimer: I'm not familiar with the ldc sources, so I may be missing any implications this change has.