### PR TITLE
Fix for issue #855.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1393,7 +1393,7 @@ int main(int argc, char **argv)
 #endif
 
         std::string errormsg;
-#if LDC_LLVM_VER >= 306
+#if LDC_LLVM_VER >= 305
         for (size_t i = 1; i < llvmModules.size(); i++)
 #else
         for (size_t i = 0; i < llvmModules.size(); i++)


### PR DESCRIPTION
If several modules are linked together, an empty module is used as
target. Starting with LLVM 3.6, there seems to be a slight difference
between an empty module and a module with IR.
The PR uses always the first module as the target. This has the nice
side effect that we are no longer affected by LLVM bug 11479.