### PR TITLE
WIP: Codegen for NewExp::argprefix.

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -130,17 +130,12 @@ DValue* DtoNewClass(Loc& loc, TypeClass* tc, NewExp* newexp)
         DtoResolveNestedContext(loc, tc->sym, mem);
     }
 
-    bool isArgprefixHandled = false;
-
     // call constructor
     if (newexp->member)
     {
         // evaluate argprefix
         if (newexp->argprefix)
-        {
-            toElemDtor(newexp->argprefix, DestructOnThrowOnly);
-            isArgprefixHandled = true;
-        }
+            toElemDtor(newexp->argprefix, DestructInFinally);
 
         Logger::println("Calling constructor");
         assert(newexp->arguments != NULL);
@@ -149,7 +144,7 @@ DValue* DtoNewClass(Loc& loc, TypeClass* tc, NewExp* newexp)
         return DtoCallFunction(newexp->loc, tc, &dfn, newexp->arguments);
     }
 
-    assert(newexp->argprefix == NULL || isArgprefixHandled);
+    assert(newexp->argprefix == NULL);
 
     // return default constructed class
     return new DImValue(tc, mem);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -130,15 +130,26 @@ DValue* DtoNewClass(Loc& loc, TypeClass* tc, NewExp* newexp)
         DtoResolveNestedContext(loc, tc->sym, mem);
     }
 
+    bool isArgprefixHandled = false;
+
     // call constructor
     if (newexp->member)
     {
+        // evaluate argprefix
+        if (newexp->argprefix)
+        {
+            toElemDtor(newexp->argprefix, DestructOnThrowOnly);
+            isArgprefixHandled = true;
+        }
+
         Logger::println("Calling constructor");
         assert(newexp->arguments != NULL);
         DtoResolveFunction(newexp->member);
         DFuncValue dfn(newexp->member, getIrFunc(newexp->member)->func, mem);
         return DtoCallFunction(newexp->loc, tc, &dfn, newexp->arguments);
     }
+
+    assert(newexp->argprefix == NULL || isArgprefixHandled);
 
     // return default constructed class
     return new DImValue(tc, mem);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -135,7 +135,7 @@ DValue* DtoNewClass(Loc& loc, TypeClass* tc, NewExp* newexp)
     {
         // evaluate argprefix
         if (newexp->argprefix)
-            toElemDtor(newexp->argprefix, DestructInFinally);
+            toElemDtor(newexp->argprefix);
 
         Logger::println("Calling constructor");
         assert(newexp->arguments != NULL);

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -228,16 +228,16 @@ llvm::CallSite IRState::CreateCallOrInvoke(LLValue* Callee, const T &args, const
     if (hasTemporaries)
         funcGen.prepareToDestructAllTemporariesOnThrow(this);
 
-    llvm::BasicBlock* oldend = scopeend();
-    llvm::BasicBlock* postinvoke = llvm::BasicBlock::Create(context(), "postinvoke", topfunc(), oldend);
-    llvm::InvokeInst* invoke = ir->CreateInvoke(Callee, postinvoke, funcGen.landingPad, args, Name);
+    llvm::BasicBlock* landingPad = funcGen.landingPad;
+    llvm::BasicBlock* postinvoke = llvm::BasicBlock::Create(context(), "postinvoke", topfunc(), landingPad);
+    llvm::InvokeInst* invoke = ir->CreateInvoke(Callee, postinvoke, landingPad, args, Name);
     if (fn)
         invoke->setAttributes(fn->getAttributes());
 
     if (hasTemporaries)
         funcGen.landingPadInfo.pop();
 
-    scope() = IRScope(postinvoke, oldend);
+    scope() = IRScope(postinvoke, landingPad);
     return invoke;
 }
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -237,8 +237,7 @@ void Declaration_codegen(Dsymbol *decl, IRState *irs);
 enum DestructionMode
 {
     DestructNormally,
-    DestructInFinally,
-    DestructOnThrowOnly
+    DestructInFinally
 };
 
 DValue *toElem(Expression *e);

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -234,9 +234,17 @@ FuncDeclaration* getParentFunc(Dsymbol* sym, bool stopOnStatic);
 void Declaration_codegen(Dsymbol *decl);
 void Declaration_codegen(Dsymbol *decl, IRState *irs);
 
+enum DestructionMode
+{
+    DestructNormally,
+    DestructInFinally,
+    DestructOnThrowOnly
+};
+
 DValue *toElem(Expression *e);
 DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
+DValue *toElemDtor(Expression *e, DestructionMode mode);
 LLConstant *toConstElem(Expression *e, IRState *p);
 
 #endif

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -234,16 +234,12 @@ FuncDeclaration* getParentFunc(Dsymbol* sym, bool stopOnStatic);
 void Declaration_codegen(Dsymbol *decl);
 void Declaration_codegen(Dsymbol *decl, IRState *irs);
 
-enum DestructionMode
-{
-    DestructNormally,
-    DestructInFinally
-};
-
 DValue *toElem(Expression *e);
 DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
-DValue *toElemDtor(Expression *e, DestructionMode mode);
 LLConstant *toConstElem(Expression *e, IRState *p);
+
+bool haveTemporariesToDestruct();
+void prepareToDestructAllTemporariesOnThrow();
 
 #endif

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -239,7 +239,4 @@ DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
 LLConstant *toConstElem(Expression *e, IRState *p);
 
-bool haveTemporariesToDestruct();
-void prepareToDestructAllTemporariesOnThrow();
-
 #endif

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1880,6 +1880,14 @@ public:
         IF_LOG Logger::print("NewExp::toElem: %s @ %s\n", e->toChars(), e->type->toChars());
         LOG_SCOPE;
 
+        if (e->argprefix)
+        {
+            // replace expression arg0 by `argprefix, arg0`
+            assert(e->arguments && e->arguments->dim > 0);
+            Expressions& arguments = *e->arguments;
+            arguments[0] = Expression::combine(e->argprefix, arguments[0]);
+        }
+
         assert(e->newtype);
         Type* ntype = e->newtype->toBasetype();
 

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -76,6 +76,11 @@ bool FuncGen::hasTemporariesToDestruct()
     return !temporariesToDestruct.empty();
 }
 
