### PR TITLE
Fix debug info builds with inlining on

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -833,7 +833,13 @@ void ldc::DIBuilder::EmitBlockEnd()
 
 void ldc::DIBuilder::EmitStopPoint(Loc& loc)
 {
-    if (!global.params.symdebug || !loc.linnum)
+    if (!global.params.symdebug)
+        return;
+
+    // If we already have a location set and the current loc is invalid
+    // (line 0), then we can just ignore it (see GitHub issue #998 for why we
+    // cannot do this in all cases).
+    if (!loc.linnum && !IR->ir->getCurrentDebugLocation().isUnknown())
         return;
 
     Logger::println("D to dwarf stoppoint at line %u, column %u", loc.linnum, loc.charnum);

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -204,7 +204,11 @@ static llvm::Function* build_module_function(const std::string &name, const std:
     IRBuilder<> builder(bb);
 
     // debug info
-    gIR->DBuilder.EmitModuleCTor(fn, name.c_str());
+    llvm::DISubprogram dis = gIR->DBuilder.EmitModuleCTor(fn, name.c_str());
+    if (global.params.symdebug) {
+        // Need _some_ debug info to avoid inliner bug, see GitHub issue #998.
+        builder.SetCurrentDebugLocation(llvm::DebugLoc::get(0, 0, dis));
+    }
 
     // Call ctor's
     typedef std::list<FuncDeclaration*>::const_iterator FuncIterator;


### PR DESCRIPTION
This is likely an LLVM bug: The code in InlineFunctions.cpp
only updates the source location metadata for the instructions
in the inlined callee when the call site has a source location
set. When the caller has no location metadata, the scope for
the inlined instructions thus still points to the DISubprogram
for the original callee. This then leads to an assertion during
codegen.

GitHub: Fixes #998.