### PR TITLE
Fix a build issue where LLVM_LDFLAGS contains newlines.

### DIFF
--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -135,7 +135,7 @@ else()
         # In LLVM 3.5+, the system library dependencies (e.g. "-lz") are accessed
         # using the separate "--system-libs" flag.
         llvm_set(SYSTEM_LIBS system-libs)
-        set(LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
+        string(REPLACE "\n" " " LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
     endif()
     llvm_set(LIBRARY_DIRS libdir)
     llvm_set_libs(LIBRARIES libfiles "${LLVM_LIBRARY_DIRS}/")


### PR DESCRIPTION
On my system. llvm_set returns a variable that contains newlines, which breaks the build. This fix makes sure that they are removed before setting LLVM_LDFLAGS for the last time.

Environment: 

Linux kartofel 3.13.0-24-generic #46-Ubuntu SMP Thu Apr 10 19:11:08 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
cmake version 2.8.12.2
llvm version 3.5
