### PR TITLE
Make function entry basic blocks unnamed.

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1068,10 +1068,8 @@ void DtoDefineFunction(FuncDeclaration* fd)
     }
 #endif
 
-    std::string entryname("entry");
-
-    llvm::BasicBlock* beginbb = llvm::BasicBlock::Create(gIR->context(), entryname,func);
-    llvm::BasicBlock* endbb = llvm::BasicBlock::Create(gIR->context(), "endentry",func);
+    llvm::BasicBlock* beginbb = llvm::BasicBlock::Create(gIR->context(), "", func);
+    llvm::BasicBlock* endbb = llvm::BasicBlock::Create(gIR->context(), "endentry", func);
 
     //assert(gIR->scopes.empty());
     gIR->scopes.push_back(IRScope(beginbb, endbb));

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -198,7 +198,7 @@ static llvm::Function* build_module_function(const std::string &name, const std:
         llvm::GlobalValue::InternalLinkage, symbolName, gIR->module);
     fn->setCallingConv(gABI->callingConv(LINKd));
 
-    llvm::BasicBlock* bb = llvm::BasicBlock::Create(gIR->context(), "entry", fn);
+    llvm::BasicBlock* bb = llvm::BasicBlock::Create(gIR->context(), "", fn);
     IRBuilder<> builder(bb);
 
     // debug info

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -340,7 +340,7 @@ llvm::GlobalVariable * IrAggr::getInterfaceVtbl(BaseClass * b, bool new_instance
                                                  DtoLinkage(fd), name.toChars(), gIR->module);
 
             // create entry and end blocks
-            llvm::BasicBlock* beginbb = llvm::BasicBlock::Create(gIR->context(), "entry", thunk);
+            llvm::BasicBlock* beginbb = llvm::BasicBlock::Create(gIR->context(), "", thunk);
             llvm::BasicBlock* endbb = llvm::BasicBlock::Create(gIR->context(), "endentry", thunk);
             gIR->scopes.push_back(IRScope(beginbb, endbb));
 


### PR DESCRIPTION
The performance impact should be completely immeasurable,
but the main benefit is that it makes IR dumps slightly nicer to
look at (as the redundant "empty:" labels are now omitted entirely).
