### PR TITLE
driver: Only use slow -debuglib libraries if explicitly asked to 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,7 @@ build_script:
   - cd ninja-ldc
   - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
   # Work around LDC issue #930
-  - ps: (gc build.ninja).replace('runtime/std/string-unittest-debug.obj -w -d -g -unittest', 'runtime/std/string-unittest-debug.obj -w -d -unittest') | sc build.ninja
+  - ps: (gc build.ninja).replace('runtime/std/string-unittest-debug.obj -w -d -g -link-debuglib -unittest', 'runtime/std/string-unittest-debug.obj -w -d -link-debuglib -unittest') | sc build.ninja
   # Build LDC, druntime and phobos
   - ninja -j2
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -90,15 +90,18 @@ static cl::list<std::string, StringsAdapter> importPaths("I",
     cl::Prefix);
 
 static cl::opt<std::string> defaultLib("defaultlib",
-    cl::desc("Default libraries for non-debug-info build (overrides previous)"),
+    cl::desc("Default libraries to link with (overrides previous)"),
     cl::value_desc("lib1,lib2,..."),
     cl::ZeroOrMore);
 
 static cl::opt<std::string> debugLib("debuglib",
-    cl::desc("Default libraries for debug info build (overrides previous)"),
+    cl::desc("Debug versions of default libraries (overrides previous)"),
     cl::value_desc("lib1,lib2,..."),
     cl::ZeroOrMore);
 
+static cl::opt<bool> linkDebugLib("link-debuglib",
+    cl::desc("Link with libraries specified in -debuglib, not -defaultlib"),
+    cl::ZeroOrMore);
 
 #if LDC_LLVM_VER < 304
 namespace llvm {
@@ -421,8 +424,7 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles, bool &
     else
     {
         // Parse comma-separated default library list.
-        std::stringstream libNames(
-            global.params.symdebug ? debugLib : defaultLib);
+        std::stringstream libNames(linkDebugLib ? debugLib : defaultLib);
         while (libNames.good())
         {
             std::string lib;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BUILD_BC_LIBS         OFF                                       CACHE BOOL  
 set(INCLUDE_INSTALL_DIR   ${CMAKE_INSTALL_PREFIX}/include/d         CACHE PATH    "Path to install D modules to")
 set(BUILD_SHARED_LIBS     OFF                                       CACHE BOOL    "Whether to build the runtime as a shared library")
 set(D_FLAGS               -w;-d                                     CACHE STRING  "Runtime build flags, separated by ;")
-set(D_FLAGS_DEBUG         -g                                        CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
+set(D_FLAGS_DEBUG         -g;-link-debuglib                         CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
 set(D_FLAGS_RELEASE       -O3;-release                              CACHE STRING  "Runtime build flags (release libraries), separated by ;")
 if(MSVC)
     set(LINK_WITH_MSVCRT  ON                                        CACHE BOOL    "Link with MSVCRT.lib (DLL) instead of LIBCMT.lib (static)")

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -25,11 +25,11 @@ endfunction()
 # Would like to specify the "-release" flag for relase builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
-add_testsuite("-debug" -gc ${host_model})
+add_testsuite("-debug" "-gc -link-debuglib" ${host_model})
 add_testsuite("" -O3 ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)
     # Also test in 32 bit mode on x86_64 multilib builds.
-    add_testsuite("-debug-32" -gc 32)
+    add_testsuite("-debug-32" "-gc -link-debuglib" 32)
     add_testsuite("-32" -O3 32)
 endif()


### PR DESCRIPTION
Should finally settle the long-lasting dilemma of abysmal performance with `-g`. I recently discovered that there really is no justification for automatically enabling the debug libraries at all, because some of the druntime contracts e.g. change AA lookup to be O(N) and similar stuff that is not just a constant overhead.

@redstar: This is my last big change/fix for 0.16.0.