### PR TITLE
Add Appveyor support for Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,15 @@ cache:
   # Appveyor configuration isn't changed
   - c:\projects\llvm-x64.7z -> appveyor.yml
 
+environment:
+  matrix:
+    - APPVEYOR_JOB_CONFIG: Debug
+    - APPVEYOR_JOB_CONFIG: Release
+
+matrix:
+  allow_failures:
+    - APPVEYOR_JOB_CONFIG: Release
+
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
@@ -114,11 +123,16 @@ test_script:
   - bin\ldc2 -version
   # Compile, link & execute a hello-world program
   - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
-  - bin\ldc2 hello.d
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( bin\ldc2 -g hello.d ) else ( bin\ldc2 hello.d )
   - hello.exe
-  # Compile and execute the druntime & phobos unit tests, but exclude dmd-testsuite for now
-  - ninja druntime-ldc-unittest-debug druntime-ldc-unittest phobos2-ldc-unittest-debug phobos2-ldc-unittest
-  - ctest -E testsuite
+  # Compile the druntime & phobos unit tests
+  - set TEST_LIB_SUFFIX=unittest
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set TEST_LIB_SUFFIX=unittest-debug)
+  - ninja druntime-ldc-%TEST_LIB_SUFFIX% phobos2-ldc-%TEST_LIB_SUFFIX%
+  # Execute the unit tests; exclude dmd-testsuite for now
+  - set CTEST_SUFFIX=-E -debug
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug)
+  - ctest --output-on-failure -E testsuite %CTEST_SUFFIX%
 
 after_test:
   # Install LDC

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,10 +88,17 @@ before_build:
 
 build_script:
   - cd c:\projects
-  # Generate build files for LDC & build
+  # Work around LDC issue #988 and add a lib required in combination with VS 2015
+  - ps: (gc ldc\ldc2.conf.in).replace('@ADDITIONAL_DEFAULT_LDC_SWITCHES@', ', "-L/FORCE:MULTIPLE", "-Llegacy_stdio_definitions.lib"@ADDITIONAL_DEFAULT_LDC_SWITCHES@') | sc ldc\ldc2.conf.in
+  - ps: (gc ldc\ldc2_install.conf.in).replace('@ADDITIONAL_DEFAULT_LDC_SWITCHES@', ', "-L/FORCE:MULTIPLE", "-Llegacy_stdio_definitions.lib"@ADDITIONAL_DEFAULT_LDC_SWITCHES@') | sc ldc\ldc2_install.conf.in
+  - ps: (gc ldc\ldc2_phobos.conf.in).replace('@ADDITIONAL_DEFAULT_LDC_SWITCHES@', ', "-L/FORCE:MULTIPLE", "-Llegacy_stdio_definitions.lib"@ADDITIONAL_DEFAULT_LDC_SWITCHES@') | sc ldc\ldc2_phobos.conf.in
+  # Generate build files for LDC
   - md ninja-ldc
   - cd ninja-ldc
   - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  # Work around LDC issue #930
+  - ps: (gc build.ninja).replace('runtime/std/string-unittest-debug.obj -w -d -g -unittest', 'runtime/std/string-unittest-debug.obj -w -d -unittest') | sc build.ninja
+  # Build LDC, druntime and phobos
   - ninja
 
 after_build:
@@ -103,11 +110,15 @@ after_build:
 before_test:
 
 test_script:
-  # Just compile, link & execute a hello-world program for now
-  - cd c:\projects
+  - cd c:\projects\ninja-ldc
+  - bin\ldc2 -version
+  # Compile, link & execute a hello-world program
   - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
-  - ninja-ldc\bin\ldc2 hello.d -Llegacy_stdio_definitions.lib -L/FORCE:MULTIPLE
+  - bin\ldc2 hello.d
   - hello.exe
+  # Compile and execute the druntime & phobos unit tests, but exclude dmd-testsuite for now
+  - ninja druntime-ldc-unittest-debug druntime-ldc-unittest phobos2-ldc-unittest-debug phobos2-ldc-unittest
+  - ctest -E testsuite
 
 after_test:
   # Install LDC

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,12 +32,13 @@ init:
   - cmake --version
   - python --version
 
-# fetch repository as zip archive
-shallow_clone: true
-
 # scripts that run after cloning repository
 install:
   - cd c:\projects
