### PR TITLE
Shorten readme

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-LDC – the LLVM D Compiler
-=========================
+LDC – the LLVM-based D Compiler
+===============================
 
 The LDC project aims to provide a portable D programming language
 compiler with modern optimization and code generation capabilities.


### PR DESCRIPTION
One of my initial goals when I wrote the current README was to make sure that there is as little duplication of information between it and the docs (i.e., the wiki), because previously our various documentation sources tended to be out of sync all the time.

However, as a nod to people who might be trying to build from the tarball without an internet connection, I included minimal build instructions in the file, with a link to the corresponding wiki page for more information.

Unfortunately, this seems to have been enough so that a sizeable chunk of people trying out LDC, particularly experienced programmers, just scan-read the file, see shell commands, copy/paste them, and then complain if something doesn't work, or are puzzled as to what dependencies are needed – even if all the necessary information would already be available on the wiki page!
