### PR TITLE
Possible fix for issue #594

### DIFF
--- a/dmd2/template.c
+++ b/dmd2/template.c
@@ -6777,17 +6777,31 @@ Identifier *TemplateInstance::genIdent(Objects *args)
             ea = ea->ctfeInterpret();
             if (ea->op == TOKerror || olderr != global.errors)
                 continue;
-#if 1
+#if !IN_LLVM
             /* Use deco that matches what it would be for a function parameter
              */
             buf.writestring(ea->type->deco);
 #else
-            // Use type of parameter, not type of argument
-            TemplateParameter *tp = (*tempdecl->parameters)[i];
-            assert(tp);
-            TemplateValueParameter *tvp = tp->isTemplateValueParameter();
-            assert(tvp);
-            buf.writestring(tvp->valType->deco);
+            // This is a workaround for DMD bug 7469 (https://issues.dlang.org/show_bug.cgi?id=7469)
+            // FIXME: The bug is resolved in DMD 2.066. Remove in 0.15.0
+
+            // The declared parameter list might be shorter because of variadic arguments
+            if (((TemplateDeclaration*)tempdecl)->parameters->dim > i)
+            {
+                // Use type of parameter, not type of argument
+                TemplateParameter *tp = (*((TemplateDeclaration*)tempdecl)->parameters)[i];
+                assert(tp);
+                TemplateValueParameter *tvp = tp->isTemplateValueParameter();
+                if (tvp && tvp->valType->deco)
+                    buf.writestring(tvp->valType->deco);
+                else
+                    goto Lusetypeofvalue;
+            }
+            else
+            {
+              Lusetypeofvalue:
+                buf.writestring(ea->type->deco);
+            }
 #endif
             ea->toMangleBuffer(&buf);
         }


### PR DESCRIPTION
DMD always uses the value type for name mangling of templates. If the type is defined in the template and the value type differs (e.g. parameter type is `long` and constant 4 (`int`) is used) then LDC got confused about this fact. As a result, sometimes the parameter type and sometime the value type was used.

This commit changes the name mangling to use the parameter type, if possible. This is incompatible with
DMD but solves the issue. The related DMD error is https://issues.dlang.org/show_bug.cgi?id=12720
