### PR TITLE
Implement @ldc.attributes.section(...) for variables

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -21,6 +21,7 @@
 #include "gen/llvmhelpers.h"
 #include "gen/logger.h"
 #include "gen/tollvm.h"
+#include "gen/uda.h"
 #include "ir/irtype.h"
 #include "ir/irvar.h"
 #include "llvm/ADT/SmallString.h"
@@ -356,6 +357,7 @@ public:
           }
 
           newGvar->setAlignment(gvar->getAlignment());
+          applyVarDeclUDAs(decl, newGvar);
           newGvar->takeName(gvar);
 
           llvm::Constant *newValue =

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -28,6 +28,7 @@
 #include "gen/runtime.h"
 #include "gen/tollvm.h"
 #include "gen/typeinf.h"
+#include "gen/uda.h"
 #include "gen/abi.h"
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
@@ -831,6 +832,8 @@ void DtoResolveVariable(VarDeclaration *vd) {
     unsigned alignment =
         std::max(DtoAlignment(vd), gDataLayout->getPointerSize());
     gvar->setAlignment(alignment);
+
+    applyVarDeclUDAs(vd, gvar);
 
     IF_LOG Logger::cout() << *gvar << '\n';
   }

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -1,0 +1,84 @@
+#include "gen/uda.h"
+
+#include "gen/llvm.h"
+#include "aggregate.h"
+#include "attrib.h"
+#include "declaration.h"
+#include "expression.h"
+#include "module.h"
+
+namespace {
+/// Names of the attribute structs we recognize.
+namespace attr {
+const std::string section = "section";
+}
+
+bool isFromLdcAttibutes(StructLiteralExp *e) {
+  Module *mod = e->sd->getModule();
+  if (strcmp("attributes", mod->md->id->string)) {
+    return false;
+  }
+
+  if (mod->md->packages->dim != 1 ||
+      strcmp("ldc", (*mod->md->packages)[0]->string)) {
+    return false;
+  }
+  return true;
+}
+
+void checkStructElems(StructLiteralExp *sle, llvm::ArrayRef<Type *> elemTypes) {
+  if (sle->elements->dim != elemTypes.size()) {
+    sle->error(
+        "unexpected field count in 'ldc.attributes.%s'; does druntime not "
+        "match compiler version?",
+        sle->sd->ident->string);
+    fatal();
+  }
+
+  for (size_t i = 0; i < sle->elements->dim; ++i) {
+    if ((*sle->elements)[i]->type != elemTypes[i]) {
+      sle->error("invalid field type in 'ldc.attributes.%s'; does druntime not "
+                 "match compiler version?",
+                 sle->sd->ident->string);
+      fatal();
+    }
+  }
+}
+}
+
+void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar) {
+  if (!decl->userAttribDecl)
+    return;
+
+  Expressions *attrs = decl->userAttribDecl->getAttributes();
+  expandTuples(attrs);
+  for (auto &attr : *attrs) {
+    // See whether we can evaluate the attribute at compile-time. All the LDC
+    // attributes are struct literals that may be constructed using a CTFE
+    // function.
+    unsigned prevErrors = global.startGagging();
+    auto e = ctfeInterpret(attr);
+    if (global.endGagging(prevErrors)) {
+      continue;
+    }
+
+    if (e->op != TOKstructliteral) {
+      continue;
+    }
+
+    auto sle = static_cast<StructLiteralExp *>(e);
+
+    if (!isFromLdcAttibutes(sle)) {
+      continue;
+    }
+
+    auto name = sle->sd->ident->string;
+    if (name == attr::section) {
+      checkStructElems(sle, {Type::tstring});
+      auto arg = (*sle->elements)[0];
+      assert(arg->op == TOKstring);
+      gvar->setSection(
+          static_cast<const char *>(static_cast<StringExp *>(arg)->string));
+    }
+  }
+}

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -1,0 +1,23 @@
+//===-- gen/uda.h - Compiler-recognized UDA handling ------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// LDC supports "magic" UDAs in druntime (ldc.attribute) which are recognized
+// by the compiler and influence code generation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef GEN_UDA_H
+#define GEN_UDA_H
+
+class VarDeclaration;
+namespace llvm { class GlobalVariable; }
+
+void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar);
+
+#endif


### PR DESCRIPTION
<del>I'm still not sure whether we really want to go the `@attribute` route, or if we should prefer individual types (e.g. `@section(...)`).

The latter seems cleaner and more flexible (regarding aliasing different UDAs for different compilers). It might make sense to have string arguments for an UDA that just sets the corresponding LLVM function attribute, but using them for this seems somewhat off. GDC uses a single magic attribute struct, but that's probably just to map directly to the C `__attribute__` syntax.</del>

This now uses actual struct literals for attributes that can be generated by arbitrary CTFE expressions. This should allow for quite a bit of flexibility when targeting multiple compilers.