### PR TITLE
OS X - fix so MULTILIB test_runner will link

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -722,6 +722,13 @@ macro(build_test_runner name_suffix d_flags c_flags)
         endif()
     endif()
 endmacro()
+
+# output_path was last left to an arch specific lib by build_runtime, need to
+# change so all lib casms ends up in correct lib dir for linking
+if(APPLE AND MULTILIB)
+    set(output_path ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX})
+endif()
+
 build_test_runner("" "${D_FLAGS_RELEASE}" "")
 build_test_runner("-debug" "${D_FLAGS_DEBUG}" "")
 if(MULTILIB AND ${HOST_BITNESS} EQUAL 64)


### PR DESCRIPTION
On OS X, test_runners were failing link because various casm libs were ending up in the wrong place.  This puts them back in lib.
