### PR TITLE
Add Coverage Analysis (à la DMD)

### DIFF
--- a/dmd2/mars.h
+++ b/dmd2/mars.h
@@ -170,8 +170,6 @@ struct Param
 #else
     bool pic;           // generate position-independent-code for shared libs
     bool color;         // use ANSI colors in console output
-    bool cov;           // generate code coverage data
-    unsigned char covPercent;   // 0..100 code coverage percentage required
     bool nofloat;       // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;      // rather than error on them
     bool enforcePropertySyntax;
@@ -179,6 +177,9 @@ struct Param
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
 #endif
+
+    bool cov;           // generate code coverage data
+    unsigned char covPercent;   // 0..100 code coverage percentage required
 
     const char *argv0;    // program name
     Strings *imppath;     // array of char*'s of where to look for import modules

--- a/dmd2/module.c
+++ b/dmd2/module.c
@@ -147,6 +147,8 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
     this->doDocComment = doDocComment;
     this->doHdrGen = doHdrGen;
     this->arrayfuncs = 0;
+    d_cover_valid = NULL;
+    d_cover_data = NULL;
 #endif
 }
 

--- a/dmd2/module.h
+++ b/dmd2/module.h
@@ -214,6 +214,11 @@ public:
 
     // array ops emitted in this module already
     AA *arrayfuncs;
