### PR TITLE
Treat atomic instructions as intrinsics

### DIFF
--- a/dmd2/expression.c
+++ b/dmd2/expression.c
@@ -1743,7 +1743,7 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             // If not D linkage, do promotions
 #if IN_LLVM
             // LDC: don't do promotions on intrinsics
-            if (tf->linkage != LINKd && (!fd || fd->llvmInternal != LLVMintrinsic))
+            if (tf->linkage != LINKd && (!fd || !DtoIsIntrinsic(fd)))
 #else
             if (tf->linkage != LINKd)
 #endif

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -288,7 +288,7 @@ llvm::FunctionType* DtoFunctionType(FuncDeclaration* fdecl)
 
     LLFunctionType* functype = DtoFunctionType(fdecl->type, getIrFunc(fdecl, true)->irFty, dthis, dnest,
                                                fdecl->isMain(), fdecl->isCtorDeclaration(),
-                                               fdecl->llvmInternal == LLVMintrinsic);
+                                               DtoIsIntrinsic(fdecl));
 
     return functype;
 }
@@ -456,7 +456,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
     //printf("declare function: %s\n", fdecl->toPrettyChars());
 
     // intrinsic sanity check
-    if (fdecl->llvmInternal == LLVMintrinsic && fdecl->fbody) {
+    if (DtoIsIntrinsic(fdecl) && fdecl->fbody) {
         error(fdecl->loc, "intrinsics cannot have function bodies");
         fatal();
     }
@@ -474,7 +474,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
 
     // calling convention
     LINK link = f->linkage;
-    if (vafunc || fdecl->llvmInternal == LLVMintrinsic
+    if (vafunc || DtoIsIntrinsic(fdecl)
         // DMD treats _Dmain as having C calling convention and this has been
         // hardcoded into druntime, even if the frontend type has D linkage.
         // See Bugzilla issue 9028.
@@ -616,7 +616,7 @@ void DtoDeclareFunction(FuncDeclaration* fdecl)
 static LinkageWithCOMDAT lowerFuncLinkage(FuncDeclaration* fdecl)
 {
     // Intrinsics are always external.
-    if (fdecl->llvmInternal == LLVMintrinsic)
+    if (DtoIsIntrinsic(fdecl))
         return LinkageWithCOMDAT(llvm::GlobalValue::ExternalLinkage, false);
 
     // Generated array op functions behave like templates in that they might be

--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -567,7 +567,18 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
 
 bool DtoIsIntrinsic(FuncDeclaration *fd)
 {
-    return (fd->llvmInternal == LLVMintrinsic || DtoIsVaIntrinsic(fd));
+    switch (fd->llvmInternal)
+    {
+    case LLVMintrinsic:
+    case LLVMatomic_store:
+    case LLVMatomic_load:
+    case LLVMatomic_cmp_xchg:
+    case LLVMatomic_rmw:
+        return true;
+
+    default:
+        return DtoIsVaIntrinsic(fd);
+    }
 }
 
 bool DtoIsVaIntrinsic(FuncDeclaration *fd)

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -629,7 +629,7 @@ DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* 
     DFuncValue* dfnval = fnval->isFunc();
 
     // handle intrinsics
-    bool intrinsic = (dfnval && dfnval->func && dfnval->func->llvmInternal == LLVMintrinsic);
+    bool intrinsic = (dfnval && dfnval->func && DtoIsIntrinsic(dfnval->func));
 
     // get function type info
     IrFuncTy &irFty = DtoIrTypeFunction(fnval);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -50,7 +50,7 @@ RET retStyle(TypeFunction *tf)
 bool DtoIsReturnInArg(CallExp *ce)
 {
     TypeFunction *tf = static_cast<TypeFunction *>(ce->e1->type->toBasetype());
-    if (tf->ty == Tfunction && (!ce->f || ce->f->llvmInternal != LLVMintrinsic))
+    if (tf->ty == Tfunction && (!ce->f || !DtoIsIntrinsic(ce->f)))
         return retStyle(tf) == RETstack;
     return false;
 }


### PR DESCRIPTION
Whose types aren't rewritten by the regular TargetABI.

Fixes the undefined reference to `llvm_atomic_load()` for MSVC builds.

There's a couple more comparisons against `LLVMintrinsic` alone. And I'm not sure whether we can add some more instructions (fence, bitops) as intrinsics in `DtoIsIntrinsic()`.