### PR TITLE
Refactor common `i1ToI8(voidToI8(DtoType(...)))` code occurrences

### DIFF
--- a/gen/aa.cpp
+++ b/gen/aa.cpp
@@ -75,7 +75,7 @@ DValue* DtoAAIndex(Loc& loc, Type* type, DValue* aa, DValue* key, bool lvalue)
     }
 
     // cast return value
-    LLType* targettype = getPtrToType(i1ToI8(DtoType(type)));
+    LLType* targettype = DtoPtrToType(type);
     if (ret->getType() != targettype)
         ret = DtoBitCast(ret, targettype);
 

--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -226,7 +226,7 @@ struct ExplicitByvalRewrite : ABIRewrite
 
     LLType* type(Type* dty, LLType* t)
     {
-        return getPtrToType(DtoType(dty));
+        return DtoPtrToType(dty);
     }
 };
 

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -207,7 +207,7 @@ struct ImplicitByvalRewrite : ABIRewrite {
     }
 
     LLType* type(Type* dty, LLType* t) {
-        return getPtrToType(DtoType(dty));
+        return DtoPtrToType(dty);
     }
 };
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -72,7 +72,7 @@ LLValue* DtoNew(Loc& loc, Type* newtype)
     // call runtime allocator
     LLValue* mem = gIR->CreateCallOrInvoke(fn, ti, ".gc_mem").getInstruction();
     // cast
-    return DtoBitCast(mem, getPtrToType(i1ToI8(DtoType(newtype))), ".gc_mem");
+    return DtoBitCast(mem, DtoPtrToType(newtype), ".gc_mem");
 }
 
 LLValue* DtoNewStruct(Loc& loc, TypeStruct* newtype)
@@ -81,7 +81,7 @@ LLValue* DtoNewStruct(Loc& loc, TypeStruct* newtype)
         newtype->isZeroInit(newtype->sym->loc) ? "_d_newitemT" : "_d_newitemiT");
     LLConstant* ti = DtoTypeInfoOf(newtype);
     LLValue* mem = gIR->CreateCallOrInvoke(fn, ti, ".gc_struct").getInstruction();
-    return DtoBitCast(mem, getPtrToType(i1ToI8(DtoType(newtype))), ".gc_struct");
+    return DtoBitCast(mem, DtoPtrToType(newtype), ".gc_struct");
 }
 
 void DtoDeleteMemory(Loc& loc, DValue* ptr)
@@ -141,8 +141,7 @@ void DtoDeleteArray(Loc& loc, DValue* arr)
 
 llvm::AllocaInst* DtoAlloca(Type* type, const char* name)
 {
-    LLType* lltype = i1ToI8(DtoType(type));
-    return DtoRawAlloca(lltype, type->alignsize(), name);
+    return DtoRawAlloca(DtoMemType(type), type->alignsize(), name);
 }
 
 llvm::AllocaInst* DtoArrayAlloca(Type* type, unsigned arraysize, const char* name)
