### PR TITLE
Fix for issue #637.

### DIFF
--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -528,7 +528,7 @@ bool X86_64TargetABI::passByVal(Type* t) {
 void X86_64TargetABI::fixup(IrFuncTyArg& arg) {
     LLType* abiTy = getAbiType(arg.type);
 
-    if (abiTy && abiTy != arg.ltype) {
+    if (abiTy && abiTy != arg.ltype && !arg.byref) {
         assert(arg.type == Type::tcomplex32 || arg.type->ty == Tstruct);
         arg.ltype = abiTy;
         arg.rewrite = &struct_rewrite;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -149,17 +149,8 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
     {
 #if LDC_LLVM_VER >= 303
         llvm::AttrBuilder attrBuilder;
-// Issue 624: In case of a ctor 'this' is passed to the function and is also
-// the return value. This could be a perfect case for the 'Returned' attribute.
-// However the 'this' type and the return type are transformed in different
-// ways, making them bitcast incompatible.
-// Example: extern(C): struct Value { this(string) {} string s; }
-// return type: { i64, i64 }
-// this type:   %ldc_github_624.Value*
-// FIXME: (1) Investigate why the types are handled in different ways
-//        (2) The attributes are cleared by some abi implementations
-//        if (isCtor)
-//            attrBuilder.addAttribute(llvm::Attribute::Returned);
+        if (isCtor)
+            attrBuilder.addAttribute(llvm::Attribute::Returned);
 #endif
         newIrFty.arg_this = new IrFuncTyArg(thistype, thistype->toBasetype()->ty == Tstruct
 #if LDC_LLVM_VER >= 303


### PR DESCRIPTION
In case of a ctor `this` is passed to the function and is also the return value. This is the perfect case for the `Returned` attribute. But the x86_64 ABI missed the fact that the return value was a pointer to a struct and did a struct rewrite, resulting in an bitcast incompatible type.
