### PR TITLE
[WIP] Implement cent/ucent data types.

### DIFF
--- a/dmd2/constfold.c
+++ b/dmd2/constfold.c
@@ -648,6 +648,16 @@ UnionExp Shr(Type *type, Expression *e1, Expression *e2)
                 value = (d_uns64)(value) >> count;
                 break;
 
+#if WANT_CENT
+        case Tint128:
+                value = (d_int128)(value) >> count;
+                break;
+
+        case Tuns128:
+                value = (d_uns128)(value) >> count;
+                break;
+#endif
+
         case Terror:
                 new(&ue) ErrorExp();
                 return ue;
@@ -690,10 +700,22 @@ UnionExp Ushr(Type *type, Expression *e1, Expression *e2)
                 value = (value & 0xFFFFFFFF) >> count;
                 break;
 
+#if WANT_CENT
+        case Tint64:
+        case Tuns64:
+                value = (value & 0xFFFFFFFFFFFFFFFF) >> count;
+                break;
+
+        case Tint128:
+        case Tuns128:
+                value = (d_uns128)(value) >> count;
+                break;
+#else
         case Tint64:
         case Tuns64:
                 value = (d_uns64)(value) >> count;
                 break;
+#endif
 
         case Terror:
                 new(&ue) ErrorExp();
@@ -1258,6 +1280,10 @@ L1:
                 case Tuns32:    result = (d_uns32)r;    break;
                 case Tint64:    result = (d_int64)r;    break;
                 case Tuns64:    result = (d_uns64)r;    break;
+#if WANT_CENT
+                case Tint128:   result = (d_int128)r;   break;
+                case Tuns128:   result = (d_uns128)r;   break;
+#endif
                 default:
                     assert(0);
             }

--- a/dmd2/ctfeexpr.c
+++ b/dmd2/ctfeexpr.c
@@ -1119,6 +1119,17 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
             case Tuns64:
                 result = (d_uns64)(value) >> count;
                 break;
+
+#if WANT_CENT
+            case Tint128:
+                result = (d_int128)(value) >> count;
+                break;
+
+            case Tuns128:
+                result = (d_uns128)(value) >> count;
+                break;
+#endif
+
             default:
                 assert(0);
         }
@@ -1152,10 +1163,22 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
                 result = (value & 0xFFFFFFFF) >> count;
                 break;
 
+#if WANT_CENT
+            case Tint64:
+            case Tuns64:
+                result = (value & 0xFFFFFFFFFFFFFFFF) >> count;
+                break;
+
+            case Tint128:
+            case Tuns128:
+                result = (d_uns128)(value) >> count;
+                break;
+#else
             case Tint64:
             case Tuns64:
                 result = (d_uns64)(value) >> count;
                 break;
+#endif
 
             default:
                 assert(0);

--- a/dmd2/expression.c
+++ b/dmd2/expression.c
@@ -2866,6 +2866,10 @@ void IntegerExp::normalize()
         case Tuns32:        value = (d_uns32) value;        break;
         case Tint64:        value = (d_int64) value;        break;
         case Tuns64:        value = (d_uns64) value;        break;
+#if WANT_CENT
+        case Tint128:       value = (d_int128) value;       break;
+        case Tuns128:       value = (d_uns128) value;       break;
+#endif
         case Tpointer:
             if (Target::ptrsize == 4)
                 value = (d_uns32) value;

--- a/dmd2/globals.h
+++ b/dmd2/globals.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "longdouble.h"
+#include "int128.h"
 #include "outbuffer.h"
 
 // Can't include arraytypes.h here, need to declare these directly.
@@ -282,6 +283,11 @@ struct Global
 
 extern Global global;
 
+#if WANT_CENT
+typedef uint128_t dinteger_t;
+typedef int128_t sinteger_t;
+typedef uint128_t uinteger_t;
+#else
 // Because int64_t and friends may be any integral type of the
 // correct size, we have to explicitly ask for the correct
 // integer type to get the correct mangling with ddmd
@@ -298,6 +304,7 @@ typedef unsigned long long dinteger_t;
 typedef long long sinteger_t;
 typedef unsigned long long uinteger_t;
 #endif
+#endif
 
 typedef int8_t                  d_int8;
 typedef uint8_t                 d_uns8;
