### PR TITLE
Do not emit /DEFAULTLIB:<lib> on mingw

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -431,7 +431,11 @@ public:
     #if LDC_LLVM_VER >= 303
             // With LLVM 3.3 or later we can place the library name in the object
             // file. This seems to be supported only on Windows.
+#if LDC_LLVM_VER >= 305
+            if (global.params.targetTriple.isWindowsMSVCEnvironment())
+#else
             if (global.params.targetTriple.getOS() == llvm::Triple::Win32)
+#endif
             {
                 llvm::SmallString<24> LibName(llvm::StringRef(static_cast<const char *>(se->string), nameLen));
 


### PR DESCRIPTION
Yet another error caused by the new triple handling in LLVM 3.5.
