### PR TITLE
[experimental] Add sanitizer options to LDC.

### DIFF
--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -137,6 +137,21 @@ static int linkObjToBinaryGcc(bool sharedLib)
     // create path to exe
     CreateDirectoryOnDisk(gExePath);
 
+#if LDC_LLVM_VER >= 303
+    // Pass sanitizer arguments to linker. Requires clang.
+    if (opts::sanitize == opts::AddressSanitizer) {
+        args.push_back("-fsanitize=address");
+    }
+
+    if (opts::sanitize == opts::MemorySanitizer) {
+        args.push_back("-fsanitize=memory");
+    }
+
+    if (opts::sanitize == opts::ThreadSanitizer) {
+        args.push_back("-fsanitize=thread");
+    }
+#endif
+
     // additional linker switches
     for (unsigned i = 0; i < global.params.linkswitches->dim; i++)
     {

--- a/gen/optimizer.h
+++ b/gen/optimizer.h
@@ -18,6 +18,17 @@
 // For llvm::CodeGenOpt::Level
 #include "llvm/Support/CodeGen.h"
 
+#if LDC_LLVM_VER >= 303
+#include "llvm/Support/CommandLine.h"
+
+namespace opts {
+
+enum SanitizerCheck { None, AddressSanitizer, MemorySanitizer, ThreadSanitizer };
+
+extern llvm::cl::opt<SanitizerCheck> sanitize;
+}
+#endif
+
 namespace llvm { class Module; }
 
 bool ldc_optimize_module(llvm::Module* m);


### PR DESCRIPTION
Add some of the sanitizer passes to LDC. This is not complete (linking must be done using clang and the right `-fsanitize=` option) and may not be useful at all.

If it proves to be usefull then a lot of other options (e.g. blacklist) must be added.
