### PR TITLE
Always zero struct padding as required by TDPL

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1425,41 +1425,20 @@ bool hasUnalignedFields(Type* t)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-size_t realignOffset(size_t offset, Type* type)
+size_t getMemberSize(Type* type)
 {
-    size_t alignsize = type->alignsize();
-    size_t alignedoffset = (offset + alignsize - 1) & ~(alignsize - 1);
-
-    // if the aligned offset already matches the input offset
-    // don't waste time checking things are ok!
-    if (alignedoffset == offset)
-        return alignedoffset;
-
-    // we cannot get the llvm alignment if the type is still opaque, this can happen in some
-    // forward reference situations, so when this happens we fall back to manual padding.
-    // also handle arbitrary "by-value" opaques nested inside aggregates.
-    LLType* T = DtoType(type);
-    if (!T->isSized())
-    {
-        return offset;
+    const dinteger_t dSize = type->size();
+    llvm::Type * const llType = DtoType(type);
+    if (!llType->isSized()) {
+        // Forward reference in a cycle or similar, we need to trust the D type.
+        return dSize;
     }
 
-    // then we check against the llvm alignment
-    size_t alignsize2 = gDataLayout->getABITypeAlignment(T);
+    const uint64_t llSize = gDataLayout->getTypeStoreSize(llType);
+    assert(llSize <= dSize && "LLVM type is bigger than the corresponding D type, "
+        "might lead to aggregate layout mismatch.");
 
-    // if it differs we need to insert manual padding as well
-    if (alignsize != alignsize2)
-    {
-        // FIXME: this assert fails on std.typecons
-        //assert(alignsize > alignsize2 && "this is not good, the D and LLVM "
-        //    "type alignments differ, but LLVM's is bigger! This will break "
-        //    "aggregate type mapping");
-        // don't try and align the offset, and let the mappers pad 100% manually
-        return offset;
-    }
-
-    // ok, we're good, llvm will align properly!
-    return alignedoffset;
+    return llSize;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1434,7 +1434,7 @@ size_t getMemberSize(Type* type)
         return dSize;
     }
 
-    const uint64_t llSize = gDataLayout->getTypeStoreSize(llType);
+    const uint64_t llSize = gDataLayout->getTypeAllocSize(llType);
     assert(llSize <= dSize && "LLVM type is bigger than the corresponding D type, "
         "might lead to aggregate layout mismatch.");
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -150,9 +150,9 @@ unsigned getFieldGEPIndex(AggregateDeclaration* ad, VarDeclaration* vd);
 ///
 DValue* DtoInlineAsmExpr(Loc& loc, FuncDeclaration* fd, Expressions* arguments);
 
-/// Update an offset to make sure it follows both the D and LLVM alignments.
-/// Returns the offset rounded up to the closest safely aligned offset.
-size_t realignOffset(size_t offset, Type* type);
+/// Returns the size the LLVM type for a member variable of the given type will
+/// take up in a struct (in bytes). This does not include padding in any way.
+size_t getMemberSize(Type* type);
 
 /// Returns the llvm::Value of the passed DValue, making sure that it is an
 /// lvalue (has a memory address), so it can be passed to the D runtime

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -52,7 +52,7 @@ void RTTIBuilder::push(llvm::Constant* C)
         inits.push_back(llvm::Constant::getNullValue(padding));
     }
     inits.push_back(C);
-    prevFieldEnd = fieldStart + gDataLayout->getTypeStoreSize(C->getType());
+    prevFieldEnd = fieldStart + gDataLayout->getTypeAllocSize(C->getType());
 }
 
 void RTTIBuilder::push_null(Type* T)

--- a/gen/rttibuilder.h
+++ b/gen/rttibuilder.h
@@ -32,15 +32,18 @@ class Type;
 class TypeClass;
 namespace llvm { class StructType; }
 
-struct RTTIBuilder
+class RTTIBuilder
 {
     AggregateDeclaration* base;
     TypeClass* basetype;
     IrAggr* baseir;
 
-    // 10 is enough for any D1 TypeInfo
-    // 14 is enough for any D1 ClassInfo
-    llvm::SmallVector<llvm::Constant*, 14> inits;
+    /// The offset (in bytes) at which the previously pushed field ended.
+    uint64_t prevFieldEnd;
+
+public:
+    // 15 is enough for any D2 ClassInfo including 64 bit pointer alignment padding
+    llvm::SmallVector<llvm::Constant*, 15> inits;
 
     RTTIBuilder(AggregateDeclaration* base_class);
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1248,7 +1248,7 @@ public:
         }
         else
         {
-            uint64_t elemSize = gDataLayout->getTypeStoreSize(
+            uint64_t elemSize = gDataLayout->getTypeAllocSize(
                 baseValue->getType()->getContainedType(0));
             if (e->offset % elemSize == 0)
             {

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -25,7 +25,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-// FIXME A similar function is in ir/iraggr.cpp
+// FIXME A similar function is in ir/iraggr.cpp and RTTIBuilder::push().
 static inline
 size_t add_zeros(std::vector<llvm::Type*>& defaultTypes,
     size_t startOffset, size_t endOffset)
@@ -170,26 +170,19 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
         if (vd == NULL)
             continue;
 
-        assert(vd->offset >= m_offset && "it's a bug... most likely DMD bug 2481");
+        assert(vd->offset >= m_offset && "Variable overlaps previous field.");
 
-        // get next aligned offset for this type
-        size_t alignedoffset = m_offset;
-        if (!m_packed)
-        {
-            alignedoffset = realignOffset(alignedoffset, vd->type);
-        }
-
-        // insert explicit padding?
-        if (alignedoffset < vd->offset)
-        {
-            m_fieldIndex += add_zeros(m_defaultTypes, alignedoffset, vd->offset);
+        // Add an explicit field for any padding so we can zero it, as per TDPL §7.1.1.
+        if (m_offset < vd->offset) {
+            m_fieldIndex += add_zeros(m_defaultTypes, m_offset, vd->offset);
+            m_offset = vd->offset;
         }
 
         // add default type
         m_defaultTypes.push_back(DtoType(vd->type));
 
         // advance offset to right past this field
-        m_offset = vd->offset + vd->type->size();
+        m_offset += getMemberSize(vd->type);
 
         // set the field index
         m_varGEPIndices[vd] = m_fieldIndex;


### PR DESCRIPTION
We already generated the memsets for zeroing the padding,
but because we relied on the native LLVM type allignment
where possible instead of generating explicit padding
values, LLVM did not always copy those bytes around (e.g.
when spilling/reloading registers).