+  # Fetch submodules
+  - cd ldc
+  - git submodule update --init --recursive
+  - cd ..
   # Clone libconfig
   - git clone https://github.com/hyperrealm/libconfig.git libconfig
   ## Download & extract LLVM source
@@ -47,7 +48,7 @@ install:
   # Download a pre-built LLVM if not cached & extract
   - ps: If (-Not (Test-Path llvm-x64.7z)) { Start-FileDownload 'https://dl.dropboxusercontent.com/s/xfbl0u0sfa7ifx5/llvm-x64.7z?dl=0' -FileName 'llvm-x64.7z' -Timeout 600000 }
   - dir
-  - 7z x llvm-x64.7z
+  - 7z x llvm-x64.7z > nul
   # Download & install Ninja
   - ps: Start-FileDownload 'https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
   - md ninja

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - cmd: cd ..
   - cmd: md downloads
   # Install CMake
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads\\cmake-3.0.2-win32-x86.zip')
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads/cmake-3.0.2-win32-x86.zip')
   - cmd: dir
   - cmd: dir downloads
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ skip_tags: true
 # Operating system (build VM template)
 os: Visual Studio 2015
 
+cache:
+  # Cache the compressed pre-built LLVM for as long as this
+  # Appveyor configuration isn't changed
+  - c:\projects\llvm-x64.7z -> appveyor.yml
+
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
@@ -35,22 +40,37 @@ install:
   - cd c:\projects
   # Clone libconfig
   - git clone https://github.com/hyperrealm/libconfig.git libconfig
-  ## Download and extract LLVM source
-  #- ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz', 'c:/projects/llvm.src.tar.xz')
+  ## Download & extract LLVM source
+  #- ps: Start-FileDownload 'http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz' -FileName 'llvm.src.tar.xz'
   #- 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
   #- ren llvm-3.7.0rc3.src llvm
-  # Download and install LLVM
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/LLVM-3.7.0-rc3-win64.exe', 'c:/projects/llvm.exe')
-  - llvm.exe /S /D=c:\projects\llvm-x64
-  - dir llvm-x64 || echo No llvm-x64 directory!
-  # Download and install Ninja
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip', 'c:/projects/ninja.zip')
+  # Download a pre-built LLVM if not cached & extract
+  - ps: If (-Not (Test-Path llvm-x64.7z)) { Start-FileDownload 'https://dl.dropboxusercontent.com/s/xfbl0u0sfa7ifx5/llvm-x64.7z?dl=0' -FileName 'llvm-x64.7z' -Timeout 600000 }
+  - dir
+  - 7z x llvm-x64.7z
+  # Download & install Ninja
+  - ps: Start-FileDownload 'https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
   - md ninja
   - cd ninja
   - 7z x ..\ninja.zip
-  - set PATH=c:\projects\ninja;%PATH%
   - cd ..
+  - set PATH=c:\projects\ninja;%PATH%
   - ninja --version
+  # Download & extract libcurl
+  - ps: Start-FileDownload 'http://d.darktech.org/libcurl-7.43.0-WinSSL-zlib-x86-x64.zip' -FileName 'libcurl.zip'
+  - md libcurl
+  - cd libcurl
+  - 7z x ..\libcurl.zip
+  - cd ..
+  # Copy libcurl.dll to final LDC installation directory and add to PATH
+  - md ldc-x64
+  - md ldc-x64\bin
+  - copy libcurl\dmd2\windows\bin64\libcurl.dll ldc-x64\bin
+  - set PATH=c:\projects\ldc-x64\bin;%PATH%
+  # Copy curl.lib to final LDC installation directory and add to LIB
+  - md ldc-x64\lib
+  - copy libcurl\dmd2\windows\lib64\curl.lib ldc-x64\lib
+  - set LIB=c:\projects\ldc-x64\lib;%LIB%
 
 #---------------------------------#
 #       build configuration       #
@@ -60,7 +80,7 @@ before_build:
   - cd c:\projects
   # Build libconfig
   - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
-  # Generate build files for LLVM and build & install
+  ## Generate build files for LLVM, build & install
   #- md ninja-llvm
   #- cd ninja-llvm
   #- cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\llvm-x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_APPEND_VC_REV=ON ..\llvm
@@ -68,11 +88,11 @@ before_build:
 
 build_script:
   - cd c:\projects