@@ -201,8 +200,8 @@ LLValue* DtoAllocaDump(LLValue* val, Type* asType, const char* name)
 
 LLValue* DtoAllocaDump(LLValue* val, LLType* asType, int alignment, const char* name)
 {
-    LLType* valType = i1ToI8(val->getType());
-    asType = i1ToI8(asType);
+    LLType* valType = i1ToI8(voidToI8(val->getType()));
+    asType = i1ToI8(voidToI8(asType));
     LLType* allocaType = (
         getTypeStoreSize(valType) <= getTypeAllocSize(asType) ? asType : valType);
     LLValue* mem = DtoRawAlloca(allocaType, alignment, name);
@@ -391,7 +390,7 @@ DValue* DtoNullValue(Type* type, Loc loc)
     else if (basety == Tarray)
     {
         LLValue* len = DtoConstSize_t(0);
-        LLValue* ptr = getNullPtr(getPtrToType(DtoType(basetype->nextOf())));
+        LLValue* ptr = getNullPtr(DtoPtrToType(basetype->nextOf()));
         return new DSliceValue(type, len, ptr);
     }
     else
@@ -727,7 +726,7 @@ DValue* DtoPaintType(Loc& loc, DValue* val, Type* to)
         {
             LLValue* ptr = val->getLVal();
             assert(isaPointer(ptr));
-            ptr = DtoBitCast(ptr, getPtrToType(DtoType(dgty)));
+            ptr = DtoBitCast(ptr, DtoPtrToType(dgty));
             IF_LOG Logger::cout() << "dg ptr: " << *ptr << '\n';
             return new DVarValue(to, ptr);
         }
@@ -866,7 +865,7 @@ void DtoResolveVariable(VarDeclaration* vd)
         }
 
         llvm::GlobalVariable* gvar = getOrCreateGlobal(vd->loc, gIR->module,
-            i1ToI8(DtoType(vd->type)), isLLConst, linkage, 0, llName,
+            DtoMemType(vd->type), isLLConst, linkage, 0, llName,
             vd->isThreadlocal());
         getIrGlobal(vd)->value = gvar;
 
@@ -1183,7 +1182,7 @@ LLConstant* DtoConstInitializer(Loc& loc, Type* type, Initializer* init)
     else if (init->isVoidInitializer())
     {
         Logger::println("const void initializer");
-        LLType* ty = voidToI8(DtoType(type));
+        LLType* ty = DtoMemType(type);
         _init = LLConstant::getNullValue(ty);
     }
     else
@@ -1225,7 +1224,7 @@ LLConstant* DtoConstExpInit(Loc& loc, Type* targetType, Expression* exp)
     }
 
     llvm::Type* llType = val->getType();
