### PR TITLE
Skip erroneous creation of implicit initializers for zero-length array in aggregates

### DIFF
--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -297,6 +297,14 @@ void IrAggr::addFieldInitializers(
         unsigned vd_begin = vd->offset;
         unsigned vd_end = vd_begin + vd->type->size();
 
+        /* Skip zero size fields like zero-length static arrays, LDC issue 812:
+            class B {
+                ubyte[0] test;
+            }
+        */
+        if (vd_begin == vd_end)
+            continue;
+
         // make sure it doesn't overlap any explicit initializers.
         bool overlaps = false;
         if (type->ty == Tstruct)


### PR DESCRIPTION
Fixes issue #812 .

I will create a separate PR that adds a testcase to the testsuite. I do not know how to combine PRs across submodules (I actually have to figure out how to effectively work with submodule branches at all...).