-  # Generate build files for LDC and build
+  # Generate build files for LDC & build
   - md ninja-ldc
   - cd ninja-ldc
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
-  - ninja all
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  - ninja
 
 after_build:
 
@@ -83,5 +103,21 @@ after_build:
 before_test:
 
 test_script:
+  # Just compile, link & execute a hello-world program for now
+  - cd c:\projects
+  - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
+  - ldc2 hello.d -Llegacy_stdio_definitions.lib
+  - hello.exe
 
 after_test:
+  # Install LDC
+  - cd c:\projects\ninja-ldc
+  - ninja install
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+
+artifacts:
+  # Push entire LDC installation directory as a zip archive
+  - path: ..\ldc-x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,4 +120,4 @@ after_test:
 
 artifacts:
   # Push entire LDC installation directory as a zip archive
-  - path: ..\ldc-x64
+  - path: ldc-x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,8 @@ clone_folder: c:\projects\ldc
 install:
   - cmd: cd ..
   - cmd: md downloads
-  - cmd: set
   # Install CMake
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads\cmake-3.0.2-win32-x86.zip')
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads\\cmake-3.0.2-win32-x86.zip')
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
   - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
   # Install libconfig

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,7 +106,7 @@ test_script:
   # Just compile, link & execute a hello-world program for now
   - cd c:\projects
   - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
-  - ninja-ldc\bin\ldc2 hello.d -Llegacy_stdio_definitions.lib
+  - ninja-ldc\bin\ldc2 hello.d -Llegacy_stdio_definitions.lib -L/FORCE:MULTIPLE
   - hello.exe
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,16 @@ skip_tags: true
 #---------------------------------#
 
 # Operating system (build VM template)
-#os: Windows Server 2012
+os: Visual Studio 2015
 
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
+  - '"c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
   - msbuild /version
+  - cl
   - cmake --version
   - python --version
-
-clone_folder: c:\projects\ldc
 
 # fetch repository as zip archive
 shallow_clone: true
@@ -35,19 +35,18 @@ install:
   - cd c:\projects
   # Clone libconfig
   - git clone https://github.com/hyperrealm/libconfig.git libconfig
-  # Download Ninja and LLVM
-  - md downloads
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip', 'c:/projects/downloads/ninja.zip')
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/releases/3.6.2/LLVM-3.6.2-win32.exe', 'c:/projects/downloads/llvm.exe')
-  # Install Ninja
+  # Download and extract LLVM source
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz', 'c:/projects/llvm.src.tar.xz')
+  - 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
+  - ren llvm-3.7.0rc3.src llvm
+  # Download and install Ninja
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip', 'c:/projects/ninja.zip')
   - md ninja
   - cd ninja
-  - 7z x ..\downloads\ninja.zip
+  - 7z x ..\ninja.zip
   - set PATH=c:\projects\ninja;%PATH%
   - cd ..
   - ninja --version
-  # Install LLVM
-  - downloads\llvm.exe
 
 #---------------------------------#
 #       build configuration       #
@@ -55,17 +54,21 @@ install:
 
 before_build:
   - cd c:\projects
-  # Generate msbuild files for LDC
-  - md msbuild-ldc
-  - cd msbuild-ldc
-  - cmake -G "Visual Studio 2015 x64" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  # Build libconfig
+  - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
+  # Generate build files for LLVM and build & install
+  - md ninja-llvm
+  - cd ninja-llvm
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\llvm-x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_APPEND_VC_REV=ON ..\llvm
+  - ninja install
 
 build_script:
   - cd c:\projects
-  # Build libconfig
-  - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
-  # Build LDC
-  - msbuild msbuild-ldc\ALL_BUILD.vcxproj
+  # Generate build files for LDC and build
+  - md ninja-ldc
+  - cd ninja-ldc
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  - ninja all
 
 after_build:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,19 +20,22 @@ clone_folder: c:\projects\ldc
 install:
   - cmd: cd ..
   - cmd: md downloads
-  # Install CMake
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads/cmake-3.0.2-win32-x86.zip')
+  - cmd: cd downloads
+  # Download all required files
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'cmake-3.0.2-win32-x86.zip')
+  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'libconfig-1.4.9.tar.gz')
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'LLVM-3.6.0-r219740-win32.exe')
   - cmd: dir
