### PR TITLE
Do not memcpy with same source and destination.

### DIFF
--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -82,7 +82,8 @@ void ReturnStatement::toIR(IRState* p)
             DValue* rvar = new DVarValue(f->type->next, f->decl->ir.irFunc->retArg);
             DValue* e = exp->toElemDtor(p);
             // store return value
-            DtoAssign(loc, rvar, e);
+            if (rvar->getLVal() != e->getRVal())
+                DtoAssign(loc, rvar, e);
 
             // call postblit if necessary
             if (!p->func()->type->isref && !(f->decl->nrvo_can && f->decl->nrvo_var))

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -545,6 +545,8 @@ void DtoMemSetZero(LLValue* dst, LLValue* nbytes)
 
 void DtoMemCpy(LLValue* dst, LLValue* src, LLValue* nbytes, unsigned align)
 {
+    assert (src != dst && "src and dst of memcpy must be different");
+
     LLType* VoidPtrTy = getVoidPtrType();
 
     dst = DtoBitCast(dst, VoidPtrTy);


### PR DESCRIPTION
This can happen for sret_args. Simply do not perform the memcpy.

I found this with valgrind. The D source looks like this:

```
char[num*2] foo(size_t num)(in ubyte[num] bar)
{
    char[num*2] result = 'A';
    return result;
}

void main()
{
    ubyte[21] data = 'A';
    auto res = foo(data);
}
```

This produced the following valgrind message:

```
Source and destination overlap in memcpy(0x7feffffdc, 0x7feffffdc, 42)
   at 0x4C2E170: memcpy@@GLIBC_2.14 (mc_replace_strmem.c:877)
   by 0x403266: _D8valgrind12__T3fooVm21Z3fooFNaNbNfxG21hZG42a (valgrind.d:4)
   by 0x4031A8: _Dmain (valgrind.d:10)
   by 0x415C00: _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZi7runMainMFZv (dmain2.d:616)
   by 0x415B8B: _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZi7tryExecMFMDFZvZv (dmain2.d:591)
   by 0x415C51: _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZi6runAllMFZv (dmain2.d:626)
   by 0x415B8B: _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZi7tryExecMFMDFZvZv (dmain2.d:591)
   by 0x415B47: _d_run_main (dmain2.d:635)
   by 0x4156F2: main (dmain2.d:387)
```

With this change the message is gone.
