### PR TITLE
LLVM 3.7: Implement FlagParser

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -347,7 +347,7 @@ cl::opt<bool> disableFpElim("disable-fp-elim",
               cl::desc("Disable frame pointer elimination optimization"),
               cl::init(false));
 
-static cl::opt<bool, true, FlagParser> asserts("asserts",
+static cl::opt<bool, true, FlagParser<bool> > asserts("asserts",
     cl::desc("(*) Enable assertions"),
     cl::value_desc("bool"),
     cl::location(global.params.useAssert),
@@ -376,25 +376,24 @@ cl::opt<BoundsCheck, true> boundsChecksNew("boundscheck",
         clEnumValN(BC_On, "on", "array bounds checks for all functions"),
         clEnumValEnd));
 
-static cl::opt<bool, true, FlagParser> invariants("invariants",
+static cl::opt<bool, true, FlagParser<bool> > invariants("invariants",
     cl::desc("(*) Enable invariants"),
     cl::location(global.params.useInvariants),
     cl::init(true));
 
-static cl::opt<bool, true, FlagParser> preconditions("preconditions",
+static cl::opt<bool, true, FlagParser<bool> > preconditions("preconditions",
     cl::desc("(*) Enable function preconditions"),
     cl::location(global.params.useIn),
     cl::init(true));
 
-static cl::opt<bool, true, FlagParser> postconditions("postconditions",
+static cl::opt<bool, true, FlagParser<bool> > postconditions("postconditions",
     cl::desc("(*) Enable function postconditions"),
     cl::location(global.params.useOut),
     cl::init(true));
 
-
 static MultiSetter ContractsSetter(false,
     &global.params.useIn, &global.params.useOut, NULL);
-static cl::opt<MultiSetter, true, FlagParser> contracts("contracts",
+static cl::opt<MultiSetter, true, FlagParser<bool> > contracts("contracts",
     cl::desc("(*) Enable function pre- and post-conditions"),
     cl::location(ContractsSetter));
 
@@ -402,7 +401,7 @@ bool nonSafeBoundsChecks = true;
 static MultiSetter ReleaseSetter(true, &global.params.useAssert,
     &nonSafeBoundsChecks, &global.params.useInvariants,
     &global.params.useOut, &global.params.useIn, NULL);
-static cl::opt<MultiSetter, true, cl::parser<bool> > release("release",
+static cl::opt<MultiSetter, true, FlagParser<bool> > release("release",
     cl::desc("Disables asserts, invariants, contracts and boundscheck"),
     cl::location(ReleaseSetter),
     cl::ValueDisallowed);
@@ -436,7 +435,7 @@ cl::opt<bool, true> vgc("vgc",
     cl::desc("list all gc allocations including hidden ones"),
     cl::location(global.params.vgc));
 
-cl::opt<bool, true, FlagParser> color("color",
+cl::opt<bool, true, FlagParser<bool> > color("color",
     cl::desc("Force colored console output"),
     cl::location(global.params.color));
 

--- a/gen/cl_helpers.cpp
+++ b/gen/cl_helpers.cpp
@@ -18,38 +18,13 @@
 
 namespace opts {
 
-#if LDC_LLVM_VER < 307
-bool FlagParser::parse(cl::Option &O, llvm::StringRef ArgName, llvm::StringRef Arg, bool &Val) {
-    // Make a std::string out of it to make comparisons easier
-    // (and avoid repeated conversion)
-    llvm::StringRef argname = ArgName;
+TEMPLATE_INSTANTIATION(class FlagParser<bool>);
+TEMPLATE_INSTANTIATION(class FlagParser<cl::boolOrDefault>);
 
-    typedef std::vector<std::pair<std::string, bool> >::iterator It;
-    for (It I = switches.begin(), E = switches.end(); I != E; ++I) {
-        llvm::StringRef name = I->first;
-        if (name == argname
-                || (name.size() < argname.size()
-                    && argname.substr(0, name.size()) == name
-                    && argname[name.size()] == '=')) {
-
-            if (!cl::parser<bool>::parse(O, ArgName, Arg, Val)) {
-                Val = (Val == I->second);
-                return false;
-            }
-            // Invalid option value
-            break;
-        }
-    }
-    return true;
-}
-
-void FlagParser::getExtraOptionNames(llvm::SmallVectorImpl<const char*> &Names) {
-    typedef std::vector<std::pair<std::string, bool> >::iterator It;
-    for (It I = switches.begin() + 1, E = switches.end(); I != E; ++I) {
-        Names.push_back(I->first.data());
-    }
-}
-#endif
+template<>
+void FlagParser<bool>::anchor() {}
+template<>
+void FlagParser<cl::boolOrDefault>::anchor() {}
 
 MultiSetter::MultiSetter(bool invert, bool* p, ...) {
     this->invert = invert;

--- a/gen/cl_helpers.h
+++ b/gen/cl_helpers.h
@@ -17,6 +17,7 @@
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
 
 #if LDC_LLVM_VER < 306
 #define LLVM_END_WITH_NULL END_WITH_NULL
@@ -28,47 +29,6 @@ typedef Array<const char *> Strings;
 namespace opts {
     namespace cl = llvm::cl;
 
-#if LDC_LLVM_VER >= 307
-typedef cl::parser<bool> FlagParser;
-#else
-    /// Helper class for fancier options
-    class FlagParser : public cl::parser<bool> {
-#if LDC_LLVM_VER >= 307
-      cl::Option &Opt;
-#endif
-      std::vector<std::pair<std::string, bool> > switches;
-    public:
-#if LDC_LLVM_VER >= 307
-      FlagParser(cl::Option &O) : parser(O), Opt(O) { }
-
-      void initialize() {
-        std::string Name(Opt.ArgStr);
-        switches.push_back(make_pair("enable-" + Name, true));
-        switches.push_back(make_pair("disable-" + Name, false));
-        // Replace <foo> with -enable-<foo> and register -disable-<foo>
-        // A literal option can only registered if the argstr is empty -
-        // just do this first.
-        Opt.setArgStr("");
-        AddLiteralOption(Opt, strdup(switches[1].first.data()));
-        Opt.setArgStr(switches[0].first.data());
-      }
-#else
-        template <class Opt>
-        void initialize(Opt &O) {
-            std::string Name = O.ArgStr;
-            switches.push_back(make_pair("enable-" + Name, true));
-            switches.push_back(make_pair("disable-" + Name, false));
-            // Replace <foo> with -enable-<foo>
-            O.ArgStr = switches[0].first.data();
-        }
-#endif
-
-        bool parse(cl::Option &O, llvm::StringRef ArgName, llvm::StringRef ArgValue, bool &Val);
-
-        void getExtraOptionNames(llvm::SmallVectorImpl<const char*> &Names);
-    };
-#endif
-
     /// Helper class for options that set multiple flags
     class MultiSetter {
         std::vector<bool*> locations;
@@ -78,6 +38,7 @@ typedef cl::parser<bool> FlagParser;
         MultiSetter(bool invert, bool* p, ...) LLVM_END_WITH_NULL;
 
         void operator=(bool val);
+        operator bool() const { return *locations[0]; }
     };
 
     /// Helper class to fill Strings with char* when given strings
@@ -100,22 +61,153 @@ typedef cl::parser<bool> FlagParser;
         }
     };
 
-    /// Helper class to allow use of a parser<bool> with BoolOrDefault
-    class BoolOrDefaultAdapter {
-        cl::boolOrDefault value;
-    public:
-        operator cl::boolOrDefault() {
-            return value;
-        }
+    /// Helper class to determine values
+    template<class DT>
+    struct FlagParserDataType {};
 
-        void operator=(cl::boolOrDefault val) {
-            value = val;
-        }
-
-        void operator=(bool val) {
-            *this = (val ? cl::BOU_TRUE : cl::BOU_FALSE);
-        }
+    template<>
+    struct FlagParserDataType<bool>{
+        static const bool true_val = true;
+        static const bool false_val = false;
     };
+
+    template<>
+    struct FlagParserDataType<cl::boolOrDefault> {
+        static const cl::boolOrDefault true_val = cl::BOU_TRUE;
+        static const cl::boolOrDefault false_val = cl::BOU_FALSE;
+    };
+
+    /// Helper class for fancier options
+    template<class DT>
+    class FlagParser : public cl::basic_parser_impl {
+#if LDC_LLVM_VER >= 307
+        cl::Option &Opt;
+#endif
+        llvm::SmallVector<std::pair<std::string, DT>, 2> switches;
+    public:
+        typedef DT parser_data_type;
+        typedef cl::OptionValue<DT> OptVal;
+
+#if LDC_LLVM_VER >= 307
+        FlagParser(cl::Option &O) : basic_parser_impl(O), Opt(O) { }
+
+        void initialize() {
+            std::string Name(Opt.ArgStr);
+            switches.push_back(make_pair("enable-" + Name, FlagParserDataType<DT>::true_val));
+            switches.push_back(make_pair("disable-" + Name, FlagParserDataType<DT>::false_val));
+            // Replace <foo> with -enable-<foo> and register -disable-<foo>
+            // A literal option can only registered if the argstr is empty -
+            // just do this first.
+            Opt.setArgStr("");
+            AddLiteralOption(Opt, strdup(switches[1].first.data()));
+            Opt.setArgStr(switches[0].first.data());
+        }
+#else
+        template <class Opt>
+        void initialize(Opt &O) {
+            std::string Name = O.ArgStr;
+            switches.push_back(make_pair("enable-" + Name, FlagParserDataType<DT>::true_val));
+            switches.push_back(make_pair("disable-" + Name, FlagParserDataType<DT>::false_val));
+            // Replace <foo> with -enable-<foo>
+            O.ArgStr = switches[0].first.data();
+        }
+#endif
+
+        enum cl::ValueExpected getValueExpectedFlagDefault() const {
+            return cl::ValueOptional;
+        }
+
+        bool parse(cl::Option &O, llvm::StringRef ArgName, llvm::StringRef ArgValue, DT &Val) {
+            // Make a std::string out of it to make comparisons easier
+            // (and avoid repeated conversion)
+            llvm::StringRef argname = ArgName;
+
+            typedef typename llvm::SmallVector<std::pair<std::string, DT>, 2>::iterator It;
+            for (It I = switches.begin(), E = switches.end(); I != E; ++I) {
+                llvm::StringRef name = I->first;
+                if (name == argname
+                    || (name.size() < argname.size()
+                    && argname.substr(0, name.size()) == name
+                    && argname[name.size()] == '=')) {
+                    if (!parse(O, ArgValue, Val))
+                    {
+                        Val = (Val == I->second) ? FlagParserDataType<DT>::true_val : FlagParserDataType<DT>::false_val;
+                        return false;
+                    }
+                    // Invalid option value
+                    break;
+                }
+            }
+            return true;
+        }
+
+        void getExtraOptionNames(llvm::SmallVectorImpl<const char*> &Names) {
+            typedef typename llvm::SmallVector<std::pair<std::string, DT>, 2>::iterator It;
+            for (It I = switches.begin() + 1, E = switches.end(); I != E; ++I) {
+                Names.push_back(I->first.data());
+            }
+        }
+
+        // getValueName - Do not print =<value> at all.
+        const char *getValueName() const override { return nullptr; }
+
+        void printOptionDiff(const cl::Option &O, bool V, OptVal Default, size_t GlobalWidth) const {
+            printOptionName(O, GlobalWidth);
+            std::string Str;
+            {
+                llvm::raw_string_ostream SS(Str);
+                SS << V;
+            }
+            llvm::outs() << "= " << Str;
+            static const size_t MaxOptWidth = 8; // arbitrary spacing for printOptionDiff
+            size_t NumSpaces = \
+                MaxOptWidth > Str.size() ? MaxOptWidth - Str.size() : 0;
+            llvm::outs().indent(NumSpaces) << " (default: ";
+            if (Default.hasValue())
+                llvm::outs() << Default.getValue();
+            else
+                llvm::outs() << "*no default*";
+            llvm::outs() << ")\n";
+        }
+
+        // An out-of-line virtual method to provide a 'home' for this class.
+        void anchor() override;
+
+    private:
+        static bool parse(cl::Option &O, llvm::StringRef Arg, DT &Val) {
+            if (Arg == "" || Arg == "true" || Arg == "TRUE" || Arg == "True" ||
+                Arg == "1") {
+                Val = FlagParserDataType<DT>::true_val;
+                return false;
+            }
+
+            if (Arg == "false" || Arg == "FALSE" || Arg == "False" || Arg == "0") {
+                Val = FlagParserDataType<DT>::false_val;
+                return false;
+            }
+            return O.error("'" + Arg +
+                "' is invalid value for boolean argument! Try 0 or 1");
+        }
+
+    };
+
+EXTERN_TEMPLATE_INSTANTIATION(class FlagParser<bool>);
+EXTERN_TEMPLATE_INSTANTIATION(class FlagParser<cl::boolOrDefault>);
+}
+
+namespace llvm {
+    namespace cl {
+        // This template is selected in 2 cases:
+        // - DT and ParserClass::parser_data_type are equal
+        // - DT can be assigned to ParserClass::parser_data_type
+        template <class ParserClass, class DT>
+        void printOptionDiff(const Option &O, const opts::FlagParser<typename ParserClass::parser_data_type> &P, const DT &V,
+            const OptionValue<DT> &Default, size_t GlobalWidth) {
+            typename ParserClass::parser_data_type Val = V;
+            const OptionValue<typename ParserClass::parser_data_type> DefaultVal = Default.getValue();
+            P.printOptionDiff(O, Val, DefaultVal, GlobalWidth);
+        }
+    }
 }
 
 #endif

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -111,7 +111,7 @@ disableGCToStack("disable-gc2stack",
     cl::desc("Disable promotion of GC allocations to stack memory"),
     cl::ZeroOrMore);
 
-static cl::opt<opts::BoolOrDefaultAdapter, false, opts::FlagParser>
+static cl::opt<cl::boolOrDefault, false, opts::FlagParser<cl::boolOrDefault> >
 enableInlining("inlining",
     cl::desc("Enable function inlining (default in -O2 and higher)"),
     cl::ZeroOrMore);


### PR DESCRIPTION
The FlagParser is now derived from `cl::basic_parser_impl` to avoid
conflicts with the `cl::parser<bool>`.