### PR TITLE
Compile debug druntime/Phobos with optimizations on

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BUILD_BC_LIBS         OFF                                       CACHE BOOL  
 set(INCLUDE_INSTALL_DIR   ${CMAKE_INSTALL_PREFIX}/include/d         CACHE PATH    "Path to install D modules to")
 set(BUILD_SHARED_LIBS     OFF                                       CACHE BOOL    "Whether to build the runtime as a shared library")
 set(D_FLAGS               -w;-d                                     CACHE STRING  "Runtime build flags, separated by ;")
-set(D_FLAGS_DEBUG         -g                                        CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
+set(D_FLAGS_DEBUG         -O3;-g                                    CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
 set(D_FLAGS_RELEASE       -O3;-release                              CACHE STRING  "Runtime build flags (release libraries), separated by ;")
 if(MSVC)
     set(LINK_WITH_MSVCRT  OFF                                       CACHE BOOL    "Link with MSVCRT.LIB instead of LIBCMT.LIB")


### PR DESCRIPTION
We still need to discuss whether it really makes sense to slow
down user code just because -g is passes (as the debug libraries
are still built without -release). But there is no reason to forgo
optimization of them completely, since the instances where you
actually want to debug into the standard library as a user are
very rare. People actually specifying -O3 -g is much more common.