### PR TITLE
Revert owningTemplate hack from 39e3e3a6.

### DIFF
--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -844,17 +844,6 @@ public:
     FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
     const char *kind();
     const char *toPrettyChars(bool QualifyTypes = false);
-
-#if IN_LLVM
-    // If this is only used as alias parameter to a template instantiation,
-    // keep track of which one, as the function will only be codegen'ed in the
-    // module the template instance is pushed to, which is not always the same
-    // as this->module because of the importedFrom check in
-    // TemplateInstance::semantic and the fact that importedFrom is only set
-    // once for the first module.
-    TemplateInstance *owningTemplate;
-#endif
-
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/dmd2/func.c
+++ b/dmd2/func.c
@@ -4568,10 +4568,6 @@ FuncLiteralDeclaration::FuncLiteralDeclaration(Loc loc, Loc endloc, Type *type,
     this->fes = fes;
     this->treq = NULL;
     //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this->ident->toChars(), type->toChars());
-
-#if IN_LLVM
-    this->owningTemplate = NULL;
-#endif
 }
 
 Dsymbol *FuncLiteralDeclaration::syntaxCopy(Dsymbol *s)

--- a/dmd2/template.c
+++ b/dmd2/template.c
@@ -7815,11 +7815,6 @@ void TemplateInstance::declareParameters(Scope *sc)
 
         //printf("\ttdtypes[%d] = %p\n", i, o);
         tempdecl->declareParameter(sc, tp, o);
-#if IN_LLVM
-        if (Dsymbol *sa = isDsymbol(o))
-            if (FuncLiteralDeclaration *fld = sa->isFuncLiteralDeclaration())
-                fld->owningTemplate = this;
-#endif
     }
 }
 

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -27,7 +27,7 @@
 Module *ldc::DIBuilder::getDefinedModule(Dsymbol *s)
 {
     // templates are defined in current module
-    if (DtoIsTemplateInstance(s, true))
+    if (DtoIsTemplateInstance(s))
     {
         return IR->dmodule;
     }

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -887,18 +887,13 @@ DValue* DtoPaintType(Loc& loc, DValue* val, Type* to)
 //      TEMPLATE HELPERS
 ////////////////////////////////////////////////////////////////////////////////////////*/
 
-TemplateInstance* DtoIsTemplateInstance(Dsymbol* s, bool checkLiteralOwner)
+TemplateInstance* DtoIsTemplateInstance(Dsymbol* s)
 {
     if (!s) return NULL;
     if (s->isTemplateInstance() && !s->isTemplateMixin())
         return s->isTemplateInstance();
-    if (FuncLiteralDeclaration* fld = s->isFuncLiteralDeclaration())
-    {
-        if (checkLiteralOwner && fld->owningTemplate)
-            return fld->owningTemplate;
-    }
     if (s->parent)
-        return DtoIsTemplateInstance(s->parent, checkLiteralOwner);
+        return DtoIsTemplateInstance(s->parent);
     return NULL;
 }
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -91,7 +91,7 @@ DValue* DtoCast(Loc& loc, DValue* val, Type* to);
 DValue* DtoPaintType(Loc& loc, DValue* val, Type* to);
 
 // is template instance check, returns module where instantiated
-TemplateInstance* DtoIsTemplateInstance(Dsymbol* s, bool checkLiteralOwner = false);
+TemplateInstance* DtoIsTemplateInstance(Dsymbol* s);
 
 /// Makes sure the declarations corresponding to the given D symbol have been
 /// emitted to the currently processed LLVM module.


### PR DESCRIPTION
It is no longer needed now that we use DMD's model for determining
whether to emit templates. We might also be able to use the more
general tinst/minst machinery from DMD Git master if we ever need
something similar.
