### PR TITLE
DMD2: Fix missing initialization of OverDeclaration::overnext.

### DIFF
--- a/dmd2/declaration.c
+++ b/dmd2/declaration.c
@@ -634,6 +634,7 @@ Dsymbol *AliasDeclaration::toAlias()
 OverDeclaration::OverDeclaration(Dsymbol *s, bool hasOverloads)
     : Declaration(s->ident)
 {
+    this->overnext = NULL;
     this->aliassym = s;
 
     this->hasOverloads = hasOverloads;


### PR DESCRIPTION
https://github.com/D-Programming-Language/dmd/pull/4598