### PR TITLE
Avoid invalid *&ex -> ex optimizations.

### DIFF
--- a/dmd2/optimize.c
+++ b/dmd2/optimize.c
@@ -392,11 +392,21 @@ Expression *PtrExp::optimize(int result, bool keepLvalue)
         ex = ((AddrExp *)e1)->e1;
         if (type->equals(ex->type))
             e = ex;
+#if IN_LLVM // Backport of D-Programming-Language/dmd#3662.
+        else if (ex->type->implicitConvTo(type) >= MATCHconst)
+        {
+            e = ex->copy();
+            e->type = type;
+        }
+        else
+            return this;
+#else
         else
         {
             e = ex->copy();
             e->type = type;
         }
+#endif
         return e;
     }
     if (keepLvalue)


### PR DESCRIPTION
This is a back-port of D-Programming-Language/dmd#3662 (commit 4da4da1), and fixes compilation of:

``` d
struct Foo { char[1] bar; }
bool checkBar(Foo* foo) { return true && *foo.bar.ptr; }
```
