### PR TITLE
Use --gc-sections on Linux.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -377,6 +377,10 @@ cl::opt<bool> linkonceTemplates("linkonce-templates",
     cl::desc("Use linkonce_odr linkage for template symbols instead of weak_odr"),
     cl::ZeroOrMore);
 
+cl::opt<bool> disableLinkerStripDead("disable-linker-strip-dead",
+    cl::desc("Do not try to remove unused symbols during linking"),
+    cl::init(false));
+
 cl::opt<bool, true> allinst("allinst",
     cl::desc("generate code for all template instantiations"),
     cl::location(global.params.allInst));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -65,6 +65,7 @@ namespace opts {
     extern cl::opt<FloatABI::Type> mFloatABI;
     extern cl::opt<bool, true> singleObj;
     extern cl::opt<bool> linkonceTemplates;
+    extern cl::opt<bool> disableLinkerStripDead;
 
     extern cl::opt<BoolOrDefaultAdapter, false, FlagParser> boundsChecks;
     extern bool nonSafeBoundsChecks;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -166,8 +166,8 @@ static int linkObjToBinaryGcc(bool sharedLib)
     for (unsigned i = 0; i < global.params.linkswitches->dim; i++)
     {
         const char *p = static_cast<const char *>(global.params.linkswitches->data[i]);
-        // Don't push -l and -L switches using -Xlinker, but pass them directly
-        // to GCC. This makes sure user-defined paths take precedence over
+        // Don't push -l and -L switches using -Xlinker, but pass them indirectly
+        // via GCC. This makes sure user-defined paths take precedence over
         // GCC's builtin LIBRARY_PATHs.
         if (!p[0] || !(p[0] == '-' && (p[1] == 'l' || p[1] == 'L')))
             args.push_back("-Xlinker");
@@ -180,6 +180,9 @@ static int linkObjToBinaryGcc(bool sharedLib)
     case llvm::Triple::Linux:
         addSoname = true;
         args.push_back("-lrt");
+        if (!opts::disableLinkerStripDead) {
+            args.push_back("-Wl,--gc-sections");
+        }
         // fallthrough
     case llvm::Triple::Darwin:
     case llvm::Triple::MacOSX:

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -226,6 +226,16 @@ static void hideLLVMOptions() {
     hide(map, "verify-scev");
     hide(map, "x86-early-ifcvt");
     hide(map, "x86-use-vzeroupper");
+
+    // We enable -fdata-sections/-ffunction-sections by default where it makes
+    // sense for reducing code size, so hide them to avoid confusion.
+    //
+    // We need our own switch as these two are defined by LLVM and linked to
+    // static TargetMachine members, but the default we want to use depends
+    // on the target triple (and thus we do not know it until after the command
+    // line has been parsed).
+    hide(map, "fdata-sections");
+    hide(map, "ffunction-sections");
 }
 #endif
 
@@ -907,7 +917,7 @@ int main(int argc, char **argv)
 
     gTargetMachine = createTargetMachine(mTargetTriple, mArch, mCPU, mAttrs,
         bitness, mFloatABI, mRelocModel, mCodeModel, codeGenOptLevel(),
-        global.params.symdebug || disableFpElim);
+        global.params.symdebug || disableFpElim, disableLinkerStripDead);
 
     {
         llvm::Triple triple = llvm::Triple(gTargetMachine->getTargetTriple());

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -54,6 +54,8 @@ llvm::TargetMachine* createTargetMachine(
     llvm::Reloc::Model relocModel,
     llvm::CodeModel::Model codeModel,
     llvm::CodeGenOpt::Level codeGenOptLevel,
-    bool noFramePointerElim);
+    bool noFramePointerElim,
+    bool noLinkerStripDead
+    );
 
 #endif // LDC_DRIVER_TARGET_H


### PR DESCRIPTION
This was painful.

<del>Before merging (or at least releasing), we'll have to decide on a flag to disable `--gc-sections`. If we had a way users to specify linker options to be passed _after_ the builtin/ldc.conf ones (which might also be interesting for the curl issues, #652), `--no-gc-sections` would do the trick.</del>


There is `-disable-linker-strip-dead` now. Choosing a name was not easy – `-no-gc-sections` would make no sense to the casual user, and e.g. on OS X the linker option is called `-dead_strip`.
