### PR TITLE
Add CPack configuration for debian packages

### DIFF
--- a/CMakeCPack.cmake
+++ b/CMakeCPack.cmake
@@ -1,0 +1,13 @@
+#
+# Common CPack configuration
+#
+set(CPACK_PACKAGE_NAME ${CMAKE_PROJECT_NAME})
+set(CPACK_PACKAGE_VERSION ${LDC_VERSION})
+set(CPACK_PACKAGE_CONTACT "public@dicebot.lv")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LDC: LLVM D Compiler")
+
+#
+# Debian specifics
+#
+execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE) 
+set(CPACK_DEBIAN_PACKAGE_SECTION "devel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,3 +525,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
     install(DIRECTORY bash_completion.d/ DESTINATION ${BASH_COMPLETION_INST_DIR})
 endif()
+
+#
+# Packaging
+#
+
+include (CMakeCPack.cmake)
+include (CPack)


### PR DESCRIPTION
Part of #573

Allows to automatically generate .deb based on current generated `install`
target. Some of package settings are taken from exiting CMake variables, some
from host system.

Dependencies currently are not set - what oldest libc version you want to support? LDC will need to be built on that system, same as DMD .deb are built on some old Debian.

One can test it via

```
git clone https://github.com/Dicebot/ldc
cd ldc; git checkout dev-package; cd ..
mkdir build; cd build
cmake ../ldc # + any normal cmake options
make
cpack -G DEB # will place .deb in same folder
```

Updating `ldc-scripts` will be done after this is merged
