### PR TITLE
Allocate structs on the heap via runtime function _d_newitem.

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -74,6 +74,15 @@ LLValue* DtoNew(Loc& loc, Type* newtype)
     return DtoBitCast(mem, getPtrToType(i1ToI8(DtoType(newtype))), ".gc_mem");
 }
 
+LLValue* DtoNewStruct(Loc& loc, TypeStruct* newtype)
+{
+    llvm::Function* fn = LLVM_D_GetRuntimeFunction(loc, gIR->module,
+        newtype->isZeroInit(newtype->sym->loc) ? "_d_newitemT" : "_d_newitemiT");
+    LLConstant* ti = DtoTypeInfoOf(newtype);
+    LLValue* mem = gIR->CreateCallOrInvoke(fn, ti, ".gc_struct").getInstruction();
+    return DtoBitCast(mem, getPtrToType(i1ToI8(DtoType(newtype))), ".gc_struct");
+}
+
 void DtoDeleteMemory(Loc& loc, DValue* ptr)
 {
     // get runtime function

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -34,6 +34,7 @@ struct EnclosingTryFinally
 
 // dynamic memory helpers
 LLValue* DtoNew(Loc& loc, Type* newtype);
+LLValue* DtoNewStruct(Loc& loc, TypeStruct* newtype);
 void DtoDeleteMemory(Loc& loc, DValue* ptr);
 void DtoDeleteStruct(Loc& loc, DValue* ptr);
 void DtoDeleteClass(Loc& loc, DValue* inst);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -91,6 +91,8 @@ static void checkForImplicitGCCall(const Loc &loc, const char *name)
             "_d_newarraymiT",
             "_d_newarrayU",
             "_d_newclass",
+            "_d_newitemT",
+            "_d_newitemiT",
         };
 
         if (binary_search(&GCNAMES[0], &GCNAMES[sizeof(GCNAMES) / sizeof(std::string)], name))
@@ -502,6 +504,19 @@ static void LLVM_D_BuildRuntimeModule()
         LLType *types[] = { classInfoTy };
         LLFunctionType* fty = llvm::FunctionType::get(objectTy, types, false);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M)
+            ->setAttributes(Attr_NoAlias);
+    }
+
+    // void* _d_newitemT (TypeInfo ti)
+    // void* _d_newitemiT(TypeInfo ti)
+    {
+        llvm::StringRef fname ("_d_newitemT");
+        llvm::StringRef fname2("_d_newitemiT");
+        LLType *types[] = { typeInfoTy };
+        LLFunctionType* fty = llvm::FunctionType::get(voidPtrTy, types, false);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M)
+            ->setAttributes(Attr_NoAlias);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname2, M)
             ->setAttributes(Attr_NoAlias);
     }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1895,6 +1895,9 @@ public:
         else if (ntype->ty == Tstruct)
         {
             IF_LOG Logger::println("new struct on heap: %s\n", e->newtype->toChars());
+
+            TypeStruct* ts = static_cast<TypeStruct*>(ntype);
+
             // allocate
             LLValue* mem = 0;
             if (e->allocator)
@@ -1908,10 +1911,8 @@ public:
             else
             {
                 // default allocator
-                mem = DtoNew(e->loc, e->newtype);
+                mem = DtoNewStruct(e->loc, ts);
             }
-
-            TypeStruct* ts = static_cast<TypeStruct*>(ntype);
 
             if (!e->member && e->arguments)
             {
@@ -1920,16 +1921,6 @@ public:
             }
             else
             {
-                // init
-                if (ts->isZeroInit(ts->sym->loc)) {
-                    DtoAggrZeroInit(mem);
-                }
-                else {
-                    assert(ts->sym);
-                    DtoResolveStruct(ts->sym, e->loc);
-                    DtoAggrCopy(mem, getIrAggr(ts->sym)->getInitSymbol());
-                }
-
                 // set nested context
                 if (ts->sym->isNested() && ts->sym->vthis)
                     DtoResolveNestedContext(e->loc, ts->sym, mem);


### PR DESCRIPTION
This is required for the GC to be able to call their dtors, if need be (by appending a `TypeInfo` pointer after the actual struct in case the struct has a dtor).

`_d_newitemT()` / `_d_newitemiT()` also perform the initialization, so we don't need to take care of that in `toir.cpp` anymore.