### PR TITLE
Remove extra load on assignment generated only for debug info

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -460,11 +460,6 @@ void DtoAssign(Loc& loc, DValue* lhs, DValue* rhs, int op, bool canSkipPostblit)
         }
         gIR->ir->CreateStore(r, l);
     }
-
-    DVarValue *var = lhs->isVar();
-    VarDeclaration *vd = var ? var->var : 0;
-    if (vd)
-        gIR->DBuilder.EmitValue(DtoLoad(var->getLVal()), vd);
 }
 
 /****************************************************************************************/


### PR DESCRIPTION
This leads to serious problems for values we really should
not be loading from, such as 100k element static arrays.

It was hard to figure out exactly why we need to emit DWARF
info here, so the easiest solution is to just have a look
at assignments during the next big debug info push.

@liranz