### PR TITLE
Add gcc and clang compilers to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: cpp
+compiler:
+  - gcc
+  - clang
 install:
   # LLVM 3.2
   - sudo sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu/ precise-proposed restricted main multiverse universe' >> /etc/apt/sources.list"


### PR DESCRIPTION

GCC and Clang builds should probably be independently tested: https://travis-ci.org/dymk/ldc

It'd be nice if builds could also be tested on different platforms; I'm looking into ways to reliably do this. 