### PR TITLE
MIPS: Implement ABI handling.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -308,6 +308,13 @@ cl::list<std::string> mAttrs("mattr",
 cl::opt<std::string> mTargetTriple("mtriple",
     cl::desc("Override target triple"));
 
+#if LDC_LLVM_VER >= 307
+cl::opt<std::string> mABI("mabi",
+    cl::desc("The name of the ABI to be targeted from the backend"),
+    cl::Hidden,
+    cl::init(""));
+#endif
+
 cl::opt<llvm::Reloc::Model> mRelocModel("relocation-model",
     cl::desc("Relocation model"),
     cl::init(llvm::Reloc::Default),

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -66,6 +66,9 @@ namespace opts {
     extern cl::opt<std::string> mCPU;
     extern cl::list<std::string> mAttrs;
     extern cl::opt<std::string> mTargetTriple;
+#if LDC_LLVM_VER >= 307
+    extern cl::opt<std::string> mABI;
+#endif
     extern cl::opt<llvm::Reloc::Model> mRelocModel;
     extern cl::opt<llvm::CodeModel::Model> mCodeModel;
     extern cl::opt<bool> disableFpElim;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -226,13 +226,39 @@ static int linkObjToBinaryGcc(bool sharedLib)
 
     // Only specify -m32/-m64 for architectures where the two variants actually
     // exist (as e.g. the GCC ARM toolchain doesn't recognize the switches).
+    // MIPS does not have -m32/-m64 but requires -mabi=.
     if (global.params.targetTriple.get64BitArchVariant().getArch() !=
-        llvm::Triple::UnknownArch
-    ) {
-        if (global.params.is64bit)
-            args.push_back("-m64");
-        else
-            args.push_back("-m32");
+        llvm::Triple::UnknownArch &&
+        global.params.targetTriple.get32BitArchVariant().getArch() !=
+        llvm::Triple::UnknownArch) {
+        if (global.params.targetTriple.get64BitArchVariant().getArch() ==
+            llvm::Triple::mips64 ||
+            global.params.targetTriple.get64BitArchVariant().getArch() ==
+            llvm::Triple::mips64el) {
+            switch (getMipsABI())
+            {
+                case MipsABI::EABI:
+                    args.push_back("-mabi=eabi");
+                    break;
+                case MipsABI::O32:
+                    args.push_back("-mabi=32");
+                    break;
+                case MipsABI::N32:
+                    args.push_back("-mabi=n32");
+                    break;
+                case MipsABI::N64:
+                    args.push_back("-mabi=64");
+                    break;
+                case MipsABI::Unknown:
+                    break;
+            }
+        }
+        else {
+            if (global.params.is64bit)
+                args.push_back("-m64");
+            else
+                args.push_back("-m32");
+        }
     }
 
     if (opts::createSharedLib && addSoname) {

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -544,26 +544,23 @@ static void initializePasses() {
 /// Register the MIPS ABI.
 static void registerMipsABI()
 {
-#if LDC_LLVM_VER >= 307
-    // FIXME: EABI?
-    auto dl = gTargetMachine->getDataLayout();
-    if (dl->getPointerSizeInBits() == 64)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_N64");
-    else if (dl->getLargestLegalIntTypeSize() == 64)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_N32");
-    else
-        VersionCondition::addPredefinedGlobalIdent("MIPS_O32");
-#else
-    llvm::StringRef features = gTargetMachine->getTargetFeatureString();
-    if (features.find("+o32") != std::string::npos)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_O32");
-    if (features.find("+n32") != std::string::npos)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_N32");
-    if (features.find("+n64") != std::string::npos)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_N64");
-    if (features.find("+eabi") != std::string::npos)
-        VersionCondition::addPredefinedGlobalIdent("MIPS_EABI");
-#endif
+    switch (getMipsABI())
+    {
+        case MipsABI::EABI:
+            VersionCondition::addPredefinedGlobalIdent("MIPS_EABI");
+            break;
+        case MipsABI::O32:
+            VersionCondition::addPredefinedGlobalIdent("MIPS_O32");
+            break;
+        case MipsABI::N32:
+            VersionCondition::addPredefinedGlobalIdent("MIPS_N32");
+            break;
+        case MipsABI::N64:
+            VersionCondition::addPredefinedGlobalIdent("MIPS_N64");
+            break;
+        case MipsABI::Unknown:
+            break;
+    }
 }
 
 /// Register the float ABI.

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -26,6 +26,87 @@
 #include "mars.h"
 #include "gen/logger.h"
 
+#if LDC_LLVM_VER >= 307
+#include "driver/cl_options.h"
+
+static const llvm::StringRef getABI(const llvm::Triple &triple)
+{
+    llvm::StringRef ABIName(opts::mABI);
+    if (ABIName != "")
+    {
+        switch (triple.getArch())
+        {
+            case llvm::Triple::arm:
+            case llvm::Triple::armeb:
+                if (ABIName.startswith("aapcs")) return "aapcs";
+                if (ABIName.startswith("eabi")) return "apcs";
+                break;
+            case llvm::Triple::mips:
+            case llvm::Triple::mipsel:
+            case llvm::Triple::mips64:
+            case llvm::Triple::mips64el:
+                if (ABIName.startswith("o32")) return "o32";
+                if (ABIName.startswith("n32")) return "n32";
+                if (ABIName.startswith("n64")) return "n64";
+                if (ABIName.startswith("eabi")) return "eabi";
+                break;
+            case llvm::Triple::ppc64:
+            case llvm::Triple::ppc64le:
+                if (ABIName.startswith("elfv1")) return "elfv1";
+                if (ABIName.startswith("elfv2")) return "elfv2";
+                break;
+            default:
+                break;
+        }
+        warning(Loc(), "Unknown ABI %s - using default ABI instead", ABIName.str().c_str());
+    }
+
+    switch (triple.getArch())
+    {
+        case llvm::Triple::mips64:
+        case llvm::Triple::mips64el:
+            return "n32";
+        case llvm::Triple::ppc64:
+            return "elfv1";
+        case llvm::Triple::ppc64le:
+            return "elfv2";
+        default:
+            return 0;
+    }
+}
+#endif
+
+extern llvm::TargetMachine* gTargetMachine;
+
+MipsABI::Type getMipsABI()
+{
+#if LDC_LLVM_VER >= 307
+    // eabi can only be set on the commandline
+    if (strncmp(opts::mABI.c_str(), "eabi", 4) == 0)
+        return MipsABI::EABI;
+    else
+    {
+        auto dl = gTargetMachine->getDataLayout();
+        if (dl->getPointerSizeInBits() == 64)
+            return MipsABI::N64;
+        else if (dl->getLargestLegalIntTypeSize() == 64)
+            return MipsABI::N32;
+        else
+            return MipsABI::O32;
+    }
+#else
+    llvm::StringRef features = gTargetMachine->getTargetFeatureString();
+    if (features.find("+o32") != std::string::npos)
+        return MipsABI::O32;
+    if (features.find("+n32") != std::string::npos)
+        return MipsABI::N32;
+    if (features.find("+n64") != std::string::npos)
+        return MipsABI::N32;
+    if (features.find("+eabi") != std::string::npos)
+        return MipsABI::EABI;
+    return MipsABI::Unknown;
+#endif
+}
 
 static std::string getX86TargetCPU(const llvm::Triple &triple)
 {
@@ -424,6 +505,9 @@ llvm::TargetMachine* createTargetMachine(
 
     llvm::TargetOptions targetOptions;
     targetOptions.NoFramePointerElim = noFramePointerElim;
+#if LDC_LLVM_VER >= 307
+    targetOptions.MCOptions.ABIName = getABI(triple);
+#endif
 
     switch (floatABI)
     {

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -36,6 +36,16 @@ namespace FloatABI {
     };
 }
 
+namespace MipsABI {
+    enum Type {
+        Unknown,
+        O32,
+        N32,
+        N64,
+        EABI
+    };
+}
+
 namespace llvm { class TargetMachine; }
 
 /**
@@ -57,5 +67,14 @@ llvm::TargetMachine* createTargetMachine(
     bool noFramePointerElim,
     bool noLinkerStripDead
     );
+
+/**
+ * Returns the Mips ABI which is used for code generation.
+ *
+ * Function may only be called after the target machine is created.
+ * Returns MipsABI::Unknown in case the ABI is not known (e.g. not compiling
+ * for Mips).
+ */
+MipsABI::Type getMipsABI();
 
 #endif // LDC_DRIVER_TARGET_H


### PR DESCRIPTION
Adds a new command line option -mabi= and uses the value to compute
the ABI to use. Adds the ABI to linker and assembler invocation, too.
Allows consistent invocation of the whole tool chain.