### PR TITLE
Fix _d_invariant mangling on MinGW/Win32.

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -915,12 +915,15 @@ static void LLVM_D_BuildRuntimeModule()
         // KLUDGE: _d_invariant is actually extern(D) in the upstream runtime, possibly
         // for more efficient parameter passing on x86. This complicates our code here
         // quite a bit, though.
-        llvm::StringRef fname("_D9invariant12_d_invariantFC6ObjectZv");
         Parameters* params = new Parameters();
         params->push(new Parameter(STCin, ClassDeclaration::object->type, NULL, NULL));
         TypeFunction* dty = new TypeFunction(params, Type::tvoid, 0, LINKd);
-        llvm::Function* fn = llvm::Function::Create(llvm::cast<llvm::FunctionType>(DtoType(dty)),
-            llvm::GlobalValue::ExternalLinkage, fname, M);
+        llvm::Function* fn = llvm::Function::Create(
+            llvm::cast<llvm::FunctionType>(DtoType(dty)),
+            llvm::GlobalValue::ExternalLinkage,
+            gABI->mangleForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd),
+            M
+        );
         gABI->newFunctionType(dty);
         gABI->rewriteFunctionType(dty);
         gABI->doneWithFunctionType();

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -17,6 +17,7 @@
 #include "rmem.h"
 #include "template.h"
 #include "gen/aa.h"
+#include "gen/abi.h"
 #include "gen/arrays.h"
 #include "gen/classes.h"
 #include "gen/complex.h"
@@ -2273,7 +2274,8 @@ DValue* AssertExp::toElem(IRState* p)
         !(static_cast<TypeClass*>(condty)->sym->isInterfaceDeclaration()))
     {
         Logger::println("calling class invariant");
-        llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_D9invariant12_d_invariantFC6ObjectZv");
+        llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module,
+            gABI->mangleForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd).c_str());
         LLValue* arg = DtoBitCast(cond->getRVal(), fn->getFunctionType()->getParamType(0));
         gIR->CreateCallOrInvoke(fn, arg);
     }


### PR DESCRIPTION
This is getting uglier and uglier, should probably just switch back
to extern(C) irrespective of what upstream DMD does.
