### PR TITLE
Do not add leading underscore to naked asm functionname for MinGW64

### DIFF
--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -196,7 +196,8 @@ void DtoDefineNakedFunction(FuncDeclaration* fd)
     {
         std::string fullMangle;
 #if LDC_LLVM_VER >= 305
-        if (global.params.targetTriple.isWindowsGNUEnvironment())
+        if ( global.params.targetTriple.isWindowsGNUEnvironment() 
+             && !global.params.targetTriple.isArch64Bit() )
 #else
         if (global.params.targetTriple.getOS() == llvm::Triple::MinGW32)
 #endif


### PR DESCRIPTION
This only concerns MinGW64.
Currently, naked asm functions [*] get a leading underscore in LLVM IR output. However, the call to the function is using the name without extra leading underscore. This seems to work fine on MinGW32, but gives unresolved symbol linker errors on MinGW64. This PR fixes that.
Together with the PR for druntime, I can now successfully build and execute Hello World!

isWindowsGNUEnvironment()  is true for Mingw32 and Mingw64. Here I added the extra check that the arch is not 64bit, so that the if-statement body (adding a leading underscore) is not executed for Mingw64.
The check for LLVM < 3.5 seems to explicitly check for MinGW32. I have LLVM 3.7 (trunk).

[*] e.g. :

    real ldexp(real n, int exp) {
        asm {
            naked;
            push RCX;
             ...