### PR TITLE
Dynamically load libcurl when needed (backport from post-2.068 upstream)

### DIFF
--- a/ldc2_install.conf.in
+++ b/ldc2_install.conf.in
@@ -10,7 +10,7 @@ default:
         "-I@INCLUDE_INSTALL_DIR@/ldc",
         "-I@INCLUDE_INSTALL_DIR@",
         "-L-L@CMAKE_INSTALL_LIBDIR@", @MULTILIB_ADDITIONAL_INSTALL_PATH@
-        "-defaultlib=phobos2-ldc,curl,druntime-ldc",
-        "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
+        "-defaultlib=phobos2-ldc,druntime-ldc",
+        "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
     ];
 };

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -11,7 +11,7 @@ default:
         "-I@RUNTIME_DIR@/src", // Needed for gc.*/rt.* unit tests.
         "-I@PHOBOS2_DIR@/",
         "-L-L@CMAKE_BINARY_DIR@/lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
-        "-defaultlib=phobos2-ldc,curl,druntime-ldc",
-        "-debuglib=phobos2-ldc-debug,curl,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
+        "-defaultlib=phobos2-ldc,druntime-ldc",
+        "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
     ];
 };

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -129,12 +129,6 @@ list(APPEND CORE_D ${LDC_D} ${RUNTIME_DIR}/src/object_.d)
 file(GLOB CORE_C ${RUNTIME_DIR}/src/core/stdc/*.c)
 
 if(PHOBOS2_DIR)
-    if(BUILD_SHARED_LIBS)
-        # std.net.curl depends on libcurl – when building a shared library, we
-        # need to take care of that.
-        find_package(CURL REQUIRED)
-    endif()
-
     file(GLOB PHOBOS2_D ${PHOBOS2_DIR}/std/*.d)
     file(GLOB PHOBOS2_D_ALGORITHM ${PHOBOS2_DIR}/std/algorithm/*.d)
     file(GLOB PHOBOS2_D_CONTAINER ${PHOBOS2_DIR}/std/container/*.d)
@@ -446,7 +440,7 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
             # TODO: As for druntime, adapt once shared libraries are supported
             # on more operating systems.
             target_link_libraries(phobos2-ldc${target_suffix}
-                druntime-ldc${target_suffix} "curl" "m" "pthread" "dl")
+                druntime-ldc${target_suffix} "m" "pthread" "dl")
         endif()
 
         list(APPEND ${outlist_targets} "phobos2-ldc${target_suffix}")
@@ -720,7 +714,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
                 COMMAND ${LDC_EXE}
                     -of${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
                     -defaultlib=druntime-ldc,${phobos2-casm} -debuglib=druntime-ldc,${phobos2-casm}
-                    -singleobj -L-lcurl ${flags} ${phobos2_o} ${RUNTIME_DIR}/src/test_runner.d
+                    -singleobj ${flags} ${phobos2_o} ${RUNTIME_DIR}/src/test_runner.d
             )
             set_tests_properties(build-phobos2-test-runner${name_suffix} PROPERTIES
                 DEPENDS build-phobos2-ldc-unittest${name_suffix}

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -13,12 +13,6 @@ function(add_testsuite config_name dflags model)
     add_test(NAME clean-${name}
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
 
-    # FIXME: Link in libcurl even though dmd-testsuite does not depend on it
-    # to avoid linking issues as described in GitHub #683.
-    if(NOT BUILD_SHARED_LIBS)
-        set(dflags "${dflags} -defaultlib=phobos2-ldc,druntime-ldc,curl -debuglib=phobos2-ldc-debug,druntime-ldc-debug,curl")
-    endif()
-
     # The DFLAGS environment variable read by LDMD is used because the DMD
     # testsuite build system provides no way to run the test cases with a
     # given set of flags without trying all combinations of them.


### PR DESCRIPTION
Besides being the right thing to do, this might also help us with the 32 bit Travis failures, since the issue seems to be that the i386 libcurl package does not include the appropriate symlinks to the shared library binaries.