### PR TITLE
Appveyor: use new pre-built LLVM in Release config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,10 @@ install:
   #- 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
   #- ren llvm-3.7.0rc3.src llvm
   # Download a pre-built LLVM & extract
-  - ps: Start-FileDownload 'https://dl.dropboxusercontent.com/s/s1tk6134mku3ei8/llvm-x64-debuginfo.7z?dl=0' -FileName 'llvm-x64.7z'
+  - ps: |
+        $llvmUrl = 'https://dl.dropboxusercontent.com/s/5cok3dvmohtduy6/llvm-x64-release.7z?dl=0'
+        If ($Env:APPVEYOR_JOB_CONFIG -eq 'Debug') { $llvmUrl = 'https://dl.dropboxusercontent.com/s/s1tk6134mku3ei8/llvm-x64-debuginfo.7z?dl=0' }
+        Start-FileDownload $llvmUrl -FileName 'llvm-x64.7z'
   - md llvm-x64
   - cd llvm-x64
   - 7z x ..\llvm-x64.7z > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,10 +50,8 @@ install:
   #- 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
   #- ren llvm-3.7.0rc3.src llvm
   # Download a pre-built LLVM & extract
-  - ps: |
-        $llvmUrl = 'https://dl.dropboxusercontent.com/s/5cok3dvmohtduy6/llvm-x64-release.7z?dl=0'
-        If ($Env:APPVEYOR_JOB_CONFIG -eq 'Debug') { $llvmUrl = 'https://dl.dropboxusercontent.com/s/s1tk6134mku3ei8/llvm-x64-debuginfo.7z?dl=0' }
-        Start-FileDownload $llvmUrl -FileName 'llvm-x64.7z'
+  # LLVM RelWithDebInfo: https://dl.dropboxusercontent.com/s/s1tk6134mku3ei8/llvm-x64-debuginfo.7z?dl=0
+  - ps: Start-FileDownload 'https://dl.dropboxusercontent.com/s/5cok3dvmohtduy6/llvm-x64-release.7z?dl=0' -FileName 'llvm-x64.7z'
   - md llvm-x64
   - cd llvm-x64
   - 7z x ..\llvm-x64.7z > nul


### PR DESCRIPTION
The RelWithDebInfo LLVM takes 4 minutes to extract (just for comparison, on my native system: 10 secs) and 10+ minutes longer when linking ldc2.exe, most likely because of insufficient RAM.

So use the pre-built LLVM with debug infos for the debug job only (which publishes the artifact) and a new pre-built LLVM compiled with Release CMake config (LLVM assertions still enabled) for the release job, which is constantly struggling to finish inside the 40 minutes we've got.

*Edit*: the 12+ minutes overhead gets the debug job way too close to the 40 minutes limit, we've just made it by a few seconds. So use the Release-LLVM for the debug job too.