### PR TITLE
Add missing include for Windows

### DIFF
--- a/driver/response.cpp
+++ b/driver/response.cpp
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <cctype>
 
 // returns true if the quote is unescaped
 bool applyBackslashRule(std::string &arg) {


### PR DESCRIPTION
According to the library description `<cctype>` must be included for `std::isalpha` et al.
