### PR TITLE
Introduce DtoAlignment() and overload DtoAlloca() for VarDeclarations

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -876,7 +876,7 @@ void DtoDefineFunction(FuncDeclaration* fd)
                 // Create the param here and set it to a "dummy" alloca that
                 // we do not store to here.
                 irparam = getIrParameter(vd, true);
-                irparam->value = DtoAlloca(vd->type, vd->ident->toChars());
+                irparam->value = DtoAlloca(vd, vd->ident->toChars());
             }
             else
             {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1379,7 +1379,7 @@ bool hasUnalignedFields(Type* t)
 {
     t = t->toBasetype();
     if (t->ty == Tsarray) {
-        assert(t->nextOf()->size() % DtoAlignment(t->nextOf()) == 0);
+        assert(t->nextOf()->size() % t->nextOf()->alignsize() == 0);
         return hasUnalignedFields(t->nextOf());
     } else if (t->ty != Tstruct)
         return false;
@@ -1395,7 +1395,7 @@ bool hasUnalignedFields(Type* t)
     for (unsigned i = 0; i < sym->fields.dim; i++)
     {
         VarDeclaration* f = static_cast<VarDeclaration*>(sym->fields.data[i]);
-        unsigned a = DtoAlignment(f) - 1;
+        unsigned a = f->type->alignsize() - 1;
         if (((f->offset + a) & ~a) != f->offset)
             return true;
         else if (f->type->toBasetype()->ty == Tstruct && hasUnalignedFields(f->type))

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -892,10 +892,9 @@ void DtoResolveVariable(VarDeclaration* vd)
             vd->isThreadlocal());
         getIrGlobal(vd)->value = gvar;
 
-        // Set the alignment (it is important not to use type->alignsize because
-        // VarDeclarations can have an align() attribute independent of the type
-        // as well).
-        gvar->setAlignment(DtoAlignment(vd));
+        // Set the alignment and use the target pointer size as lower bound.
+        unsigned alignment = std::max(DtoAlignment(vd), gDataLayout->getPointerSize());
+        gvar->setAlignment(alignment);
 
         IF_LOG Logger::cout() << *gvar << '\n';
     }

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -31,8 +31,12 @@ void DtoDeleteClass(Loc& loc, DValue* inst);
 void DtoDeleteInterface(Loc& loc, DValue* inst);
 void DtoDeleteArray(Loc& loc, DValue* arr);
 
+unsigned DtoAlignment(Type* type);
+unsigned DtoAlignment(VarDeclaration* vd);
+
 // emit an alloca
 llvm::AllocaInst* DtoAlloca(Type* type, const char* name = "");
+llvm::AllocaInst* DtoAlloca(VarDeclaration* vd, const char* name = "");
 llvm::AllocaInst* DtoArrayAlloca(Type* type, unsigned arraysize, const char* name = "");
 llvm::AllocaInst* DtoRawAlloca(LLType* lltype, size_t alignment, const char* name = "");
 LLValue* DtoGcMalloc(Loc& loc, LLType* lltype, const char* name = "");

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -16,6 +16,7 @@
 #include "gen/logger.h"
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
+#include "ir/irtypeaggr.h"
 #include "llvm/Analysis/ValueTracking.h"
 
 /****************************************************************************************/
@@ -334,24 +335,17 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd)
 
         IF_LOG Logger::cout() << "Function " << fd->toChars() << " has depth " << depth << '\n';
 
-        typedef std::vector<LLType*> TypeVec;
-        TypeVec types;
+        AggrTypeBuilder builder(false);
+
         if (depth != 0)
         {
             assert(innerFrameType);
+            unsigned ptrSize = gDataLayout->getPointerSize();
             // Add frame pointer types for all but last frame
             for (unsigned i = 0; i < (depth - 1); ++i)
-                types.push_back(innerFrameType->getElementType(i));
+                builder.addType(innerFrameType->getElementType(i), ptrSize);
             // Add frame pointer type for last frame
-            types.push_back(LLPointerType::getUnqual(innerFrameType));
-        }
-
-        if (Logger::enabled() && depth != 0)
-        {
-            Logger::println("Frame types: ");
-            LOG_SCOPE;
-            for (TypeVec::iterator i = types.begin(); i != types.end(); ++i)
-                Logger::cout() << **i << '\n';
+            builder.addType(LLPointerType::getUnqual(innerFrameType), ptrSize);
         }
 
         // Add the direct nested variables of this function, and update their indices to match.
