### PR TITLE
Workaround for issue #995.

### DIFF
--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -1,0 +1,134 @@
+//===-- abi-aarch64.cpp ---------------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// The Procedure Call Standard can be found here:
+// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/abi.h"
+#include "gen/abi-generic.h"
+#include "gen/abi-aarch64.h"
+
+struct AArch64TargetABI : TargetABI
+{
+    llvm::CallingConv::ID callingConv(LINK l)
+    {
+        switch (l)
+        {
+        case LINKc:
+        case LINKcpp:
+        case LINKpascal:
+        case LINKwindows:
+        case LINKd:
+        case LINKdefault:
+            return llvm::CallingConv::C;
+        default:
+            llvm_unreachable("Unhandled D linkage type.");
+        }
+    }
+
+    bool returnInArg(TypeFunction* tf)
+    {
+        if (tf->isref)
+            return false;
+
+        // Return structs and static arrays on the stack. The latter is needed
+        // because otherwise LLVM tries to actually return the array in a number
+        // of physical registers, which leads, depending on the target, to
+        // either horrendous codegen or backend crashes.
+        Type* rt = tf->next->toBasetype();
+        return (rt->ty == Tstruct || rt->ty == Tsarray);
+    }
+
+    bool passByVal(Type* t)
+    {
+        return t->toBasetype()->ty == Tstruct;
+    }
+
+    void rewriteFunctionType(TypeFunction* t, IrFuncTy &fty)
+    {
+        for (IrFuncTy::ArgIter I = fty.args.begin(), E = fty.args.end(); I != E; ++I)
+        {
+            IrFuncTyArg& arg = **I;
+
+            if (!arg.byref)
+                rewriteArgument(fty, arg);
+        }
+    }
+
+    void rewriteArgument(IrFuncTy& fty, IrFuncTyArg& arg)
+    {
+        // FIXME
+    }
+
+    /**
+    * The AACPS64 uses a special native va_list type:
+    *
+    * typedef struct __va_list {
+    *     void *__stack; // next stack param
+    *     void *__gr_top; // end of GP arg reg save area
+    *     void *__vr_top; // end of FP/SIMD arg reg save area
+    *     int __gr_offs; // offset from __gr_top to next GP register arg
+    *     int __vr_offs; // offset from __vr_top to next FP/SIMD register arg
+    * } va_list;
+    *
+    * In druntime, the struct is defined as core.stdc.stdarg.__va_list; the actually used
+    * core.stdc.stdarg.va_list type is a raw char* pointer though to achieve byref semantics.
+    * This requires a little bit of compiler magic in the following implementations.
+    */
+
+    LLType* getValistType() {
+        LLType* intType = LLType::getInt32Ty(gIR->context());
+        LLType* voidPointerType = getVoidPtrType();
+
+        std::vector<LLType*> parts;       // struct __va_list {
+        parts.push_back(voidPointerType); //   void *__stack;
+        parts.push_back(voidPointerType); //   void *__gr_top;
+        parts.push_back(voidPointerType); //   void *__vr_top;
+        parts.push_back(intType);         //   int __gr_offs;
+        parts.push_back(intType);         //   int __vr_offs; };
+
+        return LLStructType::get(gIR->context(), parts);
+    }
+
+    LLValue* prepareVaStart(LLValue* pAp) {
+        // Since the user only created a char* pointer (ap) on the stack before invoking va_start,
+        // we first need to allocate the actual __va_list struct and set 'ap' to its address.
+        LLValue* valistmem = DtoRawAlloca(getValistType(), 0, "__va_list_mem");
+        valistmem = DtoBitCast(valistmem, getVoidPtrType());
+        DtoStore(valistmem, pAp); // ap = (void*)__va_list_mem
+
+        // pass a void* pointer to the actual struct to LLVM's va_start intrinsic
+        return valistmem;
+    }
+
+    void vaCopy(LLValue* pDest, LLValue* src) {
+        // Analog to va_start, we need to allocate a __va_list struct on the stack first
+        // and set the passed 'dest' char* pointer to its address.
+        LLValue* valistmem = DtoRawAlloca(getValistType(), 0, "__va_list_mem");
+        DtoStore(DtoBitCast(valistmem, getVoidPtrType()), pDest);
+
+        // Now bitcopy the source struct over the destination struct.
+        src = DtoBitCast(src, valistmem->getType());
+        DtoStore(DtoLoad(src), valistmem); // *(__va_list*)dest = *(__va_list*)src
+    }
+
+    LLValue* prepareVaArg(LLValue* pAp)
+    {
+        // pass a void* pointer to the actual __va_list struct to LLVM's va_arg intrinsic
+        return DtoLoad(pAp);
+    }
+};
+
+// The public getter for abi.cpp
+TargetABI* getAArch64TargetABI()
+{
+    return new AArch64TargetABI();
+}