-  - cmd: dir downloads
+  - cmd: cd ..
+  # Install CMake
+  - cmd: dir
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
   - cmd: dir
   - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
   # Install libconfig
-  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'downloads\libconfig.tar.gz')
-  - cmd: 7z x libconfig.tar.gz
+  - cmd: 7z x downloads\libconfig-1.4.9.tar.gz
   # Install LLVM snapshot
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'LLVM-install.exe')
-  - cmd: LLVM-install.exe
+  - cmd: downloads\LLVM-3.6.0-r219740-win32.exe
   # Run CMake
   - cmd: md c:\projects\build-ldc
   - cmd: cd c:\projects\build-ldc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,49 +1,76 @@
-# version format
-version: 1.0.{build}
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
 
-# branches to build
+#version: 1.0.{build}-{branch}
+
 branches:
-  # whitelist
   only:
     - appveyor
 
 # Do not build on tags (GitHub only)
 skip_tags: true
 
-# Operating system (build VM template)
-os: Windows Server 2012
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
 
-# clone directory
+# Operating system (build VM template)
+#os: Windows Server 2012
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf input
+  - msbuild /version
+  - python --version
+
 clone_folder: c:\projects\ldc
+
+# fetch repository as zip archive
+shallow_clone: true
 
 # scripts that run after cloning repository
 install:
-  - cmd: cd ..
-  - cmd: md downloads
-  # Download all required files
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'c:/projects/downloads/cmake-3.0.2-win32-x86.zip')
-  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'c:/projects/downloads/libconfig-1.4.9.tar.gz')
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'c:/projects/downloads/LLVM-3.6.0-r219740-win32.exe')
+  - cd c:\projects
+  # Clone libconfig
+  - git clone https://github.com/hyperrealm/libconfig.git libconfig
+  # Download CMake and LLVM
+  - md downloads
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.3/cmake-3.3.1-win32-x86.zip', 'c:/projects/downloads/cmake.zip')
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/releases/3.6.2/LLVM-3.6.2-win32.exe', 'c:/projects/downloads/llvm.exe')
   # Install CMake
-  - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
-  - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH%
-  - cmd: cmake
-  # Install libconfig
-  - cmd: 7z x downloads\libconfig-1.4.9.tar.gz
-  # Install LLVM snapshot
-  - cmd: downloads\LLVM-3.6.0-r219740-win32.exe
-  # Run CMake
-  - cmd: md c:\projects\build-ldc
-  - cmd: cd c:\projects\build-ldc
-  - cmd: cmake ..\ldc
+  - 7z x downloads\cmake.zip
+  - set PATH=c:\projects\cmake\bin;%PATH%
+  - cmake --version
+  # Install LLVM
+  - downloads\llvm.exe
 
-# build platform, i.e. x86, x64, Any CPU. This setting is optional.
-platform:
-  - x64
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
 
-# build Configuration, i.e. Debug, Release, etc.
-configuration:
-  - Debug
+before_build:
+  - cd c:\projects
+  # Generate msbuild files for LDC
+  - md msbuild-ldc
+  - cd msbuild-ldc
+  - cmake -G "Visual Studio 2013 x64" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
 
-build:
-  project: ..\build-ldc\INSTALL.sln
+build_script:
+  - cd c:\projects
+  # Build libconfig
+  - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
+  # Build LDC
+  - msbuild msbuild-ldc\ALL_BUILD.vcxproj
+
+after_build:
+
+#---------------------------------#
+#       test configuration        #
+#---------------------------------#
+
+before_test:
+
+test_script:
+
+after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+# version format
+version: 1.0.{build}
+
+# branches to build
+branches:
+  # whitelist
+  only:
+    - appveyor
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+# Operating system (build VM template)
+os: Windows Server 2012
+
+# clone directory
+clone_folder: c:\projects\ldc
+
+# scripts that run after cloning repository
+install:
+  - cmd: cd ..
+  - cmd: md downloads
+  - cmd: set
+  # Install CMake
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads\cmake-3.0.2-win32-x86.zip')
+  - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
+  - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
+  # Install libconfig
+  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'downloads\libconfig.tar.gz')
+  - cmd: 7z x libconfig.tar.gz
+  # Install LLVM snapshot
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'LLVM-install.exe')
+  - cmd: LLVM-install.exe
+  # Run CMake
+  - cmd: md c:\projects\build-ldc
+  - cmd: cd c:\projects\build-ldc
+  - cmd: cmake ..\ldc
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform:
+  - x64
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration:
+  - Debug
+
+build:
+  project: ..\build-ldc\INSTALL.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,10 @@ clone_folder: c:\projects\ldc
 install:
   - cmd: cd ..
   - cmd: md downloads
