### PR TITLE
Fix ICE caused by type mismatch on casting sret return value

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -903,20 +903,30 @@ void DtoVarDeclaration(VarDeclaration* vd)
         /* NRVO again:
             T t = f();    // t's memory address is taken hidden pointer
         */
+        Type *vdBasetype = vd->type->toBasetype();
         ExpInitializer *ei = 0;
-        if ((vd->type->toBasetype()->ty == Tstruct ||
-             vd->type->toBasetype()->ty == Tsarray /* new in 2.064*/) &&
+        if ((vdBasetype->ty == Tstruct || vdBasetype->ty == Tsarray) &&
             vd->init &&
             (ei = vd->init->isExpInitializer()))
         {
             if (ei->exp->op == TOKconstruct) {
                 AssignExp *ae = static_cast<AssignExp*>(ei->exp);
-                // The return value can be casted to a different type.
-                // Just look at the original expression in this case.
-                // Happens with runnable/sdtor, test10094().
                 Expression *rhs = ae->e2;
-                if (rhs->op == TOKcast)
-                    rhs = static_cast<CastExp *>(rhs)->e1;
+
+                // Allow casts only emitted because of differing static array
+                // constness. See runnable.sdtor.test10094.
+                if (rhs->op == TOKcast && vdBasetype->ty == Tsarray) {
+                    Expression *castSource = ((CastExp *)rhs)->e1;
+                    Type *rhsElem = castSource->type->toBasetype()->nextOf();
+                    if (rhsElem) {
+                        Type *l = vdBasetype->nextOf()->arrayOf()->immutableOf();
+                        Type *r = rhsElem->arrayOf()->immutableOf();
+                        if (l->equals(r)) {
+                            rhs = castSource;
+                        }
+                    }
+                }
+
                 if (rhs->op == TOKcall) {
                     CallExp *ce = static_cast<CallExp *>(rhs);
                     if (DtoIsReturnInArg(ce))


### PR DESCRIPTION
Another one caused by special "context-specific" AST semantics. :/

GitHub: Fixes #982.