### PR TITLE
Generate missing TypeInfo initZ symbols

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -154,8 +154,16 @@ TypeInfoDeclaration *getTypeInfoDeclaration(Type *t)
 
 static bool builtinTypeInfo(Type *t)
 {
+#if 0
+    // FIXME if I enable for Tclass, the way LDC does typeinfo will cause a
+    // bunch of linker errors to missing class typeinfo definitions.
     if (t->isTypeBasic() || t->ty == Tclass)
         return !t->mod;
+#else
+    if (t->isTypeBasic())
+        return !t->mod;
+#endif
+
     if (t->ty == Tarray)
     {
         Type *next = t->nextOf();


### PR DESCRIPTION
This change prevents a bunch of missing class TypeInfo definitions when linking.

It restores the previous TypeClass::builtinTypeInfo() logic that always returns false (the IN_LLVM path below) for Tclass and puts back in a relevant FIXME comment in case there are still plans to revisit this.

Old version for reference:
```C++
int TypeClass::builtinTypeInfo()
{
    /* This is statically put out with the ClassInfo, so
     * claim it is built in so it isn't regenerated by each module.
     */
#if IN_DMD
    return mod ? 0 : 1;
#elif IN_LLVM
    // FIXME if I enable this, the way LDC does typeinfo will cause a bunch
    // of linker errors to missing class typeinfo definitions.
    return 0;
#endif
}
```