### PR TITLE
Add missing version identifiers for C runtimes.

### DIFF
--- a/dmd2/cond.c
+++ b/dmd2/cond.c
@@ -216,6 +216,9 @@ bool VersionCondition::isPredefined(const char *ident)
         "BigEndian",
         "ELFv1",
         "ELFv2",
+#if IN_LLVM
+        "CRuntime_Bionic",
+#endif
         "CRuntime_Digitalmars",
         "CRuntime_Glibc",
         "CRuntime_Microsoft",

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -742,12 +742,14 @@ static void registerPredefinedTargetVersions() {
             if (global.params.targetTriple.getEnvironment() == llvm::Triple::Android)
             {
                 VersionCondition::addPredefinedGlobalIdent("Android");
+                VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
             }
             else
 #endif
             {
                 VersionCondition::addPredefinedGlobalIdent("linux");
                 VersionCondition::addPredefinedGlobalIdent("Posix");
+                VersionCondition::addPredefinedGlobalIdent("CRuntime_Glibc");
             }
             break;
         case llvm::Triple::Haiku:


### PR DESCRIPTION
Define CRuntime_Glibc for Linux and CRuntime_Bionic for Android.