### PR TITLE
Add line number to error message of -nogc switch.

### DIFF
--- a/gen/aa.cpp
+++ b/gen/aa.cpp
@@ -47,7 +47,7 @@ DValue* DtoAAIndex(Loc& loc, Type* type, DValue* aa, DValue* key, bool lvalue)
     // extern(C) void* _aaInX(AA aa*, TypeInfo keyti, void* pkey)
 
     // first get the runtime function
-    llvm::Function* func = LLVM_D_GetRuntimeFunction(gIR->module, lvalue?"_aaGetX":"_aaInX");
+    llvm::Function* func = LLVM_D_GetRuntimeFunction(loc, gIR->module, lvalue?"_aaGetX":"_aaInX");
     LLFunctionType* funcTy = func->getFunctionType();
 
     // aa param
@@ -104,7 +104,7 @@ DValue* DtoAAIndex(Loc& loc, Type* type, DValue* aa, DValue* key, bool lvalue)
         };
 
         // call
-        llvm::Function* errorfn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_array_bounds");
+        llvm::Function* errorfn = LLVM_D_GetRuntimeFunction(loc, gIR->module, "_d_array_bounds");
         gIR->CreateCallOrInvoke(errorfn, args);
 
         // the function does not return
@@ -129,7 +129,7 @@ DValue* DtoAAIn(Loc& loc, Type* type, DValue* aa, DValue* key)
     // extern(C) void* _aaInX(AA aa*, TypeInfo keyti, void* pkey)
 
     // first get the runtime function
-    llvm::Function* func = LLVM_D_GetRuntimeFunction(gIR->module, "_aaInX");
+    llvm::Function* func = LLVM_D_GetRuntimeFunction(loc, gIR->module, "_aaInX");
     LLFunctionType* funcTy = func->getFunctionType();
 
     IF_LOG Logger::cout() << "_aaIn = " << *func << '\n';
@@ -174,7 +174,7 @@ DValue *DtoAARemove(Loc& loc, DValue* aa, DValue* key)
     // extern(C) bool _aaDelX(AA aa, TypeInfo keyti, void* pkey)
 
     // first get the runtime function
-    llvm::Function* func = LLVM_D_GetRuntimeFunction(gIR->module, "_aaDelX");
+    llvm::Function* func = LLVM_D_GetRuntimeFunction(loc, gIR->module, "_aaDelX");
     LLFunctionType* funcTy = func->getFunctionType();
 
     IF_LOG Logger::cout() << "_aaDel = " << *func << '\n';
