### PR TITLE
Use thunks instead of calling _d_toObject for D interfaces

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -365,32 +365,6 @@ DValue* DtoDynamicCastObject(Loc& loc, DValue* val, Type* _to)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-DValue* DtoCastInterfaceToObject(Loc& loc, DValue* val, Type* to)
-{
-    // call:
-    // Object _d_toObject(void* p)
-
-    llvm::Function* func = LLVM_D_GetRuntimeFunction(loc, gIR->module, "_d_toObject");
-    LLFunctionType* funcTy = func->getFunctionType();
-
-    // void* p
-    LLValue* tmp = val->getRVal();
-    tmp = DtoBitCast(tmp, funcTy->getParamType(0));
-
-    // call it
-    LLValue* ret = gIR->CreateCallOrInvoke(func, tmp).getInstruction();
-
-    // cast return value
-    if (to != NULL)
-        ret = DtoBitCast(ret, DtoType(to));
-    else
-        to = ClassDeclaration::object->type;
-
-    return new DImValue(to, ret);
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
 DValue* DtoDynamicCastInterface(Loc& loc, DValue* val, Type* _to)
 {
     // call:

--- a/gen/classes.h
+++ b/gen/classes.h
@@ -37,7 +37,6 @@ void DtoFinalizeClass(Loc& loc, llvm::Value* inst);
 DValue* DtoCastClass(Loc& loc, DValue* val, Type* to);
 DValue* DtoDynamicCastObject(Loc& loc, DValue* val, Type* to);
 
-DValue* DtoCastInterfaceToObject(Loc& loc, DValue* val, Type* to);
 DValue* DtoDynamicCastInterface(Loc& loc, DValue* val, Type* to);
 
 llvm::Value* DtoVirtualFunctionPointer(DValue* inst, FuncDeclaration* fdecl, char* name);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -677,16 +677,6 @@ static void LLVM_D_BuildRuntimeModule()
     /////////////////////////////////////////////////////////////////////////////////////
     /////////////////////////////////////////////////////////////////////////////////////
 
-    // cast to object
-    // Object _d_toObject(void* p)
-    {
-        llvm::StringRef fname("_d_toObject");
-        LLType *types[] = { voidPtrTy };
-        LLFunctionType* fty = llvm::FunctionType::get(objectTy, types, false);
-        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M)
-            ->setAttributes(Attr_ReadOnly_NoUnwind);
-    }
-
     // cast interface
     // void* _d_interface_cast(void* p, ClassInfo c)
     {


### PR DESCRIPTION
This allows us avoid the problems stemming from the 64 kiB
size limit hack in _d_toObject.

GitHub: Fix #1065.