### PR TITLE
Do not use non-existing library search paths on non-MSVC builds

### DIFF
--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -9,10 +9,7 @@ default:
     switches = [
         "-I@PROJECT_BINARY_DIR@/../import",
         "-I@RUNTIME_DIR@/src", // Needed for gc.*/rt.* unit tests.
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Debug",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Release",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/RelWithDebInfo",
+        @LIB_PATH@@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
         "-defaultlib=druntime-ldc",
         "-debuglib=druntime-ldc-debug"
     ];

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -10,10 +10,7 @@ default:
         "-I@CMAKE_BINARY_DIR@/import",
         "-I@RUNTIME_DIR@/src", // Needed for gc.*/rt.* unit tests.
         "-I@PHOBOS2_DIR@/",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Debug",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/Release",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@/RelWithDebInfo",
+        @LIB_PATH@@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
         "-defaultlib=phobos2-ldc,curl,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"
     ];

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -194,6 +194,11 @@ endif()
 #
 # Create configuration files.
 #
+if(MSVC)
+    set(LIB_PATH "\"-L-L${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/${CMAKE_BUILD_TYPE}\",")
+else()
+    set(LIB_PATH "\"-L-L${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
+endif()
 
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of


### PR DESCRIPTION
The linker on OS X emits a warning for these, breaking the
dmd-testsuite tests that verify the diagnostics.