### PR TITLE
Use LLVM intrinsic name as mangled name.

### DIFF
--- a/dmd2/builtin.c
+++ b/dmd2/builtin.c
@@ -353,14 +353,12 @@ void builtin_init()
 
 #if IN_LLVM
     // intrinsic llvm.bswap.i16/i32/i64/i128
-    add_builtin("llvm.bswap.i#", &eval_bswap);
     add_builtin("llvm.bswap.i16", &eval_bswap);
     add_builtin("llvm.bswap.i32", &eval_bswap);
     add_builtin("llvm.bswap.i64", &eval_bswap);
     add_builtin("llvm.bswap.i128", &eval_bswap);
 
     // intrinsic llvm.cttz.i8/i16/i32/i64/i128
-    add_builtin("llvm.cttz.i#", &eval_cttz);
     add_builtin("llvm.cttz.i8", &eval_cttz);
     add_builtin("llvm.cttz.i16", &eval_cttz);
     add_builtin("llvm.cttz.i32", &eval_cttz);
@@ -368,7 +366,6 @@ void builtin_init()
     add_builtin("llvm.cttz.i128", &eval_cttz);
 
     // intrinsic llvm.ctlz.i8/i16/i32/i64/i128
-    add_builtin("llvm.ctlz.i#", &eval_ctlz);
     add_builtin("llvm.ctlz.i8", &eval_ctlz);
     add_builtin("llvm.ctlz.i16", &eval_ctlz);
     add_builtin("llvm.ctlz.i32", &eval_ctlz);
@@ -376,7 +373,6 @@ void builtin_init()
     add_builtin("llvm.ctlz.i128", &eval_ctlz);
 
     // intrinsic llvm.ctpop.i8/i16/i32/i64/i128
-    add_builtin("llvm.ctpop.i#", &eval_ctpop);
     add_builtin("llvm.ctpop.i8", &eval_ctpop);
     add_builtin("llvm.ctpop.i16", &eval_ctpop);
     add_builtin("llvm.ctpop.i32", &eval_ctpop);
@@ -404,13 +400,7 @@ BUILTIN FuncDeclaration::isBuiltin()
 {
     if (builtin == BUILTINunknown)
     {
-#if IN_LLVM
-        const char *name = llvmInternal == LLVMintrinsic ? intrinsicName.c_str()
-                                                         : mangleExact();
-        builtin_fp fp = builtin_lookup(name);
-#else
         builtin_fp fp = builtin_lookup(mangleExact());
-#endif
         builtin = fp ? BUILTINyes : BUILTINno;
     }
     return builtin;
@@ -425,13 +415,7 @@ Expression *eval_builtin(Loc loc, FuncDeclaration *fd, Expressions *arguments)
 {
     if (fd->builtin == BUILTINyes)
     {
-#if IN_LLVM
-        const char *name = fd->llvmInternal == LLVMintrinsic ? fd->intrinsicName.c_str()
-                                                             : fd->mangleExact();
-        builtin_fp fp = builtin_lookup(name);
-#else
         builtin_fp fp = builtin_lookup(fd->mangleExact());
-#endif
         assert(fp);
         return fp(loc, fd, arguments);
     }

--- a/dmd2/template.c
+++ b/dmd2/template.c
@@ -34,6 +34,11 @@
 #include "id.h"
 #include "attrib.h"
 
+#if IN_LLVM
+#include "gen/pragma.h"
+void DtoOverloadedIntrinsicName(TemplateInstance* ti, TemplateDeclaration* td, std::string& name);
+#endif
+
 #define LOG     0
 
 #define IDX_NOTFOUND (0x12345678)               // index is not found
@@ -5575,7 +5580,12 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
                 if (tempdecl->llvmInternal) {
                     s->llvmInternal = tempdecl->llvmInternal;
                     if (FuncDeclaration* fd = s->isFuncDeclaration()) {
-                        fd->intrinsicName = tempdecl->intrinsicName;
+                        if (fd->llvmInternal == LLVMintrinsic) {
+                            DtoOverloadedIntrinsicName(this, tempdecl, fd->intrinsicName);
+                            fd->mangleOverride = strdup(fd->intrinsicName.c_str());
+                        }
+                        else
+                            fd->intrinsicName = tempdecl->intrinsicName;
                     }
                 }
 #endif

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -550,8 +550,8 @@ void DtoResolveFunction(FuncDeclaration* fdecl)
             else if (tempdecl->llvmInternal == LLVMintrinsic)
             {
                 Logger::println("overloaded intrinsic found");
-                fdecl->llvmInternal = LLVMintrinsic;
-                DtoOverloadedIntrinsicName(tinst, tempdecl, fdecl->intrinsicName);
+                assert(fdecl->llvmInternal == LLVMintrinsic);
+                assert(fdecl->mangleOverride);
             }
             else if (tempdecl->llvmInternal == LLVMinline_asm)
             {
@@ -788,11 +788,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
     }
 
     // mangled name
-    std::string mangledName;
-    if (fdecl->llvmInternal == LLVMintrinsic)
-        mangledName = fdecl->intrinsicName;
-    else
-        mangledName = fdecl->mangleExact();
+    std::string mangledName(fdecl->mangleExact());
     mangledName = gABI->mangleForLLVM(mangledName, link);
 
     // construct function

--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -324,6 +324,7 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
         {
             fd->llvmInternal = llvm_internal;
             fd->intrinsicName = arg1str;
+            fd->mangleOverride = strdup(fd->intrinsicName.c_str());
         }
         else if (TemplateDeclaration* td = s->isTemplateDeclaration())
         {


### PR DESCRIPTION
If the mangled name is viewed as the name emitted into IR code then the mangled name of an intrinsic is the intrinsic's name. The name is unique because of the `llvm.` prefix. The only point is that overloaded intrinsics must be resolved earlier.
This commit moves the resolution of oveloaded intrinsics into the semantic analysis pass. This results in some simplification of the code.
