### PR TITLE
Handle command line option color.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -435,9 +435,18 @@ cl::opt<unsigned, true> nestedTemplateDepth("template-depth",
     cl::location(global.params.nestedTmpl),
     cl::init(500));
 
+#if LDC_LLVM_VER < 307
 cl::opt<bool, true, FlagParser<bool> > color("color",
     cl::desc("Force colored console output"),
     cl::location(global.params.color));
+#else
+void CreateColorOption()
+{
+    new cl::opt<bool, true, FlagParser<bool> >("color",
+    cl::desc("Force colored console output"),
+    cl::location(global.params.color));
+}
+#endif
 
 cl::opt<bool, true> useDIP25("dip25",
     cl::desc("implement http://wiki.dlang.org/DIP25 (experimental)"),

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -85,5 +85,9 @@ namespace opts {
     // Arguments to -d-debug
     extern std::vector<std::string> debugArgs;
     // Arguments to -run
+
+#if LDC_LLVM_VER >= 307
+    void CreateColorOption();
+#endif
 }
 #endif

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -174,6 +174,17 @@ static void hide(llvm::StringMap<cl::Option *>& map, const char* name) {
         map[name]->setHiddenFlag(cl::Hidden);
 }
 
+static void rename(llvm::StringMap<cl::Option *>& map, const char* from, const char *to) {
+    llvm::StringMap<cl::Option*>::iterator i = map.find(from);
+    if (i != map.end())
+    {
+        cl::Option *opt = i->getValue();
+        map.erase(i);
+        opt->setArgStr(to);
+        map[to] = opt;
+    }
+}
+
 /// Removes command line options exposed from within LLVM that are unlikely
 /// to be useful for end users from the -help output.
 static void hideLLVMOptions() {
@@ -242,6 +253,14 @@ static void hideLLVMOptions() {
     // line has been parsed).
     hide(map, "fdata-sections");
     hide(map, "ffunction-sections");
+
+#if LDC_LLVM_VER >= 307
+    // LLVM 3.7 introduces compiling as shared library. The result
+    // is a clash in the command line options.
+    rename(map, "color", "llvm-color");
+    hide(map, "llvm-color");
+    opts::CreateColorOption();
+#endif
 }
 #endif
 


### PR DESCRIPTION
There is a LLVM 3.7 command line option named color. This option is
only available if ldc is linked against shared LLVM libraries.

Because the LDC color option uses a FlagParser simple renaming does
not work. The solution is now:

- Rename LLVM option `color` to `llvm-color` and hide this option
- Dynamically create the LDC option `color`

This finally enables building with shared LLVM libraries.