### PR TITLE
Fix va_arg handling.

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1916,7 +1916,8 @@ DValue* DtoSymbolAddress(const Loc& loc, Type* type, Declaration* decl)
             fatal();
         }
         DtoResolveFunction(fdecl);
-        return new DFuncValue(fdecl, fdecl->ir.irFunc->func);
+        assert(fdecl->llvmInternal == LLVMva_arg || fdecl->ir.irFunc);
+        return new DFuncValue(fdecl, fdecl->ir.irFunc ? fdecl->ir.irFunc->func : 0);
     }
 
     if (SymbolDeclaration* sdecl = decl->isSymbolDeclaration())


### PR DESCRIPTION
The change of symbol emission ignored the fact that the va_arg intrinsic must be handled in a special way. This commit corrects the omission (which leads to seg faults on Linux/PPC64).
