### PR TITLE
Fix issue 825: Correct size for TypeVector.

### DIFF
--- a/dmd2/mtype.c
+++ b/dmd2/mtype.c
@@ -217,6 +217,7 @@ void Type::init()
     sizeTy[Treturn] = sizeof(TypeReturn);
     sizeTy[Terror] = sizeof(TypeError);
     sizeTy[Tnull] = sizeof(TypeNull);
+    sizeTy[Tvector] = sizeof(TypeVector);
 
     mangleChar[Tarray] = 'A';
     mangleChar[Tsarray] = 'G';


### PR DESCRIPTION
Since ```sizeof(TypeVector)``` < ```sizeof(TypeBasic)```.
When using ```Type::nullAttributes``` to create a new ```TypeVector```, it will read (```sizeof(TypeBasic)``` - ```sizeof(TypeVector)``` ) past the end of the source ```TypeVector``` if it was allocated with the actual size e.g. with ```new TypeVector```.

Do I create a PR for both LDC and DMD, or just for DMD?