### PR TITLE
Replace AttributeWithIndex for LLVM 3.3.

### DIFF
--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -214,7 +214,7 @@ LLFunctionType* DtoExtractFunctionType(LLType* type);
 #if LDC_LLVM_VER >= 303
 void DtoBuildDVarArgList(std::vector<LLValue*>& args, llvm::AttributeSet& palist, TypeFunction* tf, Expressions* arguments, size_t argidx);
 #else
-void DtoBuildDVarArgList(std::vector<LLValue*>& args, llvm::AttrListPtr& palist, TypeFunction* tf, Expressions* arguments, size_t argidx);
+void DtoBuildDVarArgList(std::vector<LLValue*>& args, std::vector<llvm::AttributeWithIndex>& palist, TypeFunction* tf, Expressions* arguments, size_t argidx);
 #endif
 
 ///


### PR DESCRIPTION
The helper class AttribteWithIndex is gone in LLVM 3.3. Instead a
combination of AttrBuilder and AttributeSet must be used.
