### PR TITLE
Enable delete again.

### DIFF
--- a/dmd2/root/rmem.c
+++ b/dmd2/root/rmem.c
@@ -138,7 +138,7 @@ void Mem::addroots(char* pStart, char* pEnd)
 
 /* =================================================== */
 
-#if 1
+#if IN_DMD
 
 /* Allocate, but never release
  */


### PR DESCRIPTION
Some Travis-CI errors may be caused by out-of-memory.
