### PR TITLE
Fix a serious front-end issue...

### DIFF
--- a/dmd2/expression.c
+++ b/dmd2/expression.c
@@ -13678,6 +13678,9 @@ Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
     CondExp *e = (CondExp *)copy();
     e->e1 = e1->toLvalue(sc, NULL)->addressOf();
     e->e2 = e2->toLvalue(sc, NULL)->addressOf();
+#if IN_LLVM
+    e->type = type->pointerTo();
+#endif
     return new PtrExp(loc, e, type);
 }
 


### PR DESCRIPTION
... when converting conditional expressions to lvalues.

DMD2, 2.066:
```cpp
Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
{
    // convert (econd ? e1 : e2) to *(econd ? &e1 : &e2)
    PtrExp *e = new PtrExp(loc, this, type);
    e1 = e1->toLvalue(sc, NULL)->addressOf();
    e2 = e2->toLvalue(sc, NULL)->addressOf();
    type = e2->type;
    return e;
}
```
2.067:
```cpp
Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
{
    // convert (econd ? e1 : e2) to *(econd ? &e1 : &e2)
    CondExp *e = (CondExp *)copy();
    e->e1 = e1->toLvalue(sc, NULL)->addressOf();
    e->e2 = e2->toLvalue(sc, NULL)->addressOf();
    return new PtrExp(loc, e, type);
}
```
In 2.066, the conditional expression itself is modified after calling toLvalue() (incl. its type from T to T*).
This has been improved in 2.067 by using a modified copy for the injected PtrExp. The type though isn't changed anymore!

If that's really a front-end issue I wonder why it's still unchanged in current DMD master and 2.067.
Will open an upstream PR if it really is.

With this, only the std.base64 and std.typecons phobos tests fail to compile on Linux x64.