### PR TITLE
Use clang as default compiler driver on FreeBSD 10 or later.

### DIFF
--- a/gen/programs.cpp
+++ b/gen/programs.cpp
@@ -70,7 +70,12 @@ static std::string getProgram(const char *name, const cl::opt<std::string> &opt,
 
 std::string getGcc()
 {
+#if defined(__FreeBSD__) && __FreeBSD__ >= 10
+    // Default compiler on FreeBSD 10 is clang
+    return getProgram("clang", gcc, "CC");
+#else
     return getProgram("gcc", gcc, "CC");
+#endif
 }
 
 std::string getArchiver()


### PR DESCRIPTION
On FreeBSD 10 clang is the default compiler. gcc is not installed
by default. This PR changes the used compiler driver for linking
to clang.