### PR TITLE
DtoSymbolAddress: Remove support for unused ClassInfoDeclaration

### DIFF
--- a/dmd2/declaration.h
+++ b/dmd2/declaration.h
@@ -361,7 +361,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
 
-    ClassInfoDeclaration* isClassInfoDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/dmd2/dsymbol.h
+++ b/dmd2/dsymbol.h
@@ -304,8 +304,6 @@ public:
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 #if IN_LLVM
-    virtual ClassInfoDeclaration* isClassInfoDeclaration() { return NULL; }
-
     // llvm stuff
     int llvmInternal;
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1713,13 +1713,6 @@ DValue* DtoSymbolAddress(Loc& loc, Type* type, Declaration* decl)
             val = DtoArrayLen(gIR->arrays.back());
             return new DImValue(type, val);
         }
-        // classinfo
-        else if (ClassInfoDeclaration* cid = vd->isClassInfoDeclaration())
-        {
-            Logger::println("ClassInfoDeclaration: %s", cid->cd->toChars());
-            DtoResolveClass(cid->cd);
-            return new DVarValue(type, vd, getIrAggr(cid->cd)->getClassInfoSymbol());
-        }
         // typeinfo
         else if (TypeInfoDeclaration* tid = vd->isTypeInfoDeclaration())
         {


### PR DESCRIPTION
It will be gone in 2.068.