@@ -307,6 +314,10 @@ typedef int32_t                 d_int32;
 typedef uint32_t                d_uns32;
 typedef int64_t                 d_int64;
 typedef uint64_t                d_uns64;
+#if WANT_CENT
+typedef int128_t                d_int128;
+typedef uint128_t               d_uns128;
+#endif
 
 typedef float                   d_float32;
 typedef double                  d_float64;

--- a/dmd2/hdrgen.c
+++ b/dmd2/hdrgen.c
@@ -2133,6 +2133,24 @@ public:
                     buf->printf("%lluLU", v);
                     break;
 
+#if WANT_CENT
+                case Tint128: {
+                    char buffer[42];
+                    sprintf_i128(buffer, v);
+                    assert(strlen(buffer) < sizeof(buffer));
+                    buf->writestring(buffer);
+                    }
+                    break;
+
+                case Tuns128: {
+                    char buffer[42];
+                    sprintf_u128(buffer, v);
+                    assert(strlen(buffer) < sizeof(buffer));
+                    buf->writestring(buffer);
+                    }
+                    break;
+#endif
+
                 case Tbool:
                     buf->writestring(v ? "true" : "false");
                     break;

--- a/dmd2/lexer.c
+++ b/dmd2/lexer.c
@@ -495,7 +495,11 @@ void Lexer::scan(Token *t)
                                 break;
                         }
                         t->value = TOKint64v;
+#if WANT_CENT
+                        t->uns128value = major * 1000 + minor;
+#else
                         t->uns64value = major * 1000 + minor;
+#endif
                     }
                     else if (id == Id::EOFX)
                     {
@@ -1575,6 +1579,22 @@ TOK Lexer::charConstant(Token *t, int wide)
         case '\\':
             switch (*p)
             {
+#if WANT_CENT
+                case 'u':
+                    t->uns128value = escapeSequence();
+                    tk = TOKwcharv;
+                    break;
+
+                case 'U':
+                case '&':
+                    t->uns128value = escapeSequence();
+                    tk = TOKdcharv;
+                    break;
+
+                default:
+                    t->uns128value = escapeSequence();
+                    break;
+#else
                 case 'u':
                     t->uns64value = escapeSequence();
                     tk = TOKwcharv;
@@ -1589,6 +1609,7 @@ TOK Lexer::charConstant(Token *t, int wide)
                 default:
                     t->uns64value = escapeSequence();
                     break;
+#endif
             }
             break;
         case '\n':
@@ -1599,7 +1620,11 @@ TOK Lexer::charConstant(Token *t, int wide)
         case 0x1A:
         case '\'':
             error("unterminated character constant");
+#if WANT_CENT
+            t->uns128value = '?';
+#else
             t->uns64value = '?';
+#endif
             return tk;
 
         default:
@@ -1615,14 +1640,22 @@ TOK Lexer::charConstant(Token *t, int wide)
                 else
                     tk = TOKdcharv;
             }
+#if WANT_CENT
+            t->uns128value = c;
+#else
             t->uns64value = c;
+#endif
             break;
     }
 
     if (*p != '\'')
     {
         error("unterminated character constant");
+#if WANT_CENT
+        t->uns128value = '?';
+#else
         t->uns64value = '?';
+#endif
         return tk;
     }
     p++;
@@ -1808,12 +1841,21 @@ TOK Lexer::number(Token *t)
         }
         n = n2 + d;
 
+#if WANT_CENT
+        // if n needs more than 128 bits
+        if (sizeof(n) > 16 &&
+            n > UINT128C(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL))
+        {
+            overflow = true;
+        }
+#else
         // if n needs more than 64 bits
         if (sizeof(n) > 8 &&
             n > 0xFFFFFFFFFFFFFFFFULL)
         {
             overflow = true;
         }
+#endif
     }
 
 Ldone:
@@ -1879,6 +1921,13 @@ Ldone:
             /* Octal or Hexadecimal constant.
              * First that fits: int, uint, long, ulong
              */
+#if WANT_CENT
+            if (n & UINT128C(0x8000000000000000LL, 0x0LL))
+                result = TOKuns128v;
+            else if (n & UINT128C(0xFFFFFFFFFFFFFFFFLL, 0x0LL))
+                result = TOKint128v;
+            else
+#endif
             if (n & 0x8000000000000000LL)
                 result = TOKuns64v;
             else if (n & 0xFFFFFFFF00000000LL)
