### PR TITLE
Don't try to invoke non-existent dtors when deleting dynamic arrays.

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1995,7 +1995,7 @@ public:
         if (et->ty == Tpointer)
         {
             Type* elementType = et->nextOf()->toBasetype();
-            if (elementType->ty == Tstruct && static_cast<TypeStruct*>(elementType)->sym->dtor)
+            if (elementType->ty == Tstruct && elementType->needsDestruction())
                 DtoDeleteStruct(e->loc, dval);
             else
                 DtoDeleteMemory(e->loc, dval);


### PR DESCRIPTION
Runtime function `_d_delarray_t()` expects the `TypeInfo_Struct` argument to be null if the struct has no dtor.

This fixes `runnable/hospital.d`, which deletes a dynamic array of class handles (i.e., we've previously cast the element's ClassInfo to a TypeInfo_Struct and then attempted to call the StructInfo's xdtor (luckily mapping to the ClassInfo dtor apparently), additionally with an incorrect pointer argument... ;)). This patch only deletes the memory allocated for the handles and doesn't destruct the actual class instances!
For `hospital.d`, it doesn't matter as the class has no dtor.

There seem to be more GC related issues uncovered by the `rt.lifetime` tests. E.g., `GC.runFinalizers()` won't invoke dtors of structs allocated on the heap and probably neither those of class objects. We apparently also don't use `_d_newitemT/_d_newitemiT` (instead, `_d_allocmemory`) to allocate structs on the heap (in `gen/toir.cpp`, `visit(NewExp*)`), which could be a possibly related issue.