### PR TITLE
Fix for issue #1061.

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -89,6 +89,7 @@ public:
             llvm::GlobalVariable *interfaceZ = ir->getClassInfoSymbol();
             interfaceZ->setInitializer(ir->getClassInfoInit());
             interfaceZ->setLinkage(DtoLinkage(decl));
+            if (DtoIsTemplateInstance(decl)) SET_COMDAT(interfaceZ, gIR->module);
         }
     }
 
@@ -124,6 +125,7 @@ public:
             llvm::GlobalVariable *initZ = ir->getInitSymbol();
             initZ->setInitializer(ir->getDefaultInit());
             initZ->setLinkage(DtoLinkage(decl));
+            if (DtoIsTemplateInstance(decl)) SET_COMDAT(initZ, gIR->module);
 
             // emit typeinfo
             DtoTypeInfoOf(decl->type);
@@ -167,18 +169,22 @@ public:
 
             IrAggr *ir = getIrAggr(decl);
             llvm::GlobalValue::LinkageTypes const linkage = DtoLinkage(decl);
+            const bool isTemplateInstance = DtoIsTemplateInstance(decl);
 
             llvm::GlobalVariable *initZ = ir->getInitSymbol();
             initZ->setInitializer(ir->getDefaultInit());
             initZ->setLinkage(linkage);
+            if (isTemplateInstance) SET_COMDAT(initZ, gIR->module);
 
             llvm::GlobalVariable *vtbl = ir->getVtblSymbol();
             vtbl->setInitializer(ir->getVtblInit());
             vtbl->setLinkage(linkage);
+            if (isTemplateInstance) SET_COMDAT(vtbl, gIR->module);
 
             llvm::GlobalVariable *classZ = ir->getClassInfoSymbol();
             classZ->setInitializer(ir->getClassInfoInit());
             classZ->setLinkage(linkage);
+            if (isTemplateInstance) SET_COMDAT(classZ, gIR->module);
 
             // No need to do TypeInfo here, it is <name>__classZ for classes in D2.
         }

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -768,6 +768,7 @@ void DtoDefineFunction(FuncDeclaration* fd)
     gIR->functions.push_back(irFunc);
 
     func->setLinkage(lowerFuncLinkage(fd));
+    if (func->hasLinkOnceLinkage() || func->hasWeakLinkage()) SET_COMDAT(func, gIR->module);
 
     // On x86_64, always set 'uwtable' for System V ABI compatibility.
     // TODO: Find a better place for this.

--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -1,4 +1,5 @@
 #include "gen/inlineir.h"
+#include "gen/llvmhelpers.h"
 
 #include "declaration.h"
 #include "template.h"
@@ -102,6 +103,7 @@ llvm::Function* DtoInlineIRFunction(FuncDeclaration* fdecl)
 
     LLFunction* fun = gIR->module.getFunction(mangled_name);
     fun->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
+    SET_COMDAT(fun, gIR->module);
     fun->addFnAttr(LDC_ATTRIBUTE(AlwaysInline));
     return fun;
 }

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1824,3 +1824,10 @@ unsigned getFieldGEPIndex(AggregateDeclaration* ad, VarDeclaration* vd)
     assert(byteOffset == 0 && "Cannot address field by a simple GEP.");
     return fieldIndex;
 }
+
+#if LDC_LLVM_VER >= 307
+bool supportsCOMDAT()
+{
+    return !global.params.targetTriple.isOSBinFormatMachO();
+}
+#endif

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -230,4 +230,15 @@ DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
 LLConstant *toConstElem(Expression *e, IRState *p);
 
+#if LDC_LLVM_VER >= 307
+bool supportsCOMDAT();
+
+#define SET_COMDAT(x,m) if (supportsCOMDAT()) x->setComdat(m.getOrInsertComdat(x->getName()))
+
+#else
+
+#define SET_COMDAT(x,m)
+
+#endif
+
 #endif

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -102,6 +102,7 @@ void RTTIBuilder::push_void_array(llvm::Constant* CI, Type* valtype, Dsymbol* ma
 
     LLGlobalVariable* G = new LLGlobalVariable(
         gIR->module, CI->getType(), true, TYPEINFO_LINKAGE_TYPE, CI, initname);
+    SET_COMDAT(G, gIR->module);
     G->setAlignment(valtype->alignsize());
 
     push_void_array(getTypePaddedSize(CI->getType()), G);
@@ -121,6 +122,7 @@ void RTTIBuilder::push_array(llvm::Constant * CI, uint64_t dim, Type* valtype, D
 
     LLGlobalVariable* G = new LLGlobalVariable(
         gIR->module, CI->getType(), true, TYPEINFO_LINKAGE_TYPE, CI, initname);
+    SET_COMDAT(G, gIR->module);
     G->setAlignment(valtype->alignsize());
 
     push_array(dim, DtoBitCast(G, DtoType(valtype->pointerTo())));
@@ -194,6 +196,7 @@ void RTTIBuilder::finalize(LLType* type, LLValue* value)
     llvm::GlobalVariable* gvar = llvm::cast<llvm::GlobalVariable>(value);
     gvar->setInitializer(tiInit);
     gvar->setLinkage(TYPEINFO_LINKAGE_TYPE);
+    SET_COMDAT(gvar, gIR->module);
 }
 
 LLConstant* RTTIBuilder::get_constant(LLStructType *initType)


### PR DESCRIPTION
Starting with LLVM 3.7, linkage and COMDAT are 2 different concepts.
This means that LinkageODROnce does not put the object into a COMDAT.
On Windows this resulted in linker error messages.

This PR places all template functions, TypeInfo objects and other
objects into a COMDAT.