### PR TITLE
Add changes related to the llvm::Metadata refactoring in LLVM 3.6.

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -450,8 +450,13 @@ public:
                 LibName = tmp;
 
                 // Embedd library name as linker option in object file
+#if LDC_LLVM_VER >= 306
+                llvm::Metadata *Value = llvm::MDString::get(gIR->context(), LibName);
+                gIR->LinkerMetadataArgs.push_back(llvm::MDNode::get(gIR->context(), Value));
+#else
                 llvm::Value *Value = llvm::MDString::get(gIR->context(), LibName);
                 gIR->LinkerMetadataArgs.push_back(llvm::MDNode::get(gIR->context(), Value));
+#endif
             }
             else
     #endif

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -151,7 +151,12 @@ private:
 #endif
         );
     void AddBaseFields(ClassDeclaration *sd, llvm::DIFile file,
-                         std::vector<llvm::Value*> &elems);
+#if LDC_LLVM_VER >= 306
+                       std::vector<llvm::Metadata*> &elems
+#else
+                       std::vector<llvm::Value*> &elems
+#endif
+                         );
     llvm::DIFile CreateFile(Loc& loc);
     llvm::DIType CreateBasicType(Type *type);
     llvm::DIType CreateEnumType(Type *type);

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -200,7 +200,11 @@ struct IRState
 
 #if LDC_LLVM_VER >= 303
     /// Vector of options passed to the linker as metadata in object file.
+#if LDC_LLVM_VER >= 306
+    llvm::SmallVector<llvm::Metadata *, 5> LinkerMetadataArgs;
+#else
     llvm::SmallVector<llvm::Value *, 5> LinkerMetadataArgs;
+#endif
 #endif
 };
 

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -591,7 +591,12 @@ static void codegenModule(Module* m)
         llvm::NamedMDNode *IdentMetadata = gIR->module->getOrInsertNamedMetadata("llvm.ident");
         std::string Version("ldc version ");
         Version.append(global.ldc_version);
-        llvm::Value *IdentNode[] = {
+#if LDC_LLVM_VER >= 306
+        llvm::Metadata *IdentNode[] =
+#else
+        llvm::Value *IdentNode[] =
+#endif
+        {
             llvm::MDString::get(gIR->context(), Version)
         };
         IdentMetadata->addOperand(llvm::MDNode::get(gIR->context(), IdentNode));

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -294,11 +294,19 @@ namespace {
 
             // Inserting destructor calls is not implemented yet, so classes
             // with destructors are ignored for now.
+#if LDC_LLVM_VER >= 306
+            auto hasDestructor = mdconst::dyn_extract<Constant>(node->getOperand(CD_Finalize));
+#else
             Constant* hasDestructor = dyn_cast<Constant>(node->getOperand(CD_Finalize));
+#endif
             // We can't stack-allocate if the class has a custom deallocator
             // (Custom allocators don't get turned into this runtime call, so
             // those can be ignored)
+#if LDC_LLVM_VER >= 306
+            auto hasCustomDelete = mdconst::dyn_extract<Constant>(node->getOperand(CD_CustomDelete));
+#else
             Constant* hasCustomDelete = dyn_cast<Constant>(node->getOperand(CD_CustomDelete));
+#endif
             if (hasDestructor == NULL || hasCustomDelete == NULL)
                 return false;
 
@@ -306,7 +314,11 @@ namespace {
                     != ConstantInt::getFalse(A.M.getContext()))
                 return false;
 
-            Ty =node->getOperand(CD_BodyType)->getType();
+#if LDC_LLVM_VER >= 306
+            Ty = mdconst::dyn_extract<Constant>(node->getOperand(CD_BodyType))->getType();
+#else
+            Ty = node->getOperand(CD_BodyType)->getType();
+#endif
             return A.DL.getTypeAllocSize(Ty) < SizeLimit;
         }
 
@@ -579,11 +591,19 @@ Type* Analysis::getTypeFor(Value* typeinfo) const {
     if (node->getNumOperands() != TD_NumFields)
         return NULL;
 
+#if LDC_LLVM_VER >= 306
+    Value* ti = llvm::MetadataAsValue::get(node->getContext(), node->getOperand(TD_TypeInfo));
+#else
     Value* ti = node->getOperand(TD_TypeInfo);
+#endif
     if (!ti || ti->stripPointerCasts() != ti_global)
         return NULL;
 
+#if LDC_LLVM_VER >= 306
+    return llvm::MetadataAsValue::get(node->getContext(), node->getOperand(TD_Type))->getType();
+#else
     return node->getOperand(TD_Type)->getType();
+#endif
 }
 
 /// Returns whether Def is used by any instruction that is reachable from Alloc

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -306,9 +306,15 @@ static void emitTypeMetadata(TypeInfoDeclaration *tid)
 
         if (!meta) {
             // Construct the fields
+#if LDC_LLVM_VER >= 306
+            llvm::Metadata* mdVals[TD_NumFields];
+            mdVals[TD_TypeInfo] = llvm::ValueAsMetadata::get(getIrGlobal(tid)->value);
+            mdVals[TD_Type] = llvm::ConstantAsMetadata::get(llvm::UndefValue::get(DtoType(tid->tinfo)));
+#else
             MDNodeField* mdVals[TD_NumFields];
             mdVals[TD_TypeInfo] = llvm::cast<MDNodeField>(getIrGlobal(tid)->value);
             mdVals[TD_Type] = llvm::UndefValue::get(DtoType(tid->tinfo));
+#endif
 
             // Construct the metadata and insert it into the module.
             llvm::NamedMDNode* node = gIR->module->getOrInsertNamedMetadata(metaname);

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -97,10 +97,17 @@ LLGlobalVariable * IrAggr::getClassInfoSymbol()
         bool hasDestructor = (classdecl->dtor != NULL);
         bool hasCustomDelete = (classdecl->aggDelete != NULL);
         // Construct the fields
+#if LDC_LLVM_VER >= 306
+        llvm::Metadata* mdVals[CD_NumFields];
+        mdVals[CD_BodyType] = llvm::ConstantAsMetadata::get(llvm::UndefValue::get(bodyType));
+        mdVals[CD_Finalize] = llvm::ConstantAsMetadata::get(LLConstantInt::get(LLType::getInt1Ty(gIR->context()), hasDestructor));
+        mdVals[CD_CustomDelete] = llvm::ConstantAsMetadata::get(LLConstantInt::get(LLType::getInt1Ty(gIR->context()), hasCustomDelete));
+#else
         MDNodeField* mdVals[CD_NumFields];
         mdVals[CD_BodyType] = llvm::UndefValue::get(bodyType);
         mdVals[CD_Finalize] = LLConstantInt::get(LLType::getInt1Ty(gIR->context()), hasDestructor);
         mdVals[CD_CustomDelete] = LLConstantInt::get(LLType::getInt1Ty(gIR->context()), hasCustomDelete);
+#endif
         // Construct the metadata and insert it into the module.
         llvm::SmallString<64> name;
         llvm::NamedMDNode* node = gIR->module->getOrInsertNamedMetadata(


### PR DESCRIPTION
In LLVM 3.6, the llvm::Metadata hierarchy is distinct from the llvm::Value hierarchy.
This refactoring causes several changes.
