### PR TITLE
Possible fix for issue #938.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -13,6 +13,7 @@
 #include "gen/llvmhelpers.h"
 #include "gen/logger.h"
 #include "gen/tollvm.h"
+#include "gen/optimizer.h"
 #include "ir/irtypeaggr.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"
@@ -42,7 +43,7 @@ Module *ldc::DIBuilder::getDefinedModule(Dsymbol *s)
     // array operations as well
     else if (FuncDeclaration* fd = s->isFuncDeclaration())
     {
-        if (fd->isArrayOp && !isDruntimeArrayOp(fd))
+        if (fd->isArrayOp && (willInline() || !isDruntimeArrayOp(fd)))
             return IR->dmodule;
     }
     // otherwise use the symbol's module

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -733,7 +733,7 @@ static llvm::GlobalValue::LinkageTypes lowerFuncLinkage(FuncDeclaration* fdecl)
 
     // Generated array op functions behave like templates in that they might be
     // emitted into many different modules.
-    if (fdecl->isArrayOp && !isDruntimeArrayOp(fdecl))
+    if (fdecl->isArrayOp && (willInline() || !isDruntimeArrayOp(fdecl)))
         return templateLinkage;
 
     // A body-less declaration always needs to be marked as external in LLVM
@@ -782,7 +782,7 @@ void DtoDefineFunction(FuncDeclaration* fd)
     }
 
     // Skip array ops implemented in druntime
-    if (fd->isArrayOp && isDruntimeArrayOp(fd))
+    if (fd->isArrayOp && !willInline() && isDruntimeArrayOp(fd))
     {
         IF_LOG Logger::println("No code generation for array op %s implemented in druntime", fd->toChars());
         fd->ir.setDefined();


### PR DESCRIPTION
The functions for all arrayops are compiler-generated but the functions
which are also defined in druntime are never emitted. This prevents
inlining of the function body and causes issue #938.

The fix is to emit the arrayops if inlining is enabled and otherwise
use the druntime provided implementations.

An alternative approach could be to always emit the arrayops and
never use the druntime version.