### PR TITLE
Exception chaining reimplementation for correct and lean IR

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -978,12 +978,12 @@ static void LLVM_D_BuildRuntimeModule()
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
     }
 
-    // void _d_eh_handle_collision(ptr exc_struct, ptr exc_struct)
+    // void _d_eh_enter_catch()
     {
-        llvm::StringRef fname("_d_eh_handle_collision");
-        LLType *types[] = { voidPtrTy, voidPtrTy };
-        LLFunctionType* fty = llvm::FunctionType::get(voidTy, types, false);
-        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
+        llvm::StringRef fname("_d_eh_enter_catch");
+        LLFunctionType* fty = llvm::FunctionType::get(voidTy, false);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M)->
+            setAttributes(Attr_NoUnwind);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////

--- a/ir/irlandingpad.h
+++ b/ir/irlandingpad.h
@@ -24,7 +24,6 @@ namespace llvm {
     class Value;
     class BasicBlock;
     class Function;
-    class LandingPadInst;
 }
 
 // holds information about a single catch


### PR DESCRIPTION
Now we no longer require separate landing pads for collisions
in user code. This leads to less cruft being generated and opens
the door towards folding the successful and exceptional paths
through finally blocks into one.

This commit breaks Win64; ldc.deh2 will also need updating.