### PR TITLE
Inline assembly fix for MSVC: treat real ptr as 64-bit double.

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2413,7 +2413,15 @@ namespace AsmParserx8664
                     {
                         case Float_Ptr:    type_suffix = 's'; break;
                         case Double_Ptr:   type_suffix = 'l'; break;
-                        case Extended_Ptr: type_suffix = 't'; break;
+                        case Extended_Ptr:
+#if LDC_LLVM_VER >= 305
+                            // MS C runtime: real = 64-bit double
+                            if (global.params.targetTriple.isWindowsMSVCEnvironment())
+                                type_suffix = 'l';
+                            else
+#endif
+                            type_suffix = 't';
+                            break;
                         default:
                             return false;
                     }


### PR DESCRIPTION
This should allow some inline assembly originally crafted for 80-bit x87 reals to work with 64-bit doubles too, although it would still use the x87 coprocessor instead of trying to exploit enhanced x86 instruction sets.