### PR TITLE
Remove clang options if compiler is gcc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,12 @@ if (UNIX AND NOT "${LLVM_LDFLAGS}" STREQUAL "")
     # LLVM_LDFLAGS may contain -l-lld which is a wrong library reference (AIX)
     string(REPLACE "-l-lld " "-lld " LLVM_LDFLAGS ${LLVM_LDFLAGS})
 endif()
-
+# LLVM_CXXFLAGS may contain -Wcovered-switch-default and -fcolor-diagnostics
+# which are clang-only options
+if(CMAKE_COMPILER_IS_GNUCXX)
+    string(REPLACE "-Wcovered-switch-default " "" LLVM_CXXFLAGS ${LLVM_CXXFLAGS})
+    string(REPLACE "-fcolor-diagnostics " "" LLVM_CXXFLAGS ${LLVM_CXXFLAGS})
+endif()
 #
 # Run idgen and impcnvgen.
 #


### PR DESCRIPTION
LLVM may be compiled with clang. In this case there are clang-specific
options in LLVM_CXXFLAGS. Remove these optiones if the compiler is gcc.