### PR TITLE
`stripModifiers()` should recursively remove modifiers

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1529,11 +1529,15 @@ size_t realignOffset(size_t offset, Type* type)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-Type * stripModifiers( Type * type )
+Type * stripModifiers(Type * type, bool transitive)
 {
     if (type->ty == Tfunction)
         return type;
-    return type->castMod(0);
+    
+    if (transitive)
+        return type->unqualify(MODimmutable | MODconst | MODwild);
+    else
+        return type->castMod(0);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -197,7 +197,7 @@ LLFunctionType* DtoExtractFunctionType(LLType* type);
 ///
 DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* arguments, LLValue* retvar = 0);
 
-Type* stripModifiers(Type* type);
+Type* stripModifiers(Type* type, bool transitive = false);
 
 void printLabelName(std::ostream& target, const char* func_mangle, const char* label_name);
 

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -494,8 +494,8 @@ DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* 
     // repaint the type if necessary
     if (resulttype)
     {
-        Type* rbase = stripModifiers(resulttype->toBasetype());
-        Type* nextbase = stripModifiers(tf->nextOf()->toBasetype());
+        Type* rbase = stripModifiers(resulttype->toBasetype(), true);
+        Type* nextbase = stripModifiers(tf->nextOf()->toBasetype(), true);
         if (!rbase->equals(nextbase))
         {
             IF_LOG Logger::println("repainting return value from '%s' to '%s'", tf->nextOf()->toChars(), rbase->toChars());


### PR DESCRIPTION
This fixes an ICE on Win64/MSVC2013. See the discussion at the end of https://github.com/ldc-developers/ldc/pull/856

Please verify that this is indeed the intended behavior of `stripModifiers()` throughout LDC. If not, we could add an extra `bool recursive = false` argument.

If merged, please also merge into `merge-2.067`. (I don't know how to cherrypick commits, still learning git)