+VarDeclarations& FuncGen::getTemporariesToDestruct()
+{
+    return temporariesToDestruct;
+}
+
 void FuncGen::destructTemporaries(unsigned numToKeep)
 {
     // pop one temporary after the other from the temporariesToDestruct stack

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -27,6 +27,7 @@
 
 class Statement;
 struct EnclosingTryFinally;
+struct IRState;
 
 // scope statements that can be target of jumps
 // includes loops, switch, case, labels
@@ -81,6 +82,17 @@ struct FuncGen
     IRLandingPad landingPadInfo;
     llvm::BasicBlock* landingPad;
 
+    void pushToElemScope();
+    void popToElemScope();
+
+    void pushTemporaryToDestruct(VarDeclaration* vd);
+    bool hasTemporariesToDestruct();
+    void destructAllTemporaries();
+    void destructAllTemporariesAndRestoreStack();
+    // pushes a landing pad which needs to be popped after the
+    // following invoke instruction
+    void prepareToDestructAllTemporariesOnThrow(IRState* irState);
+
 private:
     // prefix for labels and gotos
     // used for allowing labels to be emitted twice
@@ -88,6 +100,9 @@ private:
 
     // next unique id stack
     std::stack<int> nextUnique;
+
+    int toElemScopeCounter;
+    VarDeclarations temporariesToDestruct;
 };
 
 // represents a function

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -83,11 +83,10 @@ struct FuncGen
     llvm::BasicBlock* landingPad;
 
     void pushToElemScope();
-    void popToElemScope();
+    void popToElemScope(bool destructTemporaries);
 
     void pushTemporaryToDestruct(VarDeclaration* vd);
     bool hasTemporariesToDestruct();
-    void destructAllTemporaries();
     void destructAllTemporariesAndRestoreStack();
     // pushes a landing pad which needs to be popped after the
     // following invoke instruction
@@ -101,8 +100,10 @@ private:
     // next unique id stack
     std::stack<int> nextUnique;
 
-    int toElemScopeCounter;
+    Array<unsigned> toElemScopes; // number of initial temporaries
     VarDeclarations temporariesToDestruct;
+
+    void destructTemporaries(unsigned numToKeep);
 };
 
 // represents a function

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -87,6 +87,8 @@ struct FuncGen
 
     void pushTemporaryToDestruct(VarDeclaration* vd);
     bool hasTemporariesToDestruct();
+    VarDeclarations& getTemporariesToDestruct();
+
     void destructAllTemporariesAndRestoreStack();
     // pushes a landing pad which needs to be popped after the
     // following invoke instruction


### PR DESCRIPTION
This is an attempt to fix `runnable/sdtor.d:3438`.

Reduced test case:
```D
import core.exception, core.stdc.stdio;

struct S {
    __gshared int count;
    ~this() { ++count; }
}

class C
{
    this(S s, int f, S s2) {}
}

int foo(bool flag)
{
    if (flag)
        throw new Exception("hello");
    return 1;
}

void main()
{
    bool flag = true;
    bool threw = false;
    try { new C(S(), foo(flag), S()); }
    catch (Exception) { threw = true; }
    assert(threw == flag);
    printf("S.count = %d\n", S.count);
    if (flag)
        assert(S.count == 1);
    else
        assert(S.count == 2);
}
```

Without this patch, the first two argument expressions `S()` and `foo(flag)` for `C::this()` cannot be resolved to the variables (`__pfx` and `__pfy`) declared for them in DMD's `functionParameters()`. Their declaration expressions (and dtor gates) form a `CommaExp` chain represented by `NewExp::argprefix` which is currently not codegen'd at all.

This patch replaces the first arg subexpression of any NewExp with `argprefix, arg0` to include argprefix during codegen. It works for above test case if flag is set to false and no exception is thrown. The two variables are allocated on the caller's stack; S instances are then passed in memory (byval) to C's ctor, and C's ctor then destructs the copies.

The problem is that if an exception occurs when evaluating argprefix, we need to destruct all until then constructed objects at the call site, as C's ctor isn't invoked.