--- a/gen/abi-aarch64.h
+++ b/gen/abi-aarch64.h
@@ -1,0 +1,21 @@
+//===-- gen/abi-ppc-64.h - PPC64 ABI description ----------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// The ABI implementation used for AArch64 targets.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_GEN_ABI_AARCH64_H
+#define LDC_GEN_ABI_AARCH64_H
+
+struct TargetABI;
+
+TargetABI* getAArch64TargetABI();
+
+#endif

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -268,7 +268,7 @@ void X86_64TargetABI::rewriteArgument(IrFuncTyArg& arg, RegCount& regCount) {
     Type* t = arg.type->toBasetype();
 
     LLType* abiTy = getAbiType(t);
-    if (abiTy && !LLTypeMemoryLayout::typesAreEquivalent(abiTy, originalLType)) {
+    if (abiTy) {
         IF_LOG {
             Logger::println("Rewriting argument type %s", t->toChars());
             LOG_SCOPE;

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -234,6 +234,8 @@ struct X86_64TargetABI : TargetABI {
 
     LLValue* prepareVaArg(LLValue* pAp);
 
+    Type *vaListType();
+
 private:
     LLType* getValistType();
     RegCount& getRegCount(IrFuncTy& fty) { return reinterpret_cast<RegCount&>(fty.tag); }
@@ -379,7 +381,7 @@ LLValue* X86_64TargetABI::prepareVaStart(LLValue* pAp) {
     // we first need to allocate the actual __va_list struct and set 'ap' to its address.
     LLValue* valistmem = DtoRawAlloca(getValistType(), 0, "__va_list_mem");
     valistmem = DtoBitCast(valistmem, getVoidPtrType());
-    DtoStore(valistmem, pAp); // ap = (void*)__va_list_mem
+    DtoStore(valistmem, DtoBitCast(pAp, getPtrToType(getVoidPtrType())));
 
     // pass a void* pointer to the actual struct to LLVM's va_start intrinsic
     return valistmem;
@@ -389,7 +391,8 @@ void X86_64TargetABI::vaCopy(LLValue* pDest, LLValue* src) {
     // Analog to va_start, we need to allocate a __va_list struct on the stack first
     // and set the passed 'dest' char* pointer to its address.
     LLValue* valistmem = DtoRawAlloca(getValistType(), 0, "__va_list_mem");
-    DtoStore(DtoBitCast(valistmem, getVoidPtrType()), pDest);
+    DtoStore(DtoBitCast(valistmem, getVoidPtrType()),
+        DtoBitCast(pDest, getPtrToType(getVoidPtrType())));
 
     // Now bitcopy the source struct over the destination struct.
     src = DtoBitCast(src, valistmem->getType());
@@ -400,4 +403,13 @@ LLValue* X86_64TargetABI::prepareVaArg(LLValue* pAp)
 {
     // pass a void* pointer to the actual __va_list struct to LLVM's va_arg intrinsic
     return DtoLoad(pAp);
+}
+
+Type* X86_64TargetABI::vaListType() {
+    // We need to pass the actual va_list type for correct mangling. Simply
+    // using TypeIdentifier here is a bit wonky but works, as long as the name
+    // is actually available in the scope (this is what DMD does, so if a better
+    // solution is found there, this should be adapted).
+    return (new TypeIdentifier(Loc(),
+        Lexer::idPool("__va_list_tag")))->pointerTo();
 }

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -10,6 +10,7 @@
 #include "gen/abi.h"
 #include "mars.h"
 #include "gen/abi-generic.h"
+#include "gen/abi-aarch64.h"
 #include "gen/abi-mips64.h"
 #include "gen/abi-ppc64.h"
 #include "gen/abi-win64.h"
@@ -140,6 +141,14 @@ LLValue* TargetABI::prepareVaArg(LLValue* pAp)
 
 //////////////////////////////////////////////////////////////////////////////
 
+Type* TargetABI::vaListType()
+{
+    // char* is used by default in druntime.
+    return Type::tchar->pointerTo();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 // Some reasonable defaults for when we don't know what ABI to use.
 struct UnknownTargetABI : TargetABI
 {
@@ -190,6 +199,17 @@ TargetABI * TargetABI::getTarget()
     case llvm::Triple::ppc64le:
 #endif
         return getPPC64TargetABI(global.params.targetTriple.isArch64Bit());
+#if LDC_LLVM_VER == 305
+    case llvm::Triple::arm64:
+    case llvm::Triple::arm64_be:
+#endif
+#if LDC_LLVM_VER >= 303
+    case llvm::Triple::aarch64:
+#if LDC_LLVM_VER >= 305
+    case llvm::Triple::aarch64_be:
+#endif
+        return getAArch64TargetABI();
+#endif
     default:
         Logger::cout() << "WARNING: Unknown ABI, guessing...\n";
         return new UnknownTargetABI;

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -128,6 +128,11 @@ struct TargetABI
     // Input:  pointer to passed ap argument (va_list*)
     // Output: value to be passed to LLVM's va_arg intrinsic (void*)
     virtual llvm::Value* prepareVaArg(llvm::Value* pAp);
+
+    /// Returns the D type to be used for va_list.
+    ///
+    /// Must match the alias in druntime.
+    virtual Type* vaListType();
 };
 
 #endif


### PR DESCRIPTION
An opaque and a non-opaque type may be rewritten differently. The fix is to always rewrite the types.

Also backport of the valist change from merge-2.067.