### PR TITLE
Always link libcurl when Phobos is linked

### DIFF
--- a/ldc2_install.conf.in
+++ b/ldc2_install.conf.in
@@ -10,7 +10,7 @@ default:
         "-I@INCLUDE_INSTALL_DIR@/ldc",
         "-I@INCLUDE_INSTALL_DIR@",
         "-L-L@CMAKE_INSTALL_LIBDIR@", @MULTILIB_ADDITIONAL_INSTALL_PATH@
-        "-defaultlib=phobos2-ldc,druntime-ldc",
-        "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
+        "-defaultlib=phobos2-ldc,curl,druntime-ldc",
+        "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"
     ];
 };

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -14,7 +14,7 @@ default:
         "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Debug",
         "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Release",
         "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/RelWithDebInfo",
-        "-defaultlib=phobos2-ldc,druntime-ldc",
-        "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
+        "-defaultlib=phobos2-ldc,curl,druntime-ldc",
+        "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"
     ];
 };


### PR DESCRIPTION
This is the only sensible solution until e.g.
D-Programming-Language/phobos#3009 is merged, which makes
Phobos load libcurl dynamically. The issue with the current
situation is is that the user cannot even manually link
libcurl if linker errors occur, because it will appear
before libphobos2-ldc in the linker command line.

GitHub: Fixes #906.