### PR TITLE
Fix AtomicCmpXchg for LLVM 3.5

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1056,6 +1056,8 @@ DValue* CallExp::toElem(IRState* p)
             LLValue* val = exp3->toElem(p)->getRVal();
 #if LDC_LLVM_VER >= 305
             LLValue* ret = gIR->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering), llvm::AtomicOrdering(atomicOrdering));
+            // Use the same quickfix as for dragonegg - see r210956
+            ret = gIR->ir->CreateExtractValue(ret, 0);
 #else
             LLValue* ret = gIR->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering));
 #endif


### PR DESCRIPTION
A weak variant was added to LLVM 3.5 and the return type changed to { iN, i1 }.
Just extract the value from this struct.
