### PR TITLE
Add more intrinsics to DtoIsIntrinsic.

### DIFF
--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -570,10 +570,18 @@ bool DtoIsIntrinsic(FuncDeclaration *fd)
     switch (fd->llvmInternal)
     {
     case LLVMintrinsic:
+    case LLVMalloca:
+    case LLVMfence:
     case LLVMatomic_store:
     case LLVMatomic_load:
     case LLVMatomic_cmp_xchg:
     case LLVMatomic_rmw:
+    case LLVMbitop_bt:
+    case LLVMbitop_btc:
+    case LLVMbitop_btr:
+    case LLVMbitop_bts:
+    case LLVMbitop_vld:
+    case LLVMbitop_vst:
         return true;
 
     default:


### PR DESCRIPTION
The wrong ABI is called for every function intrinsic. These are the
ones handled in DtoLowerMagicIntrinsic(). This PR adds the missing
instrinsic constants.