### PR TITLE
Fix alias declaration type resolution

### DIFF
--- a/dmd2/declaration.c
+++ b/dmd2/declaration.c
@@ -557,7 +557,7 @@ void AliasDeclaration::semantic(Scope *sc)
     if (s && ((s->getType() && type->equals(s->getType())) || s->isEnumMember()))
         goto L2;                        // it's a symbolic alias
 
-    type = type->addStorageClass(storage_class);
+    type = type->addSTC(storage_class);
     if (storage_class & (STCref | STCnothrow | STCnogc | STCpure | STCdisable))
     {
         // For 'ref' to be attached to function types, and picked
@@ -569,6 +569,7 @@ void AliasDeclaration::semantic(Scope *sc)
     }
     else
         type->resolve(loc, sc, &e, &t, &s);
+
     if (s)
     {
         goto L2;


### PR DESCRIPTION
Fix a bug where the mutable version of a Type is not properly resolved if it contains alias identifiers. This results in a bug later during compilation where stripModifiers() will return a not-fully-resolved type.
Fixes #893 