### PR TITLE
Refactoring the debug info for nested local variables.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -20,7 +20,6 @@
 #include "enum.h"
 #include "module.h"
 #include "mtype.h"
-#include <map>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -826,8 +825,8 @@ void ldc::DIBuilder::EmitStopPoint(unsigned ln)
 
 void ldc::DIBuilder::EmitValue(llvm::Value *val, VarDeclaration *vd)
 {
-    IrVar::DebugMap::iterator sub = getIrVar(vd)->debug.find(IR->func()->diSubprogram);
-    if (sub == getIrVar(vd)->debug.end())
+    IrFunction::VariableMap::iterator sub = IR->func()->variableMap.find(vd);
+    if (sub == IR->func()->variableMap.end())
         return;
 
     llvm::DIVariable debugVariable = sub->second;
@@ -859,9 +858,9 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
     Logger::println("D to dwarf local variable");
     LOG_SCOPE;
 
-    IrVar *irVar = getIrVar(vd);
-    IrVar::DebugMap::iterator sub = irVar->debug.find(IR->func()->diSubprogram);
-    if (sub != irVar->debug.end())
+    IrFunction::VariableMap& variableMap = IR->func()->variableMap;
+    IrFunction::VariableMap::iterator sub = variableMap.find(vd);
+    if (sub != variableMap.end())
         return; // ensure that the debug variable is created only once
 
     // get type description
@@ -910,7 +909,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
         );
     }
 #endif
-    irVar->debug[IR->func()->diSubprogram] = debugVariable;
+    variableMap[vd] = debugVariable;
 
     // declare
 #if LDC_LLVM_VER >= 306

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -16,6 +16,8 @@
 #ifndef LDC_IR_IRFUNCTION_H
 #define LDC_IR_IRFUNCTION_H
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseMapInfo.h"
 #include "gen/llvm.h"
 #include "ir/irlandingpad.h"
 #include "ir/irfuncty.h"
@@ -125,10 +127,14 @@ struct IrFunction
 #if LDC_LLVM_VER >= 307
     llvm::MDSubprogram* diSubprogram = nullptr;
     std::stack<llvm::MDLexicalBlock*> diLexicalBlocks;
+    typedef llvm::DenseMap<VarDeclaration*, llvm::MDLocalVariable*> VariableMap;
 #else
     llvm::DISubprogram diSubprogram;
     std::stack<llvm::DILexicalBlock> diLexicalBlocks;
+    typedef llvm::DenseMap<VarDeclaration*, llvm::DIVariable> VariableMap;
 #endif
+    // Debug info for all variables
+    VariableMap variableMap;
 
     IrFuncTy irFty;
 };

--- a/ir/irvar.h
+++ b/ir/irvar.h
@@ -29,8 +29,6 @@
 #include "llvm/Analysis/DebugInfo.h"
 #endif
 
-#include <map>
-
 struct IrFuncTyArg;
 class VarDeclaration;
 
@@ -43,30 +41,6 @@ struct IrVar
 
     VarDeclaration* V;
     llvm::Value* value;
-
-    // Debug description of variable.
-    // A variable can be accessed from nested functions.
-    // Each function has a debug description for the variable but with
-    // different address expression.
-#if LDC_LLVM_VER >= 307
-    struct MDSubprogramLess : public std::binary_function <const llvm::MDSubprogram*, const llvm::MDSubprogram*, bool > {
-        bool operator()(const llvm::MDSubprogram* a, const llvm::MDSubprogram* b) const
-        {
-            return a->getLinkageName() < b->getLinkageName();
-        }
-    };
-
-    typedef std::map<llvm::MDSubprogram*, llvm::MDLocalVariable*, MDSubprogramLess> DebugMap;
-#else
-    struct DISubprogramLess : public std::binary_function <const llvm::DISubprogram&, const llvm::DISubprogram&, bool > {
-        bool operator()(const llvm::DISubprogram& a, const llvm::DISubprogram& b) const
-        {
-            return a.getLinkageName() < b.getLinkageName();
-        }
-};
-    typedef std::map<llvm::DISubprogram, llvm::DIVariable, DISubprogramLess> DebugMap;
-#endif
-    DebugMap debug;
 };
 
 // represents a global variable


### PR DESCRIPTION
- the debug info is now stored in the IrFunction object
  -> saves the lookup from VarDeclaration to IrVar
- uses a llvm::DenseMap instead of std::map
  -> no comparison method required
  -> hashing should be faster than tree lookup