@@ -361,10 +355,16 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd)
                                        I != E; ++I)
         {
             VarDeclaration* vd = *I;
+
+            unsigned alignment = DtoAlignment(vd);
+            if (alignment > 1)
+                builder.alignCurrentOffset(alignment);
+
             IrLocal& irLocal = *getIrLocal(vd, true);
-            irLocal.nestedIndex = types.size();
+            irLocal.nestedIndex = builder.currentFieldIndex();
             irLocal.nestedDepth = depth;
 
+            LLType* t = NULL;
             if (vd->isParameter() && getIrParameter(vd)->arg)
             {
                 // Parameters that are part of the LLVM signature will have
@@ -380,29 +380,32 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd)
                 {
                     // This will be copied to the nesting frame.
                     if (lazy)
-                        types.push_back(irparam->value->getType()->getContainedType(0));
+                        t = irparam->value->getType()->getContainedType(0);
                     else
-                        types.push_back(DtoMemType(vd->type));
+                        t = DtoMemType(vd->type);
                 }
                 else
-                    types.push_back(irparam->value->getType());
+                    t = irparam->value->getType();
             }
             else if (isSpecialRefVar(vd))
-                types.push_back(DtoType(vd->type->pointerTo()));
+                t = DtoType(vd->type->pointerTo());
             else
-                types.push_back(DtoMemType(vd->type));
+                t = DtoMemType(vd->type);
+
+            builder.addType(t, getTypeAllocSize(t));
 
             IF_LOG Logger::cout() << "Nested var '" << vd->toChars()
-                                  << "' of type " << *types.back() << "\n";
+                                  << "' of type " << *t << "\n";
         }
 
-        LLStructType* frameType = LLStructType::create(gIR->context(), types,
+        LLStructType* frameType = LLStructType::create(gIR->context(), builder.defaultTypes(),
                                                        std::string("nest.") + fd->toChars());
 
         IF_LOG Logger::cout() << "frameType = " << *frameType << '\n';
 
         // Store type in IrFunction
         irFunc.frameType = frameType;
+        irFunc.frameTypeAlignment = builder.overallAlignment();
     }
     else // no captured variables
     {
@@ -411,6 +414,7 @@ static void DtoCreateNestedContextType(FuncDeclaration* fd)
             // Propagate context arg properties if the context arg is passed on unmodified.
             IrFunction& parentIrFunc = *getIrFunc(parentFunc);
             irFunc.frameType = parentIrFunc.frameType;
+            irFunc.frameTypeAlignment = parentIrFunc.frameTypeAlignment;
             irFunc.depth = parentIrFunc.depth;
         }
     }
