### PR TITLE
More changes to std::vector usage.

### DIFF
--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -143,38 +143,27 @@ LLCallSite IRState::CreateCallOrInvoke(LLValue* Callee, const char* Name)
 
 LLCallSite IRState::CreateCallOrInvoke(LLValue* Callee, LLValue* Arg1, const char* Name)
 {
-    LLSmallVector<LLValue*, 1> args;
-    args.push_back(Arg1);
+    LLValue* args[] = { Arg1 };
     return CreateCallOrInvoke(Callee, args, Name);
 }
 
 LLCallSite IRState::CreateCallOrInvoke2(LLValue* Callee, LLValue* Arg1, LLValue* Arg2, const char* Name)
 {
-    LLSmallVector<LLValue*, 2> args;
-    args.push_back(Arg1);
-    args.push_back(Arg2);
+    LLValue* args[] = { Arg1, Arg2 };
     return CreateCallOrInvoke(Callee, args, Name);
 }
 
 LLCallSite IRState::CreateCallOrInvoke3(LLValue* Callee, LLValue* Arg1, LLValue* Arg2, LLValue* Arg3, const char* Name)
 {
-    LLSmallVector<LLValue*, 3> args;
-    args.push_back(Arg1);
-    args.push_back(Arg2);
-    args.push_back(Arg3);
+    LLValue* args[] = { Arg1, Arg2, Arg3 };
     return CreateCallOrInvoke(Callee, args, Name);
 }
 
 LLCallSite IRState::CreateCallOrInvoke4(LLValue* Callee, LLValue* Arg1, LLValue* Arg2,  LLValue* Arg3, LLValue* Arg4, const char* Name)
 {
-    LLSmallVector<LLValue*, 4> args;
-    args.push_back(Arg1);
-    args.push_back(Arg2);
-    args.push_back(Arg3);
-    args.push_back(Arg4);
+    LLValue* args[] = { Arg1, Arg2, Arg3, Arg4 };
     return CreateCallOrInvoke(Callee, args, Name);
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////////
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -59,8 +59,7 @@ void DtoDeleteMemory(LLValue* ptr)
     // get runtime function
     llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_delmemory");
     // build args
-    LLSmallVector<LLValue*,1> arg;
-    arg.push_back(DtoBitCast(ptr, getVoidPtrType(), ".tmp"));
+    LLValue* arg[] = { DtoBitCast(ptr, getVoidPtrType(), ".tmp") };
     // call
     gIR->CreateCallOrInvoke(fn, arg);
 }
@@ -69,13 +68,14 @@ void DtoDeleteClass(LLValue* inst)
 {
     // get runtime function
     llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_delclass");
-    // build args
-    LLSmallVector<LLValue*,1> arg;
     // druntime wants a pointer to object
     LLValue *ptr = DtoRawAlloca(inst->getType(), 0, "objectPtr");
     DtoStore(inst, ptr);
     inst = ptr;
-    arg.push_back(DtoBitCast(inst, fn->getFunctionType()->getParamType(0), ".tmp"));
+    // build args
+    LLValue* arg[] = {
+        DtoBitCast(inst, fn->getFunctionType()->getParamType(0), ".tmp")
+    };
     // call
     gIR->CreateCallOrInvoke(fn, arg);
 }
@@ -85,8 +85,9 @@ void DtoDeleteInterface(LLValue* inst)
     // get runtime function
     llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_delinterface");
     // build args
-    LLSmallVector<LLValue*,1> arg;
-    arg.push_back(DtoBitCast(inst, fn->getFunctionType()->getParamType(0), ".tmp"));
+    LLValue* arg[] = {
+        DtoBitCast(inst, fn->getFunctionType()->getParamType(0), ".tmp")
+    };
     // call
     gIR->CreateCallOrInvoke(fn, arg);
 }
@@ -97,9 +98,10 @@ void DtoDeleteArray(DValue* arr)
     llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_delarray_t");
 
     // build args
-    LLSmallVector<LLValue*,2> arg;
-    arg.push_back(DtoBitCast(arr->getLVal(), fn->getFunctionType()->getParamType(0)));
-    arg.push_back(DtoBitCast(DtoTypeInfoOf(arr->type->nextOf()), fn->getFunctionType()->getParamType(1)));
+    LLValue* arg[] = {
+        DtoBitCast(arr->getLVal(), fn->getFunctionType()->getParamType(0)),
+        DtoBitCast(DtoTypeInfoOf(arr->type->nextOf()), fn->getFunctionType()->getParamType(1))
+    };
 
     // call
     gIR->CreateCallOrInvoke(fn, arg);
