### PR TITLE
Fix initialization of TupleExps with static array members.

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2968,7 +2968,7 @@ public:
             Expression *el = (*e->exps)[i];
             DValue* ep = toElem(el);
             LLValue *gep = DtoGEPi(val,0,i);
-            if (el->type->ty == Tstruct)
+            if (DtoIsPassedByRef(el->type))
                 DtoStore(DtoLoad(ep->getRVal()), gep);
             else if (el->type->ty != Tvoid)
                 DtoStoreZextI8(ep->getRVal(), gep);


### PR DESCRIPTION
Just as for structs, `DVarValue::getRVal()` doesn't dereference the
address for these.

GitHub: Fixes #797.
