### PR TITLE
Do not try to use RTTI for C++ classes

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -239,6 +239,12 @@ DValue* DtoCastClass(Loc& loc, DValue* val, Type* _to)
     Type* from = val->getType()->toBasetype();
     TypeClass* fc = static_cast<TypeClass*>(from);
 
+    if (fc->sym->isCPPclass()) {
+        IF_LOG Logger::println("C++ class/interface, just bitcasting");
+        LLValue* rval = DtoBitCast(val->getRVal(), DtoType(_to));
+        return new DImValue(_to, rval);
+    }
+
     // x -> interface
     if (InterfaceDeclaration* it = tc->sym->isInterfaceDeclaration()) {
         Logger::println("to interface");

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2119,7 +2119,8 @@ public:
         if(
             global.params.useInvariants &&
             condty->ty == Tclass &&
-            !(static_cast<TypeClass*>(condty)->sym->isInterfaceDeclaration()))
+            !(static_cast<TypeClass*>(condty)->sym->isInterfaceDeclaration()) &&
+            !(static_cast<TypeClass*>(condty)->sym->isCPPclass()))
         {
             Logger::println("calling class invariant");
             llvm::Function* fn = LLVM_D_GetRuntimeFunction(e->loc, gIR->module,


### PR DESCRIPTION
Casts are just bitcasts, and do not try to invoke
class invariants on asserts.

@yebblies mentioned he would extend the DMD test suite
accordingly.