### PR TITLE
Fix for issue #535.

### DIFF
--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -454,11 +454,11 @@ llvm::GlobalValue::LinkageTypes DtoInternalLinkage(Dsymbol* sym)
         return llvm::GlobalValue::InternalLinkage;
 }
 
-llvm::GlobalValue::LinkageTypes DtoExternalLinkage(Dsymbol* sym)
+llvm::GlobalValue::LinkageTypes DtoExternalLinkage(Dsymbol* sym, bool checkInline)
 {
     if (DtoIsTemplateInstance(sym))
         return templateLinkage;
-    else if (isAvailableExternally(sym))
+    else if (checkInline && isAvailableExternally(sym))
         return llvm::GlobalValue::AvailableExternallyLinkage;
     else
         return llvm::GlobalValue::ExternalLinkage;

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -58,7 +58,7 @@ LLValue* DtoDelegateEquals(TOK op, LLValue* lhs, LLValue* rhs);
 // return linkage type for symbol using the current ir state for context
 LLGlobalValue::LinkageTypes DtoLinkage(Dsymbol* sym);
 LLGlobalValue::LinkageTypes DtoInternalLinkage(Dsymbol* sym);
-LLGlobalValue::LinkageTypes DtoExternalLinkage(Dsymbol* sym);
+LLGlobalValue::LinkageTypes DtoExternalLinkage(Dsymbol* sym, bool checkInline = true);
 
 // some types
 LLIntegerType* DtoSize_t();

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -293,8 +293,10 @@ llvm::GlobalVariable * IrAggr::getInterfaceVtbl(BaseClass * b, bool new_instance
             DtoConstSize_t(interfaces_index)
         };
 
+        llvm::GlobalVariable* interfaceInfosZ = getInterfaceArraySymbol();
+        interfaceInfosZ->setLinkage(DtoExternalLinkage(cd, false));
         llvm::Constant* c = llvm::ConstantExpr::getGetElementPtr(
-            getInterfaceArraySymbol(), idxs, true);
+            interfaceInfosZ, idxs, true);
 
         constants.push_back(c);
     }
@@ -389,7 +391,7 @@ llvm::GlobalVariable * IrAggr::getInterfaceVtbl(BaseClass * b, bool new_instance
         *gIR->module,
         vtbl_constant->getType(),
         true,
-        llvm::GlobalValue::ExternalLinkage,
+        DtoExternalLinkage(cd, false),
         vtbl_constant,
         mangle
     );


### PR DESCRIPTION
The symbols must have weak_odr linkage if they result from a template instantiation.