@@ -155,11 +157,12 @@ LLValue* DtoGcMalloc(LLType* lltype, const char* name)
 
 void DtoAssert(Module* M, Loc loc, DValue* msg)
 {
-    std::vector<LLValue*> args;
-
     // func
     const char* fname = msg ? "_d_assert_msg" : "_d_assert";
     llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, fname);
+
+    // Arguments
+    llvm::SmallVector<LLValue*, 3> args;
 
     // msg param
     if (msg)
@@ -182,8 +185,7 @@ void DtoAssert(Module* M, Loc loc, DValue* msg)
     }
 
     // line param
-    LLConstant* c = DtoConstUint(loc.linnum);
-    args.push_back(c);
+    args.push_back(DtoConstUint(loc.linnum));
 
     // call
     gIR->CreateCallOrInvoke(fn, args);

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -172,10 +172,11 @@ static LLFunction* build_module_reference_and_ctor(LLConstant* moduleinfo)
 
     // provide the default initializer
     LLStructType* modulerefTy = DtoModuleReferenceType();
-    std::vector<LLConstant*> mrefvalues;
-    mrefvalues.push_back(LLConstant::getNullValue(modulerefTy->getContainedType(0)));
-    mrefvalues.push_back(llvm::ConstantExpr::getBitCast(moduleinfo, modulerefTy->getContainedType(1)));
-    LLConstant* thismrefinit = LLConstantStruct::get(modulerefTy, mrefvalues);
+    LLConstant* mrefvalues[] = {
+        LLConstant::getNullValue(modulerefTy->getContainedType(0)),
+        llvm::ConstantExpr::getBitCast(moduleinfo, modulerefTy->getContainedType(1))
+    };
+    LLConstant* thismrefinit = LLConstantStruct::get(modulerefTy, llvm::ArrayRef<LLConstant*>(mrefvalues));
 
     // create the ModuleReference node for this module
     std::string thismrefname = "_D";

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -165,8 +165,10 @@ void RTTIBuilder::finalize(LLType* type, LLValue* value)
 
     // set struct body
     if (st->isOpaque()) {
+        const int n = inits.size();
         std::vector<LLType*> types;
-        for (int i = 0, n = inits.size(); i < n; ++i)
+        types.reserve(n);
+        for (int i = 0; i < n; ++i)
             types.push_back(inits[i]->getType());
         st->setBody(types);
     }

--- a/gen/structs.cpp
+++ b/gen/structs.cpp
@@ -328,6 +328,7 @@ LLType* DtoUnpaddedStructType(Type* dty) {
     Array& fields = sty->sym->fields;
 
     std::vector<LLType*> types;
+    types.reserve(fields.dim);
 
     for (unsigned i = 0; i < fields.dim; i++) {
         VarDeclaration* vd = static_cast<VarDeclaration*>(fields.data[i]);

--- a/gen/todebug.cpp
+++ b/gen/todebug.cpp
@@ -216,16 +216,6 @@ static llvm::DIType dwarfCompositeType(Type* type)
     LLType* T = DtoType(type);
     Type* t = type->toBasetype();
 
-    // defaults
-    llvm::StringRef name;
-    unsigned linnum = 0;
-    llvm::DIFile file;
-
-    // elements
-    std::vector<llvm::Value*> elems;
-
-    llvm::DIType derivedFrom;
-
     assert((t->ty == Tstruct || t->ty == Tclass) &&
            "unsupported type for dwarfCompositeType");
     AggregateDeclaration* sd;
@@ -254,9 +244,15 @@ static llvm::DIType dwarfCompositeType(Type* type)
     if (static_cast<llvm::MDNode*>(ir->diCompositeType) != 0)
         return ir->diCompositeType;
 
-    name = sd->toChars();
-    linnum = sd->loc.linnum;
-    file = DtoDwarfFile(sd->loc);
+    // elements
+    std::vector<llvm::Value*> elems;
+
+    // defaults
+    llvm::StringRef name = sd->toChars();
+    unsigned linnum = sd->loc.linnum;
+    llvm::DIFile file = DtoDwarfFile(sd->loc);
+    llvm::DIType derivedFrom;
+
     // set diCompositeType to handle recursive types properly
     if (!ir->diCompositeType)
         ir->diCompositeType = gIR->dibuilder.createTemporaryType();


### PR DESCRIPTION
Replace with std::vector with static array, llvm::SmallVector or add code to reserve space.
