### PR TITLE
Fix an assertion error regarding void type with LLVM 3.4.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -446,7 +446,11 @@ llvm::DIType ldc::DIBuilder::CreateTypeDescription(Type* type,
     }
 
     if (t->ty == Tvoid)
+#if LDC_LLVM_VER >= 304
+        return DBuilder.createUnspecifiedType(t->toChars());
+#else
         return llvm::DIType(NULL);
+#endif
     else if (t->isintegral() || t->isfloating())
     {
         if (t->ty == Tvector)


### PR DESCRIPTION
In Dwarf debug symbol generation the void type was modelled as `DIType(NULL)`.
This triggers an assertion error with LLVM 3.4. The solution is to use the unspecified type provided by Dwarf for this purpose.
