### PR TITLE
Preliminary fix for debug info generation with LLVM 3.4.

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -64,6 +64,12 @@ extern const llvm::TargetData* gDataLayout;
 
 namespace ldc {
 
+#if LDC_LLVM_VER >= 304
+typedef llvm::DICompositeType DIFunctionType;
+#else
+typedef llvm::DIType DIFunctionType;
+#endif
+
 class DIBuilder
 {
     IRState *const IR;
@@ -141,6 +147,9 @@ private:
     llvm::DIType CreateCompositeType(Type *type);
     llvm::DIType CreateArrayType(Type *type);
     llvm::DIType CreateSArrayType(Type *type);
+    llvm::DIType CreateAArrayType(Type *type);
+    DIFunctionType CreateFunctionType(Type *type);
+    DIFunctionType CreateDelegateType(Type *type);
     llvm::DIType CreateTypeDescription(Type* type, const char* c_name, bool derefclass = false);
 
 public:


### PR DESCRIPTION
There is no debug information generated for several types. As LLVM 3.4 does not support empty nodes, it is now time to implement the missing debug info.
