### PR TITLE
Implement FlagParser using llvm::cl::generic_parser_base.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -347,7 +347,7 @@ cl::opt<bool> disableFpElim("disable-fp-elim",
               cl::desc("Disable frame pointer elimination optimization"),
               cl::init(false));
 
-static cl::opt<bool, true, FlagParser> asserts("asserts",
+static cl::opt<bool, true, FlagParser<bool> > asserts("asserts",
     cl::desc("(*) Enable assertions"),
     cl::value_desc("bool"),
     cl::location(global.params.useAssert),
@@ -362,13 +362,11 @@ public:
     }
 };
 
-#if LDC_LLVM_VER < 307
-cl::opt<BoundsChecksAdapter, false, FlagParser> boundsChecksOld("boundscheck",
+cl::opt<BoundsChecksAdapter, false, FlagParser<bool> > boundsChecksOld("boundscheck",
     cl::desc("(*) Enable array bounds check (deprecated, use -boundscheck=on|off)"));
-#endif
 
 cl::opt<BoundsCheck, true> boundsChecksNew("boundscheck",
-    cl::desc("(*) Enable array bounds check"),
+    cl::desc("Enable array bounds check"),
     cl::location(boundsCheck),
     cl::values(
         clEnumValN(BC_Off, "off", "no array bounds checks"),
@@ -376,17 +374,17 @@ cl::opt<BoundsCheck, true> boundsChecksNew("boundscheck",
         clEnumValN(BC_On, "on", "array bounds checks for all functions"),
         clEnumValEnd));
 
-static cl::opt<bool, true, FlagParser> invariants("invariants",
+static cl::opt<bool, true, FlagParser<bool> > invariants("invariants",
     cl::desc("(*) Enable invariants"),
     cl::location(global.params.useInvariants),
     cl::init(true));
 
-static cl::opt<bool, true, FlagParser> preconditions("preconditions",
+static cl::opt<bool, true, FlagParser<bool> > preconditions("preconditions",
     cl::desc("(*) Enable function preconditions"),
     cl::location(global.params.useIn),
     cl::init(true));
 
-static cl::opt<bool, true, FlagParser> postconditions("postconditions",
+static cl::opt<bool, true, FlagParser<bool> > postconditions("postconditions",
     cl::desc("(*) Enable function postconditions"),
     cl::location(global.params.useOut),
     cl::init(true));
@@ -394,7 +392,7 @@ static cl::opt<bool, true, FlagParser> postconditions("postconditions",
 
 static MultiSetter ContractsSetter(false,
     &global.params.useIn, &global.params.useOut, NULL);
-static cl::opt<MultiSetter, true, FlagParser> contracts("contracts",
+static cl::opt<MultiSetter, true, FlagParser<bool> > contracts("contracts",
     cl::desc("(*) Enable function pre- and post-conditions"),
     cl::location(ContractsSetter));
 
@@ -436,7 +434,7 @@ cl::opt<bool, true> vgc("vgc",
     cl::desc("list all gc allocations including hidden ones"),
     cl::location(global.params.vgc));
 
-cl::opt<bool, true, FlagParser> color("color",
+cl::opt<bool, true, FlagParser<bool> > color("color",
     cl::desc("Force colored console output"),
     cl::location(global.params.color));
 

--- a/gen/cl_helpers.cpp
+++ b/gen/cl_helpers.cpp
@@ -18,39 +18,6 @@
 
 namespace opts {
 
-#if LDC_LLVM_VER < 307
-bool FlagParser::parse(cl::Option &O, llvm::StringRef ArgName, llvm::StringRef Arg, bool &Val) {
-    // Make a std::string out of it to make comparisons easier
-    // (and avoid repeated conversion)
-    llvm::StringRef argname = ArgName;
-
-    typedef std::vector<std::pair<std::string, bool> >::iterator It;
-    for (It I = switches.begin(), E = switches.end(); I != E; ++I) {
-        llvm::StringRef name = I->first;
-        if (name == argname
-                || (name.size() < argname.size()
-                    && argname.substr(0, name.size()) == name
-                    && argname[name.size()] == '=')) {
-
-            if (!cl::parser<bool>::parse(O, ArgName, Arg, Val)) {
-                Val = (Val == I->second);
-                return false;
-            }
-            // Invalid option value
-            break;
-        }
-    }
-    return true;
-}
-
-void FlagParser::getExtraOptionNames(llvm::SmallVectorImpl<const char*> &Names) {
-    typedef std::vector<std::pair<std::string, bool> >::iterator It;
-    for (It I = switches.begin() + 1, E = switches.end(); I != E; ++I) {
-        Names.push_back(I->first.data());
-    }
-}
-#endif
-
 MultiSetter::MultiSetter(bool invert, bool* p, ...) {
     this->invert = invert;
     if (p) {

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -111,7 +111,7 @@ disableGCToStack("disable-gc2stack",
     cl::desc("Disable promotion of GC allocations to stack memory"),
     cl::ZeroOrMore);
 
-static cl::opt<opts::BoolOrDefaultAdapter, false, opts::FlagParser>
+static cl::opt<cl::boolOrDefault, false, opts::FlagParser<cl::boolOrDefault> >
 enableInlining("inlining",
     cl::desc("Enable function inlining (default in -O2 and higher)"),
     cl::ZeroOrMore);

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -322,11 +322,7 @@ macro(compile_druntime d_flags lib_suffix path_suffix outlist_o outlist_bc)
     # Always disable invariants for debug builds of core.* and gc.* (there
     # are/were some broken invariants around; druntime is always built in
     # release mode in upstream builds).
-    if(${LDC_LLVM_VER} LESS 307)
-        set(rt_flags "${d_flags};-disable-invariants")
-    else ()
-        set(rt_flags "${d_flags};-invariants=false")
-    endif()
+    set(rt_flags "${d_flags};-disable-invariants")
 
     if(BUILD_SHARED_LIBS)
         set(shared ";-d-version=Shared")


### PR DESCRIPTION
This approach is easier and requires less code. With some template foo
the BoolOrDefaultAdapter is not required.

This solutions applies to previous LLVM versions, too.