-    llvm::Type* targetLLType = i1ToI8(DtoType(targetBase));
+    llvm::Type* targetLLType = DtoMemType(targetBase);
     if (llType == targetLLType)
     {
         Logger::println("Matching LLVM types, ignoring frontend glitch.");
@@ -1653,7 +1652,7 @@ DValue* DtoSymbolAddress(Loc& loc, Type* type, Declaration* decl)
 
             if (isGlobal)
             {
-                llvm::Type* expectedType = llvm::PointerType::getUnqual(i1ToI8(DtoType(type)));
+                llvm::Type* expectedType = llvm::PointerType::getUnqual(DtoMemType(type));
                 // The type of globals is determined by their initializer, so
                 // we might need to cast. Make sure that the type sizes fit -
                 // '==' instead of '<=' should probably work as well.
@@ -1841,7 +1840,7 @@ LLValue* DtoIndexAggregate(LLValue* src, AggregateDeclaration* ad, VarDeclaratio
     }
 
     // Cast the (possibly void*) pointer to the canonical variable type.
-    val = DtoBitCast(val, getPtrToType(i1ToI8(DtoType(vd->type))));
+    val = DtoBitCast(val, DtoPtrToType(vd->type));
 
     IF_LOG Logger::cout() << "Value: " << *val << '\n';
     return val;

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -424,8 +424,7 @@ static void build_dso_ctor_dtor_body(
 static void build_module_ref(std::string moduleMangle, llvm::Constant* thisModuleInfo)
 {
     // Build the ModuleInfo reference and bracketing symbols.
-    llvm::Type* const moduleInfoPtrTy =
-        getPtrToType(DtoType(Module::moduleinfo->type));
+    llvm::Type* const moduleInfoPtrTy = DtoPtrToType(Module::moduleinfo->type);
 
     std::string thismrefname = "_D";
     thismrefname += moduleMangle;
@@ -445,8 +444,7 @@ static void build_module_ref(std::string moduleMangle, llvm::Constant* thisModul
 static void build_dso_registry_calls(std::string moduleMangle, llvm::Constant* thisModuleInfo)
 {
     // Build the ModuleInfo reference and bracketing symbols.
-    llvm::Type* const moduleInfoPtrTy =
-        getPtrToType(DtoType(Module::moduleinfo->type));
+    llvm::Type* const moduleInfoPtrTy = DtoPtrToType(Module::moduleinfo->type);
 
     // Order is important here: We must create the symbols in the
     // bracketing sections right before/after the ModuleInfo reference
@@ -789,8 +787,7 @@ static void genModuleInfo(Module *m, bool emitFullModuleInfo)
     RTTIBuilder b(Module::moduleinfo);
 
     // some types
-    llvm::Type* const moduleInfoPtrTy =
-        getPtrToType(DtoType(Module::moduleinfo->type));
+    llvm::Type* const moduleInfoPtrTy = DtoPtrToType(Module::moduleinfo->type);
     LLType* classinfoTy = Type::typeinfoclass->type->ctype->getLLType();
 
     // importedModules[]

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -64,7 +64,7 @@ DValue* DtoNestedVariable(Loc& loc, Type* astype, VarDeclaration* vd, bool byref
     while (fd != vdparent) {
         if (fd->isStatic()) {
             error(loc, "function %s cannot access frame of function %s", irfunc->decl->toPrettyChars(), vdparent->toPrettyChars());
-            return new DVarValue(astype, vd, llvm::UndefValue::get(getPtrToType(DtoType(astype))));
+            return new DVarValue(astype, vd, llvm::UndefValue::get(DtoPtrToType(astype)));
         }
         fd = getParentFunc(fd, false);
         assert(fd);
@@ -379,14 +379,14 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd) {
                     if (lazy)
                         types.push_back(irparam->value->getType()->getContainedType(0));
                     else
-                        types.push_back(i1ToI8(DtoType(vd->type)));
+                        types.push_back(DtoMemType(vd->type));
                 } else {
                     types.push_back(irparam->value->getType());
                 }
             } else if (isSpecialRefVar(vd)) {
                 types.push_back(DtoType(vd->type->pointerTo()));
             } else {
-                types.push_back(i1ToI8(DtoType(vd->type)));
+                types.push_back(DtoMemType(vd->type));
             }
             IF_LOG Logger::cout() << "Nested var '" << vd->toChars()
                                   << "' of type " << *types.back() << "\n";

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -175,7 +175,7 @@ public:
         bool nullterm = (t->ty != Tsarray);
         size_t endlen = nullterm ? e->len+1 : e->len;
 
-        LLType* ct = voidToI8(DtoType(cty));
+        LLType* ct = DtoMemType(cty);
         LLArrayType* at = LLArrayType::get(ct,endlen);
 
         llvm::StringMap<llvm::GlobalVariable*>* stringLiteralCache = 0;
@@ -571,7 +571,7 @@ public:
         Type* elemt = bt->nextOf();
 
         // build llvm array type
-        LLArrayType* arrtype = LLArrayType::get(i1ToI8(voidToI8(DtoType(elemt))), e->elements->dim);
+        LLArrayType* arrtype = LLArrayType::get(DtoMemType(elemt), e->elements->dim);
 
         // dynamic arrays can occur here as well ...
         bool dyn = (bt->ty != Tsarray);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -202,44 +202,21 @@ LLType* DtoType(Type* t)
         return IrTypeVector::get(t)->getLLType();
     }
 
-/*
-    Not needed atm as VarDecls for tuples are rewritten as a string of
-    VarDecls for the fields (u -> _u_field_0, ...)
-
-    case Ttuple:
-    {
-        TypeTuple* ttupl = static_cast<TypeTuple*>(t);
-        return DtoStructTypeFromArguments(ttupl->arguments);
-    }
-*/
-
     default:
         llvm_unreachable("Unknown class of D Type!");
     }
     return 0;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
-
-/*
-LLType* DtoStructTypeFromArguments(Arguments* arguments)
+LLType* DtoMemType(Type* t)
 {
-    if (!arguments)
-        return LLType::getVoidTy(gIR->context());
-
-    std::vector<LLType*> types;
-    for (size_t i = 0; i < arguments->dim; i++)
-    {
-        Argument *arg = (*arguments)[i];
-        assert(arg && arg->type);
-
-        types.push_back(DtoType(arg->type));
-    }
-    return LLStructType::get(types);
+    return i1ToI8(voidToI8(DtoType(t)));
 }
-*/
 
-//////////////////////////////////////////////////////////////////////////////////////////
+LLPointerType* DtoPtrToType(Type* t)
+{
+    return DtoMemType(t)->getPointerTo();
+}
 
 LLType* voidToI8(LLType* t)
 {
@@ -247,8 +224,6 @@ LLType* voidToI8(LLType* t)
         return LLType::getInt8Ty(gIR->context());
     return t;
 }
-
-//////////////////////////////////////////////////////////////////////////////////////////
 
 LLType* i1ToI8(LLType* t)
 {

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -32,6 +32,11 @@
  * DtoTypeFunction(FuncDeclaration*) is to be used instead.
  */
 LLType* DtoType(Type* t);
+// Uses DtoType(), but promotes i1 and void to i8.
+LLType* DtoMemType(Type* t);
+// Returns a pointer to the type returned by DtoMemType(t).
+LLPointerType* DtoPtrToType(Type* t);
+
 LLType* voidToI8(LLType* t);
 LLType* i1ToI8(LLType* t);
 

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -132,7 +132,7 @@ LLConstant* get_default_initializer(VarDeclaration* vd, Initializer* init)
     {
         // We need to be able to handle void[0] struct members even if void has
         // no default initializer.
-        return llvm::ConstantPointerNull::get(getPtrToType(DtoType(vd->type)));
+        return llvm::ConstantPointerNull::get(DtoPtrToType(vd->type));
     }
     return DtoConstExpInit(vd->loc, vd->type, vd->type->defaultInit(vd->loc));
 }

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -174,7 +174,7 @@ IrTypePointer* IrTypePointer::get(Type* dt)
     }
     else
     {
-        elemType = i1ToI8(voidToI8(DtoType(dt->nextOf())));
+        elemType = DtoMemType(dt->nextOf());
 
         // DtoType could have already created the same type, e.g. for
         // dt == Node* in struct Node { Node* n; }.
@@ -212,7 +212,7 @@ llvm::Type * IrTypeSArray::sarray2llvm(Type * t)
     assert(t->ty == Tsarray && "not static array type");
     TypeSArray* tsa = static_cast<TypeSArray*>(t);
     uint64_t dim = static_cast<uint64_t>(tsa->dim->toUInteger());
-    LLType* elemType = i1ToI8(voidToI8(DtoType(t->nextOf())));
+    LLType* elemType = DtoMemType(t->nextOf());
     return llvm::ArrayType::get(elemType, dim);
 }
 
@@ -232,7 +232,7 @@ IrTypeArray* IrTypeArray::get(Type* dt)
     assert(!dt->ctype);
     assert(dt->ty == Tarray && "not dynamic array type");
 
-    LLType* elemType = i1ToI8(voidToI8(DtoType(dt->nextOf())));
+    LLType* elemType = DtoMemType(dt->nextOf());
 
     // Could have already built the type as part of a struct forward reference,
     // just as for pointers.
@@ -273,7 +273,7 @@ llvm::Type* IrTypeVector::vector2llvm(Type* dt)
     assert(tv->basetype->ty == Tsarray);
     TypeSArray* tsa = static_cast<TypeSArray*>(tv->basetype);
     uint64_t dim = static_cast<uint64_t>(tsa->dim->toUInteger());
-    LLType* elemType = voidToI8(DtoType(tsa->next));
+    LLType* elemType = DtoMemType(tsa->next);
     return llvm::VectorType::get(elemType, dim);
 }
 

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -179,7 +179,7 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
         }
 
         // add default type
-        m_defaultTypes.push_back(i1ToI8(DtoType(vd->type)));
+        m_defaultTypes.push_back(DtoMemType(vd->type));
 
         // advance offset to right past this field
         m_offset += getMemberSize(vd->type);


### PR DESCRIPTION
Hopefully there are no issues due to potentially more promotions.