### PR TITLE
Fix crash due to invalid iterators in DtoEnclosingHandlers

### DIFF
--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -47,9 +47,6 @@ const IRScope& IRScope::operator=(const IRScope& rhs)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-IRTargetScope::IRTargetScope()
-{
-}
 
 IRTargetScope::IRTargetScope(
     Statement* s,

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -46,7 +46,6 @@ struct IRTargetScope
     /// specified (via s), and not for unqualified "break;" statements.
     bool onlyLabeledBreak;
 
-    IRTargetScope();
     IRTargetScope(
         Statement* s,
         EnclosingTryFinally* enclosinghandler,


### PR DESCRIPTION
Unfortunately, I could not manage to isolate a self-contained
test case. The bug is quite specific to the exact memory
allocation decisions made by the standard library, as it would
not occur if the elements appended by the finally block codegen
fit into the current capacity.