### PR TITLE
Gracefully handle struct decl/type mismatch when generating TypeInfo.

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -618,7 +618,7 @@ void TypeInfoStructDeclaration::llvmDefine()
         initPtr = getNullValue(getVoidPtrType());
     else
         initPtr = iraggr->getInitSymbol();
-    b.push_void_array(getTypeStoreSize(tc->irtype->getLLType()), initPtr);
+    b.push_void_array(getTypeStoreSize(DtoType(tc)), initPtr);
 
     // toX functions ground work
     static TypeFunction *tftohash;


### PR DESCRIPTION
The type should have already been resolved if the struct
itself is, but due to multiple-types-per-declaration issues
in DMD, this might not be the case.

GitHub: Fixes #470.
