### PR TITLE
Watch out for functions returning "ref void".

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -80,6 +80,7 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
     else
     {
         Type* rt = f->next;
+        const bool byref = f->isref && rt->toBasetype()->ty != Tvoid;
         AttrBuilder attrBuilder;
 
         // sret return
@@ -93,12 +94,9 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
         // sext/zext return
         else
         {
-            Type *t = rt;
-            if (f->isref)
-                t = t->pointerTo();
-            attrBuilder.add(DtoShouldExtend(t));
+            attrBuilder.add(DtoShouldExtend(byref ? rt->pointerTo() : rt));
         }
-        newIrFty.ret = new IrFuncTyArg(rt, f->isref, attrBuilder);
+        newIrFty.ret = new IrFuncTyArg(rt, byref, attrBuilder);
     }
     lidx++;
 


### PR DESCRIPTION
The 2.067 front-end doesn't rewrite these to void anymore, so let's rewrite in ```DtoFunctionType()```.

This issue has surfaced in a ```std.conv``` unit test, where ```std.range.primitives.front()``` is instantiated for ```const(void)[]```. The void return expression is swallowed by the front-end, so that ```return a[0];``` is rewritten to an empty ```return;``` statement. Our LL version of the ref-void function returns an i8*...
The ```front()``` template refuses ```void[]``` but accepts this ```const(void)[]```...