### PR TITLE
Remove CastExp::disableOptimization.

### DIFF
--- a/dmd2/expression.c
+++ b/dmd2/expression.c
@@ -9052,9 +9052,6 @@ CastExp::CastExp(Loc loc, Expression *e, Type *t)
 {
     to = t;
     this->mod = ~0;
-#if IN_LLVM
-    disableOptimization = false;
-#endif
 }
 
 #if DMDV2
@@ -9065,9 +9062,6 @@ CastExp::CastExp(Loc loc, Expression *e, unsigned mod)
 {
     to = NULL;
     this->mod = mod;
-#if IN_LLVM
-    disableOptimization = false;
-#endif
 }
 #endif
 

--- a/dmd2/expression.h
+++ b/dmd2/expression.h
@@ -1345,7 +1345,6 @@ struct CastExp : UnaExp
 #if IN_LLVM
     DValue* toElem(IRState* irs);
     llvm::Constant *toConstElem(IRState *irs);
-    bool disableOptimization;
 #endif
 };
 

--- a/dmd2/mtype.c
+++ b/dmd2/mtype.c
@@ -3798,16 +3798,7 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
         arguments = new Expressions();
         if (dup)
             arguments->push(getTypeInfo(sc));
-
-        // LDC repaint array type to void[]
-        if (n->ty != Tvoid) {
-            CastExp *exp = new CastExp(e->loc, e, e->type);
-            exp->type = Type::tvoid->arrayOf();
-            exp->disableOptimization = true;
-            e = exp;
-        }
         arguments->push(e);
-
         if (!dup)
             arguments->push(new IntegerExp(0, size, Type::tsize_t));
         e = new CallExp(e->loc, ec, arguments);
@@ -3846,14 +3837,6 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
         ec = new VarExp(0, adSort_fd);
         e = e->castTo(sc, n->arrayOf());        // convert to dynamic array
         arguments = new Expressions();
-
-        // LDC repaint array type to void[]
-        if (n->ty != Tvoid) {
-            CastExp *exp = new CastExp(e->loc, e, e->type);
-            exp->type = Type::tvoid->arrayOf();
-            exp->disableOptimization = true;
-            e = exp;
-        }
         arguments->push(e);
         // LDC, we don't support the getInternalTypeInfo
         // optimization arbitrarily, not yet at least...

--- a/dmd2/optimize.c
+++ b/dmd2/optimize.c
@@ -578,10 +578,6 @@ Expression *CallExp::optimize(int result, bool keepLvalue)
 
 Expression *CastExp::optimize(int result, bool keepLvalue)
 {
-#if IN_LLVM
-    if (disableOptimization)
-        return this;
-#endif
     //printf("CastExp::optimize(result = %d) %s\n", result, toChars());
     //printf("from %s to %s\n", type->toChars(), to->toChars());
     //printf("from %s\n", type->toChars());


### PR DESCRIPTION
Seems like our glue code handles the type adaption just fine now.
