### PR TITLE
LLVM 3.7+: fix toConstElem(SymOffExp*).

### DIFF
--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -410,7 +410,7 @@ public:
                 // We can turn this into a "nice" GEP.
                 result = llvm::ConstantExpr::getGetElementPtr(
 #if LDC_LLVM_VER >= 307
-                    LLType::getInt8Ty(gIR->context()),
+                    NULL,
 #endif
                     base,
                     DtoConstSize_t(e->offset / elemSize));
@@ -421,7 +421,7 @@ public:
                 // apply the byte offset.
                 result = llvm::ConstantExpr::getGetElementPtr(
 #if LDC_LLVM_VER >= 307
-                    getVoidPtrType(),
+                    NULL,
 #endif
                     DtoBitCast(base, getVoidPtrType()),
                     DtoConstSize_t(e->offset));


### PR DESCRIPTION
The new type parameter for `llvm::ConstantExpr::getGetElementPtr()` is checked for being the pointee of the provided base (or more precisely, the pointee of the base's scalar type).
So for the 'ugly' GEP, i8* as type for an i8* base was clearly wrong, and the 'nice' GEP with the fixed i8 type would only work for i8* bases.
By simply using `nullptr`, the type is inferred, and we perform a bitcast afterwards anyway.

This fixes dmd-testsuite issues on Win64, e.g., `runnable/test11.d`.