### PR TITLE
Windows: don't overwrite object file extension to .o

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -99,7 +99,7 @@ CodeGenerator::~CodeGenerator() {
         const char *filename;
         if ((oname = global.params.exefile) ||
             (oname = global.params.objname)) {
-            filename = FileName::forceExt(oname, global.obj_ext);
+            filename = FileName::forceExt(oname, global.params.targetTriple.isOSWindows() ? global.obj_ext_alt : global.obj_ext);
             if (global.params.objdir) {
                 filename = FileName::combine(global.params.objdir,
                                              FileName::name(filename));

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -168,15 +168,6 @@ File* Module::buildFilePath(const char* forcename, const char* path, const char*
     FileName::ensurePathExists(FileName::path(argobj));
 
     // always append the extension! otherwise hard to make output switches consistent
-    //   if (forcename)
-    //     return new File(argobj);
-    //   else
-    //     allow for .o and .obj on windows
-#if _WIN32
-    if (ext == global.params.objdir && FileName::ext(argobj)
-        && Port::stricmp(FileName::ext(argobj), global.obj_ext_alt) == 0)
-    return new File((char*)argobj);
-#endif
     return new File(FileName::forceExt(argobj, ext));
 }
 


### PR DESCRIPTION
In case of a singleobj build and a provided output file (.exe or .obj). The dmd-testsuite tests used to produce lots of .o files while expecting .obj ones as specified in the command line.