### PR TITLE
Fix uninitialized access to protection fields.

### DIFF
--- a/dmd2/enum.c
+++ b/dmd2/enum.c
@@ -38,6 +38,7 @@ EnumDeclaration::EnumDeclaration(Loc loc, Identifier *id, Type *memtype)
 #if IN_DMD
     objFileDone = 0;
 #endif
+    protection = PROTundefined;
 }
 
 Dsymbol *EnumDeclaration::syntaxCopy(Dsymbol *s)

--- a/dmd2/template.c
+++ b/dmd2/template.c
@@ -421,6 +421,7 @@ TemplateDeclaration::TemplateDeclaration(Loc loc, Identifier *id,
     this->literal = 0;
     this->ismixin = ismixin;
     this->previous = NULL;
+    this->protection = PROTundefined;
 
     // Compute in advance for Ddoc's use
     if (members)


### PR DESCRIPTION
This is fixed in 2.063. Valgrind complains about this.

The `protection` field is used in `DSymbol::search`. Using an uninitialized value may lead to some surprises, therefore this pull request.
