### PR TITLE
Use a more robust way of dumping a LL value to memory.

### DIFF
--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -966,8 +966,9 @@ DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* 
 
     // if we are returning through a pointer arg
     // or if we are returning a reference
+    // or if we are returning a struct or static array
     // make sure we provide a lvalue back!
-    if (retinptr || (tf->isref && returnTy != Tvoid))
+    if (retinptr || (tf->isref && returnTy != Tvoid) || DtoIsPassedByRef(dReturnType))
         return new DVarValue(resulttype, retllval);
 
     return new DImValue(resulttype, retllval);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -302,8 +302,10 @@ public:
             if (result && result->getType()->ty != Tvoid &&
                 (result->isIm() || result->isSlice())
             ) {
-                llvm::AllocaInst* alloca = DtoAlloca(result->getType());
-                DtoStoreZextI8(result->getRVal(), alloca);
+                LLValue* rval = result->getRVal();
+                llvm::AllocaInst* alloca = DtoRawAlloca(i1ToI8(rval->getType()),
+                    result->getType()->alignsize());
+                DtoStoreZextI8(rval, alloca);
                 result = new DVarValue(result->getType(), alloca);
             }
 


### PR DESCRIPTION
This fixes a previous ICE in https://github.com/ldc-developers/dmd-testsuite/blob/ldc/runnable/sdtor.d#L3331 on Win64. The temporary is rewritten to `(auto x = HasDtortest11763(), x)`, and `x` is somehow already an alloca (most likely due it being an instance of an empty struct with a dummy size of 1 byte).

Not sure if this is enough or whether we should actually make sure these empty structs get represented by a dummy i8 value. Ideally, empty structs wouldn't require any memory at all.