### PR TITLE
Workaround for issue #318.

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -606,6 +606,11 @@ function(add_tests module_files)
         if(${LDC_LLVM_VER} EQUAL 301 AND ${HOST_BITNESS} EQUAL 64 AND
             "${testroot}" STREQUAL "phobos_std_exception")
             testcase(release "-O1;-release")
+        # Building the std.range tests triggers an assertion error on
+        # every LLVM release before 3.3. See PR15608.
+        elseif(${LDC_LLVM_VER} LESS 303 AND
+            "${testroot}" STREQUAL "phobos_std_range")
+            testcase(release "-O1;-release")
         else()
             testcase(release "-O3;-release")
         endif()


### PR DESCRIPTION
The std.range tests are failing because of a LLVM bug. See PR15608 for deatils. The bug is fixed in LLVM 3.3.
The workaroung is to run the std.range test only with -O1.
