### PR TITLE
We always define functions for which we emit DWARF subprograms

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/dibuilder.h"
+
 #include "gen/functions.h"
 #include "gen/irstate.h"
 #include "gen/llvmhelpers.h"
@@ -709,7 +710,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd)
         fd->loc.linnum, // line no
         DIFnType, // type
         fd->protection == PROTprivate, // is local to unit
-        IR->dmodule == getDefinedModule(fd), // isdefinition
+        true, // isdefinition
         fd->loc.linnum, // FIXME: scope line
         DIFlags::FlagPrototyped, // Flags
         isOptimizationEnabled(), // isOptimized


### PR DESCRIPTION
This fixes a crash with debug info for lambdas, where DMD appends
the lambda function declaration to the wrong module.

But the comparison is supposed to be tautological anyway, as we
only ever call it from DtoDefineFunction. Furthermore, it seems as
passing false can never work unless you manually (without going
through llvm::DIBuilder) resolve the Vars node later. Clang does
not try to do this either.