### PR TITLE
Update of deprecated PassManager interface

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -19,7 +19,11 @@
 #include "llvm/Analysis/Verifier.h"
 #endif
 #include "llvm/Bitcode/ReaderWriter.h"
+#if LDC_LLVM_VER >= 307
+#include "llvm/IR/LegacyPassManager.h"
+#elif
 #include "llvm/PassManager.h"
+#endif
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormattedStream.h"
@@ -65,6 +69,9 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module& m,
 
     // Create a PassManager to hold and optimize the collection of passes we are
     // about to build.
+#if LDC_LLVM_VER >= 307
+    legacy::
+#endif
     PassManager Passes;
 
 #if LDC_LLVM_VER >= 306

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Bitcode/ReaderWriter.h"
 #if LDC_LLVM_VER >= 307
 #include "llvm/IR/LegacyPassManager.h"
-#elif
+#else
 #include "llvm/PassManager.h"
 #endif
 #include "llvm/Support/CommandLine.h"

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -360,7 +360,9 @@ llvm::DIType ldc::DIBuilder::CreateCompositeType(Type *type)
     // set diCompositeType to handle recursive types properly
     unsigned tag = (t->ty == Tstruct) ? llvm::dwarf::DW_TAG_structure_type
                                         : llvm::dwarf::DW_TAG_class_type;
-#if LDC_LLVM_VER >= 305
+#if LDC_LLVM_VER >= 307
+    ir->diCompositeType = DBuilder.createReplaceableCompositeType(
+#elif LDC_LLVM_VER >= 305
     ir->diCompositeType = DBuilder.createReplaceableForwardDecl(
 #else
     ir->diCompositeType = DBuilder.createForwardDecl(

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -13,7 +13,11 @@
 #include "gen/logger.h"
 #include "gen/passes/Passes.h"
 #include "llvm/LinkAllPasses.h"
+#if LDC_LLVM_VER >= 307
+#include "llvm/IR/LegacyPassManager.h"
+#else
 #include "llvm/PassManager.h"
+#endif
 #if LDC_LLVM_VER >= 303
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DataLayout.h"
@@ -233,7 +237,11 @@ static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
  * The selection mirrors Clang behavior and is based on LLVM's
  * PassManagerBuilder.
  */
+#if LDC_LLVM_VER >= 307
+static void addOptimizationPasses(legacy::PassManagerBase &mpm, legacy::FunctionPassManager &fpm,
+#elif
 static void addOptimizationPasses(PassManagerBase &mpm, FunctionPassManager &fpm,
+#endif
                                   unsigned optLevel, unsigned sizeLevel) {
     fpm.add(createVerifierPass());                  // Verify that input is correct
 
@@ -322,7 +330,11 @@ bool ldc_optimize_module(llvm::Module *M)
 {
     // Create a PassManager to hold and optimize the collection of
     // per-module passes we are about to build.
+#if LDC_LLVM_VER >= 307
+    legacy::
+#endif
     PassManager mpm;
+
 
 #if LDC_LLVM_VER >= 307
     // Add an appropriate TargetLibraryInfo pass for the module's triple.
@@ -366,7 +378,11 @@ bool ldc_optimize_module(llvm::Module *M)
 #endif
 
     // Also set up a manager for the per-function passes.
+#if LDC_LLVM_VER >= 307
+    legacy::
+#endif
     FunctionPassManager fpm(M);
+
 #if LDC_LLVM_VER >= 307
     // Add internal analysis passes from the target machine.
     fpm.add(createTargetTransformInfoWrapperPass(gTargetMachine->getTargetIRAnalysis()));

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -239,7 +239,7 @@ static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
  */
 #if LDC_LLVM_VER >= 307
 static void addOptimizationPasses(legacy::PassManagerBase &mpm, legacy::FunctionPassManager &fpm,
-#elif
+#else
 static void addOptimizationPasses(PassManagerBase &mpm, FunctionPassManager &fpm,
 #endif
                                   unsigned optLevel, unsigned sizeLevel) {

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -335,7 +335,6 @@ bool ldc_optimize_module(llvm::Module *M)
 #endif
     PassManager mpm;
 
-
 #if LDC_LLVM_VER >= 307
     // Add an appropriate TargetLibraryInfo pass for the module's triple.
     TargetLibraryInfoImpl *tlii = new TargetLibraryInfoImpl(Triple(M->getTargetTriple()));


### PR DESCRIPTION
Update of PassManager interface to match the corresponding deprecation in LLVM's trunk for 3.7