### PR TITLE
Cache global variables for string literals.

### DIFF
--- a/dmd2/module.h
+++ b/dmd2/module.h
@@ -151,6 +151,11 @@ public:
     void parse();       // syntactic parse
 #endif
     void importAll(Scope *sc);
+#if IN_LLVM
+    using Package::semantic;
+    using Dsymbol::semantic2;
+    using Dsymbol::semantic3;
+#endif
     void semantic();    // semantic analysis
     void semantic2();   // pass 2 semantic analysis
     void semantic3();   // pass 3 semantic analysis

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -30,6 +30,7 @@
 #if LDC_LLVM_VER >= 305
 #include "llvm/IR/CallSite.h"
 #else
+#include <map>
 #include "llvm/Support/CallSite.h"
 #endif
 
@@ -197,6 +198,20 @@ struct IRState
 
     /// Whether to emit array bounds checking in the current function.
     bool emitArrayBoundsChecks();
+
+    // Global variables bound to string literals.  Once created such a
+    // variable is reused whenever the same string literal is
+    // referenced in the module.  Caching them per module prevents the
+    // duplication of identical literals.
+#if LDC_LLVM_VER >= 305
+    llvm::StringMap<llvm::GlobalVariable*> stringLiteral1ByteCache;
+    llvm::StringMap<llvm::GlobalVariable*> stringLiteral2ByteCache;
+    llvm::StringMap<llvm::GlobalVariable*> stringLiteral4ByteCache;
+#else
+    std::map<llvm::StringRef, llvm::GlobalVariable*> stringLiteral1ByteCache;
+    std::map<llvm::StringRef, llvm::GlobalVariable*> stringLiteral2ByteCache;
+    std::map<llvm::StringRef, llvm::GlobalVariable*> stringLiteral4ByteCache;
+#endif
 
 #if LDC_LLVM_VER >= 303
     /// Vector of options passed to the linker as metadata in object file.

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -340,6 +340,11 @@ public:
         LLType* ct = voidToI8(DtoType(cty));
         LLArrayType* at = LLArrayType::get(ct, e->len+1);
 
+#if LDC_LLVM_VER >= 305
+        llvm::StringMap<llvm::GlobalVariable*>* stringLiteralCache = 0;
+#else
+        std::map<llvm::StringRef, llvm::GlobalVariable*>* stringLiteralCache = 0;
+#endif
         LLConstant* _init;
         switch (cty->size())
         {
@@ -347,22 +352,33 @@ public:
             llvm_unreachable("Unknown char type");
         case 1:
             _init = toConstantArray(ct, at, static_cast<uint8_t *>(e->string), e->len);
+            stringLiteralCache = &(gIR->stringLiteral1ByteCache);
             break;
         case 2:
             _init = toConstantArray(ct, at, static_cast<uint16_t *>(e->string), e->len);
+            stringLiteralCache = &(gIR->stringLiteral2ByteCache);
             break;
         case 4:
             _init = toConstantArray(ct, at, static_cast<uint32_t *>(e->string), e->len);
+            stringLiteralCache = &(gIR->stringLiteral4ByteCache);
             break;
         }
 
-        llvm::GlobalValue::LinkageTypes _linkage = llvm::GlobalValue::InternalLinkage;
-        IF_LOG {
-            Logger::cout() << "type: " << *at << '\n';
-            Logger::cout() << "init: " << *_init << '\n';
+        llvm::StringRef key(e->toChars());
+        llvm::GlobalVariable* gvar = (stringLiteralCache->find(key) ==
+                                      stringLiteralCache->end())
+                                     ? 0 : (*stringLiteralCache)[key];
+        if (gvar == 0)
+        {
+            llvm::GlobalValue::LinkageTypes _linkage = llvm::GlobalValue::PrivateLinkage;
+            IF_LOG {
+                Logger::cout() << "type: " << *at << '\n';
+                Logger::cout() << "init: " << *_init << '\n';
+            }
+            gvar = new llvm::GlobalVariable(*gIR->module, at, true, _linkage, _init, ".str");
+            gvar->setUnnamedAddr(true);
+            (*stringLiteralCache)[key] = gvar;
         }
-        llvm::GlobalVariable* gvar = new llvm::GlobalVariable(*gIR->module, at, true, _linkage, _init, ".str");
-        gvar->setUnnamedAddr(true);
 
         llvm::ConstantInt* zero = LLConstantInt::get(LLType::getInt32Ty(gIR->context()), 0, false);
         LLConstant* idxs[2] = { zero, zero };

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -497,16 +497,23 @@ LLConstant* DtoConstFP(Type* t, longdouble value)
 LLConstant* DtoConstString(const char* str)
 {
     llvm::StringRef s(str ? str : "");
-    llvm::Constant* init = llvm::ConstantDataArray::getString(gIR->context(), s, true);
-    llvm::GlobalVariable* gvar = new llvm::GlobalVariable(
-        *gIR->module, init->getType(), true, llvm::GlobalValue::InternalLinkage, init, ".str");
-    gvar->setUnnamedAddr(true);
+    llvm::GlobalVariable* gvar = (gIR->stringLiteral1ByteCache.find(s) ==
+                                  gIR->stringLiteral1ByteCache.end())
+                                 ? 0 : gIR->stringLiteral1ByteCache[s];
+    if (gvar == 0)
+    {
+        llvm::Constant* init = llvm::ConstantDataArray::getString(gIR->context(), s, true);
+        gvar = new llvm::GlobalVariable(*gIR->module, init->getType(), true,
+                                        llvm::GlobalValue::PrivateLinkage, init, ".str");
+        gvar->setUnnamedAddr(true);
+        gIR->stringLiteral1ByteCache[s] = gvar;
+    }
     LLConstant* idxs[] = { DtoConstUint(0), DtoConstUint(0) };
     return DtoConstSlice(
         DtoConstSize_t(s.size()),
         llvm::ConstantExpr::getGetElementPtr(
 #if LDC_LLVM_VER >= 307
-            init->getType(),
+            gvar->getInitializer()->getType(),
 #endif
             gvar, idxs, true),
         Type::tchar->arrayOf()


### PR DESCRIPTION
This is redone PR for caching the string literal global variables. Added caching to `DtoConstString` and `ToConstElemVisitor`. Got rid of pair<GlovalVariable*, DValue*>. Switched to use StringRef as the map key, and StringMap as the global variable cache.  One thing I'm not sure about is whether it is necessary to make a copy of e->string.  Since StringExp objects are never destroyed, it seems ok to store e->string pointer in `StringRef key`.  Please, review.