### PR TITLE
extern(D): Return static arrays via sret parameters.

### DIFF
--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -425,7 +425,11 @@ bool X86_64TargetABI::returnInArg(TypeFunction* tf) {
             return false;
 #endif
         // All non-structs can be returned in registers.
-        return (rt->ty == Tstruct);
+        return rt->ty == Tstruct
+#if SARRAYVALUE
+            || rt->ty == Tsarray
+#endif
+        ;
     } else {
         if (rt == Type::tvoid || keepUnchanged(rt))
             return false;

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -89,7 +89,13 @@ struct X86TargetABI : TargetABI
         Type* rt = tf->next->toBasetype();
         // D only returns structs on the stack
         if (tf->linkage == LINKd)
-            return (rt->ty == Tstruct);
+        {
+            return rt->ty == Tstruct
+#if SARRAYVALUE
+                || rt->ty == Tsarray
+#endif
+            ;
+        }
         // other ABI's follow C, which is cdouble and creal returned on the stack
         // as well as structs
         else


### PR DESCRIPTION
On x86_64, a proper solution (see GitHub #120) is still needed,
but this will have to wait until the special case for extern(D)
is gone from the implementation.

We need this right now as std.digest.md in 2.061 triggers a
miscompilation issue in the LLVM x86 backend (not the optimizer!)
when returning them directly as LLVM arrays.
