### PR TITLE
Fix compile error with LLVM 3.6.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -915,6 +915,11 @@ static void emitEntryPointInto(llvm::Module* lm)
         emitSymbolAddrGlobal(*entryModule, "_end", "_d_execBssEndAddr");
     }
 
+#if LDC_LLVM_VER >= 306
+    // FIXME: A possible error message is written to the diagnostic context
+    //        Do we show these messages?
+    linker.linkInModule(entryModule);
+#else
     std::string linkError;
 #if LDC_LLVM_VER >= 303
     const bool hadError = linker.linkInModule(entryModule, &linkError);
@@ -924,6 +929,7 @@ static void emitEntryPointInto(llvm::Module* lm)
 #endif
     if (hadError)
         error(Loc(), "%s", linkError.c_str());
+#endif
 }
 
 
@@ -1364,12 +1370,16 @@ int main(int argc, char **argv)
         std::string errormsg;
         for (size_t i = 0; i < llvmModules.size(); i++)
         {
+#if LDC_LLVM_VER >= 306
+            linker.linkInModule(llvmModules[i], llvm::Linker::DestroySource);
+#else
 #if LDC_LLVM_VER >= 303
             if (linker.linkInModule(llvmModules[i], llvm::Linker::DestroySource, &errormsg))
 #else
             if (linker.LinkInModule(llvmModules[i], &errormsg))
 #endif
                 error(Loc(), "%s", errormsg.c_str());
+#endif
             delete llvmModules[i];
         }
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -403,6 +403,9 @@ LLFunction* DtoInlineIRFunction(FuncDeclaration* fdecl)
             (std::string(err.getColumnNo(), ' ') + '^').c_str(),
             errstr.c_str(), stream.str().c_str());
 
+#if LDC_LLVM_VER >= 306
+    llvm::Linker(gIR->module).linkInModule(m.get());
+#else
 #if LDC_LLVM_VER >= 303
     std::string errstr2 = "";
 #if LDC_LLVM_VER >= 306
@@ -413,6 +416,7 @@ LLFunction* DtoInlineIRFunction(FuncDeclaration* fdecl)
     if(errstr2 != "")
         error(tinst->loc,
             "Error when linking in llvm inline ir: %s", errstr2.c_str());
+#endif
 #endif
 
     LLFunction* fun = gIR->module->getFunction(mangled_name);


### PR DESCRIPTION
The llvm::Linker class now uses diagnostic messages.