+
+    // Coverage analysis
+    llvm::GlobalVariable* d_cover_valid;  // private immutable size_t[] _d_cover_valid;
+    llvm::GlobalVariable* d_cover_data;   // private uint[] _d_cover_data;
+    std::vector<size_t> d_cover_valid_init; // initializer for _d_cover_valid
 #endif
 
     Module *isModule() { return this; }

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -23,6 +23,34 @@
 
 namespace opts {
 
+/* Option parser that defaults to zero when no explicit number is given.
+ * i.e.:  -cov    --> value = 0
+ *        -cov=9  --> value = 9
+ *        -cov=101 --> error, value must be in range [0..100]
+ */ 
+struct CoverageParser : public cl::parser<unsigned char> {
+#if LDC_LLVM_VER >= 307
+    CoverageParser(cl::Option &O) : cl::parser<unsigned char>(O) {}
+#endif
+
+    bool parse(cl::Option &O, llvm::StringRef ArgName, llvm::StringRef Arg, unsigned char &Val)
+    {
+        if (Arg == "") {
+            Val = 0;
+            return false;
+        }
+
+        if (Arg.getAsInteger(0, Val))
+            return O.error("'" + Arg + "' value invalid for required coverage percentage");
+
+        if (Val > 100) {
+            return O.error("Required coverage percentage must be <= 100");
+        }
+        return false;
+    }
+};
+
+
 // Positional options first, in order:
 cl::list<std::string> fileList(
     cl::Positional, cl::desc("files"));
@@ -411,6 +439,12 @@ cl::opt<bool, true> vgc("vgc",
 cl::opt<bool, true, FlagParser> color("color",
     cl::desc("Force colored console output"),
     cl::location(global.params.color));
+
+cl::opt<unsigned char, true, CoverageParser> coverageAnalysis("cov",
+    cl::desc("Compile-in code coverage analysis\n(use -cov=n for n% minimum required coverage)"),
+    cl::location(global.params.covPercent),
+    cl::ValueOptional,
+    cl::init(127));
 
 static cl::extrahelp footer("\n"
 "-d-debug can also be specified without options, in which case it enables all\n"

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -234,11 +234,10 @@ Usage:\n\
   files.d        D source files\n\
   @cmdfile       read arguments from cmdfile\n\
   -c             do not link\n\
-  -color[=on|off]   force colored console output on or off\n"
-#if 0
-"  -cov           do code coverage analysis\n"
-#endif
-"  -D             generate documentation\n\
+  -color[=on|off]   force colored console output on or off\n\
+  -cov           do code coverage analysis\n\
+  -cov=nnn       require at least nnn%% code coverage\n\
+  -D             generate documentation\n\
   -Dddocdir      write documentation file to docdir directory\n\
   -Dffilename    write documentation file to filename\n\
   -d             allow deprecated features\n\
@@ -599,7 +598,10 @@ Params parseArgs(size_t originalArgc, char** originalArgv, const std::string &ld
                     goto Lerror;
             }
             else if (strcmp(p + 1, "cov") == 0)
-                result.coverage = true;
+                // For "-cov=...", the whole cmdline switch is forwarded to LDC.
+                // For plain "-cov", the cmdline switch must be explicitly forwarded
+                // and result.coverage must be set to true to that effect.
+                result.coverage = (p[4] != '=');
             else if (strcmp(p + 1, "shared") == 0
                 // backwards compatibility with old switch
                 || strcmp(p + 1, "dylib") == 0
@@ -935,7 +937,7 @@ void buildCommandLine(std::vector<const char*>& r, const Params& p)
 {
     if (p.allowDeprecated) r.push_back("-d");
     if (p.compileOnly) r.push_back("-c");
-    if (p.coverage) warning("Coverage report generation not yet supported by LDC.");
+    if (p.coverage) r.push_back("-cov");
     if (p.emitSharedLib) r.push_back("-shared");
     if (p.pic) r.push_back("-relocation-model=pic");
     if (p.emitMap) warning("Map file generation not yet supported by LDC.");

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -373,6 +373,8 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles, bool &
     global.params.output_ll = opts::output_ll ? OUTPUTFLAGset : OUTPUTFLAGno;
     global.params.output_s  = opts::output_s  ? OUTPUTFLAGset : OUTPUTFLAGno;
 
+    global.params.cov = (global.params.covPercent <= 100);
+
     templateLinkage =
         opts::linkonceTemplates ? LLGlobalValue::LinkOnceODRLinkage
                                 : LLGlobalValue::WeakODRLinkage;

--- a/gen/coverage.cpp
+++ b/gen/coverage.cpp
@@ -1,0 +1,51 @@
+//===-- gen/coverage.h - Code Coverage Analysis -----------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/coverage.h"
+
+#include "mars.h"
+#include "module.h"
+#include "gen/irstate.h"
+#include "gen/logger.h"
+
+void emitCoverageLinecountInc(Loc &loc) {
+    // Only emit coverage increment for locations in the source of the current module
+    // (for example, 'inlined' methods from other source files should be skipped).
+    if ( global.params.cov && (loc.linnum != 0) && loc.filename
+         && (gIR->module->getModuleIdentifier().compare(loc.filename) == 0) )
+    {
+        unsigned line = loc.linnum-1; // convert to 0-based line# index
+        assert(line < gIR->dmodule->numlines);
+        {
+            IF_LOG Logger::println("Coverage: increment _d_cover_data[%d]", line);
+
+            // Get GEP into _d_cover_data array
+            LLConstant* idxs[] = { DtoConstUint(0), DtoConstUint(line) };
+            LLValue* ptr = llvm::ConstantExpr::getGetElementPtr(gIR->dmodule->d_cover_data, idxs, true);
+
+            // Do an atomic increment, so this works when multiple threads are executed.
+            gIR->ir->CreateAtomicRMW(
+               llvm::AtomicRMWInst::Add,
+               ptr,
+               DtoConstUint(1),
+               llvm::Monotonic
+            );
+        }
+
+        {
+            unsigned num_sizet_bits = gDataLayout->getTypeSizeInBits(DtoSize_t());
+            unsigned idx = line / num_sizet_bits;
+            unsigned bitidx = line % num_sizet_bits;
+            
+            IF_LOG Logger::println("          _d_cover_valid[%d] |= (1 << %d)", idx, bitidx);
+
+            gIR->dmodule->d_cover_valid_init[idx] |= (size_t(1) << bitidx);
+        }
+    }
+}

--- a/gen/coverage.h
+++ b/gen/coverage.h
@@ -1,0 +1,22 @@
+//===-- gen/coverage.h - Code Coverage Analysis -----------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains functions to generate code for code coverage analysis.
+// The coverage analysis is enabled by the "-cov" commandline switch.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_GEN_COVERAGE_H
+#define LDC_GEN_COVERAGE_H
+
+struct Loc;
+
+void emitCoverageLinecountInc(Loc &loc);
+
+#endif

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -1021,4 +1021,21 @@ static void LLVM_D_BuildRuntimeModule()
         llvm::FunctionType* fty = llvm::FunctionType::get(voidTy, params, false);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
     }
+
+    // extern (C) void _d_cover_register2(string filename, size_t[] valid, uint[] data, ubyte minPercent)
+    // as defined in druntime/rt/cover.d.
+    if (global.params.cov) {
+        llvm::StringRef fname("_d_cover_register2");
+
+        LLType* params[] = {
+            stringTy,
+            rt_array(sizeTy),
+            rt_array(intTy),
+            byteTy
+        };
+
+        LLFunctionType* fty = LLFunctionType::get(voidTy, params, false);
+        llvm::Function* fn = LLFunction::Create(fty, LLGlobalValue::ExternalLinkage, fname, M);
+        fn->setCallingConv(gABI->callingConv(LINKc));
+    }
 }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -22,6 +22,7 @@
 #include "gen/arrays.h"
 #include "gen/classes.h"
 #include "gen/complex.h"
+#include "gen/coverage.h"
 #include "gen/dvalue.h"
 #include "gen/functions.h"
 #include "gen/irstate.h"
@@ -2125,6 +2126,7 @@ public:
         llvm::BranchInst::Create(andand, andandend, ubool, p->scopebb());
 
         p->scope() = IRScope(andand, andandend);
+        emitCoverageLinecountInc(e->e2->loc);
         DValue* v = toElemDtor(e->e2);
 
         LLValue* vbool = 0;
@@ -2172,6 +2174,7 @@ public:
         llvm::BranchInst::Create(ororend,oror,ubool,p->scopebb());
 
         p->scope() = IRScope(oror, ororend);
+        emitCoverageLinecountInc(e->e2->loc);
         DValue* v = toElemDtor(e->e2);
 
         LLValue* vbool = 0;


### PR DESCRIPTION
This PR adds coverage analysis to LDC2 (cmdline option -cov[=n%]), equal to DMD's coverage analysis (http://dlang.org/code_coverage.html).

Two data structures are added to the module object file for coverage analysis: _d_cover_data and _d_cover_valid. _d_cover_data is an array of the execution count for each line of code (the execution count is atomically incremented at the start of each statement). _d_cover_valid is a bit-array that for each line says whether there is a statement on that line for which the execution count must be printed.
Each module compiled with -cov is registered for coverage output by calling _d_cover_register2() in druntime/rt/cover.d, passing _d_cover_data and _d_cover_valid. Then, druntime will take care of outputting the coverage listing. _d_cover_register2() is called by a shared static constructor.

There is a bug in druntime's interface of _d_cover_register2(). The _d_cover_valid bit array must be passed as a "size_t[] valid", however, the length field of the slice must be the number of bits in the array (number of lines). I will submit a PR to druntime to fix this, but do not know if it will be accepted. The code in this PR is very conservative and creates an oversized array for _d_cover_valid, such that the slice length field is equal to (at least) number of lines.

Tested using MSVC, x64.