### PR TITLE
Fix alignment of interface info in class with align(1) members

### DIFF
--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -337,6 +337,14 @@ void IrAggr::addFieldInitializers(
         // has interface vtbls?
         if (cd->vtblInterfaces && cd->vtblInterfaces->dim > 0)
         {
+            // Align interface infos to pointer size.
+            unsigned aligned = (offset + Target::ptrsize - 1) & ~(Target::ptrsize - 1);
+            if (offset < aligned)
+            {
+                add_zeros(constants, offset, aligned);
+                offset = aligned;
+            }
+
             // false when it's not okay to use functions from super classes
             bool newinsts = (cd == aggrdecl->isClassDeclaration());
 

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -192,7 +192,11 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
 
 void AggrTypeBuilder::alignCurrentOffset(unsigned alignment)
 {
-    m_offset = (m_offset + alignment - 1) & ~(alignment - 1);
+    unsigned aligned = (m_offset + alignment - 1) & ~(alignment - 1);
+    if (m_offset < aligned) {
+        m_fieldIndex += add_zeros(m_defaultTypes, m_offset, aligned);
+        m_offset = aligned;
+    }
 }
 
 void AggrTypeBuilder::addTailPadding(unsigned aggregateSize)


### PR DESCRIPTION
GitHub: Fix #1058.