-  - cmd: cd downloads
   # Download all required files
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'cmake-3.0.2-win32-x86.zip')
-  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'libconfig-1.4.9.tar.gz')
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'LLVM-3.6.0-r219740-win32.exe')
+  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'c:/projects/downloads/cmake-3.0.2-win32-x86.zip')
+  - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'c:/projects/downloads/libconfig-1.4.9.tar.gz')
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'c:/projects/downloads/LLVM-3.6.0-r219740-win32.exe')
   - cmd: dir
   - cmd: cd ..
   # Install CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,10 @@ install:
   - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'c:/projects/downloads/cmake-3.0.2-win32-x86.zip')
   - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'c:/projects/downloads/libconfig-1.4.9.tar.gz')
   - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'c:/projects/downloads/LLVM-3.6.0-r219740-win32.exe')
-  - cmd: dir downloads
   # Install CMake
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
-  - cmd: dir
-  - cmd: dir cmake-3.0.2-win32-x86
-  - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
+  - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH%
+  - cmd: cmake
   # Install libconfig
   - cmd: 7z x downloads\libconfig-1.4.9.tar.gz
   # Install LLVM snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,7 +128,7 @@ test_script:
   # Compile the druntime & phobos unit tests
   - set TEST_LIB_SUFFIX=unittest
   - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set TEST_LIB_SUFFIX=unittest-debug)
-  - ninja druntime-ldc-%TEST_LIB_SUFFIX% phobos2-ldc-%TEST_LIB_SUFFIX%
+  - ninja -j 1 druntime-ldc-%TEST_LIB_SUFFIX% phobos2-ldc-%TEST_LIB_SUFFIX%
   # Execute the unit tests; exclude dmd-testsuite for now
   - set CTEST_SUFFIX=-E -debug
   - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@
 
 #version: 1.0.{build}-{branch}
 
-#branches:
-#  only:
-#    - appveyor
+branches:
+  only:
+    - merge-2.067
 
 # Do not build on tags (GitHub only)
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ skip_tags: true
 init:
   - git config --global core.autocrlf input
   - msbuild /version
+  - cmake --version
   - python --version
 
 clone_folder: c:\projects\ldc
@@ -34,14 +35,17 @@ install:
   - cd c:\projects
   # Clone libconfig
   - git clone https://github.com/hyperrealm/libconfig.git libconfig
-  # Download CMake and LLVM
+  # Download Ninja and LLVM
   - md downloads
-  - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.3/cmake-3.3.1-win32-x86.zip', 'c:/projects/downloads/cmake.zip')
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip', 'c:/projects/downloads/ninja.zip')
   - ps: (new-object net.webclient).DownloadFile('http://llvm.org/releases/3.6.2/LLVM-3.6.2-win32.exe', 'c:/projects/downloads/llvm.exe')
-  # Install CMake
-  - 7z x downloads\cmake.zip
-  - set PATH=c:\projects\cmake\bin;%PATH%
-  - cmake --version
+  # Install Ninja
+  - md ninja
+  - cd ninja
+  - 7z x ..\downloads\ninja.zip
+  - set PATH=c:\projects\ninja;%PATH%
+  - cd ..
+  - ninja --version
   # Install LLVM
   - downloads\llvm.exe
 
@@ -54,7 +58,7 @@ before_build:
   # Generate msbuild files for LDC
   - md msbuild-ldc
   - cd msbuild-ldc
-  - cmake -G "Visual Studio 2013 x64" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  - cmake -G "Visual Studio 2015 x64" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
 
 build_script:
   - cd c:\projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,10 @@ install:
   - cmd: md downloads
   # Install CMake
   - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'downloads\\cmake-3.0.2-win32-x86.zip')
