### PR TITLE
Fix for issue #809.

### DIFF
--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -98,6 +98,8 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
     const size_t n = ad->fields.dim;
     LLSmallVector<VarDeclaration*, 16> data(n, NULL);
 
+    int errors = global.errors;
+
     // first fill in the fields with explicit initializers
     for (size_t index = 0; index < n; ++index)
     {
@@ -136,8 +138,11 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
         }
     }
 
-    if (global.errors)
+    if (errors != global.errors)
     {
+        // There was an overlapping initialization.
+        // Return if errors are gagged otherwise abort.
+        if (global.gag) return;
         fatal();
     }
 


### PR DESCRIPTION
If there are gagged errors then `fatal()` is called in `irtypeaggr.cpp/AggrTypeBuilder::addAggregate()`.
In this case `fatal()` should only be called is there is no error gagging and an overlapping initialization
has been detected.
