### PR TITLE
Avoid unnecessary memset when allocating array literals.

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -583,7 +583,9 @@ DSliceValue* DtoNewDynArray(Loc& loc, Type* arrayType, DValue* dim, bool default
         defaultInit = false;
     bool zeroInit = eltType->isZeroInit();
 
-    const char* fnname = zeroInit ? "_d_newarrayT" : "_d_newarrayiT";
+    const char* fnname = defaultInit ?
+        (zeroInit ? "_d_newarrayT" : "_d_newarrayiT") :
+        "_d_newarrayvT";
     LLFunction* fn = LLVM_D_GetRuntimeFunction(gIR->module, fnname);
 
     // call allocator

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -358,7 +358,7 @@ FunctionPass *createGarbageCollect2Stack() {
 GarbageCollect2Stack::GarbageCollect2Stack()
 : FunctionPass(ID),
   AllocMemoryT(0, true, false),
-  NewArrayVT(0, true, false, false, 1),
+  NewArrayVT(0, true, true, false, 1),
   NewArrayT(0, true, true, true, 1)
 {
     KnownFunctions["_d_allocmemoryT"] = &AllocMemoryT;

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -342,13 +342,16 @@ static void LLVM_D_BuildRuntimeModule()
     }
     // void[] _d_newarrayT(TypeInfo ti, size_t length)
     // void[] _d_newarrayiT(TypeInfo ti, size_t length)
+    // void[] _d_newarrayvT(TypeInfo ti, size_t length)
     {
         llvm::StringRef fname("_d_newarrayT");
         llvm::StringRef fname2("_d_newarrayiT");
+        llvm::StringRef fname3("_d_newarrayvT");
         LLType *types[] = { typeInfoTy, sizeTy };
         LLFunctionType* fty = llvm::FunctionType::get(voidArrayTy, types, false);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname2, M);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname3, M);
     }
     // void[] _d_newarraymT(TypeInfo ti, size_t length, size_t* dims)
     // void[] _d_newarraymiT(TypeInfo ti, size_t length, size_t* dims)


### PR DESCRIPTION
This completes the merge of pull request #294. Thanks a lot to
Chris Holdsworth who originally wrote the patch!

GitHub: Fixes #294.
GitHub: Fixes #141.
