### PR TITLE
Fix for part 1 of issue 424.

### DIFF
--- a/dmd2/init.c
+++ b/dmd2/init.c
@@ -1022,6 +1022,10 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
 
     // Look for the case of statically initializing an array
     // with a single member.
+#if IN_LLVM
+    // Fix for part 1 of issue 424.
+    if (tb->ty == Tvector) tb = static_cast<TypeVector *>(tb)->basetype;
+#endif
     if (tb->ty == Tsarray &&
         !tb->nextOf()->equals(ti->toBasetype()->nextOf()) &&
         exp->implicitConvTo(tb->nextOf())


### PR DESCRIPTION
Yet another difference between static arrays and vectors. Initializing a static array with one element is handled  especially. This fix adds the same handling for vector types.
