### PR TITLE
Win64 ABI: pass 'this' before 'sret' for extern (C++)

### DIFF
--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -40,6 +40,8 @@ struct Win64TargetABI : TargetABI
 
     bool passByVal(Type* t);
 
+    bool passThisBeforeSret(TypeFunction* tf);
+
     void rewriteFunctionType(TypeFunction* tf, IrFuncTy &fty);
 
     void rewriteArgument(IrFuncTy& fty, IrFuncTyArg& arg);
@@ -115,6 +117,11 @@ bool Win64TargetABI::returnInArg(TypeFunction* tf)
 bool Win64TargetABI::passByVal(Type* t)
 {
     return false;
+}
+
+bool Win64TargetABI::passThisBeforeSret(TypeFunction* tf)
+{
+    return tf->linkage == LINKcpp;
 }
 
 void Win64TargetABI::rewriteFunctionType(TypeFunction* tf, IrFuncTy &fty)

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -106,6 +106,9 @@ struct TargetABI
     /// Returns true if the type is passed by value
     virtual bool passByVal(Type* t) = 0;
 
+    // Returns true if the 'this' argument is to be passed before the 'sret' argument.
+    virtual bool passThisBeforeSret(TypeFunction* tf) { return false; }
+
     /// Called to give ABI the chance to rewrite the types
     virtual void rewriteFunctionType(TypeFunction* t, IrFuncTy& fty) = 0;
     virtual void rewriteVarargs(IrFuncTy& fty, std::vector<IrFuncTyArg*>& args);

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -33,6 +33,7 @@
 #include "gen/metadata.h"
 #include "gen/runtime.h"
 #include "gen/functions.h"
+#include "gen/abi.h"
 
 #include "ir/iraggr.h"
 #include "ir/irfunction.h"
@@ -372,7 +373,7 @@ llvm::GlobalVariable * IrAggr::getInterfaceVtbl(BaseClass * b, bool new_instance
             }
 
             // cast 'this' to Object
-            LLValue* &thisArg = args[(!irFunc->irFty.arg_sret) ? 0 : 1];
+            LLValue* &thisArg = args[(!irFunc->irFty.arg_sret || gABI->passThisBeforeSret(irFunc->type)) ? 0 : 1];
             LLType* targetThisType = thisArg->getType();
             thisArg = DtoBitCast(thisArg, getVoidPtrType());
             thisArg = DtoGEP1(thisArg, DtoConstInt(-b->offset));


### PR DESCRIPTION
Fixes https://github.com/ldc-developers/ldc/issues/1156.