### PR TITLE
Add support for new parameter attribute `returned`.

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -129,7 +129,16 @@ llvm::FunctionType* DtoFunctionType(Type* type, Type* thistype, Type* nesttype, 
     // member functions
     if (thistype)
     {
-        fty.arg_this = new IrFuncTyArg(thistype, thistype->toBasetype()->ty == Tstruct);
+#if LDC_LLVM_VER >= 303
+        llvm::AttrBuilder attrBuilder;
+        if (f->funcdecl && f->funcdecl->isCtorDeclaration())
+            attrBuilder.addAttribute(llvm::Attribute::Returned);
+#endif
+        fty.arg_this = new IrFuncTyArg(thistype, thistype->toBasetype()->ty == Tstruct
+#if LDC_LLVM_VER >= 303
+                                       , attrBuilder
+#endif
+                                       );
         lidx++;
     }
 


### PR DESCRIPTION
Starting with LLVM 3.3 a new parameter attribute `returned` is supported.
The attribute states that the parameter is the return value, too. This is the case in constructors. (Destructors and postblits do not return `this`.)

Attribute `returned` is now added to the `this` parameter of constructors.
