### PR TITLE
briefly ctest howto in the README, with -R explained

### DIFF
--- a/README
+++ b/README
@@ -43,6 +43,13 @@ For the impatient, a quick guide for building on *nix systems:
  4) Run the test suite to verify your build. Still in the build/ dir:
   $ ctest --output-on-failure -R release -j8  # adjust 8 to cpu count
 
+  # Note: The "-R release" option does speed up testing (so it is
+  # used in the CI builds) by filtering for tests with 'release'
+  # in their name (see: man ctest). However, for better coverage 
+  # (2x more tests, 60% longer to run), ctest without the '-R release'
+  # option. -R <regex> is also useful for running just one test
+  # quickly.
+
 In case the above steps do not work, please first visit the extended
 documentation at http://wiki.dlang.org/Building_LDC_from_source.
 


### PR DESCRIPTION
The ctest was the only part was new to me in the README, so I suggest it deserves a little extra info here.  This addition to the README indicates that ctest is a standard tool (that has a man page), and also indicates the most FAQ about how to run a test tool: how do I run just one test (the new one that I just added) quickly.