@@ -1892,6 +1941,19 @@ Ldone:
         case FLAGS_decimal:
             /* First that fits: int, long, long long
              */
+#if WANT_CENT
+            if (n & UINT128C(0x8000000000000000LL, 0x0LL))
+            {
+                if (!err)
+                {
+                    error("signed integer overflow");
+                    err = true;
+                }
+                result = TOKuns128v;
+            }
+            else if (n & UINT128C(0xFFFFFFFFFFFFFFFF, 0x8000000000000000LL))
+                result = TOKint128v;
+#else
             if (n & 0x8000000000000000LL)
             {
                 if (!err)
@@ -1901,6 +1963,7 @@ Ldone:
                 }
                 result = TOKuns64v;
             }
+#endif
             else if (n & 0xFFFFFFFF80000000LL)
                 result = TOKint64v;
             else
@@ -1911,6 +1974,11 @@ Ldone:
         case FLAGS_decimal | FLAGS_unsigned:
             /* First that fits: uint, ulong
              */
+#if WANT_CENT
+            if (n & UINT128C(0xFFFFFFFFFFFFFFFFLL, 0x0LL))
+                result = TOKuns128v;
+            else
+#endif
             if (n & 0xFFFFFFFF00000000LL)
                 result = TOKuns64v;
             else
@@ -1918,6 +1986,19 @@ Ldone:
             break;
 
         case FLAGS_decimal | FLAGS_long:
+#if WANT_CENT
+            if (n & UINT128C(0x8000000000000000LL, 0x0LL))
+            {
+                if (!err)
+                {
+                    error("signed integer overflow");
+                    err = true;
+                }
+                result = TOKuns128v;
+            }
+            else if (n & UINT128C(0xFFFFFFFFFFFFFFFF, 0x8000000000000000LL))
+                result = TOKint128v;
+#else
             if (n & 0x8000000000000000LL)
             {
                 if (!err)
@@ -1927,11 +2008,19 @@ Ldone:
                 }
                 result = TOKuns64v;
             }
+#endif
             else
                 result = TOKint64v;
             break;
 
         case FLAGS_long:
+#if WANT_CENT
+            if (n & UINT128C(0x8000000000000000LL, 0x0LL))
+                result = TOKuns128v;
+            else if (n & UINT128C(0xFFFFFFFFFFFFFFFFLL, 0x0LL))
+                result = TOKint128v;
+            else
+#endif
             if (n & 0x8000000000000000LL)
                 result = TOKuns64v;
             else
@@ -1940,6 +2029,11 @@ Ldone:
 
         case FLAGS_unsigned | FLAGS_long:
         case FLAGS_decimal | FLAGS_unsigned | FLAGS_long:
+#if WANT_CENT
+            if (n & UINT128C(0xFFFFFFFFFFFFFFFFLL, 0x0LL))
+                result = TOKuns128v;
+            else
+#endif
             result = TOKuns64v;
             break;
 
@@ -1949,7 +2043,11 @@ Ldone:
             #endif
             assert(0);
     }
+#if WANT_CENT
+    t->uns128value = n;
+#else
     t->uns64value = n;
+#endif
     return result;
 }
 
@@ -2133,6 +2231,16 @@ void Lexer::poundLine()
     Loc loc = this->loc();
 
     scan(&tok);
+#if WANT_CENT
+    if (tok.value == TOKint32v || tok.value == TOKint64v || tok.value == TOKint128v)
+    {
+        int lin = (int)(tok.uns128value - 1);
+        if (lin != tok.uns128value - 1)
+            error("line number %lld out of range", (unsigned long long)tok.uns128value);
+        else
+            linnum = lin;
+    }
+#else
     if (tok.value == TOKint32v || tok.value == TOKint64v)
     {
         int lin = (int)(tok.uns64value - 1);
@@ -2141,6 +2249,7 @@ void Lexer::poundLine()
         else
             linnum = lin;
     }
+#endif
     else if (tok.value == TOKline)
     {
     }

--- a/dmd2/mtype.c
+++ b/dmd2/mtype.c
@@ -318,11 +318,13 @@ unsigned Type::alignsize()
 
 Type *Type::semantic(Loc loc, Scope *sc)
 {
+#if !WANT_CENT
     if (ty == Tint128 || ty == Tuns128)
     {
         error(loc, "cent and ucent types not implemented");
         return terror;
     }
+#endif
 
     return merge();
 }
