### PR TITLE
[WIP] DMD inline asm: allow labels as generic operands

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -3755,15 +3755,21 @@ namespace AsmParserx8664
                         }
                     }
 
-                    if ( opTakesLabel() && e->op == TOKidentifier )
+                    if ( e->op == TOKidentifier )
                     {
                         // DMD uses labels secondarily to other symbols, so check
                         // if IdentifierExp::semantic won't find anything.
                         Dsymbol *scopesym;
-
                         if ( ! sc->search ( stmt->loc, ident, & scopesym ) )
-                            return new DsymbolExp ( stmt->loc,
-                                                    sc->func->searchLabel ( ident ) );
+                        {
+                            if ( LabelDsymbol *labelsym = sc->func->searchLabel ( ident ) )
+                            {
+                                e = new DsymbolExp ( stmt->loc, labelsym );
+                                if ( opTakesLabel() )
+                                    return e;
+                                return new AddrExp ( stmt->loc, e );
+                            }
+                        }
                     }
 
                     e = e->semantic ( sc );


### PR DESCRIPTION
`compilable/iasm_labeloperand.d` is the last official 2.067 issue (edit: okay, there's still shared libs and `rt.util.typeinfo-debug`) on Linux x64 after David's latest commits. :+1: It uses labels as source operands for `mov` instructions, which is currently not supported.

This commit checks whether an identifier operand is a function label, for all instructions and not just those explicitly supporting labels (`opTakesLabel()`). If the instruction doesn't take labels directly, the operands yield the label's address. Not sure whether this is all it takes, but we have the first green 2.067 builds at last! :)