### PR TITLE
Do not emit globals with void initializer as LLVM constants

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -929,7 +929,11 @@ void DtoResolveVariable(VarDeclaration* vd)
                 Logger::println("parent: null");
         }
 
-        const bool isLLConst = (vd->isConst() || vd->isImmutable()) && vd->init;
+        // If a const/immutable value has a proper initializer (not "= void"),
+        // it cannot be assigned again in a static constructor. Thus, we can
+        // emit it as read-only data.
+        const bool isLLConst = (vd->isConst() || vd->isImmutable()) &&
+            vd->init && !vd->init->isVoidInitializer();
 
         assert(!vd->ir.isInitialized());
         if (gIR->dmodule)


### PR DESCRIPTION
Fixes things like `const(Foo) f = void; static shared this() { f = …; }`.