### PR TITLE
Export pure, safe and property to json

### DIFF
--- a/dmd2/func.c
+++ b/dmd2/func.c
@@ -643,7 +643,15 @@ void FuncDeclaration::semantic(Scope *sc)
         tfo->purity     = tfx->purity;
         tfo->trust      = tfx->trust;
 
-        storage_class &= ~(STC_TYPECTOR | STC_FUNCATTR);
+        if (tfo->purity == PUREfwdref) {
+          storage_class |= STCpure;
+        }
+        if (tfo->trust == TRUSTsafe) {
+          storage_class |= STCsafe;
+        }
+        if (tfo->isproperty) {
+          storage_class |= STCproperty;
+        }
     }
 
     f = (TypeFunction *)type;


### PR DESCRIPTION
No idea whether exporting them is the right thing to do (or whether this is the right place to fix it), but unit tests still pass after the dmd-testsuite counterpart (https://github.com/ldc-developers/dmd-testsuite/pull/2). I'm relying on this information to be available in the json, so it'd be nice to have this in the upstream.
