### PR TITLE
Fixes #544

### DIFF
--- a/gen/logger.h
+++ b/gen/logger.h
@@ -16,6 +16,7 @@
 #define LDC_GEN_LOGGER_H
 
 #include <iosfwd>
+#include <iostream>
 
 namespace llvm {
     class Type;


### PR DESCRIPTION
Including `<iostream>` in `gen/logger.h` allows LDC to compile correctly on some Macs running OS X Mavericks.
