### PR TITLE
Include Git revision in version info.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ include(GetLinuxDistribution)
 # Main configuration.
 #
 
+# Version information
+set(LDC_VERSION "0.12.0") # May be overridden by git hash tag
+set(DMD_VERSION "2.63.1")
+
 # Generally, we want to install everything into CMAKE_INSTALL_PREFIX, but when
 # it is /usr, put the config files into /etc to meet common practice.
 if(NOT DEFINED SYSCONF_INSTALL_DIR)
@@ -154,6 +158,12 @@ set(LDC_GENERATED
 #
 # Gather source files.
 #
+include(GetGitRevisionDescription)
+get_git_head_revision(REFSPEC HASH)
+if(NOT HASH STREQUAL "GITDIR-NOTFOUND")
+    string(SUBSTRING "${HASH}" 0 6 LDC_VERSION)
+endif()
+configure_file(driver/ldc-version.cpp.in driver/ldc-version.cpp)
 
 # Also add the header files to the build so that they are available in IDE
 # project files generated via CMake.
@@ -171,11 +181,13 @@ set(DRV_SRC
     driver/tool.cpp
     driver/linker.cpp
     driver/main.cpp
+    ${CMAKE_BINARY_DIR}/driver/ldc-version.cpp
 )
 set(DRV_HDR
     driver/linker.h
     driver/cl_options.h
     driver/configfile.h
+    driver/ldc-version.h
     driver/target.h
     driver/toobj.h
     driver/tool.h
@@ -267,7 +279,6 @@ add_definitions(
     -DOPAQUE_VTBLS
     -DLDC_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
     -DLDC_LLVM_VER=${LDC_LLVM_VER}
-    -DLDC_LLVM_VERSION_STRING="${LLVM_VERSION_STRING}"
 )
 
 if(UNIX)

--- a/cmake/Modules/GetGitRevisionDescription.cmake
+++ b/cmake/Modules/GetGitRevisionDescription.cmake
@@ -1,0 +1,123 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()

--- a/cmake/Modules/GetGitRevisionDescription.cmake.in
+++ b/cmake/Modules/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,38 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	elseif(EXISTS "@GIT_DIR@/logs/${HEAD_REF}")
+		configure_file("@GIT_DIR@/logs/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+		set(HEAD_HASH "${HEAD_REF}")
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/dmd2/mars.c
+++ b/dmd2/mars.c
@@ -103,9 +103,6 @@ void Global::init()
     compiler.vendor = "Digital Mars D";
 #endif
 #if IN_LLVM
-    version = "v2.063";
-    ldc_version = "trunk";
-    llvm_version = "LLVM " LDC_LLVM_VERSION_STRING;
     compiler.vendor = "LDC";
 #endif
 

--- a/dmd2/mars.h
+++ b/dmd2/mars.h
@@ -341,8 +341,8 @@ struct Global
 
     const char *version;
 #if IN_LLVM
-    char *ldc_version;
-    char *llvm_version;
+    const char *ldc_version;
+    const char *llvm_version;
 
     bool inExtraInliningSemantic;
 #endif

--- a/driver/ldc-version.cpp.in
+++ b/driver/ldc-version.cpp.in
@@ -1,0 +1,18 @@
+//===-- driver/ldc-version.c - ----------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "driver/ldc-version.h"
+
+namespace ldc {
+
+const char * const ldc_version = "@LDC_VERSION@";
+const char * const dmd_version = "@DMD_VERSION@";
+const char * const llvm_version = "@LLVM_VERSION_STRING@";
+
+}

--- a/driver/ldc-version.h
+++ b/driver/ldc-version.h
@@ -1,0 +1,21 @@
+//===-- driver/ldc-version.h - ----------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_DRIVER_LDC_VERSION_H
+#define LDC_DRIVER_LDC_VERSION_H
+
+namespace ldc {
+
+extern const char * const ldc_version;
+extern const char * const dmd_version;
+extern const char * const llvm_version;
+
+}
+
+#endif

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -17,6 +17,7 @@
 #include "dmd2/target.h"
 #include "driver/cl_options.h"
 #include "driver/configfile.h"
+#include "driver/ldc-version.h"
 #include "driver/linker.h"
 #include "driver/target.h"
 #include "driver/toobj.h"
@@ -86,7 +87,7 @@ static cl::list<std::string, StringsAdapter> debuglibs("debuglib",
 
 void printVersion() {
     printf("LDC - the LLVM D compiler (%s):\n", global.ldc_version);
-    printf("  based on DMD %s and %s\n", global.version, global.llvm_version);
+    printf("  based on DMD v%s and LLVM %s\n", global.version, global.llvm_version);
     printf("  Default target: %s\n", llvm::sys::getDefaultTargetTriple().c_str());
     std::string CPU = llvm::sys::getHostCPUName();
     if (CPU == "generic") CPU = "(unknown)";
@@ -165,6 +166,9 @@ int main(int argc, char** argv)
     int status = EXIT_SUCCESS;
 
     global.init();
+    global.version = ldc::dmd_version;
+    global.ldc_version = ldc::ldc_version;
+    global.llvm_version = ldc::llvm_version;
 
     // Set some default values
 #if _WIN32


### PR DESCRIPTION
CMakeLists.txt contains now the version numbers for DMD and (next) LDC release.
If a .git folder is found then the LDC version is replaced by the first 6 chars
of the Git revision.

Possible improvements:
- If the build is not done at the master branch then it could be useful to
  check for a tag and use the tag instead of the revision. (for release builds)
- Maybe it is useful to include the branch name.

This fixes issue #366.
