### PR TITLE
Call _d_delstruct() runtime function when deleting struct pointers.

### DIFF
--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -34,9 +34,10 @@ struct EnclosingTryFinally
 
 // dynamic memory helpers
 LLValue* DtoNew(Loc& loc, Type* newtype);
-void DtoDeleteMemory(Loc& loc, LLValue* ptr);
-void DtoDeleteClass(Loc& loc, LLValue* inst);
-void DtoDeleteInterface(Loc& loc, LLValue* inst);
+void DtoDeleteMemory(Loc& loc, DValue* ptr);
+void DtoDeleteStruct(Loc& loc, DValue* ptr);
+void DtoDeleteClass(Loc& loc, DValue* inst);
+void DtoDeleteInterface(Loc& loc, DValue* inst);
 void DtoDeleteArray(Loc& loc, DValue* arr);
 
 // emit an alloca

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -82,6 +82,7 @@ static void checkForImplicitGCCall(const Loc &loc, const char *name)
             "_d_callfinalizer",
             "_d_delarray_t",
             "_d_delclass",
+            "_d_delstruct",
             "_d_delinterface",
             "_d_delmemory",
             "_d_newarrayT",
@@ -535,6 +536,14 @@ static void LLVM_D_BuildRuntimeModule()
     {
         llvm::StringRef fname("_d_delclass");
         LLType *types[] = { rt_ptr(objectTy) };
+        LLFunctionType* fty = llvm::FunctionType::get(voidTy, types, false);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
+    }
+
+    // void _d_delstruct(void** p, TypeInfo_Struct inf)
+    {
+        llvm::StringRef fname("_d_delstruct");
+        LLType *types[] = { rt_ptr(voidPtrTy), DtoType(Type::typeinfostruct->type) };
         LLFunctionType* fty = llvm::FunctionType::get(voidTy, types, false);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
     }


### PR DESCRIPTION
As long as the struct has a dtor, otherwise continue forwarding to `_d_delmemory()`.

I've also refactored the `DtoDelete*()` helper functions to take D values instead of LL ones, so that the caller doesn't need to know whether to pass in a LL lvalue or rvalue.