@@ -2447,6 +2449,10 @@ uinteger_t Type::sizemask()
         case Tuns32:    m = 0xFFFFFFFFUL;               break;
         case Tint64:
         case Tuns64:    m = 0xFFFFFFFFFFFFFFFFULL;      break;
+#if WANT_CENT
+        case Tint128:
+        case Tuns128:   m = UINT128C(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFFFFULL); break;
+#endif
         default:
                 assert(0);
     }
@@ -2986,6 +2992,10 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tuns32:        ivalue = 0xFFFFFFFFUL;  goto Livalue;
             case Tint64:        ivalue = 0x7FFFFFFFFFFFFFFFLL;  goto Livalue;
             case Tuns64:        ivalue = 0xFFFFFFFFFFFFFFFFULL; goto Livalue;
+#if WANT_CENT
+            case Tint128:       ivalue = INT128C(0x7FFFFFFFFFFFFFFFLL, 0xFFFFFFFFFFFFFFFFULL);   goto Livalue;
+            case Tuns128:       ivalue = UINT128C(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL); goto Livalue;
+#endif
             case Tbool:         ivalue = 1;             goto Livalue;
             case Tchar:         ivalue = 0xFF;          goto Livalue;
             case Twchar:        ivalue = 0xFFFFUL;      goto Livalue;
@@ -3014,6 +3024,10 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tuns32:        ivalue = 0;                     goto Livalue;
             case Tint64:        ivalue = (-9223372036854775807LL-1LL);  goto Livalue;
             case Tuns64:        ivalue = 0;             goto Livalue;
+#if WANT_CENT
+            case Tint128:       ivalue = INT128C(0x8000000000000000LL, 0x0LL); goto Livalue;
+            case Tuns128:       ivalue = 0;             goto Livalue;
+#endif
             case Tbool:         ivalue = 0;             goto Livalue;
             case Tchar:         ivalue = 0;             goto Livalue;
             case Twchar:        ivalue = 0;             goto Livalue;

--- a/dmd2/root/int128.c
+++ b/dmd2/root/int128.c
@@ -1,0 +1,58 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/int128.c
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "int128.h"
+
+#if WANT_CENT
+// see http://stackoverflow.com/question/11656241/how-to-print-uint128-t-number-using-gcc
+#ifndef UINT64_MAX
+#define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
+#endif
+
+#define INT128_MIN INT128C(0x8000000000000000ULL, 0x0000000000000000ULL)
+
+#define P10_UINT64 10000000000000000000ULL
+
+void sprintf_u128(char *buffer, uint128_t u128)
+{
+    if (u128 > UINT64_MAX)
+    {
+        uint128_t leading = u128 / P10_UINT64;
+        uint64_t trailing = u128 % P10_UINT64;
+        sprintf_u128(buffer, leading);
+        sprintf(&buffer[strlen(buffer)], "%.19llu", trailing);
+    }
+    else
+    {
+         sprintf(buffer,"%llu",(uint64_t) u128);
+    }
+}
+
+void sprintf_i128(char *buffer, int128_t i128)
+{
+    if (i128 == INT128_MIN)
+        strcpy(buffer, "-170141183460469231731687303715884105728");
+    else
+    {
+        if (i128 < 0)
+        {
+            *buffer++ = '-';
+            i128 = -i128;
+        }
+        sprintf_u128(buffer, (uint128_t) i128);
+    }
+}
+
+#endif

--- a/dmd2/root/int128.h
+++ b/dmd2/root/int128.h
@@ -1,0 +1,30 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/int128.h
+ */
+
+#ifndef DMD_INT128_H
+#define DMD_INT128_H
+
+#define WANT_CENT __GNUC__
+
+#if WANT_CENT
+typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
+
+// 128bit literals are not supported
+#define INT128C(hi,lo) ((((int128_t)hi)<<64)|lo)
+#define UINT128C(hi,lo) ((((uint128_t)hi)<<64)|lo)
+
+void sprintf_i128(char* buffer, int128_t v);
+void sprintf_u128(char* buffer, uint128_t v);
+
+#endif
+
+#endif // DMD_INT128_H

