### PR TITLE
Make '-O' equivalent to '-O3'.

### DIFF
--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -807,7 +807,7 @@ void buildCommandLine(std::vector<const char*>& r, const Params& p)
     if (p.logTlsUse) warning("-vtls not yet supported by LDC.");
     if (p.warnings == Warnings::asErrors) r.push_back("-w");
     else if (p.warnings == Warnings::informational) r.push_back("-wi");
-    if (p.optimize) r.push_back("-O2");
+    if (p.optimize) r.push_back("-O3");
     if (p.noObj) r.push_back("-o-");
     if (p.objDir) r.push_back(concat("-od=", p.objDir));
     if (p.objName) r.push_back(concat("-of=", p.objName));

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -47,7 +47,7 @@ static cl::opt<signed char> optimizeLevel(
     cl::desc("Setting the optimization level:"),
     cl::ZeroOrMore,
     cl::values(
-        clEnumValN(2, "O",  "Equivalent to -O2"),
+        clEnumValN(3, "O",  "Equivalent to -O3"),
         clEnumValN(0, "O0", "No optimizations (default)"),
         clEnumValN(1, "O1", "Simple optimizations"),
         clEnumValN(2, "O2", "Good optimizations"),


### PR DESCRIPTION
I have seen it used several times in benchmarks comparing it to 'gdc -O3' and
'dmd -O -inline' now, so people apparently expect it to yield the highest
available optimization level.
