### PR TITLE
FindLLVM: Pick up system libraries on LLVM 3.5+.

### DIFF
--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -127,6 +127,12 @@ else()
     endif()
 
     llvm_set(LDFLAGS ldflags)
+    if(NOT ${LLVM_VERSION_STRING} MATCHES "3.[0-4][A-Za-z]*")
+        # In LLVM 3.5+, the system library dependencies (e.g. "-lz") are accessed
+        # using the separate "--system-libs" flag.
+        llvm_set(SYSTEM_LIBS system-libs)
+        set(LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
+    endif()
     llvm_set(LIBRARY_DIRS libdir)
     llvm_set_libs(LIBRARIES libfiles "${LLVM_LIBRARY_DIRS}/")
 endif()


### PR DESCRIPTION
Fixes the build on OS X 10.9/LLVM trunk.