@@ -430,13 +434,18 @@ void DtoCreateNestedContext(FuncDeclaration* fd) {
         unsigned depth = irfunction->depth;
         LLStructType *frameType = irfunction->frameType;
         // Create frame for current function and append to frames list
-        // FIXME: alignment ?
         LLValue* frame = 0;
         bool needsClosure = fd->needsClosure();
         if (needsClosure)
+        {
+            // FIXME: alignment ?
             frame = DtoGcMalloc(fd->loc, frameType, ".frame");
+        }
         else
-            frame = DtoRawAlloca(frameType, 0, ".frame");
+        {
+            unsigned alignment = std::max(getABITypeAlign(frameType), irfunction->frameTypeAlignment);
+            frame = DtoRawAlloca(frameType, alignment, ".frame");
+        }
 
         // copy parent frames into beginning
         if (depth != 0) {

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -103,7 +103,7 @@ void RTTIBuilder::push_void_array(llvm::Constant* CI, Type* valtype, Dsymbol* ma
     LLGlobalVariable* G = new LLGlobalVariable(
         gIR->module, CI->getType(), true, TYPEINFO_LINKAGE_TYPE, CI, initname);
     SET_COMDAT(G, gIR->module);
-    G->setAlignment(valtype->alignsize());
+    G->setAlignment(DtoAlignment(valtype));
 
     push_void_array(getTypePaddedSize(CI->getType()), G);
 }
@@ -123,7 +123,7 @@ void RTTIBuilder::push_array(llvm::Constant * CI, uint64_t dim, Type* valtype, D
     LLGlobalVariable* G = new LLGlobalVariable(
         gIR->module, CI->getType(), true, TYPEINFO_LINKAGE_TYPE, CI, initname);
     SET_COMDAT(G, gIR->module);
-    G->setAlignment(valtype->alignsize());
+    G->setAlignment(DtoAlignment(valtype));
 
     push_array(dim, DtoBitCast(G, DtoType(valtype->pointerTo())));
 }

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -10,6 +10,7 @@
 #include "target.h"
 #include "gen/abi.h"
 #include "gen/irstate.h"
+#include "gen/llvmhelpers.h"
 #include "mars.h"
 #include "mtype.h"
 #include <assert.h>
@@ -59,8 +60,7 @@ unsigned Target::alignsize (Type* type)
 
 unsigned Target::fieldalign (Type* type)
 {
-    // LDC_FIXME: Verify this.
-    return type->alignsize();
+    return DtoAlignment(type);
 }
 
 // sizes based on those from tollvm.cpp:DtoMutexType()

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -663,7 +663,7 @@ private:
 
         LLValue* var = retvar;
         if (!var)
-            var = DtoRawAlloca(llArgType->getContainedType(0), resulttype->alignsize(), ".rettmp");
+            var = DtoRawAlloca(llArgType->getContainedType(0), DtoAlignment(resulttype), ".rettmp");
 
         args.push_back(var);
         attrs.add(index + 1, irFty.arg_sret->attrs);

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -503,7 +503,7 @@ public:
                 se->globalVar = finalGlobalVar;
             }
             se->globalVar->setInitializer(constValue);
-            se->globalVar->setAlignment(e->e1->type->alignsize());
+            se->globalVar->setAlignment(DtoAlignment(se->type));
 
             result = se->globalVar;
         }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2587,7 +2587,7 @@ public:
         }
         else
         {
-            llvm::Value* storage = DtoRawAlloca(llStoType, e->type->alignsize(), "arrayliteral");
+            llvm::Value* storage = DtoRawAlloca(llStoType, DtoAlignment(e->type), "arrayliteral");
             initializeArrayLiteral(p, e, storage);
             result = new DImValue(e->type, storage);
         }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -723,7 +723,7 @@ size_t getTypeAllocSize(LLType* t)
     return gDataLayout->getTypeAllocSize(t);
 }
 
-unsigned char getABITypeAlign(LLType* t)
+unsigned int getABITypeAlign(LLType* t)
 {
     return gDataLayout->getABITypeAlignment(t);
 }

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -131,7 +131,7 @@ size_t getTypePaddedSize(LLType* t);
 size_t getTypeAllocSize(LLType* t);
 
 // type alignments
-unsigned char getABITypeAlign(LLType* t);
+unsigned int getABITypeAlign(LLType* t);
 
 // pair type helpers
 LLValue* DtoAggrPair(LLType* type, LLValue* V1, LLValue* V2, const char* name = "");

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -483,7 +483,7 @@ public:
         b.push_funcptr(xpostblit);
 
         //uint m_align;
-        b.push_uint(tc->alignsize());
+        b.push_uint(DtoAlignment(tc));
 
         if (global.params.is64bit)
         {

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -58,10 +58,7 @@ LLGlobalVariable * IrAggr::getInitSymbol()
         gIR->module, init_type, true, llvm::GlobalValue::ExternalLinkage, NULL, initname);
 
     // set alignment
