### PR TITLE
Prefer named tags to Git revision hashes for LDC verison.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,10 +167,21 @@ set(LDC_GENERATED
 # Gather source files.
 #
 include(GetGitRevisionDescription)
-get_git_head_revision(REFSPEC HASH)
-if(NOT HASH STREQUAL "GITDIR-NOTFOUND")
-    string(SUBSTRING "${HASH}" 0 6 LDC_VERSION)
+git_get_exact_tag(TAG)
+if(NOT TAG MATCHES "NOTFOUND")
+    if(TAG MATCHES "v[0-9].*")
+        # For a version tag, remove the leading 'v'.
+        string(SUBSTRING "${TAG}" 1 -1 LDC_VERSION)
+    else()
+        set(LDC_VERSION "${TAG}")
+    endif()
+else()
+    get_git_head_revision(REFSPEC HASH)
+    if(NOT HASH STREQUAL "GITDIR-NOTFOUND")
+        string(SUBSTRING "${HASH}" 0 6 LDC_VERSION)
+    endif()
 endif()
+message(STATUS "LDC version identifier: ${LDC_VERSION}")
 configure_file(driver/ldc-version.cpp.in driver/ldc-version.cpp)
 
 # Also add the header files to the build so that they are available in IDE

--- a/cmake/Modules/GetGitRevisionDescription.cmake
+++ b/cmake/Modules/GetGitRevisionDescription.cmake
@@ -118,6 +118,6 @@ function(git_describe _var)
 endfunction()
 
 function(git_get_exact_tag _var)
-	git_describe(out --exact-match ${ARGN})
+	git_describe(out --exact-match --tag ${ARGN})
 	set(${_var} "${out}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
This allows for building of release packages without
manually overriding the version string.

The --tag argument is needed to pick up un-annotated tags
as well.
