### PR TITLE
Don't memcmp() empty struct types.

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -351,14 +351,17 @@ void DtoAssign(Loc& loc, DValue* lhs, DValue* rhs, int op, bool canSkipPostblit)
         DtoStoreZextI8(rhs->getRVal(), lhs->getLVal());
     }
     else if (t->ty == Tstruct) {
-        llvm::Value* src = rhs->getRVal();
-        llvm::Value* dst = lhs->getLVal();
+        // don't copy anything to empty structs
+        if (static_cast<TypeStruct*>(t)->sym->fields.dim > 0) {
+            llvm::Value* src = rhs->getRVal();
+            llvm::Value* dst = lhs->getLVal();
 
-        // Check whether source and destination values are the same at compile
-        // time as to not emit an invalid (overlapping) memcpy on trivial
-        // struct self-assignments like 'A a; a = a;'.
-        if (src != dst)
-            DtoAggrCopy(dst, src);
+            // Check whether source and destination values are the same at compile
+            // time as to not emit an invalid (overlapping) memcpy on trivial
+            // struct self-assignments like 'A a; a = a;'.
+            if (src != dst)
+                DtoAggrCopy(dst, src);
+        }
     }
     else if (t->ty == Tarray) {
         // lhs is slice

--- a/gen/structs.cpp
+++ b/gen/structs.cpp
@@ -85,6 +85,10 @@ LLValue* DtoStructEquals(TOK op, DValue* lhs, DValue* rhs)
     else
         cmpop = llvm::ICmpInst::ICMP_NE;
 
+    // empty struct? EQ always true, NE always false
+    if (static_cast<TypeStruct*>(t)->sym->fields.dim == 0)
+        return DtoConstBool(cmpop == llvm::ICmpInst::ICMP_EQ);
+
     // call memcmp
     size_t sz = getTypePaddedSize(DtoType(t));
     LLValue* val = DtoMemCmp(lhs->getRVal(), rhs->getRVal(), DtoConstSize_t(sz));


### PR DESCRIPTION
Although they occupy 1 byte, D now apparently doesn't care about the actual data when comparing instances for (in)equality.

Fixes `runnable/xtest46.d` and `runnable/cppa.d`.