### PR TITLE
Add coverage testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ install:
     if [[ "${LLVM_PACKAGE}" == *3\.[567]* ]] && [[ "${CXX}" == "clang++" ]]; then
       sudo apt-get install --allow-unauthenticated -qq clang-3.4; export CXX="clang++-3.4";
     fi
+  -
+    if [[ "${OPTS}" == *TEST_COVERAGE*ON* ]]; then
+      sudo pip install cpp-coveralls;
+    fi
 env:
   - LLVM_PACKAGE="llvm-3.1 llvm-3.1-dev"
   - LLVM_PACKAGE="llvm-3.2 llvm-3.2-dev"
@@ -49,6 +53,7 @@ env:
   - LLVM_PACKAGE="llvm-3.4 llvm-3.4-dev" OPTS="-DBUILD_SHARED_LIBS=ON"
   - LLVM_PACKAGE="llvm-3.5 llvm-3.5-dev libedit2 libedit-dev" TEST_DEBUG=1
   - LLVM_PACKAGE="llvm-3.5 llvm-3.5-dev libedit2 libedit-dev"
+  - LLVM_PACKAGE="llvm-3.5 llvm-3.5-dev libedit2 libedit-dev" OPTS="-DTEST_COVERAGE=ON"
   - LLVM_PACKAGE="llvm-3.6 llvm-3.6-dev libedit2 libedit-dev" TEST_DEBUG=1
   - LLVM_PACKAGE="llvm-3.6 llvm-3.6-dev libedit2 libedit-dev"
   - LLVM_PACKAGE="llvm-3.7 llvm-3.7-dev libedit2 libedit-dev" TEST_DEBUG=1
@@ -100,6 +105,12 @@ script:
     fi;
   - ctest -j2 --verbose ${BUILD_SEL}
   - ctest -j2 --output-on-failure ${RUN_SEL}
+
+after_success:
+  -
+    if [[ "${OPTS}" == *TEST_COVERAGE*ON* ]]; then
+      coveralls -e runtime -e tests -e vcbuild --gcov gcov-4.9 --gcov-options '\-lp' > /dev/null 2>&1;
+    fi
 
 notifications:
   # Temporarily disabled due to time limit problems.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,19 @@ if( NOT WIN32 OR CYGWIN )
 endif()
 
 #
+# Enable instrumentation for code coverage analysis
+#
+set(TEST_COVERAGE OFF CACHE BOOL "instrument compiler for code coverage analysis")
+if(TEST_COVERAGE)
+    if(CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
+        append("-O0 -g -fprofile-arcs -ftest-coverage" EXTRA_CXXFLAGS)
+        append("--coverage" LLVM_LDFLAGS)
+    else()
+        message(WARNING "Coverage testing is not available.")
+    endif()
+endif()
+
+#
 # Set up the main ldc/ldc2 target.
 #
 if(BUILD_SHARED)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 LDC – the LLVM-based D Compiler
 ===============================
 
-[![Build Status](https://travis-ci.org/ldc-developers/ldc.png?branch=master)](https://travis-ci.org/ldc-developers/ldc) [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283332)](https://www.bountysource.com/trackers/283332-ldc?utm_source=283332&utm_medium=shield&utm_campaign=TRACKER_BADGE)
+[![Build Status](https://travis-ci.org/ldc-developers/ldc.png?branch=master)][1]
+[![Test Coverage](https://coveralls.io/repos/ldc-developers/ldc/badge.svg)][2]
+[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283332)][3]
 
 The LDC project aims to provide a portable D programming language
 compiler with modern optimization and code generation capabilities.
@@ -52,3 +54,8 @@ For further documentation, contributor information, etc. please see
 the D wiki: http://wiki.dlang.org/LDC
 
 Feedback of any kind is very much appreciated!
+
+
+[1]: https://travis-ci.org/ldc-developers/ldc "Build Status"
+[2]: https://coveralls.io/r/ldc-developers/ldc "Test Coverage"
+[3]: https://www.bountysource.com/trackers/283332-ldc?utm_source=283332&utm_medium=shield&utm_campaign=TRACKER_BADGE "Bountysource"


### PR DESCRIPTION
This PR enables collecting gcov code coverage statistics and pushing them to coveralls.io.  It also adds the coveralls badge to README.  Someone with access to ldc-developers account has to create/connect a coveralls.io account to ldc-develoepr/ldc repository to make this work. This PR should close the issue #380.  I enabled test coverage for llvm 3.5 build, but of course any other one can be used as well. Please, review.