@@ -210,7 +210,7 @@ LLValue* DtoAAEquals(Loc& loc, TOK op, DValue* l, DValue* r)
 {
     Type* t = l->getType()->toBasetype();
     assert(t == r->getType()->toBasetype() && "aa equality is only defined for aas of same type");
-    llvm::Function* func = LLVM_D_GetRuntimeFunction(gIR->module, "_aaEqual");
+    llvm::Function* func = LLVM_D_GetRuntimeFunction(loc, gIR->module, "_aaEqual");
     LLFunctionType* funcTy = func->getFunctionType();
 
     LLValue* aaval = DtoBitCast(l->getRVal(), funcTy->getParamType(1));

--- a/gen/arrays.h
+++ b/gen/arrays.h
@@ -45,26 +45,26 @@ llvm::Constant* arrayLiteralToConst(IRState* p, ArrayLiteralExp* ale);
 /// dstMem is expected to be a pointer to the array allocation.
 void initializeArrayLiteral(IRState* p, ArrayLiteralExp* ale, LLValue* dstMem);
 
-void DtoArrayCopySlices(DSliceValue* dst, DSliceValue* src);
-void DtoArrayCopyToSlice(DSliceValue* dst, DValue* src);
+void DtoArrayCopySlices(Loc& loc, DSliceValue* dst, DSliceValue* src);
+void DtoArrayCopyToSlice(Loc& loc, DSliceValue* dst, DValue* src);
 
 void DtoArrayInit(Loc& loc, DValue* array, DValue* value, int op);
 Type *DtoArrayElementType(Type *arrayType);
 bool arrayNeedsPostblit(Type *t);
-void DtoArrayAssign(DValue *from, DValue *to, int op);
-void DtoArraySetAssign(Loc &loc, DValue *array, DValue *value, int op);
+void DtoArrayAssign(Loc& loc, DValue *from, DValue *to, int op);
+void DtoArraySetAssign(Loc& loc, DValue *array, DValue *value, int op);
 void DtoSetArray(DValue* array, LLValue* dim, LLValue* ptr);
 void DtoSetArrayToNull(LLValue* v);
 
 DSliceValue* DtoNewDynArray(Loc& loc, Type* arrayType, DValue* dim, bool defaultInit=true);
 DSliceValue* DtoNewMulDimDynArray(Loc& loc, Type* arrayType, DValue** dims, size_t ndims, bool defaultInit=true);
-DSliceValue* DtoResizeDynArray(Type* arrayType, DValue* array, llvm::Value* newdim);
+DSliceValue* DtoResizeDynArray(Loc& loc, Type* arrayType, DValue* array, llvm::Value* newdim);
 
 void DtoCatAssignElement(Loc& loc, Type* type, DValue* arr, Expression* exp);
-DSliceValue* DtoCatAssignArray(DValue* arr, Expression* exp);
-DSliceValue* DtoCatArrays(Type* type, Expression* e1, Expression* e2);
-DSliceValue* DtoAppendDCharToString(DValue* arr, Expression* exp);
-DSliceValue* DtoAppendDCharToUnicodeString(DValue* arr, Expression* exp);
+DSliceValue* DtoCatAssignArray(Loc& loc, DValue* arr, Expression* exp);
+DSliceValue* DtoCatArrays(Loc& loc, Type* type, Expression* e1, Expression* e2);
+DSliceValue* DtoAppendDCharToString(Loc& loc, DValue* arr, Expression* exp);
+DSliceValue* DtoAppendDCharToUnicodeString(Loc& loc, DValue* arr, Expression* exp);
 
 void DtoStaticArrayCopy(LLValue* dst, LLValue* src);
 
@@ -73,7 +73,7 @@ LLValue* DtoArrayCompare(Loc& loc, TOK op, DValue* l, DValue* r);
 
 LLValue* DtoDynArrayIs(TOK op, DValue* l, DValue* r);
 
-LLValue* DtoArrayCastLength(LLValue* len, LLType* elemty, LLType* newelemty);
+LLValue* DtoArrayCastLength(Loc& loc, LLValue* len, LLType* elemty, LLType* newelemty);
 
 LLValue* DtoArrayLen(DValue* v);
 LLValue* DtoArrayPtr(DValue* v);

--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -108,7 +108,7 @@ DValue* DtoBinRem(Type* targettype, DValue* lhs, DValue* rhs)
 
 //////////////////////////////////////////////////////////////////////////////
 
-LLValue* DtoBinNumericEquals(Loc loc, DValue* lhs, DValue* rhs, TOK op)
+LLValue* DtoBinNumericEquals(Loc& loc, DValue* lhs, DValue* rhs, TOK op)
 {
     assert(op == TOKequal || op == TOKnotequal ||
            op == TOKidentity || op == TOKnotidentity);
@@ -134,7 +134,7 @@ LLValue* DtoBinNumericEquals(Loc loc, DValue* lhs, DValue* rhs, TOK op)
 
 //////////////////////////////////////////////////////////////////////////////
 
-LLValue* DtoBinFloatsEquals(Loc loc, DValue* lhs, DValue* rhs, TOK op)
+LLValue* DtoBinFloatsEquals(Loc& loc, DValue* lhs, DValue* rhs, TOK op)
 {
     LLValue* res = 0;
     if (op == TOKequal) {

--- a/gen/classes.h
+++ b/gen/classes.h
@@ -39,15 +39,15 @@ void DtoDefineClass(ClassDeclaration* cd);
 /// FIXME: this should be put into IrStruct and eventually IrClass.
 llvm::Constant* DtoDefineClassInfo(ClassDeclaration* cd);
 
-DValue* DtoNewClass(Loc loc, TypeClass* type, NewExp* newexp);
+DValue* DtoNewClass(Loc& loc, TypeClass* type, NewExp* newexp);
 void DtoInitClass(TypeClass* tc, llvm::Value* dst);
-void DtoFinalizeClass(llvm::Value* inst);
+void DtoFinalizeClass(Loc& loc, llvm::Value* inst);
 
-DValue* DtoCastClass(DValue* val, Type* to);
-DValue* DtoDynamicCastObject(DValue* val, Type* to);
+DValue* DtoCastClass(Loc& loc, DValue* val, Type* to);
+DValue* DtoDynamicCastObject(Loc& loc, DValue* val, Type* to);
 
-DValue* DtoCastInterfaceToObject(DValue* val, Type* to);
-DValue* DtoDynamicCastInterface(DValue* val, Type* to);
+DValue* DtoCastInterfaceToObject(Loc& loc, DValue* val, Type* to);
+DValue* DtoDynamicCastInterface(Loc& loc, DValue* val, Type* to);
 
 llvm::Value* DtoIndexClass(llvm::Value* src, ClassDeclaration* sd, VarDeclaration* vd);
 

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -69,7 +69,7 @@ void ldc::DIBuilder::Declare(llvm::Value *var, llvm::DIVariable divar)
     instr->setDebugLoc(IR->ir->getCurrentDebugLocation());
 }
 
-llvm::DIFile ldc::DIBuilder::CreateFile(Loc loc)
+llvm::DIFile ldc::DIBuilder::CreateFile(Loc& loc)
 {
     llvm::SmallString<128> path(loc.filename ? loc.filename : "");
     llvm::sys::fs::make_absolute(path);
@@ -392,7 +392,8 @@ llvm::DIType ldc::DIBuilder::CreateArrayType(Type *type)
 
     assert(t->ty == Tarray && "Only arrays allowed for debug info in DIBuilder::CreateArrayType");
 
-    llvm::DIFile file = CreateFile(Loc(IR->dmodule, 0));
+    Loc loc(IR->dmodule, 0);
+    llvm::DIFile file = CreateFile(loc);
 
     llvm::Value *elems[] = {
         CreateMemberType(0, Type::tsize_t, file, "length", 0),
@@ -458,7 +459,8 @@ ldc::DIFunctionType ldc::DIBuilder::CreateFunctionType(Type *type)
     TypeFunction *t = static_cast<TypeFunction*>(type);
     Type *retType = t->next;
 
-    llvm::DIFile file = CreateFile(Loc(IR->dmodule, 0));
+    Loc loc(IR->dmodule, 0);
+    llvm::DIFile file = CreateFile(loc);
 
     // Create "dummy" subroutine type for the return type
     llvm::SmallVector<llvm::Value*, 16> Elts;
@@ -472,7 +474,8 @@ ldc::DIFunctionType ldc::DIBuilder::CreateDelegateType(Type *type)
     // FIXME: Implement
     TypeDelegate *t = static_cast<TypeDelegate*>(type);
 
-    llvm::DIFile file = CreateFile(Loc(IR->dmodule, 0));
+    Loc loc(IR->dmodule, 0);
+    llvm::DIFile file = CreateFile(loc);
 
     // Create "dummy" subroutine type for the return type
     llvm::SmallVector<llvm::Value*, 16> Elts;
@@ -607,7 +610,8 @@ llvm::DISubprogram ldc::DIBuilder::EmitSubProgramInternal(llvm::StringRef pretty
     Logger::println("D to dwarf subprogram");
     LOG_SCOPE;
 
-    llvm::DIFile file(CreateFile(Loc(IR->dmodule, 0)));
+    Loc loc(IR->dmodule, 0);
+    llvm::DIFile file(CreateFile(loc));
 
     // Create "dummy" subroutine type for the return type
     llvm::SmallVector<llvm::Value *, 1> Elts;
@@ -656,7 +660,7 @@ void ldc::DIBuilder::EmitFuncEnd(FuncDeclaration *fd)
     assert(static_cast<llvm::MDNode *>(fd->ir.irFunc->diSubprogram) != 0);
 }
 
-void ldc::DIBuilder::EmitBlockStart(Loc loc)
+void ldc::DIBuilder::EmitBlockStart(Loc& loc)
 {
     if (!global.params.symdebug)
         return;

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -113,7 +113,7 @@ public:
     void EmitFuncEnd(FuncDeclaration *fd);
 
     /// \brief Emits debug info for block start
-    void EmitBlockStart(Loc loc);
+    void EmitBlockStart(Loc& loc);
 
     /// \brief Emits debug info for block end
     void EmitBlockEnd();
@@ -143,7 +143,7 @@ private:
     void Declare(llvm::Value *var, llvm::DIVariable divar);
     void AddBaseFields(ClassDeclaration *sd, llvm::DIFile file,
                          std::vector<llvm::Value*> &elems);
-    llvm::DIFile CreateFile(Loc loc);
+    llvm::DIFile CreateFile(Loc& loc);
     llvm::DIType CreateBasicType(Type *type);
     llvm::DIType CreateEnumType(Type *type);
     llvm::DIType CreatePointerType(Type *type);

--- a/gen/functions.h
+++ b/gen/functions.h
@@ -39,7 +39,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl);
 void DtoDefineFunction(FuncDeclaration* fd);
 
 void DtoDefineNakedFunction(FuncDeclaration* fd);
-void emitABIReturnAsmStmt(IRAsmBlock* asmblock, Loc loc, FuncDeclaration* fdecl);
+void emitABIReturnAsmStmt(IRAsmBlock* asmblock, Loc& loc, FuncDeclaration* fdecl);
 
 DValue* DtoArgument(Parameter* fnarg, Expression* argexp);
 void DtoVariadicArgument(Expression* argexp, llvm::Value* dst);

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -44,47 +44,47 @@ struct EnclosingSynchro : EnclosingHandler
 
 
 // dynamic memory helpers
-LLValue* DtoNew(Type* newtype);
-void DtoDeleteMemory(LLValue* ptr);
-void DtoDeleteClass(LLValue* inst);
-void DtoDeleteInterface(LLValue* inst);
-void DtoDeleteArray(DValue* arr);
+LLValue* DtoNew(Loc& loc, Type* newtype);
+void DtoDeleteMemory(Loc& loc, LLValue* ptr);
+void DtoDeleteClass(Loc& loc, LLValue* inst);
+void DtoDeleteInterface(Loc& loc, LLValue* inst);
+void DtoDeleteArray(Loc& loc, DValue* arr);
 
 // emit an alloca
 llvm::AllocaInst* DtoAlloca(Type* type, const char* name = "");
 llvm::AllocaInst* DtoArrayAlloca(Type* type, unsigned arraysize, const char* name = "");
 llvm::AllocaInst* DtoRawAlloca(LLType* lltype, size_t alignment, const char* name = "");
-LLValue* DtoGcMalloc(LLType* lltype, const char* name = "");
+LLValue* DtoGcMalloc(Loc& loc, LLType* lltype, const char* name = "");
 
 // assertion generator
-void DtoAssert(Module* M, Loc loc, DValue* msg);
+void DtoAssert(Module* M, Loc& loc, DValue* msg);
 
 // return the LabelStatement from the current function with the given identifier or NULL if not found
 LabelStatement* DtoLabelStatement(Identifier* ident);
 
 /// emits goto to LabelStatement with the target identifier
 /// the sourceFinally is only used for error checking
-void DtoGoto(Loc loc, Identifier* target, TryFinallyStatement* sourceFinally);
+void DtoGoto(Loc& loc, Identifier* target, TryFinallyStatement* sourceFinally);
 
 // Generates IR for enclosing handlers between the current state and
 // the scope created by the 'target' statement.
-void DtoEnclosingHandlers(Loc loc, Statement* target);
+void DtoEnclosingHandlers(Loc& loc, Statement* target);
 
 /// Enters a critical section.
-void DtoEnterCritical(LLValue* g);
+void DtoEnterCritical(Loc& loc, LLValue* g);
 /// leaves a critical section.
-void DtoLeaveCritical(LLValue* g);
+void DtoLeaveCritical(Loc& loc, LLValue* g);
 
 /// Enters a monitor lock.
-void DtoEnterMonitor(LLValue* v);
+void DtoEnterMonitor(Loc& loc, LLValue* v);
 /// Leaves a monitor lock.
-void DtoLeaveMonitor(LLValue* v);
+void DtoLeaveMonitor(Loc& loc, LLValue* v);
 
 // basic operations
 void DtoAssign(Loc& loc, DValue* lhs, DValue* rhs, int op = -1, bool canSkipPostblit = false);
 
-DValue* DtoSymbolAddress(const Loc& loc, Type* type, Declaration* decl);
-llvm::Constant* DtoConstSymbolAddress(const Loc& loc,Declaration* decl);
+DValue* DtoSymbolAddress(Loc& loc, Type* type, Declaration* decl);
+llvm::Constant* DtoConstSymbolAddress(Loc& loc,Declaration* decl);
 
 /// Create a null DValue.
 DValue* DtoNullValue(Type* t);
@@ -118,8 +118,8 @@ DValue* DtoDeclarationExp(Dsymbol* declaration);
 LLValue* DtoRawVarDeclaration(VarDeclaration* var, LLValue* addr = 0);
 
 // initializer helpers
-LLConstant* DtoConstInitializer(Loc loc, Type* type, Initializer* init);
-LLConstant* DtoConstExpInit(Loc loc, Type* targetType, Expression* exp);
+LLConstant* DtoConstInitializer(Loc& loc, Type* type, Initializer* init);
+LLConstant* DtoConstExpInit(Loc& loc, Type* targetType, Expression* exp);
 
 // getting typeinfo of type, base=true casts to object.TypeInfo
 LLConstant* DtoTypeInfoOf(Type* ty, bool base=true);
@@ -132,8 +132,8 @@ DValue* DtoBinSub(DValue* lhs, DValue* rhs);
 DValue* DtoBinMul(Type* resulttype, DValue* lhs, DValue* rhs);
 DValue* DtoBinDiv(Type* resulttype, DValue* lhs, DValue* rhs);
 DValue* DtoBinRem(Type* resulttype, DValue* lhs, DValue* rhs);
-LLValue* DtoBinNumericEquals(Loc loc, DValue* lhs, DValue* rhs, TOK op);
-LLValue* DtoBinFloatsEquals(Loc loc, DValue* lhs, DValue* rhs, TOK op);
+LLValue* DtoBinNumericEquals(Loc& loc, DValue* lhs, DValue* rhs, TOK op);
+LLValue* DtoBinFloatsEquals(Loc& loc, DValue* lhs, DValue* rhs, TOK op);
 
 // target stuff
 void findDefaultTarget();
@@ -145,7 +145,7 @@ void DtoOverloadedIntrinsicName(TemplateInstance* ti, TemplateDeclaration* td, s
 bool hasUnalignedFields(Type* t);
 
 ///
-DValue* DtoInlineAsmExpr(Loc loc, FuncDeclaration* fd, Expressions* arguments);
+DValue* DtoInlineAsmExpr(Loc& loc, FuncDeclaration* fd, Expressions* arguments);
 
 /// Create the IrModule if necessary and returns it.
 IrModule* getIrModule(Module* M);
@@ -159,7 +159,7 @@ size_t realignOffset(size_t offset, Type* type);
 /// functions without problems.
 LLValue* makeLValue(Loc& loc, DValue* value);
 
-void callPostblit(Loc &loc, Expression *exp, LLValue *val);
+void callPostblit(Loc& loc, Expression *exp, LLValue *val);
 
 /// Returns whether the given variable is a DMD-internal "ref variable".
 ///
@@ -235,7 +235,7 @@ LLConstant* toConstantArray(LLType* ct, LLArrayType* at, T* str, size_t len, boo
 ///
 /// Necessary to support multiple declarations with the same mangled name, as
 /// can be the case due to pragma(mangle).
-llvm::GlobalVariable* getOrCreateGlobal(Loc loc, llvm::Module& module,
+llvm::GlobalVariable* getOrCreateGlobal(Loc& loc, llvm::Module& module,
     llvm::Type* type, bool isConstant, llvm::GlobalValue::LinkageTypes linkage,
     llvm::Constant* init, llvm::StringRef name, bool isThreadLocal = false);
 

--- a/gen/logger.cpp
+++ b/gen/logger.cpp
@@ -128,7 +128,7 @@ namespace Logger
             va_end(va);
         }
     }
-    void attention(Loc loc, const char* fmt,...)
+    void attention(Loc& loc, const char* fmt,...)
     {
         va_list va;
         va_start(va,fmt);

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -302,7 +302,8 @@ static LLFunction* build_module_reference_and_ctor(LLConstant* moduleinfo)
     std::string thismrefname = "_D";
     thismrefname += gIR->dmodule->mangle();
     thismrefname += "11__moduleRefZ";
-    LLGlobalVariable* thismref = getOrCreateGlobal(Loc(), *gIR->module,
+    Loc loc;
+    LLGlobalVariable* thismref = getOrCreateGlobal(loc, *gIR->module,
         modulerefTy, false, LLGlobalValue::InternalLinkage, thismrefinit,
         thismrefname);
     // make sure _Dmodule_ref is declared
@@ -352,7 +353,7 @@ static void build_dso_ctor_dtor_body(
     llvm::Value* minfoUsedPointer,
     bool executeWhenInitialized
 ) {
-    llvm::Function* const dsoRegistry = LLVM_D_GetRuntimeFunction(
+    llvm::Function* const dsoRegistry = LLVM_D_GetRuntimeFunction(Loc(),
         gIR->module, "_d_dso_registry");
     llvm::Type* const recordPtrTy = dsoRegistry->getFunctionType()->getContainedType(1);
 

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -257,7 +257,7 @@ void DtoDefineNakedFunction(FuncDeclaration* fd)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void emitABIReturnAsmStmt(IRAsmBlock* asmblock, Loc loc, FuncDeclaration* fdecl)
+void emitABIReturnAsmStmt(IRAsmBlock* asmblock, Loc& loc, FuncDeclaration* fdecl)
 {
     IF_LOG Logger::println("emitABIReturnAsmStmt(%s)", fdecl->mangleExact());
     LOG_SCOPE;
@@ -414,7 +414,7 @@ void emitABIReturnAsmStmt(IRAsmBlock* asmblock, Loc loc, FuncDeclaration* fdecl)
 
 // sort of kinda related to naked ...
 
-DValue * DtoInlineAsmExpr(Loc loc, FuncDeclaration * fd, Expressions * arguments)
+DValue * DtoInlineAsmExpr(Loc& loc, FuncDeclaration * fd, Expressions * arguments)
 {
     IF_LOG Logger::println("DtoInlineAsmExpr @ %s", loc.toChars());
     LOG_SCOPE;

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -32,7 +32,7 @@ static void storeVariable(VarDeclaration *vd, LLValue *dst)
     assert(fd && "No parent function for nested variable?");
     if (fd->needsClosure() && !vd->isRef() && (ty == Tstruct || ty == Tsarray) && isaPointer(value->getType())) {
         // Copy structs and static arrays
-        LLValue *mem = DtoGcMalloc(DtoType(vd->type), ".gc_mem");
+        LLValue *mem = DtoGcMalloc(vd->loc, DtoType(vd->type), ".gc_mem");
         DtoAggrCopy(mem, value);
         DtoAlignedStore(mem, dst);
     } else
@@ -42,7 +42,7 @@ static void storeVariable(VarDeclaration *vd, LLValue *dst)
 
 static void DtoCreateNestedContextType(FuncDeclaration* fd);
 
-DValue* DtoNestedVariable(Loc loc, Type* astype, VarDeclaration* vd, bool byref)
+DValue* DtoNestedVariable(Loc& loc, Type* astype, VarDeclaration* vd, bool byref)
 {
     IF_LOG Logger::println("DtoNestedVariable for %s @ %s", vd->toChars(), loc.toChars());
     LOG_SCOPE;
@@ -165,7 +165,7 @@ DValue* DtoNestedVariable(Loc loc, Type* astype, VarDeclaration* vd, bool byref)
     return new DVarValue(astype, vd, val);
 }
 
-void DtoResolveNestedContext(Loc loc, AggregateDeclaration *decl, LLValue *value)
+void DtoResolveNestedContext(Loc& loc, AggregateDeclaration *decl, LLValue *value)
 {
     IF_LOG Logger::println("Resolving nested context");
     LOG_SCOPE;
@@ -189,7 +189,7 @@ void DtoResolveNestedContext(Loc loc, AggregateDeclaration *decl, LLValue *value
     }
 }
 
-LLValue* DtoNestedContext(Loc loc, Dsymbol* sym)
+LLValue* DtoNestedContext(Loc& loc, Dsymbol* sym)
 {
     IF_LOG Logger::println("DtoNestedContext for %s", sym->toPrettyChars());
     LOG_SCOPE;
@@ -416,7 +416,7 @@ void DtoCreateNestedContext(FuncDeclaration* fd) {
         LLValue* frame = 0;
         bool needsClosure = fd->needsClosure();
         if (needsClosure)
-            frame = DtoGcMalloc(frameType, ".frame");
+            frame = DtoGcMalloc(fd->loc, frameType, ".frame");
         else
             frame = DtoRawAlloca(frameType, 0, ".frame");
 

--- a/gen/nested.h
+++ b/gen/nested.h
@@ -28,13 +28,13 @@
 void DtoCreateNestedContext(FuncDeclaration* fd);
 
 /// Resolves the nested context for classes and structs with arbitrary nesting.
-void DtoResolveNestedContext(Loc loc, AggregateDeclaration *decl, LLValue *value);
+void DtoResolveNestedContext(Loc& loc, AggregateDeclaration *decl, LLValue *value);
 
 /// Gets the context value for a call to a nested function or creating a nested
 /// class or struct with arbitrary nesting.
-llvm::Value* DtoNestedContext(Loc loc, Dsymbol* sym);
+llvm::Value* DtoNestedContext(Loc& loc, Dsymbol* sym);
 
 /// Gets the DValue of a nested variable with arbitrary nesting.
-DValue* DtoNestedVariable(Loc loc, Type* astype, VarDeclaration* vd, bool byref = false);
+DValue* DtoNestedVariable(Loc& loc, Type* astype, VarDeclaration* vd, bool byref = false);
 
 #endif

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -126,9 +126,9 @@ void LLVM_D_FreeRuntime()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-llvm::Function* LLVM_D_GetRuntimeFunction(llvm::Module* target, const char* name)
+llvm::Function* LLVM_D_GetRuntimeFunction(const Loc &loc, llvm::Module* target, const char* name)
 {
-    checkForImplicitGCCall(Loc(), name);
+    checkForImplicitGCCall(loc, name);
 
     if (!M) {
         LLVM_D_InitRuntime();
@@ -150,14 +150,14 @@ llvm::Function* LLVM_D_GetRuntimeFunction(llvm::Module* target, const char* name
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(llvm::Module* target, const char* name)
+llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(Loc& loc, llvm::Module* target, const char* name)
 {
     LLGlobalVariable* gv = target->getNamedGlobal(name);
     if (gv) {
         return gv;
     }
 
-    checkForImplicitGCCall(Loc(), name);
+    checkForImplicitGCCall(loc, name);
 
     if (!M) {
         LLVM_D_InitRuntime();
@@ -165,13 +165,13 @@ llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(llvm::Module* target, const char* 
 
     LLGlobalVariable* g = M->getNamedGlobal(name);
     if (!g) {
-        error(Loc(), "Runtime global '%s' was not found", name);
+        error(loc, "Runtime global '%s' was not found", name);
         fatal();
         //return NULL;
     }
 
     LLPointerType* t = g->getType();
-    return getOrCreateGlobal(Loc(), *target, t->getElementType(), g->isConstant(),
+    return getOrCreateGlobal(loc, *target, t->getElementType(), g->isConstant(),
                              g->getLinkage(), NULL, g->getName());
 }
 

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -21,14 +21,16 @@ namespace llvm
     class Module;
 }
 
+struct Loc;
+
 // D runtime support helpers
 
 bool LLVM_D_InitRuntime();
 void LLVM_D_FreeRuntime();
 
-llvm::Function* LLVM_D_GetRuntimeFunction(llvm::Module* target, const char* name);
+llvm::Function* LLVM_D_GetRuntimeFunction(const Loc &loc, llvm::Module* target, const char* name);
 
-llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(llvm::Module* target, const char* name);
+llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(const Loc &loc, llvm::Module* target, const char* name);
 
 #define _adEq "_adEq2"
 #define _adCmp "_adCmp2"

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -85,7 +85,7 @@ static LLValue* call_string_switch_runtime(llvm::Value* table, Expression* e)
         llvm_unreachable("not char/wchar/dchar");
     }
 
-    llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, fname);
+    llvm::Function* fn = LLVM_D_GetRuntimeFunction(e->loc, gIR->module, fname);
 
     IF_LOG {
         Logger::cout() << *table->getType() << '\n';
@@ -866,7 +866,7 @@ public:
 
         gIR->DBuilder.EmitFuncEnd(gIR->func()->decl);
 
-        llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_throw_exception");
+        llvm::Function* fn = LLVM_D_GetRuntimeFunction(stmt->loc, gIR->module, "_d_throw_exception");
         //Logger::cout() << "calling: " << *fn << '\n';
         LLValue* arg = DtoBitCast(e->getRVal(), fn->getFunctionType()->getParamType(0));
         //Logger::cout() << "arg: " << *arg << '\n';
@@ -1550,12 +1550,12 @@ public:
         if (stmt->exp)
         {
             stmt->llsync = stmt->exp->toElem(irs)->getRVal();
-            DtoEnterMonitor(stmt->llsync);
+            DtoEnterMonitor(stmt->loc, stmt->llsync);
         }
         else
         {
             stmt->llsync = generate_unique_critical_section();
-            DtoEnterCritical(stmt->llsync);
+            DtoEnterCritical(stmt->loc, stmt->llsync);
         }
 
         // emit body
@@ -1570,9 +1570,9 @@ public:
         if (irs->scopereturned())
             return;
         else if (stmt->exp)
-            DtoLeaveMonitor(stmt->llsync);
+            DtoLeaveMonitor(stmt->loc, stmt->llsync);
         else
-            DtoLeaveCritical(stmt->llsync);
+            DtoLeaveCritical(stmt->loc, stmt->llsync);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1581,7 +1581,7 @@ public:
         IF_LOG Logger::println("SwitchErrorStatement::toIR(): %s", stmt->loc.toChars());
         LOG_SCOPE;
 
-        llvm::Function* fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_switch_error");
+        llvm::Function* fn = LLVM_D_GetRuntimeFunction(stmt->loc, gIR->module, "_d_switch_error");
 
         LLValue *moduleInfoSymbol = gIR->func()->decl->getModule()->moduleInfoSymbol();
         LLType *moduleInfoType = DtoType(Module::moduleinfo->type);

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -81,7 +81,7 @@ DValue* DtoVaArg(Loc& loc, Type* type, Expression* valistArg)
     // issue a warning for broken va_arg instruction.
     if (global.params.targetTriple.getArch() != llvm::Triple::x86
         && global.params.targetTriple.getArch() != llvm::Triple::ppc64)
-        warning(Loc(), "%s: va_arg for C variadic functions is probably broken for anything but x86 and ppc64", loc.toChars());
+        warning(loc, "va_arg for C variadic functions is probably broken for anything but x86 and ppc64");
     // done
     return new DImValue(type, gIR->ir->CreateVAArg(expelem->getLVal(), llt, "tmp"));
 }

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -214,7 +214,7 @@ LLConstant * IrAggr::getVtblInit()
                         else
                             cd->deprecation("use of %s hidden by %s is deprecated", fd->toPrettyChars(), cd->toChars());
 
-                        c = DtoBitCast(LLVM_D_GetRuntimeFunction(gIR->module, "_d_hidden_func"), c->getType());
+                        c = DtoBitCast(LLVM_D_GetRuntimeFunction(Loc(), gIR->module, "_d_hidden_func"), c->getType());
                         break;
                     }
                 }

--- a/ir/irlandingpad.cpp
+++ b/ir/irlandingpad.cpp
@@ -19,7 +19,7 @@
 // creates new landing pad
 static llvm::LandingPadInst *createLandingPadInst()
 {
-    llvm::Function* personality_fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_eh_personality");
+    llvm::Function* personality_fn = LLVM_D_GetRuntimeFunction(Loc(), gIR->module, "_d_eh_personality");
     LLType *retType = LLStructType::get(LLType::getInt8PtrTy(gIR->context()),
                                         LLType::getInt32Ty(gIR->context()),
                                         NULL);
@@ -98,7 +98,7 @@ void IRLandingPadFinallyStatementInfo::toIR(LLValue *eh_ptr)
     llvm::LandingPadInst *collisionLandingPad = createLandingPadInst();
     LLValue* collision_eh_ptr = DtoExtractValue(collisionLandingPad, 0);
     collisionLandingPad->setCleanup(true);
-    llvm::Function* collision_fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_eh_handle_collision");
+    llvm::Function* collision_fn = LLVM_D_GetRuntimeFunction(Loc(), gIR->module, "_d_eh_handle_collision");
     gIR->CreateCallOrInvoke2(collision_fn, collision_eh_ptr, eh_ptr);
     gIR->ir->CreateUnreachable();
     gIR->scope() = IRScope(bb, gIR->scopeend());
@@ -222,7 +222,7 @@ void IRLandingPad::constructLandingPad(IRLandingPadScope scope)
     gIR->func()->gen->landingPad = get();
 
     // no catch matched and all finallys executed - resume unwind
-    llvm::Function* unwind_resume_fn = LLVM_D_GetRuntimeFunction(gIR->module, "_d_eh_resume_unwind");
+    llvm::Function* unwind_resume_fn = LLVM_D_GetRuntimeFunction(Loc(), gIR->module, "_d_eh_resume_unwind");
     gIR->ir->CreateCall(unwind_resume_fn, eh_ptr);
     gIR->ir->CreateUnreachable();
 


### PR DESCRIPTION
This was suggested by bearophile in the news group.
It also changes all passed Loc objects to be const ref.
