### PR TITLE
Revise CMake scripts some more for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,24 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     if(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS "4.7.0")
         append("-Wno-pedantic" LDC_CXXFLAGS)
     endif()
+elseif(MSVC)
+    # Remove flags here, for exceptions and RTTI.
+    # CL.EXE complains to override flags like "/GR /GR-".
+    string(REGEX REPLACE "(^| )[/-]EH[-cs]*( |$)" "\\2" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REGEX REPLACE "(^| )[/-]GR-?( |$)" "\\2" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    append("/GR- /EHs-c-" CMAKE_CXX_FLAGS)
+    add_definitions(/D_HAS_EXCEPTIONS=0)
+
+    # warning C4018: signed/unsigned mismatch
+    # warning C4101: unreferenced local variable
+    # warning C4102: unreferenced label
+    # warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # warnings C4244 and C4267: conversion from '...' to '...', possible loss of data
+    # warnings C4456-4459: declaration of '...' hides ...
+    # warning C4624: destructor was implicitly defined as deleted because a base class destructor is inaccessible or deleted
+    # warning C4800: forcing value to bool 'true' or 'false' (performance warning)
+    # warning C4996: we're not using Microsoft's secure stringOp_s() functions
+    append("/wd4018 /wd4101 /wd4102 /wd4146 /wd4244 /wd4267 /wd4456 /wd4457 /wd4458 /wd4459 /wd4624 /wd4800 /wd4996" DMD_CXXFLAGS LDC_CXXFLAGS)
 endif()
 # Append -mminimal-toc for gcc 4.0.x - 4.5.x on ppc64
 if( CMAKE_COMPILER_IS_GNUCXX
@@ -320,23 +338,14 @@ if(GENERATE_OFFTI)
     add_definitions(-DGENERATE_OFFTI)
 endif()
 
-if(MSVC)
-    # Remove flags here, for exceptions and RTTI.
-    # CL.EXE complains to override flags like "/GR /GR-".
-    string(REGEX REPLACE "(^| ) */EH[-cs]+ *( |$)" "\\1 \\2" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    string(REGEX REPLACE "(^| ) */GR-? *( |$)" "\\1 \\2" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
-    add_definitions(-D_HAS_EXCEPTIONS=0)
-    set(EXTRA_CXXFLAGS "${EXTRA_CXXFLAGS} /GF /GR- /EHs-c- /MP")
-endif()
-
 # if llvm was built with assertions we have to do the same
 # as there are some headers with differing behavior based on NDEBUG
 if(LLVM_ENABLE_ASSERTIONS)
-    set(EXTRA_CXXFLAGS "${EXTRA_CXXFLAGS} -UNDEBUG")
-    # avoid msvc warning D9025
-    string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" " " CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-    string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" " " CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    append("-UNDEBUG" EXTRA_CXXFLAGS)
+    # avoid MSVC warning D9025 about "-DNDEBUG ... -UNDEBUG"
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
 #

--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -9,7 +9,7 @@ default:
     switches = [
         "-I@PROJECT_BINARY_DIR@/../import",
         "-I@RUNTIME_DIR@/src", // Needed for gc.*/rt.* unit tests.
-        @LIB_PATH@@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
+        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
         "-defaultlib=druntime-ldc",
         "-debuglib=druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
     ];

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -10,7 +10,7 @@ default:
         "-I@CMAKE_BINARY_DIR@/import",
         "-I@RUNTIME_DIR@/src", // Needed for gc.*/rt.* unit tests.
         "-I@PHOBOS2_DIR@/",
-        @LIB_PATH@@MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
+        "-L-L@CMAKE_BINARY_DIR@/lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
         "-defaultlib=phobos2-ldc,curl,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
     ];

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -16,7 +16,7 @@ set(D_FLAGS               -w;-d                                     CACHE STRING
 set(D_FLAGS_DEBUG         -g                                        CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
 set(D_FLAGS_RELEASE       -O3;-release                              CACHE STRING  "Runtime build flags (release libraries), separated by ;")
 if(MSVC)
-    set(LINK_WITH_MSVCRT  OFF                                       CACHE BOOL    "Link with MSVCRT.LIB instead of LIBCMT.LIB")
+    set(LINK_WITH_MSVCRT  ON                                        CACHE BOOL    "Link with MSVCRT.lib (DLL) instead of LIBCMT.lib (static)")
 endif()
 
 # Note: In the below building helpers, this is more fittingly called
@@ -45,7 +45,6 @@ if(BUILD_SHARED_LIBS)
     set(D_LIBRARY_TYPE SHARED)
 else()
     set(D_LIBRARY_TYPE STATIC)
-    set(CXX_COMPILE_FLAGS " ")
 endif()
 
 get_directory_property(PROJECT_PARENT_DIR DIRECTORY ${PROJECT_SOURCE_DIR} PARENT_DIRECTORY)
@@ -195,10 +194,7 @@ endif()
 # Create configuration files.
 #
 if(MSVC)
-    set(LIB_PATH "\"-L-L${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/${CMAKE_BUILD_TYPE}\",")
     set(ADDITIONAL_DEFAULT_LDC_SWITCHES ",\n        \"-L/LARGEADDRESSAWARE:NO\"")
-else()
-    set(LIB_PATH "\"-L-L${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
 endif()
 
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
@@ -227,38 +223,28 @@ add_custom_command(
     COMMAND gen_gccbuiltins ${GCCBUILTINS} "x86"
 )
 
-if(MSVC)
-    if(NOT LINK_WITH_MSVCRT)
-        set(variables
-            CMAKE_C_FLAGS_DEBUG
-            CMAKE_C_FLAGS_MINSIZEREL
-            CMAKE_C_FLAGS_RELEASE
-            CMAKE_C_FLAGS_RELWITHDEBINFO
-            CMAKE_CXX_FLAGS_DEBUG
-            CMAKE_CXX_FLAGS_MINSIZEREL
-            CMAKE_CXX_FLAGS_RELEASE
-            CMAKE_CXX_FLAGS_RELWITHDEBINFO
-        )
-        foreach(variable ${variables})
-          if(${variable} MATCHES "/MT")
-            string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
-          endif()
-        endforeach()
-    endif()
-    # /wd4996: suppress deprecation warnings about zlib using POSIX names
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996")
-    set(CMAKE_C_FLAGS_DEBUG "")
-endif()
-
 # Always build zlib and other C parts of the runtime in release mode, regardless
 # of what the user chose for LDC itself.
-set(cfiles "${CORE_C};${DCRT_C}")
-if(PHOBOS2_DIR)
-    list(APPEND cfiles "${ZLIB_C}")
+# 1) Set up CMAKE_C_FLAGS_RELEASE
+if(MSVC)
+    if(NOT LINK_WITH_MSVCRT)
+        string(REGEX REPLACE "(^| )[/-]MD( |$)" "\\2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+        if(NOT CMAKE_C_FLAGS_RELEASE MATCHES "(^| )[/-]MT( |$)")
+            append("/MT" CMAKE_C_FLAGS_RELEASE)
+        endif()
+    endif()
+    # warning C4996: zlib uses 'deprecated' POSIX names
+    append("/wd4996" CMAKE_C_FLAGS_RELEASE)
 endif()
-set_source_files_properties(${cfiles} PROPERTIES
-    COMPILE_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}"
+# 2) Set all other CMAKE_C_FLAGS variants to CMAKE_C_FLAGS_RELEASE
+set(variables
+    CMAKE_C_FLAGS_DEBUG
+    CMAKE_C_FLAGS_MINSIZEREL
+    CMAKE_C_FLAGS_RELWITHDEBINFO
 )
+foreach(variable ${variables})
+    set(${variable} "${CMAKE_C_FLAGS_RELEASE}")
+endforeach()
 
 # Compiles the given D module into an object file, and if enabled, a bitcode
 # file. The ouput is written to a path based on output_dir. The paths of the


### PR DESCRIPTION
These changes allow for LDC to be built with only a handful of warnings using VS 2015, without the need for any explicit CMake compiler flags.
We make it through warning level 3 by disabling a dozen specific warnings.
I've tested the Debug and RelWithDebInfo CMake build types.

For reference, here are the default CMake 3.3 variables for the Ninja generator and MSVC 2015:
```
-- CMAKE_C_FLAGS:  /DWIN32 /D_WINDOWS /W3
-- CMAKE_C_FLAGS_DEBUG: /D_DEBUG /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_C_FLAGS_MINSIZEREL: /MD /O1 /Ob1 /D NDEBUG
-- CMAKE_C_FLAGS_RELEASE: /MD /O2 /Ob2 /D NDEBUG
-- CMAKE_C_FLAGS_RELWITHDEBINFO: /MD /Zi /O2 /Ob1 /D NDEBUG
-- CMAKE_CXX_FLAGS:  /DWIN32 /D_WINDOWS /W3 /GR /EHsc
-- CMAKE_CXX_FLAGS_DEBUG: /D_DEBUG /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_CXX_FLAGS_MINSIZEREL: /MD /O1 /Ob1 /D NDEBUG
-- CMAKE_CXX_FLAGS_RELEASE: /MD /O2 /Ob2 /D NDEBUG
-- CMAKE_CXX_FLAGS_RELWITHDEBINFO: /MD /Zi /O2 /Ob1 /D NDEBUG
```

Issue https://github.com/ldc-developers/ldc/issues/988 about multiple definitions when linking the runtimes is unfortunately unaffected. Interestingly, this issue doesn't arise when using LLVM 3.6 (but does for 3.7).