### PR TITLE
Disable internalizing of nested functions.

### DIFF
--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -382,6 +382,10 @@ LLGlobalValue::LinkageTypes DtoLinkage(Dsymbol* sym)
         llvm_unreachable("not global/function");
     }
 
+    // The logic here should be sound in theory, but as long as the frontend
+    // keeps inserting templates into wrong modules, this yields to linking
+    // errors (see e.g. GitHub issue #558).
+#if 0
     // Check if sym is a nested function and we can declare it as internal.
     //
     // Nested naked functions and the implicitly generated __require/__ensure
@@ -427,7 +431,7 @@ LLGlobalValue::LinkageTypes DtoLinkage(Dsymbol* sym)
             }
         }
     }
-
+#endif
     // default to external linkage
     return llvm::GlobalValue::ExternalLinkage;
 }


### PR DESCRIPTION
This works around linking problems such as rejectedsoftware/vibe.d#338,
caused by the frontend appending template instances to the wrong
module.

GitHub: Fixes #558.
