### PR TITLE
Make ldc compatible with LLVM 3.4

### DIFF
--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -102,7 +102,7 @@ static int linkObjToBinaryGcc(bool sharedLib)
     Logger::println("*** Linking executable ***");
 
     // find gcc for linking
-    llvm::sys::Path gcc = getGcc();
+    llvm::sys::Path gcc(getGcc());
 
     // build arguments
     std::vector<std::string> args;
@@ -222,7 +222,7 @@ static int linkObjToBinaryWin(bool sharedLib)
     Logger::println("*** Linking executable ***");
 
     // find link.exe for linking
-    llvm::sys::Path tool = getLink();
+    llvm::sys::Path tool(getLink());
 
     // build arguments
     std::vector<std::string> args;
@@ -346,7 +346,7 @@ void createStaticLibrary()
     const bool isTargetWindows = global.params.targetTriple.getOS() == llvm::Triple::Win32;
 
     // find archiver
-    llvm::sys::Path tool = isTargetWindows ? getLib() : getArchiver();
+    llvm::sys::Path tool(isTargetWindows ? getLib() : getArchiver());
 
     // build arguments
     std::vector<std::string> args;

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -83,7 +83,8 @@ static void assemble(const llvm::sys::Path& asmpath, const llvm::sys::Path& objp
         args.push_back("-m32");
 
     // Run the compiler to assembly the program.
-    int R = executeToolAndWait(getGcc(), args, global.params.verbose);
+    llvm::sys::Path gcc(getGcc());
+    int R = executeToolAndWait(gcc, args, global.params.verbose);
     if (R)
     {
         error("Error while invoking external assembler.");

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -36,7 +36,11 @@ int executeToolAndWait(llvm::sys::Path tool, std::vector<std::string> const & ar
 
     // Execute tool.
     std::string errstr;
+#if LDC_LLVM_VER >= 304
+    if (int status = llvm::sys::ExecuteAndWait(tool.str(), &realargs[0], NULL, NULL, 0, 0, &errstr))
+#else
     if (int status = llvm::sys::Program::ExecuteAndWait(tool, &realargs[0], NULL, NULL, 0, 0, &errstr))
+#endif
     {
         error("%s failed with status: %d", tool.c_str(), status);
         if (!errstr.empty())

--- a/gen/programs.cpp
+++ b/gen/programs.cpp
@@ -35,19 +35,37 @@ static cl::opt<std::string> mslib("ms-lib",
     cl::Hidden,
     cl::ZeroOrMore);
 
-sys::Path getProgram(const char *name, const cl::opt<std::string> &opt, const char *envVar = 0)
+#if LDC_LLVM_VER >= 304
+typedef std::string RetType;
+#else
+typedef sys::Path RetType;
+#endif
+
+RetType getProgram(const char *name, const cl::opt<std::string> &opt, const char *envVar = 0)
 {
-    sys::Path path;
+    RetType path;
     const char *prog = NULL;
 
     if (opt.getNumOccurrences() > 0 && opt.length() > 0 && (prog = opt.c_str()))
+#if LDC_LLVM_VER >= 304
+        path = sys::FindProgramByName(prog);
+#else
         path = sys::Program::FindProgramByName(prog);
+#endif
 
     if (path.empty() && envVar && (prog = getenv(envVar)))
+#if LDC_LLVM_VER >= 304
+        path = sys::FindProgramByName(prog);
+#else
         path = sys::Program::FindProgramByName(prog);
+#endif
 
     if (path.empty())
+#if LDC_LLVM_VER >= 304
+        path = sys::FindProgramByName(name);
+#else
         path = sys::Program::FindProgramByName(name);
+#endif
 
     if (path.empty()) {
         error("failed to locate %s", name);
@@ -57,22 +75,22 @@ sys::Path getProgram(const char *name, const cl::opt<std::string> &opt, const ch
     return path;
 }
 
-sys::Path getGcc()
+RetType getGcc()
 {
     return getProgram("gcc", gcc, "CC");
 }
 
-sys::Path getArchiver()
+RetType getArchiver()
 {
     return getProgram("ar", ar);
 }
 
-sys::Path getLink()
+RetType getLink()
 {
     return getProgram("link.exe", mslink);
 }
 
-sys::Path getLib()
+RetType getLib()
 {
     return getProgram("lib.exe", mslib);
 }

--- a/gen/programs.h
+++ b/gen/programs.h
@@ -14,6 +14,19 @@
 #ifndef LDC_GEN_PROGRAMS_H
 #define LDC_GEN_PROGRAMS_H
 
+#if LDC_LLVM_VER >= 304
+
+#include <string>
+
+std::string getGcc();
+std::string getArchiver();
+
+// For Windows with MS tool chain
+std::string getLink();
+std::string getLib();
+
+#else
+
 #include "llvm/Support/Path.h"
 
 llvm::sys::Path getGcc();
@@ -22,5 +35,7 @@ llvm::sys::Path getArchiver();
 // For Windows with MS tool chain
 llvm::sys::Path getLink();
 llvm::sys::Path getLib();
+
+#endif
 
 #endif

--- a/gen/todebug.cpp
+++ b/gen/todebug.cpp
@@ -27,6 +27,9 @@
 #include "llvm/Support/Dwarf.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#if LDC_LLVM_VER >= 304
+#include "llvm/Support/PathV1.h"
+#endif
 
 using namespace llvm::dwarf;
 


### PR DESCRIPTION
Development of LLVM 3.4 started with a cleanup of the path class (PathV1).
The changes here let ldc compile at least with rev. 183941 of LLVM.

I think that it is possible to minimize the differences further but I like to wait until the dust is settled.
