### PR TITLE
Properly ignore statically known SliceExp bounds

### DIFF
--- a/gen/arrays.h
+++ b/gen/arrays.h
@@ -71,6 +71,10 @@ LLValue* DtoArrayPtr(DValue* v);
 DValue* DtoCastArray(Loc& loc, DValue* val, Type* to);
 
 // generates an array bounds check
-void DtoArrayBoundsCheck(Loc& loc, DValue* arr, DValue* index, DValue* lowerBound = 0);
+void DtoIndexBoundsCheck(Loc& loc, DValue* arr, DValue* index);
+
+/// Inserts a call to the druntime function that throws the range error, with
+/// the given location.
+void DtoBoundsCheckFailCall(IRState* p, Loc& loc);
 
 #endif // LDC_GEN_ARRAYS_H


### PR DESCRIPTION
GitHub: Fixes #1008.