### PR TITLE
C ABI: Do not pass empty structs as parameters at all

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -946,7 +946,7 @@ static LLValue* DtoArrayEqCmp_impl(Loc& loc, const char* func, DValue* l, DValue
 //////////////////////////////////////////////////////////////////////////////////////////
 LLValue* DtoArrayEquals(Loc& loc, TOK op, DValue* l, DValue* r)
 {
-    LLValue* res = DtoArrayEqCmp_impl(loc, _adEq, l, r, true);
+    LLValue* res = DtoArrayEqCmp_impl(loc, "_adEq2", l, r, true);
     res = gIR->ir->CreateICmpNE(res, DtoConstInt(0));
     if (op == TOKnotequal)
         res = gIR->ir->CreateNot(res);
@@ -967,7 +967,7 @@ LLValue* DtoArrayCompare(Loc& loc, TOK op, DValue* l, DValue* r)
         if (t->ty == Tchar)
             res = DtoArrayEqCmp_impl(loc, "_adCmpChar", l, r, false);
         else
-            res = DtoArrayEqCmp_impl(loc, _adCmp, l, r, true);
+            res = DtoArrayEqCmp_impl(loc, "_adCmp2", l, r, true);
         res = gIR->ir->CreateICmp(cmpop, res, DtoConstInt(0));
     }
 

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -158,7 +158,7 @@ DValue* DtoNestedVariable(Loc& loc, Type* astype, VarDeclaration* vd, bool byref
         Logger::cout() << "Addr: " << *val << '\n';
         Logger::cout() << "of type: " << *val->getType() << '\n';
     }
-    if (byref || (vd->isParameter() && getIrParameter(vd)->arg->byref)) {
+    if (byref || (vd->isParameter() && getIrParameter(vd)->arg && getIrParameter(vd)->arg->byref)) {
         val = DtoAlignedLoad(val);
         //dwarfOpDeref(dwarfAddr);
         IF_LOG {
@@ -364,9 +364,11 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd) {
             irLocal->nestedIndex = types.size();
             irLocal->nestedDepth = depth;
 
-            if (vd->isParameter()) {
-                // Parameters will have storage associated with them (to handle byref etc.),
-                // so handle those cases specially by storing a pointer instead of a value.
+            if (vd->isParameter() && getIrParameter(vd)->arg) {
+                // Parameters that are part of the LLVM signature will have
+                // storage associated with them (to handle byref etc.), so
+                // handle those cases specially by storing a pointer instead
+                // of a value.
                 const IrParameter* irparam = getIrParameter(vd);
                 const bool refout = vd->storage_class & (STCref | STCout);
                 const bool lazy = vd->storage_class & STClazy;
@@ -479,7 +481,7 @@ void DtoCreateNestedContext(FuncDeclaration* fd) {
                 LOG_SCOPE
                 IrParameter* parm = getIrParameter(vd);
 
-                if (parm->arg->byref)
+                if (parm->arg && parm->arg->byref)
                 {
                     storeVariable(vd, gep);
                 }

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -753,8 +753,8 @@ static void LLVM_D_BuildRuntimeModule()
     // int _adEq(void[] a1, void[] a2, TypeInfo ti)
     // int _adCmp(void[] a1, void[] a2, TypeInfo ti)
     {
-        llvm::StringRef fname(_adEq);
-        llvm::StringRef fname2(_adCmp);
+        llvm::StringRef fname("_adEq2");
+        llvm::StringRef fname2("_adCmp2");
         LLType *types[] = { voidArrayTy, voidArrayTy, typeInfoTy };
         LLFunctionType* fty = llvm::FunctionType::get(intTy, types, false);
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M)

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -32,7 +32,4 @@ llvm::Function* LLVM_D_GetRuntimeFunction(const Loc &loc, llvm::Module& target, 
 
 llvm::GlobalVariable* LLVM_D_GetRuntimeGlobal(const Loc &loc, llvm::Module& target, const char* name);
 
-#define _adEq "_adEq2"
-#define _adCmp "_adCmp2"
-
 #endif // LDC_GEN_RUNTIME_H

--- a/ir/irfuncty.cpp
+++ b/ir/irfuncty.cpp
@@ -16,7 +16,7 @@
 #include "gen/tollvm.h"
 
 IrFuncTyArg::IrFuncTyArg(Type* t, bool bref, const AttrBuilder& a)
-    : type(t),
+    : type(t), parametersIdx(0),
       ltype(t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t)),
       attrs(a), byref(bref), rewrite(0)
 {

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -37,13 +37,20 @@ namespace llvm {
     class FunctionType;
 }
 
-// represents a function type argument
-// both explicit and implicit as well as return values
+/// Represents a function type argument (both explicit and implicit as well as
+/// return values).
+///
+/// Instances of this only exist for arguments that are actually lowered to an
+/// LLVM parameter (e.g. not for empty structs).
 struct IrFuncTyArg
 {
     /** This is the original D type as the frontend knows it
      *  May NOT be rewritten!!! */
     Type* const type;
+
+    /// The index of the declaration in the FuncDeclaration::parameters array
+    /// corresponding to this argument.
+    size_t parametersIdx;
 
     /// This is the final LLVM Type used for the parameter/return value type
     llvm::Type* ltype;


### PR DESCRIPTION
This is most visible on x86 (32-bit), where the stack
alignment is off otherwise.

This change is quite messy because many places assumed
that there was always exactly one LLVM parameter per
TypeFunction::parameters entry.