### PR TITLE
[Don't merge yet] Internalize everything but _Dmain when emitting a -singleobj executable.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1064,7 +1064,9 @@ int main(int argc, char** argv)
         }
 
         m->deleteObjFile();
-        writeModule(linker.getModule(), filename);
+        const bool completeExecutable = global.params.link &&
+            !createSharedLib && global.params.objfiles->dim == 0;
+        writeModule(linker.getModule(), filename, completeExecutable);
         global.params.objfiles->push(const_cast<char*>(filename));
 
 #if LDC_LLVM_VER >= 303

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -113,10 +113,10 @@ static void assemble(const std::string &asmpath, const std::string &objpath)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void writeModule(llvm::Module* m, std::string filename)
+void writeModule(llvm::Module* m, std::string filename, bool isCompleteExecutable)
 {
     // run optimizer
-    ldc_optimize_module(m);
+    ldc_optimize_module(m, isCompleteExecutable);
 
     // We don't use the integrated assembler with MinGW as it does not support
     // emitting DW2 exception handling tables.

--- a/driver/toobj.h
+++ b/driver/toobj.h
@@ -18,6 +18,6 @@
 
 namespace llvm { class Module; }
 
-void writeModule(llvm::Module* m, std::string filename);
+void writeModule(llvm::Module* m, std::string filename, bool isCompleteExecutable = false);
 
 #endif

--- a/gen/optimizer.h
+++ b/gen/optimizer.h
@@ -20,7 +20,7 @@
 
 namespace llvm { class Module; }
 
-bool ldc_optimize_module(llvm::Module* m);
+bool ldc_optimize_module(llvm::Module* m, bool isCompleteExecutable);
 
 // Returns whether the normal, full inlining pass will be run.
 bool willInline();


### PR DESCRIPTION
This is just a first draft; there are certainly cases
where this still breaks (e.g. naked inline asm).

The general direction looks promising, though: Building a
fully optimized Phobos "Hello World" is noticably faster
with the internalizing enabled (0.7s vs 1s) on my machine.

Enabling the pass by default on -O4 and above is more of
a cute idea (to finally do the flag description justice)
than a serious proposal.

Don't merge yet, this is just up for discussion.