### PR TITLE
Use another Travis-CI build order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ addons:
 install:
   - if [[ "${LLVM_CONFIG}" == *3\.[567]* ]]; then export CC="gcc-4.9"; export CXX="g++-4.9"; fi
 env:
-  - LLVM_CONFIG="llvm-config-3.7"
-  - LLVM_CONFIG="llvm-config-3.6" OPTS="-DMULTILIB=ON"
-  - LLVM_CONFIG="llvm-config-3.5" OPTS="-DBUILD_SHARED_LIBS=ON"
-  - LLVM_CONFIG="llvm-config-3.4" OPTS="-DTEST_COVERAGE=ON"
+  - LLVM_CONFIG="llvm-config-3.7" OPTS="-DMULTILIB=ON"
+  - LLVM_CONFIG="llvm-config-3.6" OPTS="-DBUILD_SHARED_LIBS=ON"
+  - LLVM_CONFIG="llvm-config-3.5" OPTS="-DTEST_COVERAGE=ON"
+  - LLVM_CONFIG="llvm-config-3.4"
   - LLVM_CONFIG="llvm-config-3.3"
   - LLVM_CONFIG="llvm-config-3.2"
   - LLVM_CONFIG="llvm-config-3.1"


### PR DESCRIPTION
This PR re-arranges the build parameters a bit. Basically, I moved
every option to a higher LLVM version. I expect that this will
show some more failures. It also prepares for the drop of support
of LLVM 3.1-3.4.