### PR TITLE
Updates to the CPP mangler

### DIFF
--- a/dmd2/cppmangle.c
+++ b/dmd2/cppmangle.c
@@ -170,7 +170,11 @@ class CppMangleVisitor : public Visitor
                     else
                     {
                         s->error("ICE: C++ %s template value parameter is not supported", tv->valType->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
                 }
                 else if (!tp || tp->isTemplateTypeParameter())
@@ -186,7 +190,11 @@ class CppMangleVisitor : public Visitor
                     if (!d && !e)
                     {
                         s->error("ICE: %s is unsupported parameter for C++ template: (%s)", o->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
                     if (d && d->isFuncDeclaration())
                     {
@@ -215,14 +223,22 @@ class CppMangleVisitor : public Visitor
                     else
                     {
                         s->error("ICE: %s is unsupported parameter for C++ template", o->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
 
                 }
                 else
                 {
                     s->error("ICE: C++ templates support only integral value , type parameters, alias templates and alias function parameters");
+#if IN_LLVM
+                    fatal();
+#else
                     assert(0);
+#endif
                 }
             }
             if (is_var_arg)
@@ -295,7 +311,11 @@ class CppMangleVisitor : public Visitor
         if (!(d->storage_class & (STCextern | STCgshared)))
         {
             d->error("ICE: C++ static non- __gshared non-extern variables not supported");
+#if IN_LLVM
+            fatal();
+#else
             assert(0);
+#endif
         }
 
         Dsymbol *p = d->toParent();
@@ -379,7 +399,11 @@ class CppMangleVisitor : public Visitor
         {   // Mangle static arrays as pointers
             t->error(Loc(), "ICE: Unable to pass static array to extern(C++) function.");
             t->error(Loc(), "Use pointer instead.");
+#if IN_LLVM
+            fatal();
+#else
             assert(0);
+#endif
             //t = t->nextOf()->pointerTo();
         }
 
@@ -441,7 +465,11 @@ public:
         {
             t->error(Loc(), "ICE: Unsupported type %s\n", t->toChars());
         }
+#if IN_LLVM
+        fatal();
+#else
         assert(0); //Assert, because this error should be handled in frontend
+#endif
     }
 
     void visit(TypeBasic *t)
@@ -781,7 +809,11 @@ public:
         {
             type->error(Loc(), "ICE: Unsupported type %s\n", type->toChars());
         }
+#if IN_LLVM
+        fatal();
+#else
         assert(0); // Assert, because this error should be handled in frontend
+#endif
     }
 
     void visit(TypeBasic *type)
@@ -1166,7 +1198,11 @@ private:
         if (!(d->storage_class & (STCextern | STCgshared)))
         {
             d->error("ICE: C++ static non- __gshared non-extern variables not supported");
+#if IN_LLVM
+            fatal();
+#else
             assert(0);
+#endif
         }
         buf.writeByte('?');
         mangleIdent(d);
@@ -1298,7 +1334,11 @@ private:
                     else
                     {
                         sym->error("ICE: C++ %s template value parameter is not supported", tv->valType->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
                 }
                 else if (!tp || tp->isTemplateTypeParameter())
@@ -1314,7 +1354,11 @@ private:
                     if (!d && !e)
                     {
                         sym->error("ICE: %s is unsupported parameter for C++ template", o->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
                     if (d && d->isFuncDeclaration())
                     {
@@ -1356,7 +1400,11 @@ private:
                             else
                             {
                                 sym->error("ICE: C++ templates support only integral value , type parameters, alias templates and alias function parameters");
+#if IN_LLVM
+                                fatal();
+#else
                                 assert(0);
+#endif
                             }
                         }
                         tmp.mangleIdent(d);
@@ -1364,14 +1412,22 @@ private:
                     else
                     {
                         sym->error("ICE: %s is unsupported parameter for C++ template: (%s)", o->toChars());
+#if IN_LLVM
+                        fatal();
+#else
                         assert(0);
+#endif
                     }
 
                 }
                 else
                 {
                     sym->error("ICE: C++ templates support only integral value , type parameters, alias templates and alias function parameters");
+#if IN_LLVM
+                    fatal();
+#else
                     assert(0);
+#endif
                 }
             }
             name = tmp.buf.extractString();
@@ -1663,7 +1719,11 @@ private:
         {
             t->error(Loc(), "ICE: Unable to pass static array to extern(C++) function.");
             t->error(Loc(), "Use pointer instead.");
+#if IN_LLVM
+            fatal();
+#else
             assert(0);
+#endif
         }
         flags &= ~IS_NOT_TOP_TYPE;
         flags &= ~IGNORE_CONST;


### PR DESCRIPTION
- Calls now `fatal()` instead of `assert(0)` after an error message. This should reduce the ugly stack traces on windows.
- Chooses the CPP mangler based on the current target. Up to now the Visual C++ mangler was not used.