### PR TITLE
Add new dmd -verrors option

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -70,6 +70,10 @@ static cl::opt<bool, true> verbose_cg("v-cg",
     cl::ZeroOrMore,
     cl::location(global.params.verbose_cg));
 
+static cl::opt<unsigned, true> errorLimit("verrors",
+    cl::desc("limit the number of error messages (0 means unlimited)"),
+    cl::location(global.errorLimit));
+
 static cl::opt<ubyte, true> warnings(
     cl::desc("Warnings:"),
     cl::ZeroOrMore,


### PR DESCRIPTION
Implement dmd `-verrors` option in ldc2 and ldmd2.  This also fixes the dmd-testsuite failures that use `-verrors` missing.