### PR TITLE
Do not imply ` -singleObj` if creating lib.

### DIFF
--- a/dmd2/module.h
+++ b/dmd2/module.h
@@ -209,7 +209,7 @@ public:
 #if IN_LLVM
     // LDC
     llvm::Module* genLLVMModule(llvm::LLVMContext& context);
-    void buildTargetFiles(bool singleObj);
+    void buildTargetFiles(bool singleObj, bool library);
     File* buildFilePath(const char* forcename, const char* path, const char* ext);
     llvm::GlobalVariable* moduleInfoSymbol();
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -496,11 +496,7 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles, bool &
         error(Loc(), "flags conflict with -run");
     }
     else if (global.params.objname && sourceFiles.dim > 1) {
-        if (createStaticLib || createSharedLib)
-        {
-            singleObj = true;
-        }
-        if (!singleObj)
+        if (!(createStaticLib || createSharedLib) && !singleObj)
         {
             error(Loc(), "multiple source files, but only one .obj name");
         }
@@ -1246,7 +1242,7 @@ int main(int argc, char **argv)
         }
 
         m->parse(global.params.doDocComments);
-        m->buildTargetFiles(singleObj);
+        m->buildTargetFiles(singleObj, createSharedLib || createStaticLib);
         m->deleteObjFile();
         if (m->isDocFile)
         {

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -86,7 +86,7 @@ static void check_and_add_output_file(Module* NewMod, const std::string& str)
     files.insert(std::make_pair(str, NewMod));
 }
 
-void Module::buildTargetFiles(bool singleObj)
+void Module::buildTargetFiles(bool singleObj, bool library)
 {
     if (objfile &&
        (!doDocComment || docfile) &&
@@ -94,15 +94,16 @@ void Module::buildTargetFiles(bool singleObj)
         return;
 
     if (!objfile) {
+		const char *objname = library ? 0 : global.params.objname;
         if (global.params.output_o)
-            objfile = Module::buildFilePath(global.params.objname, global.params.objdir,
+            objfile = Module::buildFilePath(objname, global.params.objdir,
                 global.params.targetTriple.isOSWindows() ? global.obj_ext_alt : global.obj_ext);
         else if (global.params.output_bc)
-            objfile = Module::buildFilePath(global.params.objname, global.params.objdir, global.bc_ext);
+            objfile = Module::buildFilePath(objname, global.params.objdir, global.bc_ext);
         else if (global.params.output_ll)
-            objfile = Module::buildFilePath(global.params.objname, global.params.objdir, global.ll_ext);
+            objfile = Module::buildFilePath(objname, global.params.objdir, global.ll_ext);
         else if (global.params.output_s)
-            objfile = Module::buildFilePath(global.params.objname, global.params.objdir, global.s_ext);
+            objfile = Module::buildFilePath(objname, global.params.objdir, global.s_ext);
     }
     if (doDocComment && !docfile)
         docfile = Module::buildFilePath(global.params.docname, global.params.docdir, global.doc_ext);


### PR DESCRIPTION
If a target file name is given (`-of`) and a library is created then
`-singleObj` is implied. This results in behaviour not compatible
with dmd. This commit checks for this situation and does not set
`-singleObj`. This fixes issue #978.