### PR TITLE
Fix for issue #841.

### DIFF
--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -86,10 +86,9 @@ llvm::Constant * IrAggr::getDefaultInit()
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-static bool isAligned(llvm::Type* type, size_t offset) {
-    if (offset == 0)
-        return true;
-    return gDataLayout->getABITypeAlignment(type) % offset == 0;
+static bool isAligned(llvm::Type* type, size_t Offset) {
+    unsigned TyAlign = gDataLayout->getABITypeAlignment(type);
+    return (Offset & (TyAlign-1)) == 0;
 }
 
 // helper function that adds zero bytes to a vector of constants
@@ -98,9 +97,11 @@ size_t add_zeros(llvm::SmallVectorImpl<llvm::Constant*>& constants,
 {
     size_t const oldLength = constants.size();
 
-    llvm::Type* const eightByte = llvm::Type::getInt64Ty(gIR->context());
-    llvm::Type* const fourByte = llvm::Type::getInt32Ty(gIR->context());
-    llvm::Type* const twoByte = llvm::Type::getInt16Ty(gIR->context());
+    llvm::LLVMContext& context = gIR->context();
+    llvm::Type* const eightByte = llvm::Type::getInt64Ty(context);
+    llvm::Type* const fourByte = llvm::Type::getInt32Ty(context);
+    llvm::Type* const twoByte = llvm::Type::getInt16Ty(context);
+    llvm::Type* const oneByte = llvm::Type::getInt8Ty(context);
 
     assert(startOffset <= endOffset);
     size_t paddingLeft = endOffset - startOffset;
@@ -123,8 +124,7 @@ size_t add_zeros(llvm::SmallVectorImpl<llvm::Constant*>& constants,
         }
         else
         {
-            constants.push_back(llvm::Constant::getNullValue(
-                llvm::Type::getInt8Ty(gIR->context())));
+            constants.push_back(llvm::Constant::getNullValue(oneByte));
             startOffset += 1;
         }
 

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -252,6 +252,7 @@ IrTypeAggr::IrTypeAggr(AggregateDeclaration * ad)
 
 bool IrTypeAggr::isPacked(AggregateDeclaration* ad)
 {
+    if (ad->isUnionDeclaration()) return true;
     for (unsigned i = 0; i < ad->fields.dim; i++)
     {
         VarDeclaration* vd = static_cast<VarDeclaration*>(ad->fields.data[i]);


### PR DESCRIPTION
The `union` is not created as packed type. This seems to create problems with the default initializer:

    struct Foo
    {
        static union Bar
        {
            bool b;
            ulong l;
        }

        Bar bar;
    }

    static this()
    {
        Foo foo = Foo();
    }

creates an error. If you change the order inside the union

        static union Bar
        {
            ulong l;
            bool b;
        }

then the code works.

Also cleans up the creation of the additonal zeroes for the initializer.