### PR TITLE
WIP: compiling ldc trunk llvm-3.5

### DIFF
--- a/dmd2/aggregate.h
+++ b/dmd2/aggregate.h
@@ -110,7 +110,7 @@ struct AggregateDeclaration : ScopeDsymbol
     void inlineScan();
     unsigned size(Loc loc);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);
-    static unsigned placeField(unsigned *nextoffset,
+    static signed long placeField(unsigned *nextoffset,
         unsigned memsize, unsigned memalignsize, structalign_t memalign,
         unsigned *paggsize, unsigned *paggalignsize, bool isunion);
     Type *getType();

--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -19,7 +19,9 @@
 #include <set>
 #include <map>
 #include <string>
-#if LDC_LLVM_VER >= 302
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/DebugInfo.h"
+#elif LDC_LLVM_VER >= 302
 #include "llvm/DebugInfo.h"
 #else
 #include "llvm/Analysis/DebugInfo.h"

--- a/dmd2/func.c
+++ b/dmd2/func.c
@@ -463,7 +463,7 @@ void FuncDeclaration::semantic(Scope *sc)
 
     cd = parent->isClassDeclaration();
     if (cd)
-    {   size_t vi;
+    {   signed long vi;
         CtorDeclaration *ctor;
         DtorDeclaration *dtor;
 

--- a/dmd2/mars.h
+++ b/dmd2/mars.h
@@ -318,7 +318,7 @@ struct Compiler
     const char *vendor;     // Compiler backend name
 };
 
-typedef unsigned structalign_t;
+typedef signed long structalign_t;
 #define STRUCTALIGN_DEFAULT ~0  // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
 

--- a/dmd2/mtype.c
+++ b/dmd2/mtype.c
@@ -2811,7 +2811,7 @@ unsigned TypeBasic::alignsize()
 }
 
 #if IN_LLVM
-unsigned TypeBasic::alignment()
+signed long TypeBasic::alignment()
 {
     if (global.params.targetTriple.getArch() == llvm::Triple::x86_64 &&
         (ty == Tfloat80 || ty == Timaginary80))

--- a/dmd2/mtype.h
+++ b/dmd2/mtype.h
@@ -418,7 +418,7 @@ struct TypeBasic : Type
     d_uns64 size(Loc loc);
     unsigned alignsize();
 #if IN_LLVM
-    unsigned alignment();
+    signed long alignment();
 #endif
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);

--- a/dmd2/struct.c
+++ b/dmd2/struct.c
@@ -271,7 +271,7 @@ void AggregateDeclaration::alignmember(
  * Returns:
  *      offset to place field at
  */
-unsigned AggregateDeclaration::placeField(
+signed long AggregateDeclaration::placeField(
         unsigned *nextoffset,   // next location in aggregate
         unsigned memsize,       // size of member
         unsigned memalignsize,  // size of member for alignment purposes

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -18,7 +18,11 @@
 #include "gen/optimizer.h"
 #include "gen/programs.h"
 #include "llvm/ADT/Triple.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/Linker/Linker.h"
+#else
 #include "llvm/Linker.h"
+#endif
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Program.h"
 #if _WIN32

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -30,7 +30,11 @@
 #include "gen/optimizer.h"
 #include "gen/passes/Passes.h"
 #include "gen/runtime.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/Linker/Linker.h"
+#else
 #include "llvm/Linker.h"
+#endif
 #include "llvm/Support/Host.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/TargetRegistry.h"

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -308,7 +308,11 @@ llvm::TargetMachine* createTargetMachine(
             llvm::StringMapConstIterator<bool> i = hostFeatures.begin(),
                 end = hostFeatures.end();
             for (; i != end; ++i)
+#if LDC_LLVM_VER >= 305
+                if(i->second) features.AddFeature(i->first());
+#else
                 features.AddFeature(i->first(), i->second);
+#endif
         }
     }
     for (unsigned i = 0; i < attrs.size(); ++i)

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -657,12 +657,22 @@ void ldc::DIBuilder::EmitBlockStart(Loc loc)
     Logger::println("D to dwarf block start");
     LOG_SCOPE;
 
+#if LDC_LLVM_VER >= 305
+    llvm::DILexicalBlock block = DBuilder.createLexicalBlock(
+            GetCurrentScope(), // scope
+            CreateFile(loc), // file
+            loc.linnum, // line
+            0, // column
+            0 // DWARF path discriminator value
+            );
+#else
     llvm::DILexicalBlock block = DBuilder.createLexicalBlock(
             GetCurrentScope(), // scope
             CreateFile(loc), // file
             loc.linnum, // line
             0 // column
             );
+#endif
     IR->func()->diLexicalBlocks.push(block);
     EmitStopPoint(loc.linnum);
 }

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -14,8 +14,13 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/DataLayout.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DIBuilder.h"
+#else
 #include "llvm/DebugInfo.h"
 #include "llvm/DIBuilder.h"
+#endif
 #else
 #if LDC_LLVM_VER == 302
 #include "llvm/DataLayout.h"
@@ -25,7 +30,11 @@
 #include "llvm/Constants.h"
 #include "llvm/Type.h"
 #include "llvm/Analysis/DebugInfo.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/DIBuilder.h"
+#else
 #include "llvm/Analysis/DIBuilder.h"
+#endif
 #include "llvm/Target/TargetData.h"
 #endif
 #endif
@@ -74,7 +83,11 @@ class DIBuilder
 {
     IRState *const IR;
     const llvm::MDNode *CUNode;
+#if LDC_LLVM_VER >= 305
     llvm::DIBuilder DBuilder;
+#else
+    llvm::DIBuilder DBuilder;
+#endif
 
     const llvm::MDNode *GetCU()
     {

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -29,13 +29,18 @@
 #include "gen/pragma.h"
 #include "gen/runtime.h"
 #include "gen/tollvm.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/Linker/Linker.h"
+#include "llvm/Analysis/CFG.h"
+#else
 #include "llvm/Linker.h"
+#include "llvm/Support/CFG.h"
+#endif
 #if LDC_LLVM_VER >= 303
 #include "llvm/IR/Intrinsics.h"
 #else
 #include "llvm/Intrinsics.h"
 #endif
-#include "llvm/Support/CFG.h"
 #include <iostream>
 
 #if LDC_LLVM_VER == 302
@@ -265,7 +270,11 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
     abi->doneWithFunctionType();
 
     // Now we can modify irFty safely.
+#if LDC_LLVM_VER >= 305
+    irFty = std::move(newIrFty);
+#else
     irFty = llvm_move(newIrFty);
+#endif
 
     // build the function type
     std::vector<LLType*> argtypes;
@@ -360,7 +369,7 @@ LLFunction* DtoInlineIRFunction(FuncDeclaration* fdecl)
 
     llvm::SMDiagnostic err;
 
-#if LDC_LLVM_VER >= 303 
+#if LDC_LLVM_VER >= 303
     llvm::Module* m = llvm::ParseAssemblyString(
         stream.str().c_str(), NULL, err, gIR->context());
 #else
@@ -380,7 +389,7 @@ LLFunction* DtoInlineIRFunction(FuncDeclaration* fdecl)
             (std::string(err.getColumnNo(), ' ') + '^').c_str(),
             errstr.c_str(), stream.str().c_str());
 
-#if LDC_LLVM_VER >= 303 
+#if LDC_LLVM_VER >= 303
     std::string errstr2 = "";
     llvm::Linker(gIR->module).linkInModule(m, &errstr2);
     if(errstr2 != "")

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -26,7 +26,11 @@
 #include <sstream>
 #include <vector>
 
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/CallSite.h"
+#else
 #include "llvm/Support/CallSite.h"
+#endif
 
 namespace llvm {
     class LLVMContext;

--- a/gen/llvm.h
+++ b/gen/llvm.h
@@ -31,7 +31,11 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/DebugInfo.h"
+#else
 #include "llvm/DebugInfo.h"
+#endif
 #else
 #include "llvm/Type.h"
 #include "llvm/DerivedTypes.h"
@@ -57,7 +61,11 @@
 
 #include "gen/llvmcompat.h"
 
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/CallSite.h"
+#else
 #include "llvm/Support/CallSite.h"
+#endif
 
 using llvm::IRBuilder;
 

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -34,7 +34,11 @@
 #include "llvm/Target/TargetLibraryInfo.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Support/CommandLine.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/LegacyPassNameParser.h"
+#else
 #include "llvm/Support/PassNameParser.h"
+#endif
 #include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
@@ -292,7 +296,9 @@ bool ldc_optimize_module(llvm::Module* m)
     mpm.add(tli);
 
     // Add an appropriate TargetData instance for this module.
-#if LDC_LLVM_VER >= 302
+#if LDC_LLVM_VER >= 305
+    mpm.add(Pass::createPass(m));
+#elif LDC_LLVM_VER >= 302
     mpm.add(new DataLayout(m));
 #else
     mpm.add(new TargetData(m));
@@ -300,7 +306,9 @@ bool ldc_optimize_module(llvm::Module* m)
 
     // Also set up a manager for the per-function passes.
     FunctionPassManager fpm(m);
-#if LDC_LLVM_VER >= 302
+#if LDC_LLVM_VER >= 305
+    fpm.add(Pass::createPass(m));
+#elif LDC_LLVM_VER >= 302
     fpm.add(new DataLayout(m));
 #else
     fpm.add(new TargetData(m));

--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -303,7 +303,11 @@ namespace {
         bool runOnce(Function &F, const DataLayout& DL, AliasAnalysis& AA);
 
         virtual void getAnalysisUsage(AnalysisUsage &AU) const {
+#if LDC_LLVM_VER >= 305
+          AU.addRequired<DataLayoutPass>();
+#else
           AU.addRequired<DataLayout>();
+#endif
           AU.addRequired<AliasAnalysis>();
         }
     };
@@ -353,7 +357,11 @@ bool SimplifyDRuntimeCalls::runOnFunction(Function &F) {
     if (Optimizations.empty())
         InitOptimizations();
 
+#if LDC_LLVM_VER >= 305
+    const DataLayout &DL = getAnalysis<DataLayoutPass>().getDataLayout();
+#else
     const DataLayout &DL = getAnalysis<DataLayout>();
+#endif
     AliasAnalysis &AA = getAnalysis<AliasAnalysis>();
 
     // Iterate to catch opportunities opened up by other optimizations,

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -24,7 +24,11 @@
 #include "ir/irfunction.h"
 #include "ir/irlandingpad.h"
 #include "ir/irmodule.h"
+#if LDC_LLVM_VER >= 305
+#include "llvm/Analysis/CFG.h"
+#else
 #include "llvm/Support/CFG.h"
+#endif
 #if LDC_LLVM_VER >= 303
 #include "llvm/IR/InlineAsm.h"
 #else

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1050,7 +1050,12 @@ DValue* CallExp::toElem(IRState* p)
             LLValue* ptr = exp1->toElem(p)->getRVal();
             LLValue* cmp = exp2->toElem(p)->getRVal();
             LLValue* val = exp3->toElem(p)->getRVal();
+#if LDC_LLVM_VER >= 305
+            // FIXME: The failure order should be resolved correctly
+            LLValue* ret = gIR->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering), llvm::AtomicOrdering(atomicOrdering));
+#else
             LLValue* ret = gIR->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering));
+#endif
             return new DImValue(exp3->type, ret);
         // atomicrmw instruction
         } else if (fndecl->llvmInternal == LLVMatomic_rmw) {

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -12,7 +12,9 @@
 
 #include "ir/irtype.h"
 #include "llvm/ADT/ArrayRef.h"
-#if LDC_LLVM_VER >= 302
+#if LDC_LLVM_VER >= 305
+#include "llvm/IR/DebugInfo.h"
+#elif LDC_LLVM_VER >= 302
 #include "llvm/DebugInfo.h"
 #else
 #include "llvm/Analysis/DebugInfo.h"


### PR DESCRIPTION
hey guys,
so, for a week or so now, I have been trying to get ldc compiling on my mac (OSX 10.9.3). I finally got it (compiling)! previously I had used D quite a bit and wanted to get back into it and also I wanted to learn how to use llvm at the same time, so I figured this is a perfect opportunity. I managed to get llvm compiling, however it's still not linking yet. this is largely a WIP but I'd like to contribute my changes so you don't have to spend a weekend to get ldc compiling with the bazillion name changes that llvm does on a regular basis.. hehe

for starters, I compile with this script: (I have gcc-4.8 installed with homebrew)
1. clang is symlinked to tools/clang -> ~/Projects/clang (origin: https://github.com/llvm-mirror/clang.git - cea7244 + changes)
2. I've had some strange bugs with clang - notably, lib/CodeGen/BackendUtil.cpp.. I fix them manually to get the latest llvm compiling, but I'm not 100% sure I'm doing it right. however, I don't think these are related to the linking problem
3. make is run until it exits successfully because of a race condition in llvm between libLLVMSupport.a and fpcmp (however this is an infinite loop if llvm is broken, lol - so after your cigarette hopefully your computer hasn't caught fire before you return... lol)

```
cd ~/Projects/llvm/build
git pull
CC=/usr/local/Cellar/gcc/4.8.3/bin/gcc-4.8 CXX=/usr/local/Cellar/gcc/4.8.3/bin/g++-4.8 ../configure --disable-cxx1y --enable-debug-runtime --enable-debug-symbols --disable-assertions --enable-optimized --enable-targets=x86_64 --with-gcc-toolchain
make -j8; until !!; do :; done
# make -j8 || make -j1
# make -j8 || make -j8 || make -j8
cd ~/Projects/clang
git pull
cd ~/Projects/ldc/build
git pull
cmake .. -DCMAKE_CXX_FLAGS=-std=c++11 -DLLVM_ROOT_DIR=../../llvm/build/ -DLLVM_CONFIG=../../llvm/build/bin/llvm-config
make -j8
```

more notes:
1. I ran into this bug here: https://www.bountysource.com/issues/1133554-errors-with-clang-in-c-11-mode (so, I patched the dmd frontend sources. you can see those changes in the dmd2 paths... I basically made the relevant `size_t` into `signed long` - please give feedback, as I'm not even sure that's right and can't run the tests yet to find out either... :(
2. in some places I altered the order of the header inclusion to make the #ifdef look nicer. I don't believe this will break older versions of llvm, however please say something if it matters.

finally, my linking error is this:

```
Undefined symbols for architecture x86_64:
  "_AnnotateHappensAfter", referenced from:
      llvm::Statistic::init() in libldc.a(StripExternals.cpp.o)
      llvm::Statistic::init() in libldc.a(GarbageCollect2Stack.cpp.o)
      llvm::Statistic::init() in libldc.a(SimplifyDRuntimeCalls.cpp.o)
      llvm::ManagedStatic<llvm::DenseMap<Type*, llvm::StructType*, llvm::DenseMapInfo<Type*> > >::operator->() in libldc.a(structs.cpp.o)
  "llvm::isCurrentDebugType(char const*)", referenced from:
      (anonymous namespace)::StripExternals::runOnModule(llvm::Module&) in libldc.a(StripExternals.cpp.o)
      (anonymous namespace)::GarbageCollect2Stack::runOnFunction(llvm::Function&) in libldc.a(GarbageCollect2Stack.cpp.o)
      mayBeUsedAfterRealloc(llvm::Instruction*, llvm::Instruction*, llvm::DominatorTree&) in libldc.a(GarbageCollect2Stack.cpp.o)
      (anonymous namespace)::SimplifyDRuntimeCalls::runOnce(llvm::Function&, llvm::DataLayout const&, llvm::AliasAnalysis&) in libldc.a(SimplifyDRuntimeCalls.cpp.o)
  "llvm::DebugFlag", referenced from:
      (anonymous namespace)::StripExternals::runOnModule(llvm::Module&) in libldc.a(StripExternals.cpp.o)
      (anonymous namespace)::GarbageCollect2Stack::runOnFunction(llvm::Function&) in libldc.a(GarbageCollect2Stack.cpp.o)
      mayBeUsedAfterRealloc(llvm::Instruction*, llvm::Instruction*, llvm::DominatorTree&) in libldc.a(GarbageCollect2Stack.cpp.o)
      (anonymous namespace)::SimplifyDRuntimeCalls::runOnce(llvm::Function&, llvm::DataLayout const&, llvm::AliasAnalysis&) in libldc.a(SimplifyDRuntimeCalls.cpp.o)
  "_compress2", referenced from:
      llvm::zlib::compress(llvm::StringRef, llvm::SmallVectorImpl<char>&, llvm::zlib::CompressionLevel) in libLLVMSupport.a(Compression.cpp.o)
  "_compressBound", referenced from:
      llvm::zlib::compress(llvm::StringRef, llvm::SmallVectorImpl<char>&, llvm::zlib::CompressionLevel) in libLLVMSupport.a(Compression.cpp.o)
  "_crc32", referenced from:
      llvm::zlib::crc32(llvm::StringRef) in libLLVMSupport.a(Compression.cpp.o)
  "_uncompress", referenced from:
      llvm::zlib::uncompress(llvm::StringRef, llvm::SmallVectorImpl<char>&, unsigned long) in libLLVMSupport.a(Compression.cpp.o)
```

any help? I tried recompiling llvm _without_ the configure options `--disable-cxx1y  --disable-assertions --enable-optimized` to see if it make any difference. it didn't. I have the configure option `--enable-debug-runtime` set too, so I don't understand why it can't find `llvm::isCurrentDebugType` -- and I'm totally confused about the zlib `_compress2` and `_crc32` ones... I think that may be a ldc cmake config thing.

I have to get back to my real work now, so I'll leave it here for now...
cheers!