-    init->setAlignment(type->alignsize());
-    StructDeclaration *sd = aggrdecl->isStructDeclaration();
-    if (sd && sd->alignment != STRUCTALIGN_DEFAULT)
-        init->setAlignment(sd->alignment);
+    init->setAlignment(DtoAlignment(type));
 
     return init;
 }

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -423,6 +423,7 @@ IrFunction::IrFunction(FuncDeclaration* fd) {
 
     nestedVar = NULL;
     frameType = NULL;
+    frameTypeAlignment = 0;
     depth = -1;
     nestedContextCreated = false;
 

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -411,6 +411,7 @@ struct IrFunction {
 
     llvm::Value* nestedVar; // alloca for the nested context of this function
     llvm::StructType* frameType; // type of nested context
+    unsigned frameTypeAlignment; // its alignment
     // number of enclosing functions with variables accessed by nested functions
     // (-1 if neither this function nor any enclosing ones access variables from enclosing functions)
     int depth;

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -225,7 +225,7 @@ bool IrTypeAggr::isPacked(AggregateDeclaration* ad)
     for (unsigned i = 0; i < ad->fields.dim; i++)
     {
         VarDeclaration* vd = static_cast<VarDeclaration*>(ad->fields.data[i]);
-        unsigned a = DtoAlignment(vd) - 1;
+        unsigned a = vd->type->alignsize() - 1;
         if (((vd->offset + a) & ~a) != vd->offset)
             return true;
     }

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -223,7 +223,7 @@ bool IrTypeAggr::isPacked(AggregateDeclaration* ad)
     for (unsigned i = 0; i < ad->fields.dim; i++)
     {
         VarDeclaration* vd = static_cast<VarDeclaration*>(ad->fields.data[i]);
-        unsigned a = vd->type->alignsize() - 1;
+        unsigned a = DtoAlignment(vd) - 1;
         if (((vd->offset + a) & ~a) != vd->offset)
             return true;
     }

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -50,7 +50,7 @@ bool var_offset_sort_cb(const VarDeclaration* v1, const VarDeclaration* v2)
 }
 
 AggrTypeBuilder::AggrTypeBuilder(bool packed) :
-    m_offset(0), m_fieldIndex(0), m_packed(packed)
+    m_offset(0), m_fieldIndex(0), m_overallAlignment(0), m_packed(packed)
 {
     m_defaultTypes.reserve(32);
 }
@@ -192,6 +192,8 @@ void AggrTypeBuilder::addAggregate(AggregateDeclaration *ad)
 
 void AggrTypeBuilder::alignCurrentOffset(unsigned alignment)
 {
+    m_overallAlignment = std::max(alignment, m_overallAlignment);
+
     unsigned aligned = (m_offset + alignment - 1) & ~(alignment - 1);
     if (m_offset < aligned) {
         m_fieldIndex += add_zeros(m_defaultTypes, m_offset, aligned);

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -43,11 +43,13 @@ public:
     unsigned currentFieldIndex() const { return m_fieldIndex; }
     std::vector<llvm::Type*> defaultTypes() const { return m_defaultTypes; }
     VarGEPIndices varGEPIndices() const { return m_varGEPIndices; }
+    unsigned overallAlignment() const { return m_overallAlignment; }
 protected:
     std::vector<llvm::Type*> m_defaultTypes;
     VarGEPIndices m_varGEPIndices;
     unsigned m_offset;
     unsigned m_fieldIndex;
+    unsigned m_overallAlignment;
     bool m_packed;
 };
 


### PR DESCRIPTION
Trying to get the alignment right by using the first non-default one in the following order of descending priority:

`VarDeclaration::alignment` [variables only of course]
`Type::alignment()`
`Type::alignsize()`

This fixes the alignment of `align(x) struct S { ... }` instances on the stack.
Local variables with an explicit align attribute are still default-aligned though. :/