### PR TITLE
Add 'v' back in at beginning of global.version.

### DIFF
--- a/driver/ldc-version.cpp.in
+++ b/driver/ldc-version.cpp.in
@@ -12,7 +12,7 @@
 namespace ldc {
 
 const char * const ldc_version = "@LDC_VERSION@";
-const char * const dmd_version = "@DMD_VERSION@";
+const char * const dmd_version = "v@DMD_VERSION@";
 const char * const llvm_version = "@LLVM_VERSION_STRING@";
 
 }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -87,7 +87,7 @@ static cl::list<std::string, StringsAdapter> debuglibs("debuglib",
 
 void printVersion() {
     printf("LDC - the LLVM D compiler (%s):\n", global.ldc_version);
-    printf("  based on DMD v%s and LLVM %s\n", global.version, global.llvm_version);
+    printf("  based on DMD %s and LLVM %s\n", global.version, global.llvm_version);
     printf("  Default target: %s\n", llvm::sys::getDefaultTargetTriple().c_str());
     std::string CPU = llvm::sys::getHostCPUName();
     if (CPU == "generic") CPU = "(unknown)";


### PR DESCRIPTION
The lexer expects it to be there for handling **VERSION**.
