### PR TITLE
Several updates to debug info generation.

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -98,13 +98,13 @@ public:
     /// \returns        the Dwarf subprogram global.
     llvm::DISubprogram EmitSubProgram(FuncDeclaration *fd); // FIXME
 
-    /// \brief Emit the Dwarf subprogram global for a internal function.
+    /// \brief Emit the Dwarf subprogram global for a module ctor.
     /// This is used for generated functions like moduleinfoctors,
     /// module ctors/dtors and unittests.
+    /// \param Fn           llvm::Function pointer.
     /// \param prettyname   The name as seen in the source.
-    /// \param mangledname  The mangled name in the object file.
     /// \returns       the Dwarf subprogram global.
-    llvm::DISubprogram EmitSubProgramInternal(llvm::StringRef prettyname, llvm::StringRef mangledname);  // FIXME
+    llvm::DISubprogram EmitModuleCTor(llvm::Function* Fn, llvm::StringRef prettyname);  // FIXME
 
     /// \brief Emits debug info for function start
     void EmitFuncStart(FuncDeclaration *fd);
@@ -169,7 +169,7 @@ private:
     llvm::DIType CreateAArrayType(Type *type);
     DIFunctionType CreateFunctionType(Type *type);
     DIFunctionType CreateDelegateType(Type *type);
-    llvm::DIType CreateTypeDescription(Type* type, const char* c_name, bool derefclass = false);
+    llvm::DIType CreateTypeDescription(Type* type, bool derefclass = false);
 
 public:
     template<typename T>

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -190,8 +190,8 @@ static llvm::Function* build_module_function(const std::string &name, const std:
             return getIrFunc(funcs.front())->func;
     }
 
-    std::vector<LLType*> argsTy;
-    LLFunctionType* fnTy = LLFunctionType::get(LLType::getVoidTy(gIR->context()),argsTy,false);
+    // build ctor type
+    LLFunctionType* fnTy = LLFunctionType::get(LLType::getVoidTy(gIR->context()), std::vector<LLType*>(), false);
 
     std::string const symbolName = gABI->mangleForLLVM(name, LINKd);
     assert(gIR->module->getFunction(symbolName) == NULL);
@@ -203,7 +203,7 @@ static llvm::Function* build_module_function(const std::string &name, const std:
     IRBuilder<> builder(bb);
 
     // debug info
-    gIR->DBuilder.EmitSubProgramInternal(name.c_str(), symbolName.c_str());
+    gIR->DBuilder.EmitModuleCTor(fn, name.c_str());
 
     // Call ctor's
     typedef std::list<FuncDeclaration*>::const_iterator FuncIterator;
@@ -319,7 +319,7 @@ static LLFunction* build_module_reference_and_ctor(LLConstant* moduleinfo)
     IRBuilder<> builder(bb);
 
     // debug info
-    gIR->DBuilder.EmitSubProgramInternal(fname.c_str(), fname.c_str());
+    gIR->DBuilder.EmitModuleCTor(ctor, fname.c_str());
 
     // get current beginning
     LLValue* curbeg = builder.CreateLoad(mref, "current");
@@ -569,9 +569,6 @@ static void codegenModule(Module* m)
 
     if (global.errors) return;
 
-    // finalize debug info
-    gIR->DBuilder.EmitModuleEnd();
-
     // Skip emission of all the additional module metadata if requested by the user.
     if (!m->noModuleInfo)
     {
@@ -602,6 +599,9 @@ static void codegenModule(Module* m)
         IdentMetadata->addOperand(llvm::MDNode::get(gIR->context(), IdentNode));
     #endif
     }
+
+    // finalize debug info
+    gIR->DBuilder.EmitModuleEnd();
 
     // verify the llvm
     verifyModule(*gIR->module);


### PR DESCRIPTION
- Do not create debug info after we called finalize.
- Clean up debug info generation for module ctor/dtor.
- Rename EmitSubProgramInternal() to EmitModuleCTor().
- Remove unused parameter from CreateTypeDescription().