### PR TITLE
Change location of assign to irFty.

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -256,14 +256,14 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
         lidx++;
     }
 
-    // Now we can modify irFty safely.
-    irFty = newIrFty;
-
     // let the abi rewrite the types as necesary
-    abi->rewriteFunctionType(f, irFty);
+    abi->rewriteFunctionType(f, newIrFty);
 
     // Tell the ABI we're done with this function type
     abi->doneWithFunctionType();
+
+    // Now we can modify irFty safely.
+    irFty = llvm_move(newIrFty);
 
     // build the function type
     std::vector<LLType*> argtypes;

--- a/gen/llvmcompat.h
+++ b/gen/llvmcompat.h
@@ -32,4 +32,8 @@
 #define HAS_ATTRIBUTES(x) (x)
 #endif
 
+#if LDC_LLVM_VER < 302
+#define llvm_move(value) (value)
+#endif
+
 #endif


### PR DESCRIPTION
If the comment about this function is still right (can be called recursively) then the assignment
to irFty should be done after all functions are called.
Takes advantage of move assignment, too.
