### PR TITLE
Fix for issue #553.

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -1135,8 +1135,24 @@ void DtoArrayBoundsCheck(Loc& loc, DValue* arr, DValue* index, DValue* lowerBoun
     assert((arrty->ty == Tsarray || arrty->ty == Tarray || arrty->ty == Tpointer) &&
         "Can only array bounds check for static or dynamic arrays");
 
-    // static arrays could get static checks for static indices
-    // but shouldn't since it might be generic code that's never executed
+    // Do not emit bounds check code if the index is statically known to be
+    // within bounds.
+    if (arrty->ty == Tsarray && isaConstantInt(index->getRVal())) {
+        assert(!arr->isSlice());
+        assert(!arr->isNull());
+        assert(!lowerBound);
+
+        TypeSArray *sarray = static_cast<TypeSArray*>(arrty);
+        llvm::ConstantInt *constIndex = static_cast<llvm::ConstantInt*>(index->getRVal());
+        if (sarray->dim->toUInteger() < constIndex->getZExtValue()) {
+            // If this happens then it is possible a frontend bug.
+            // Just output a warning and continue generating a runtime check.
+            // This could be generic code which is never executed.
+            warning(loc, "Static array index out of bounds (should have been detected during semantic analysis)");
+        }
+        else
+            return ;
+    }
 
     // runtime check
 


### PR DESCRIPTION
Check if a static array is accessed with a known index. In this case the bounds check can be omitted.

A bit irritating is the comment:

```
// static arrays could get static checks for static indices
// but shouldn't since it might be generic code that's never executed
```

because I do not see where the static bounds and indices might be changed later.
