### PR TITLE
Fix dmd test template2962 by removing nestedVars.

### DIFF
--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -921,11 +921,6 @@ struct FuncDeclaration : Declaration
     /// Codegen traversal
     void codegen(IRState* ir);
 
-    // vars declared in this function that nested funcs reference
-    // is this is not empty, nestedFrameRef is set and these VarDecls
-    // probably have nestedref set too, see VarDeclaration::checkNestedReference
-    std::set<VarDeclaration*> nestedVars;
-
     std::string intrinsicName;
     uint32_t priority;
 

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -285,17 +285,8 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd) {
         return;
     fd->ir.irFunc->nestedContextCreated = true;
 
-    // fill nestedVars
-    assert(fd->nestedVars.empty() && "nestedVars should only be filled here");
-    size_t nnest = fd->closureVars.dim;
-    for (size_t i = 0; i < nnest; ++i)
-    {
-        VarDeclaration* vd = static_cast<VarDeclaration*>(fd->closureVars.data[i]);
-        fd->nestedVars.insert(vd);
-    }
-
     // construct nested variables array
-    if (!fd->nestedVars.empty())
+    if (fd->closureVars.dim > 0)
     {
         Logger::println("has nested frame");
         // start with adding all enclosing parent frames until a static parent is reached
@@ -345,9 +336,9 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd) {
 
         // Add the direct nested variables of this function, and update their indices to match.
         // TODO: optimize ordering for minimal space usage?
-        for (std::set<VarDeclaration*>::iterator i=fd->nestedVars.begin(); i!=fd->nestedVars.end(); ++i)
+        for (size_t i = 0; i < fd->closureVars.dim; ++i)
         {
-            VarDeclaration* vd = *i;
+            VarDeclaration* vd = fd->closureVars[i];
             if (!vd->ir.irLocal)
                 vd->ir.irLocal = new IrLocal(vd);
 
@@ -404,7 +395,7 @@ void DtoCreateNestedContext(FuncDeclaration* fd) {
     DtoCreateNestedContextType(fd);
 
     // construct nested variables array
-    if (!fd->nestedVars.empty())
+    if (fd->closureVars.dim > 0)
     {
         IrFunction* irfunction = fd->ir.irFunc;
         unsigned depth = irfunction->depth;
@@ -451,9 +442,9 @@ void DtoCreateNestedContext(FuncDeclaration* fd) {
         irfunction->nestedVar = frame;
 
         // go through all nested vars and assign addresses where possible.
-        for (std::set<VarDeclaration*>::iterator i=fd->nestedVars.begin(); i!=fd->nestedVars.end(); ++i)
+        for (size_t i = 0; i < fd->closureVars.dim; ++i)
         {
-            VarDeclaration* vd = *i;
+            VarDeclaration* vd = fd->closureVars[i];
 
             LLValue* gep = DtoGEPi(frame, 0, vd->ir.irLocal->nestedIndex, vd->toChars());
             if (vd->isParameter()) {


### PR DESCRIPTION
nestedVars was always a copy of closureVars. There was no point to it
existing.
