### PR TITLE
Use C calling convention for variadic functions on x86.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ env:
   - LLVM_PACKAGE="llvm-3.7 llvm-3.7-dev libedit2 libedit-dev"
 matrix:
   allow_failures:
-  - env: LLVM_PACKAGE="llvm-3.6 llvm-3.6-dev libedit2 libedit-dev" OPTS="-DMULTILIB=ON" TEST_BITNESS=32
   - env: LLVM_PACKAGE="llvm-3.7 llvm-3.7-dev libedit2 libedit-dev" TEST_DEBUG=1
   - env: LLVM_PACKAGE="llvm-3.7 llvm-3.7-dev libedit2 libedit-dev"
 script:

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -28,22 +28,6 @@ struct MIPS64TargetABI : TargetABI {
     MIPS64TargetABI(const bool Is64Bit) : Is64Bit(Is64Bit)
     { }
 
-    llvm::CallingConv::ID callingConv(LINK l)
-    {
-        switch (l)
-        {
-        case LINKc:
-        case LINKcpp:
-        case LINKpascal:
-        case LINKwindows:
-        case LINKd:
-        case LINKdefault:
-            return llvm::CallingConv::C;
-        default:
-            llvm_unreachable("Unhandled D linkage type.");
-        }
-    }
-
     bool returnInArg(TypeFunction* tf)
     {
         if (tf->isref)

--- a/gen/abi-ppc64.cpp
+++ b/gen/abi-ppc64.cpp
@@ -28,22 +28,6 @@ struct PPC64TargetABI : TargetABI {
     PPC64TargetABI(const bool Is64Bit) : Is64Bit(Is64Bit)
     { }
 
-    llvm::CallingConv::ID callingConv(LINK l)
-    {
-        switch (l)
-        {
-        case LINKc:
-        case LINKcpp:
-        case LINKpascal:
-        case LINKwindows:
-        case LINKd:
-        case LINKdefault:
-            return llvm::CallingConv::C;
-        default:
-            llvm_unreachable("Unhandled D linkage type.");
-        }
-    }
-
     bool returnInArg(TypeFunction* tf)
     {
         if (tf->isref)

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -36,8 +36,6 @@ struct Win64TargetABI : TargetABI
     ExplicitByvalRewrite byvalRewrite;
     IntegerRewrite integerRewrite;
 
-    llvm::CallingConv::ID callingConv(LINK l);
-
     bool returnInArg(TypeFunction* tf);
 
     bool passByVal(Type* t);
@@ -93,23 +91,6 @@ private:
 TargetABI* getWin64TargetABI()
 {
     return new Win64TargetABI;
-}
-
-
-llvm::CallingConv::ID Win64TargetABI::callingConv(LINK l)
-{
-    switch (l)
-    {
-    case LINKc:
-    case LINKcpp:
-    case LINKpascal:
-    case LINKd:
-    case LINKdefault:
-    case LINKwindows:
-        return llvm::CallingConv::C;
-    default:
-        llvm_unreachable("Unhandled D linkage type.");
-    }
 }
 
 bool Win64TargetABI::returnInArg(TypeFunction* tf)

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -219,8 +219,6 @@ struct X86_64TargetABI : TargetABI {
     X86_64_C_struct_rewrite struct_rewrite;
     ImplicitByvalRewrite byvalRewrite;
 
-    llvm::CallingConv::ID callingConv(LINK l);
-
     bool returnInArg(TypeFunction* tf);
 
     bool passByVal(Type* t);
@@ -245,21 +243,6 @@ private:
 // The public getter for abi.cpp
 TargetABI* getX86_64TargetABI() {
     return new X86_64TargetABI;
-}
-
-
-llvm::CallingConv::ID X86_64TargetABI::callingConv(LINK l) {
-    switch (l) {
-        case LINKc:
-        case LINKcpp:
-        case LINKpascal:
-        case LINKwindows: // Doesn't really make sense, user should use Win64 target.
-        case LINKd:
-        case LINKdefault:
-            return llvm::CallingConv::C;
-        default:
-            llvm_unreachable("Unhandled D linkage type.");
-    }
 }
 
 bool X86_64TargetABI::returnInArg(TypeFunction* tf) {

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -24,7 +24,7 @@ struct X86TargetABI : TargetABI
 {
     IntegerRewrite integerRewrite;
 
-    llvm::CallingConv::ID callingConv(LINK l)
+    llvm::CallingConv::ID callingConv(llvm::FunctionType* ft, LINK l)
     {
         switch (l)
         {
@@ -35,7 +35,7 @@ struct X86TargetABI : TargetABI
         case LINKdefault:
         case LINKpascal:
         case LINKwindows:
-            return llvm::CallingConv::X86_StdCall;
+            return ft->isVarArg() ? llvm::CallingConv::C : llvm::CallingConv::X86_StdCall;
         default:
             llvm_unreachable("Unhandled D linkage type.");
         }

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -143,23 +143,6 @@ LLValue* TargetABI::prepareVaArg(LLValue* pAp)
 // Some reasonable defaults for when we don't know what ABI to use.
 struct UnknownTargetABI : TargetABI
 {
-    llvm::CallingConv::ID callingConv(LINK l)
-    {
-        switch (l)
-        {
-        case LINKc:
-        case LINKcpp:
-        case LINKpascal:
-        case LINKwindows:
-            return llvm::CallingConv::C;
-        case LINKd:
-        case LINKdefault:
-            return llvm::CallingConv::Fast;
-        default:
-            llvm_unreachable("Unhandled D linkage type.");
-        }
-    }
-
     bool returnInArg(TypeFunction* tf)
     {
         if (tf->isref)
@@ -219,11 +202,6 @@ TargetABI * TargetABI::getTarget()
 struct IntrinsicABI : TargetABI
 {
     RemoveStructPadding remove_padding;
-
-    llvm::CallingConv::ID callingConv(LINK l)
-    {
-        return llvm::CallingConv::C;
-    }
 
     bool returnInArg(TypeFunction* tf)
     {

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -35,6 +35,7 @@ namespace llvm
 {
     class Type;
     class Value;
+    class FunctionType;
 }
 
 // return rewrite rule
@@ -87,8 +88,11 @@ struct TargetABI
     static TargetABI* getIntrinsic();
 
     /// Returns the LLVM calling convention to be used for the given D linkage
-    /// type on the target.
-    virtual llvm::CallingConv::ID callingConv(LINK l) = 0;
+    /// type on the target. Defaults to the C calling convention.
+    virtual llvm::CallingConv::ID callingConv(llvm::FunctionType* ft, LINK l)
+    {
+        return llvm::CallingConv::C;
+    }
 
     /// Applies any rewrites that might be required to accurately reproduce the
     /// passed function name on LLVM given a specific calling convention.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -503,7 +503,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
         fatal();
     }
 
-    func->setCallingConv(gABI->callingConv(link));
+    func->setCallingConv(gABI->callingConv(func->getFunctionType(), link));
 
     IF_LOG Logger::cout() << "func = " << *func << std::endl;
 

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -198,7 +198,7 @@ static llvm::Function* build_module_function(const std::string &name, const std:
     assert(gIR->module.getFunction(symbolName) == NULL);
     llvm::Function* fn = llvm::Function::Create(fnTy,
         llvm::GlobalValue::InternalLinkage, symbolName, &gIR->module);
-    fn->setCallingConv(gABI->callingConv(LINKd));
+    fn->setCallingConv(gABI->callingConv(fn->getFunctionType(), LINKd));
 
     llvm::BasicBlock* bb = llvm::BasicBlock::Create(gIR->context(), "", fn);
     IRBuilder<> builder(bb);
@@ -219,7 +219,11 @@ static llvm::Function* build_module_function(const std::string &name, const std:
 #else
         llvm::CallInst* call = builder.CreateCall(f, "");
 #endif
-        call->setCallingConv(gABI->callingConv(LINKd));
+        call->setCallingConv(gABI->callingConv(call->
+#if LDC_LLVM_VER < 307
+                             getCalledFunction()->
+#endif
+                             getFunctionType(), LINKd));
     }
 
     // Increment vgate's
@@ -666,7 +670,7 @@ static void addCoverageAnalysis(Module* m)
 
         LLFunctionType* ctorTy = LLFunctionType::get(LLType::getVoidTy(gIR->context()), std::vector<LLType*>(), false);
         ctor = LLFunction::Create(ctorTy, LLGlobalValue::InternalLinkage, ctorname, &gIR->module);
-        ctor->setCallingConv(gABI->callingConv(LINKd));
+        ctor->setCallingConv(gABI->callingConv(ctor->getFunctionType(), LINKd));
         // Set function attributes. See functions.cpp:DtoDefineFunction()
         if (global.params.targetTriple.getArch() == llvm::Triple::x86_64)
         {

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -992,7 +992,7 @@ static void LLVM_D_BuildRuntimeModule()
 #else
         fn->addAttribute(1, irFty.args[0]->attrs.attrs);
 #endif
-        fn->setCallingConv(gABI->callingConv(LINKd));
+        fn->setCallingConv(gABI->callingConv(fn->getFunctionType(), LINKd));
     }
 
     // void _d_hidden_func(Object o)
@@ -1036,6 +1036,6 @@ static void LLVM_D_BuildRuntimeModule()
 
         LLFunctionType* fty = LLFunctionType::get(voidTy, params, false);
         llvm::Function* fn = LLFunction::Create(fty, LLGlobalValue::ExternalLinkage, fname, M);
-        fn->setCallingConv(gABI->callingConv(LINKc));
+        fn->setCallingConv(gABI->callingConv(fn->getFunctionType(), LINKc));
     }
 }

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -277,12 +277,11 @@ DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* 
     bool nestedcall = irFty.arg_nest;
     bool dvarargs = irFty.arg_arguments;
 
-    llvm::CallingConv::ID callconv = gABI->callingConv(tf->linkage);
-
     // get callee llvm value
     LLValue* callable = DtoCallableValue(fnval);
     LLFunctionType* callableTy = DtoExtractFunctionType(callable->getType());
     assert(callableTy);
+    llvm::CallingConv::ID callconv = gABI->callingConv(callableTy, tf->linkage);
 
 //     IF_LOG Logger::cout() << "callable: " << *callable << '\n';
 


### PR DESCRIPTION
0.15.1 used stdcall convention everywhere. But the ABI change in 0.15.2
requires use of the C calling convention for variadic calls on x86
because the stdcall convention does not support vararg functions.

Solution is to check the llvm::FunctionType if the function has varargs.
This commit also makes the C calling convention the global default
because according to the LLVM documentation the fastcc convention used
for D linkage does not support varargs.

This fixes issue #1000.