--- a/dmd2/tokens.c
+++ b/dmd2/tokens.c
@@ -58,6 +58,34 @@ const char *Token::toChars()
     const char *p = &buffer[0];
     switch (value)
     {
+#if WANT_CENT
+        case TOKint32v:
+            sprintf(&buffer[0],"%d",(d_int32)int128value);
+            break;
+
+        case TOKuns32v:
+        case TOKcharv:
+        case TOKwcharv:
+        case TOKdcharv:
+            sprintf(&buffer[0],"%uU",(d_uns32)uns128value);
+            break;
+
+        case TOKint64v:
+            sprintf(&buffer[0],"%lldL",(longlong)int128value);
+            break;
+
+        case TOKuns64v:
+            sprintf(&buffer[0],"%lluUL",(ulonglong)uns128value);
+            break;
+
+        case TOKint128v:
+            sprintf_i128(&buffer[0], int128value);
+            break;
+
+        case TOKuns128v:
+            sprintf_u128(&buffer[0], uns128value);
+            break;
+#else
         case TOKint32v:
             sprintf(&buffer[0],"%d",(d_int32)int64value);
             break;
@@ -76,6 +104,7 @@ const char *Token::toChars()
         case TOKuns64v:
             sprintf(&buffer[0],"%lluUL",(ulonglong)uns64value);
             break;
+#endif
 
         case TOKfloat32v:
             ld_sprint(&buffer[0], 'g', float80value);

--- a/dmd2/tokens.h
+++ b/dmd2/tokens.h
@@ -201,8 +201,13 @@ struct Token
     union
     {
         // Integers
+#if WANT_CENT
+        d_int128 int128value;
+        d_uns128 uns128value;
+#else
         d_int64 int64value;
         d_uns64 uns64value;
+#endif
 
         // Floats
         d_float80 float80value;

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2193,6 +2193,16 @@ namespace AsmParserx8664
                 switch ( type )
                 {
                     case Arg_Integer:
+#if WANT_CENT
+                        if ( e->type->isunsigned() )
+                            insnTemplate << "$" << static_cast<uint64_t>(e->toUInteger());
+                        else
+#ifndef ASM_X86_64
+                            insnTemplate << "$" << static_cast<int64_t>(e->toInteger());
+#else
+                            insnTemplate << "$" << static_cast<int64_t>(e->toInteger());
+#endif
+#else
                         if ( e->type->isunsigned() )
                             insnTemplate << "$" << e->toUInteger();
                         else
@@ -2200,6 +2210,7 @@ namespace AsmParserx8664
                             insnTemplate << "$" << (sinteger_t)e->toInteger();
 #else
                             insnTemplate << "$" << e->toInteger();
+#endif
 #endif
                         break;
 
@@ -2808,7 +2819,11 @@ namespace AsmParserx8664
                             LOG_SCOPE
                             Logger::cout() << "baseReg: " << operand->baseReg << '\n';
                             Logger::cout() << "segmentPrefix: " << operand->segmentPrefix << '\n';
+#if WANT_CENT
+                            Logger::cout() << "constDisplacement: " << static_cast<int64_t>(operand->constDisplacement) << '\n';
+#else
                             Logger::cout() << "constDisplacement: " << operand->constDisplacement << '\n';
+#endif
                             for (unsigned i = 0; i < operand->symbolDisplacement.dim; i++) {
                                 Expression* expr = static_cast<Expression*>(operand->symbolDisplacement.data[i]);
                                 Logger::cout() << "symbolDisplacement[" << i << "] = " << expr->toChars() << '\n';
@@ -2827,7 +2842,11 @@ namespace AsmParserx8664
                         if ( (operand->segmentPrefix != Reg_Invalid && operand->symbolDisplacement.dim == 0)
                             || operand->constDisplacement )
                         {
+#if WANT_CENT
+                            insnTemplate << static_cast<int64_t>(operand->constDisplacement);
+#else
                             insnTemplate << operand->constDisplacement;
+#endif
                             if ( operand->symbolDisplacement.dim )
                             {
                                 insnTemplate << '+';
@@ -3648,11 +3667,22 @@ namespace AsmParserx8664
                 case TOKint64v:
                 case TOKuns64v:
                     // semantic here?
+#if WANT_CENT
+                case TOKint128v:
+                case TOKuns128v:
+#ifndef ASM_X86_64
+                    // %% for tok64 really should use 64bit type
+                    e = new IntegerExp ( stmt->loc, token->uns128value, Type::tint32 );
+#else
+                    e = new IntegerExp ( stmt->loc, token->uns128value, Type::tint64 );
+#endif
+#else
 #ifndef ASM_X86_64
                     // %% for tok64 really should use 64bit type
                     e = new IntegerExp ( stmt->loc, token->uns64value, Type::tint32 );
 #else
                     e = new IntegerExp ( stmt->loc, token->uns64value, Type::tint64 );
+#endif
 #endif
                     nextToken();
                     break;
@@ -3717,8 +3747,14 @@ namespace AsmParserx8664
                                     {
                                     case TOKint32v: case TOKuns32v:
                                     case TOKint64v: case TOKuns64v:
+#if WANT_CENT
+                                    case TOKint128v: case TOKuns128v:
+                                            if ( token->uns128value < 8 )
+                                                e = newRegExp ( ( Reg ) ( Reg_ST + token->uns128value ) );
+#else
                                             if ( token->uns64value < 8 )
                                                 e = newRegExp ( ( Reg ) ( Reg_ST + token->uns64value ) );
+#endif
                                             else
                                             {
                                                 stmt->error ( "invalid floating point register index" );
@@ -3822,10 +3858,18 @@ namespace AsmParserx8664
             {
                 //FIXME: This printf is not portable. The use of `align` varies from system to system;
                 // on i386 using a.out, .align `n` will align on a 2^`n` boundary instead of an `n` boundary
+#if WANT_CENT
+#ifdef HAVE_GAS_BALIGN_AND_P2ALIGN
+                insnTemplate << ".balign\t" << static_cast<uint64_t>(align);
+#else
+                insnTemplate << ".align\t" << static_cast<uint64_t>(align);
+#endif
+#else
 #ifdef HAVE_GAS_BALIGN_AND_P2ALIGN
                 insnTemplate << ".balign\t" << align;
 #else
                 insnTemplate << ".align\t" << align;
+#endif
 #endif
             }
             else
@@ -3873,6 +3917,20 @@ namespace AsmParserx8664
                     case Op_ds:
                     case Op_di:
                     case Op_dl:
+#if WANT_CENT
+                    if (token->value == TOKint32v || token->value == TOKuns32v ||
+                        token->value == TOKint64v || token->value == TOKuns64v ||
+                        token->value == TOKint128v || token->value == TOKuns128v) {
+                        // As per usual with GNU, assume at least 32-bit host
+                        if (op != Op_dl)
+                        insnTemplate->printf("%u", (d_uns32) token->uns128value);
+                        else {
+                        // Output two .longS.  GAS has .quad, but would have to rely on 'L' format ..
+                        // just need to use HOST_WIDE_INT_PRINT_DEC
+                        insnTemplate->printf("%u,%u",
+                            (d_uns32) token->uns64value, (d_uns32) (token->uns128value >> 32));
+                        }
+#else
                     if (token->value == TOKint32v || token->value == TOKuns32v ||
                         token->value == TOKint64v || token->value == TOKuns64v) {
                         // As per usual with GNU, assume at least 32-bit host
@@ -3884,6 +3942,7 @@ namespace AsmParserx8664
                         insnTemplate->printf("%u,%u",
                             (d_uns32) token->uns64value, (d_uns32) (token->uns64value >> 32));
                         }
+#endif
                     } else {
                         stmt->error("expected integer constant");
                     }

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -119,6 +119,15 @@ public:
         else
         {
             assert(llvm::isa<LLIntegerType>(t));
+#if WANT_CENT
+            if (t->getPrimitiveSizeInBits() == 128)
+            {
+                int128_t i128 = e->getInteger();
+                llvm::APInt v128(128, llvm::ArrayRef<uint64_t>(reinterpret_cast<uint64_t*>(&i128), 2));
+                result = LLConstantInt::get(t, v128);
+            }
+            else
+#endif
             result = LLConstantInt::get(t, (uint64_t)e->getInteger(), !e->type->isunsigned());
             assert(result);
             IF_LOG Logger::cout() << "value = " << *result << '\n';


### PR DESCRIPTION
This is a first try at implementing the data types cent and ucent.
All changes are wrapped in #if WANT_CENT .. #endif. It takes
advantage of the GCC builtin type __int128 and is currently only
enabled if compiled with gcc.

As soon as this is stable it should go upstream, too.