### PR TITLE
Remove magic constants from Target::critsecsize().

### DIFF
--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -9,15 +9,10 @@
 
 #include "target.h"
 #include "gen/irstate.h"
+#include "gen/tollvm.h"
 #include "mars.h"
 #include "mtype.h"
 #include <assert.h>
-
-#if defined(_MSC_VER)
-#include <windows.h>
-#else
-#include <pthread.h>
-#endif
 
 int Target::ptrsize;
 int Target::realsize;
@@ -58,18 +53,7 @@ unsigned Target::fieldalign (Type* type)
     return type->alignsize();
 }
 
-// sizes based on those from tollvm.cpp:DtoMutexType()
 unsigned Target::critsecsize()
 {
-#if defined(_MSC_VER)
-    // Return sizeof(RTL_CRITICAL_SECTION)
-    return global.params.is64bit ? 40 : 24;
-#else
-    if (global.params.targetTriple.isOSWindows())
-        return global.params.is64bit ? 40 : 24;
-    else if (global.params.targetTriple.getOS() == llvm::Triple::FreeBSD)
-        return sizeof(size_t);
-    else
-        return sizeof(pthread_mutex_t);
-#endif
+    return getTypeStoreSize(DtoMutexType());
 }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -976,16 +976,18 @@ LLStructType* DtoInterfaceInfoType()
 
 LLStructType* DtoMutexType()
 {
-    if (gIR->mutexType)
+    if (gIR && gIR->mutexType)
         return gIR->mutexType;
+
+    llvm::LLVMContext& context = gIR ? gIR->context() : llvm::getGlobalContext();
 
     // The structures defined here must be the same as in druntime/src/rt/critical.c
 
     // Windows
     if (global.params.targetTriple.isOSWindows())
     {
-        llvm::Type *VoidPtrTy = llvm::Type::getInt8PtrTy(gIR->context());
-        llvm::Type *Int32Ty = llvm::Type::getInt32Ty(gIR->context());
+        llvm::Type *VoidPtrTy = llvm::Type::getInt8PtrTy(context);
+        llvm::Type *Int32Ty = llvm::Type::getInt32Ty(context);
 
         // Build RTL_CRITICAL_SECTION; size is 24 (32bit) or 40 (64bit)
         LLType *rtl_types[] = {
@@ -996,15 +998,15 @@ LLStructType* DtoMutexType()
             VoidPtrTy, // Handle of LockSemaphore
             VoidPtrTy  // SpinCount
         };
-        LLStructType* rtl = LLStructType::create(gIR->context(), rtl_types, "RTL_CRITICAL_SECTION");
+        LLStructType* rtl = LLStructType::create(context, rtl_types, "RTL_CRITICAL_SECTION");
 
         // Build D_CRITICAL_SECTION; size is 28 (32bit) or 48 (64bit)
-        LLStructType *mutex = LLStructType::create(gIR->context(), "D_CRITICAL_SECTION");
+        LLStructType *mutex = LLStructType::create(context, "D_CRITICAL_SECTION");
         LLType *types[] = { getPtrToType(mutex), rtl };
         mutex->setBody(types);
 
         // Cache type
-        gIR->mutexType = mutex;
+        if (gIR) gIR->mutexType = mutex;
 
         return mutex;
     }
@@ -1012,33 +1014,33 @@ LLStructType* DtoMutexType()
     // FreeBSD
     else if (global.params.targetTriple.getOS() == llvm::Triple::FreeBSD) {
         // Just a pointer
-        return LLStructType::get(gIR->context(), DtoSize_t());
+        return LLStructType::get(context, DtoSize_t());
     }
 
     // pthread_fastlock
     LLType *types2[] = {
         DtoSize_t(),
-        LLType::getInt32Ty(gIR->context()) 
+        LLType::getInt32Ty(context) 
     };
-    LLStructType* fastlock = LLStructType::get(gIR->context(), types2, false);
+    LLStructType* fastlock = LLStructType::get(context, types2, false);
 
     // pthread_mutex
     LLType *types1[] = {
-        LLType::getInt32Ty(gIR->context()),
-        LLType::getInt32Ty(gIR->context()),
+        LLType::getInt32Ty(context),
+        LLType::getInt32Ty(context),
         getVoidPtrType(),
-        LLType::getInt32Ty(gIR->context()),
+        LLType::getInt32Ty(context),
         fastlock
     };
-    LLStructType* pmutex = LLStructType::get(gIR->context(), types1, false);
+    LLStructType* pmutex = LLStructType::get(context, types1, false);
 
     // D_CRITICAL_SECTION
-    LLStructType* mutex = LLStructType::create(gIR->context(), "D_CRITICAL_SECTION");
+    LLStructType* mutex = LLStructType::create(context, "D_CRITICAL_SECTION");
     LLType *types[] = { getPtrToType(mutex), pmutex };
     mutex->setBody(types);
 
     // Cache type
-    gIR->mutexType = mutex;
+    if (gIR) gIR->mutexType = mutex;
 
     return pmutex;
 }


### PR DESCRIPTION
The type of a critical section is returned by DtoMutexType() and can be used to derive the size.
This is required for correct cross-compilation.