+  - cmd: dir
+  - cmd: dir downloads
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
+  - cmd: dir
   - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
   # Install libconfig
   - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'downloads\libconfig.tar.gz')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,11 @@ install:
   - ps: (new-object net.webclient).DownloadFile('http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.zip', 'c:/projects/downloads/cmake-3.0.2-win32-x86.zip')
   - ps: (new-object net.webclient).DownloadFile('http://www.hyperrealm.com/libconfig/libconfig-1.4.9.tar.gz', 'c:/projects/downloads/libconfig-1.4.9.tar.gz')
   - ps: (new-object net.webclient).DownloadFile('http://llvm.org/builds/downloads/LLVM-3.6.0-r219740-win32.exe', 'c:/projects/downloads/LLVM-3.6.0-r219740-win32.exe')
-  - cmd: dir
-  - cmd: cd ..
+  - cmd: dir downloads
   # Install CMake
-  - cmd: dir
   - cmd: 7z x downloads\cmake-3.0.2-win32-x86.zip
   - cmd: dir
+  - cmd: dir cmake-3.0.2-win32-x86
   - cmd: set PATH=c:\projects\cmake-3.0.2-win32-x86\bin;%PATH
   # Install libconfig
   - cmd: 7z x downloads\libconfig-1.4.9.tar.gz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@
 
 #version: 1.0.{build}-{branch}
 
-branches:
-  only:
-    - appveyor
+#branches:
+#  only:
+#    - appveyor
 
 # Do not build on tags (GitHub only)
 skip_tags: true
@@ -47,7 +47,6 @@ install:
   #- ren llvm-3.7.0rc3.src llvm
   # Download a pre-built LLVM if not cached & extract
   - ps: If (-Not (Test-Path llvm-x64.7z)) { Start-FileDownload 'https://dl.dropboxusercontent.com/s/xfbl0u0sfa7ifx5/llvm-x64.7z?dl=0' -FileName 'llvm-x64.7z' -Timeout 600000 }
-  - dir
   - 7z x llvm-x64.7z > nul
   # Download & install Ninja
   - ps: Start-FileDownload 'https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
@@ -107,7 +106,7 @@ test_script:
   # Just compile, link & execute a hello-world program for now
   - cd c:\projects
   - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
-  - ldc2 hello.d -Llegacy_stdio_definitions.lib
+  - ninja-ldc\bin\ldc2 hello.d -Llegacy_stdio_definitions.lib
   - hello.exe
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,14 @@ install:
   - cd c:\projects
   # Clone libconfig
   - git clone https://github.com/hyperrealm/libconfig.git libconfig
-  # Download and extract LLVM source
-  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz', 'c:/projects/llvm.src.tar.xz')
-  - 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
-  - ren llvm-3.7.0rc3.src llvm
+  ## Download and extract LLVM source
+  #- ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz', 'c:/projects/llvm.src.tar.xz')
+  #- 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
+  #- ren llvm-3.7.0rc3.src llvm
+  # Download and install LLVM
+  - ps: (new-object net.webclient).DownloadFile('http://llvm.org/pre-releases/3.7.0/rc3/LLVM-3.7.0-rc3-win64.exe', 'c:/projects/llvm.exe')
+  - llvm.exe /S /D=c:\projects\llvm-x64
+  - dir llvm-x64 || echo No llvm-x64 directory!
   # Download and install Ninja
   - ps: (new-object net.webclient).DownloadFile('https://github.com/martine/ninja/releases/download/v1.6.0/ninja-win.zip', 'c:/projects/ninja.zip')
   - md ninja
@@ -57,10 +61,10 @@ before_build:
   # Build libconfig
   - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
   # Generate build files for LLVM and build & install
-  - md ninja-llvm
-  - cd ninja-llvm
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\llvm-x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_APPEND_VC_REV=ON ..\llvm
-  - ninja install
+  #- md ninja-llvm
+  #- cd ninja-llvm
+  #- cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\llvm-x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_APPEND_VC_REV=ON ..\llvm
+  #- ninja install
 
 build_script:
   - cd c:\projects


### PR DESCRIPTION
https://ci.appveyor.com/project/kinke/ldc/history

2 jobs now (debug & release): Win64, Visual Studio 2015, `RelWithDebInfo` configuration for LLVM and LDC, preferring Ninja over msbuild and using a pre-built LLVM 3.7 RC (assertions enabled) from my DropBox. ;)
The unit tests are run; release ones are allowed to fail (core.thread fails in release). dmd-testsuite is excluded for now.
The resulting 'installed' LDC should be published as artifact, that somehow doesn't work yet.

We have at most 40 minutes before a job is killed and just 1 job at a time.