### PR TITLE
Drop support for LLVM < 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,17 +480,10 @@ add_definitions(-DLLVM_INTRINSIC_TD_PATH="${LLVM_INTRINSIC_TD_PATH}")
 
 add_executable(gen_gccbuiltins utils/gen_gccbuiltins.cpp)
 
-# Prior to LLVM 3.2, TableGen still uses RTTI, contrary to the rest of LLVM.
-# Thus, we have to remove the -fno-rtti flag from the llvm-config output.
-set(TABLEGEN_CXXFLAGS "${LLVM_CXXFLAGS}")
-if(${LDC_LLVM_VER} LESS 302)
-    string(REPLACE "-fno-rtti" "" TABLEGEN_CXXFLAGS ${TABLEGEN_CXXFLAGS})
-endif()
-
 set_target_properties(
     gen_gccbuiltins PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-    COMPILE_FLAGS "${TABLEGEN_CXXFLAGS} ${LDC_CXXFLAGS}"
+    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
     LINK_FLAGS "${SANITIZE_LDFLAGS}"
 )
 target_link_libraries(gen_gccbuiltins ${LLVM_TABLEGEN_LIBRARY} ${LLVM_LIBRARIES} ${PTHREAD_LIBS} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} "${LLVM_LDFLAGS}")

--- a/dmd2/cppmangle.c
+++ b/dmd2/cppmangle.c
@@ -1988,11 +1988,7 @@ private:
 #if IN_LLVM
 char *toCppMangle(Dsymbol *s)
 {
-#if LDC_LLVM_VER >= 305
-	const bool isTargetWindowsMSVC = global.params.targetTriple.isWindowsMSVCEnvironment();
-#else
-	const bool isTargetWindowsMSVC = global.params.targetTriple.getOS() == llvm::Triple::Win32;
-#endif
+    const bool isTargetWindowsMSVC = global.params.targetTriple.isWindowsMSVCEnvironment();
     if (isTargetWindowsMSVC)
     {
         VisualCPPMangler v(!global.params.is64bit);

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -13,13 +13,7 @@
 #include "gen/logger.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DataLayout.h"
-#elif LDC_LLVM_VER == 302
-#include "llvm/DataLayout.h"
-#else
-#include "llvm/Target/TargetData.h"
-#endif
 
 namespace opts {
 

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -150,14 +150,11 @@ void CodeGenerator::finishLLModule(Module *m) {
 void CodeGenerator::writeAndFreeLLModule(const char *filename) {
     ir_->DBuilder.Finalize();
 
-#if LDC_LLVM_VER >= 303
     // Add the linker options metadata flag.
     ir_->module.addModuleFlag(
         llvm::Module::AppendUnique, "Linker Options",
         llvm::MDNode::get(ir_->context(), ir_->LinkerMetadataArgs));
-#endif
 
-#if LDC_LLVM_VER >= 304
     // Emit ldc version as llvm.ident metadata.
     llvm::NamedMDNode *IdentMetadata =
         ir_->module.getOrInsertNamedMetadata("llvm.ident");
@@ -170,7 +167,6 @@ void CodeGenerator::writeAndFreeLLModule(const char *filename) {
 #endif
         {llvm::MDString::get(ir_->context(), Version)};
     IdentMetadata->addOperand(llvm::MDNode::get(ir_->context(), IdentNode));
-#endif
 
     writeModule(&ir_->module, filename);
     global.params.objfiles->push(const_cast<char *>(filename));

--- a/driver/configfile.cpp
+++ b/driver/configfile.cpp
@@ -34,7 +34,6 @@ llvm::cl::opt<std::string> clConf("conf",
     llvm::cl::desc("Use configuration file <filename>"),
     llvm::cl::value_desc("filename"));
 
-#if LDC_LLVM_VER >= 304
 #if _WIN32
 std::string getUserHomeDirectory() {
   char buff[MAX_PATH];
@@ -51,11 +50,6 @@ std::string getUserHomeDirectory() {
 std::string getUserHomeDirectory() {
   const char* home = getenv("HOME");
   return home ? home : "/";
-}
-#endif
-#else
-std::string getUserHomeDirectory() {
-  return llvm::sys::Path::GetUserHomeDirectory().str();
 }
 #endif
 

--- a/driver/exe_path.cpp
+++ b/driver/exe_path.cpp
@@ -10,9 +10,7 @@
 #include "exe_path.h"
 
 #include <llvm/Support/Path.h>
-#if LDC_LLVM_VER >= 304
 #include <llvm/Support/FileSystem.h>
-#endif
 
 using std::string;
 namespace path = llvm::sys::path;
@@ -22,11 +20,7 @@ namespace { string exePath; }
 void exe_path::initialize(const char* arg0, void* mainAddress)
 {
     assert(exePath.empty());
-#if LDC_LLVM_VER >= 304
     exePath = llvm::sys::fs::getMainExecutable(arg0, mainAddress);
-#else
-    exePath = llvm::sys::Path::GetMainExecutable(arg0, mainAddress).str();
-#endif
 }
 
 const string& exe_path::getExePath()

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -37,9 +37,7 @@
 #include "gen/passes/Passes.h"
 #include "gen/runtime.h"
 #include "gen/abi.h"
-#if LDC_LLVM_VER >= 304
 #include "llvm/InitializePasses.h"
-#endif
 #include "llvm/LinkAllPasses.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
@@ -51,13 +49,8 @@
 #if LDC_LLVM_VER >= 306
 #include "llvm/Target/TargetSubtargetInfo.h"
 #endif
-#if LDC_LLVM_VER >= 303
 #include "llvm/LinkAllIR.h"
 #include "llvm/IR/LLVMContext.h"
-#else
-#include "llvm/LinkAllVMCore.h"
-#include "llvm/LLVMContext.h"
-#endif
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
@@ -166,7 +159,6 @@ static void initFromString(const char*& dest, const cl::opt<std::string>& src) {
 }
 
 
-#if LDC_LLVM_VER >= 303
 static void hide(llvm::StringMap<cl::Option *>& map, const char* name) {
     // Check if option exists first for resilience against LLVM changes
     // between versions.
@@ -262,7 +254,6 @@ static void hideLLVMOptions() {
     opts::CreateColorOption();
 #endif
 }
-#endif
 
 int main(int argc, char **argv);
 
@@ -309,15 +300,9 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles, bool &
     final_args.insert(final_args.end(), &argv[1], &argv[argc]);
 
     cl::SetVersionPrinter(&printVersion);
-#if LDC_LLVM_VER >= 303
     hideLLVMOptions();
-#endif
     cl::ParseCommandLineOptions(final_args.size(), const_cast<char**>(final_args.data()),
-        "LDC - the LLVM D compiler\n"
-#if LDC_LLVM_VER < 302
-        , true
-#endif
-    );
+        "LDC - the LLVM D compiler\n");
 
     helpOnly = mCPU == "help" ||
         (std::find(mAttrs.begin(), mAttrs.end(), "help") != mAttrs.end());
@@ -523,7 +508,6 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles, bool &
 }
 
 static void initializePasses() {
-#if LDC_LLVM_VER >= 304
     using namespace llvm;
     // Initialize passes
     PassRegistry &Registry = *PassRegistry::getPassRegistry();
@@ -548,9 +532,8 @@ static void initializePasses() {
 #if LDC_LLVM_VER >= 306
     initializeAtomicExpandPass(Registry);
     initializeRewriteSymbolsPass(Registry);
-#elif LDC_LLVM_VER == 305
+#else
     initializeAtomicExpandLoadLinkedPass(Registry);
-#endif
 #endif
 }
 
@@ -628,9 +611,7 @@ static void registerPredefinedTargetVersions() {
             registerPredefinedFloatABI("PPC_SoftFloat", "PPC_HardFloat");
             break;
         case llvm::Triple::ppc64:
-#if LDC_LLVM_VER >= 305
         case llvm::Triple::ppc64le:
-#endif
             VersionCondition::addPredefinedGlobalIdent("PPC64");
             registerPredefinedFloatABI("PPC_SoftFloat", "PPC_HardFloat");
             if (global.params.targetTriple.getOS() == llvm::Triple::Linux)
@@ -638,9 +619,7 @@ static void registerPredefinedTargetVersions() {
                                                        ? "ELFv1" : "ELFv2");
             break;
         case llvm::Triple::arm:
-#if LDC_LLVM_VER >= 305
         case llvm::Triple::armeb:
-#endif
             VersionCondition::addPredefinedGlobalIdent("ARM");
             registerPredefinedFloatABI("ARM_SoftFloat", "ARM_HardFloat", "ARM_SoftFP");
             break;
@@ -654,15 +633,11 @@ static void registerPredefinedTargetVersions() {
         case llvm::Triple::arm64:
         case llvm::Triple::arm64_be:
 #endif
-#if LDC_LLVM_VER >= 303
         case llvm::Triple::aarch64:
-#if LDC_LLVM_VER >= 305
         case llvm::Triple::aarch64_be:
-#endif
             VersionCondition::addPredefinedGlobalIdent("AArch64");
             registerPredefinedFloatABI("ARM_SoftFloat", "ARM_HardFloat", "ARM_SoftFP");
             break;
-#endif
         case llvm::Triple::mips:
         case llvm::Triple::mipsel:
             VersionCondition::addPredefinedGlobalIdent("MIPS");
@@ -684,7 +659,6 @@ static void registerPredefinedTargetVersions() {
             VersionCondition::addPredefinedGlobalIdent("SPARC64");
             registerPredefinedFloatABI("SPARC_SoftFloat", "SPARC_HardFloat");
             break;
-#if LDC_LLVM_VER >= 302
         case llvm::Triple::nvptx:
             VersionCondition::addPredefinedGlobalIdent("NVPTX");
             VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
@@ -693,14 +667,11 @@ static void registerPredefinedTargetVersions() {
             VersionCondition::addPredefinedGlobalIdent("NVPTX64");
             VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
             break;
-#endif
-#if LDC_LLVM_VER >= 303
         case llvm::Triple::systemz:
             VersionCondition::addPredefinedGlobalIdent("SystemZ");
             VersionCondition::addPredefinedGlobalIdent("S390X"); // For backwards compatibility.
             VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
             break;
-#endif
         default:
             error(Loc(), "invalid cpu architecture specified: %s", global.params.targetTriple.getArchName().str().c_str());
             fatal();
@@ -731,15 +702,10 @@ static void registerPredefinedTargetVersions() {
         case llvm::Triple::Win32:
             VersionCondition::addPredefinedGlobalIdent("Windows");
             VersionCondition::addPredefinedGlobalIdent(global.params.is64bit ? "Win64" : "Win32");
-#if LDC_LLVM_VER >= 305
             if (global.params.targetTriple.isKnownWindowsMSVCEnvironment())
             {
                 VersionCondition::addPredefinedGlobalIdent("CRuntime_Microsoft");
             }
-#else
-            VersionCondition::addPredefinedGlobalIdent("CRuntime_Microsoft");
-#endif
-#if LDC_LLVM_VER >= 305
             if (global.params.targetTriple.isWindowsGNUEnvironment())
             {
                 VersionCondition::addPredefinedGlobalIdent("mingw32"); // For backwards compatibility.
@@ -752,29 +718,13 @@ static void registerPredefinedTargetVersions() {
                 VersionCondition::addPredefinedGlobalIdent("Cygwin");
             }
             break;
-#else
-            break;
-        case llvm::Triple::MinGW32:
-            VersionCondition::addPredefinedGlobalIdent("Windows");
-            VersionCondition::addPredefinedGlobalIdent(global.params.is64bit ? "Win64" : "Win32");
-            VersionCondition::addPredefinedGlobalIdent("mingw32"); // For backwards compatibility.
-            VersionCondition::addPredefinedGlobalIdent("MinGW");
-            break;
-        case llvm::Triple::Cygwin:
-            error(Loc(), "Cygwin is not yet supported");
-            fatal();
-            VersionCondition::addPredefinedGlobalIdent("Cygwin");
-            break;
-#endif
         case llvm::Triple::Linux:
-#if LDC_LLVM_VER >= 302
             if (global.params.targetTriple.getEnvironment() == llvm::Triple::Android)
             {
                 VersionCondition::addPredefinedGlobalIdent("Android");
                 VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
             }
             else
-#endif
             {
                 VersionCondition::addPredefinedGlobalIdent("linux");
                 VersionCondition::addPredefinedGlobalIdent("Posix");
@@ -810,20 +760,16 @@ static void registerPredefinedTargetVersions() {
             VersionCondition::addPredefinedGlobalIdent("OpenBSD");
             VersionCondition::addPredefinedGlobalIdent("Posix");
             break;
-#if LDC_LLVM_VER >= 302
         case llvm::Triple::AIX:
             VersionCondition::addPredefinedGlobalIdent("AIX");
             VersionCondition::addPredefinedGlobalIdent("Posix");
             break;
-#endif
         default:
             switch (global.params.targetTriple.getEnvironment())
             {
-#if LDC_LLVM_VER >= 302
                 case llvm::Triple::Android:
                     VersionCondition::addPredefinedGlobalIdent("Android");
                     break;
-#endif
                 default:
                     error(Loc(), "target '%s' is not yet supported", global.params.targetTriple.str().c_str());
                     fatal();
@@ -852,7 +798,6 @@ static void registerPredefinedVersions() {
 
     registerPredefinedTargetVersions();
 
-#if LDC_LLVM_VER >= 303
     // Pass sanitizer arguments to linker. Requires clang.
     if (opts::sanitize == opts::AddressSanitizer) {
         VersionCondition::addPredefinedGlobalIdent("LDC_AddressSanitizer");
@@ -865,7 +810,6 @@ static void registerPredefinedVersions() {
     if (opts::sanitize == opts::ThreadSanitizer) {
         VersionCondition::addPredefinedGlobalIdent("LDC_ThreadSanitizer");
     }
-#endif
 
     // Expose LLVM version to runtime
 #define STR(x) #x
@@ -1011,10 +955,8 @@ int main(int argc, char **argv)
     gDataLayout = gTargetMachine->getDataLayout();
 #elif LDC_LLVM_VER >= 306
     gDataLayout = gTargetMachine->getSubtargetImpl()->getDataLayout();
-#elif LDC_LLVM_VER >= 302
-    gDataLayout = gTargetMachine->getDataLayout();
 #else
-    gDataLayout = gTargetMachine->getTargetData();
+    gDataLayout = gTargetMachine->getDataLayout();
 #endif
 
     {

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -36,12 +36,7 @@ int executeToolAndWait(const std::string &tool, std::vector<std::string> const &
 
     // Execute tool.
     std::string errstr;
-#if LDC_LLVM_VER >= 304
     if (int status = llvm::sys::ExecuteAndWait(tool, &realargs[0], NULL, NULL, 0, 0, &errstr))
-#else
-    llvm::sys::Path toolpath(tool);
-    if (int status = llvm::sys::Program::ExecuteAndWait(toolpath, &realargs[0], NULL, NULL, 0, 0, &errstr))
-#endif
     {
         error(Loc(), "%s failed with status: %d", tool.c_str(), status);
         if (!errstr.empty())

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -68,11 +68,7 @@ private:
 
     bool realIs80bits()
     {
-#if LDC_LLVM_VER >= 305
         return !global.params.targetTriple.isWindowsMSVCEnvironment();
-#else
-        return true;
-#endif
     }
 
     // Returns true if the D type is passed byval (the callee getting a pointer

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -188,21 +188,15 @@ TargetABI * TargetABI::getTarget()
     case llvm::Triple::mips64el:
         return getMIPS64TargetABI(global.params.is64bit);
     case llvm::Triple::ppc64:
-#if LDC_LLVM_VER >= 305
     case llvm::Triple::ppc64le:
-#endif
         return getPPC64TargetABI(global.params.targetTriple.isArch64Bit());
 #if LDC_LLVM_VER == 305
     case llvm::Triple::arm64:
     case llvm::Triple::arm64_be:
 #endif
-#if LDC_LLVM_VER >= 303
     case llvm::Triple::aarch64:
-#if LDC_LLVM_VER >= 305
     case llvm::Triple::aarch64_be:
-#endif
         return getAArch64TargetABI();
-#endif
     default:
         Logger::cout() << "WARNING: Unknown ABI, guessing...\n";
         return new UnknownTargetABI;

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -18,11 +18,7 @@
 #define LDC_GEN_ABI_H
 
 #include "mars.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/CallingConv.h"
-#else
-#include "llvm/CallingConv.h"
-#endif
 #include <vector>
 
 class Type;

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2414,13 +2414,11 @@ namespace AsmParserx8664
                         case Float_Ptr:    type_suffix = 's'; break;
                         case Double_Ptr:   type_suffix = 'l'; break;
                         case Extended_Ptr:
-#if LDC_LLVM_VER >= 305
                             // MS C runtime: real = 64-bit double
                             if (global.params.targetTriple.isWindowsMSVCEnvironment())
                                 type_suffix = 'l';
                             else
-#endif
-                            type_suffix = 't';
+                                type_suffix = 't';
                             break;
                         default:
                             return false;

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -8,11 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/llvm.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/InlineAsm.h"
-#else
-#include "llvm/InlineAsm.h"
-#endif
 
 //#include "d-gcc-includes.h"
 //#include "total.h"

--- a/gen/attributes.cpp
+++ b/gen/attributes.cpp
@@ -12,68 +12,39 @@
 
 bool AttrBuilder::hasAttributes() const
 {
-#if LDC_LLVM_VER >= 302
     return attrs.hasAttributes();
-#else
-    return attrs.Raw() != 0;
-#endif
 }
 
 bool AttrBuilder::contains(A attribute) const
 {
-#if LDC_LLVM_VER >= 303
     return attrs.contains(attribute);
-#elif LDC_LLVM_VER == 302
-    return attrs.hasAttribute(attribute);
-#else
-    return (attrs & attribute).Raw() != 0;
-#endif
 }
 
 AttrBuilder& AttrBuilder::clear()
 {
-#if LDC_LLVM_VER >= 302
     attrs.clear();
-#else
-    attrs = A(0);
-#endif
     return *this;
 }
 
 AttrBuilder& AttrBuilder::add(A attribute)
 {
-#if LDC_LLVM_VER >= 302
     // never set 'None' explicitly
     if (attribute)
         attrs.addAttribute(attribute);
-#else
-    attrs |= attribute;
-#endif
     return *this;
 }
 
 AttrBuilder& AttrBuilder::remove(A attribute)
 {
-#if LDC_LLVM_VER >= 302
     // never remove 'None' explicitly
     if (attribute)
         attrs.removeAttribute(attribute);
-#else
-    attrs &= ~attribute;
-#endif
     return *this;
 }
 
 AttrBuilder& AttrBuilder::merge(const AttrBuilder& other)
 {
-#if LDC_LLVM_VER >= 303
     attrs.merge(other.attrs);
-#elif LDC_LLVM_VER == 302
-    AttrBuilder mutableCopy = other;
-    attrs.addAttributes(llvm::Attributes::get(gIR->context(), mutableCopy.attrs));
-#else
-    attrs |= other.attrs;
-#endif
     return *this;
 }
 
@@ -82,29 +53,9 @@ AttrSet AttrSet::extractFunctionAndReturnAttributes(const llvm::Function* functi
 {
     AttrSet set;
 
-#if LDC_LLVM_VER >= 303
     NativeSet old = function->getAttributes();
     llvm::AttributeSet existingAttrs[] = { old.getFnAttributes(), old.getRetAttributes() };
     set.entries = llvm::AttributeSet::get(gIR->context(), existingAttrs);
-#else
-    unsigned fnIndex = ~0u;
-    unsigned retIndex = 0;
-
-#if LDC_LLVM_VER == 302
-    #define ADD_ATTRIBS(i, a) \
-    if (a.Raw()) \
-        set.entries[i].attrs.addAttributes(a);
-#else
-    #define ADD_ATTRIBS(i, a) \
-    if (a.Raw()) \
-        set.entries[i].attrs = a;
-#endif
-
-    ADD_ATTRIBS(fnIndex, function->getAttributes().getFnAttributes());
-    ADD_ATTRIBS(retIndex, function->getAttributes().getRetAttributes());
-
-    #undef ADD_ATTRIBS
-#endif
 
     return set;
 }
@@ -113,50 +64,15 @@ AttrSet& AttrSet::add(unsigned index, const AttrBuilder& builder)
 {
     if (builder.hasAttributes())
     {
-#if LDC_LLVM_VER >= 303
         AttrBuilder mutableBuilderCopy = builder;
         llvm::AttributeSet as = llvm::AttributeSet::get(
             gIR->context(), index, mutableBuilderCopy.attrs);
         entries = entries.addAttributes(gIR->context(), index, as);
-#else
-        entries[index].merge(builder);
-#endif
     }
     return *this;
 }
 
 AttrSet::NativeSet AttrSet::toNativeSet() const
 {
-#if LDC_LLVM_VER >= 303
     return entries;
-#else
-    if (entries.empty())
-        return NativeSet();
-
-    std::vector<llvm::AttributeWithIndex> attrsWithIndex;
-    attrsWithIndex.reserve(entries.size());
-
-    typedef std::map<unsigned, AttrBuilder>::const_iterator I;
-    for (I it = entries.begin(); it != entries.end(); ++it)
-    {
-        unsigned index = it->first;
-        const AttrBuilder& builder = it->second;
-        if (!builder.hasAttributes())
-            continue;
-
-#if LDC_LLVM_VER == 302
-        AttrBuilder mutableBuilderCopy = builder;
-        attrsWithIndex.push_back(llvm::AttributeWithIndex::get(index,
-            llvm::Attributes::get(gIR->context(), mutableBuilderCopy.attrs)));
-#else
-        attrsWithIndex.push_back(llvm::AttributeWithIndex::get(index, builder.attrs));
-#endif
-    }
-
-#if LDC_LLVM_VER == 302
-    return NativeSet::get(gIR->context(), attrsWithIndex);
-#else
-    return NativeSet::get(attrsWithIndex.begin(), attrsWithIndex.end());
-#endif
-#endif
 }

--- a/gen/attributes.h
+++ b/gen/attributes.h
@@ -18,16 +18,8 @@ struct AttrBuilder
 {
     // A: basic attribute type
     // B: builder type
-#if LDC_LLVM_VER >= 303
     typedef llvm::Attribute::AttrKind A;
     typedef llvm::AttrBuilder B;
-#elif LDC_LLVM_VER == 302
-    typedef llvm::Attributes::AttrVal A;
-    typedef llvm::AttrBuilder B;
-#else
-    typedef llvm::Attributes A;
-    typedef llvm::Attributes B;
-#endif
 
     B attrs;
 
@@ -45,13 +37,8 @@ struct AttrBuilder
 
 struct AttrSet
 {
-#if LDC_LLVM_VER >= 303
     typedef llvm::AttributeSet NativeSet;
     NativeSet entries;
-#else
-    typedef llvm::AttrListPtr NativeSet;
-    std::map<unsigned, AttrBuilder> entries;
-#endif
 
     AttrSet() {}
     static AttrSet extractFunctionAndReturnAttributes(const llvm::Function* function);
@@ -66,12 +53,6 @@ struct AttrSet
 // * or an llvm::Attribute::AttrConst value for LLVM 3.1,
 //   which can be implicitly converted to AttrBuilder::A
 //   (i.e., llvm::Attributes)
-#if LDC_LLVM_VER >= 303
 #define LDC_ATTRIBUTE(name) llvm::Attribute::name
-#elif LDC_LLVM_VER == 302
-#define LDC_ATTRIBUTE(name) llvm::Attributes::name
-#else
-#define LDC_ATTRIBUTE(name) llvm::Attribute::name
-#endif
 
 #endif

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -484,11 +484,7 @@ public:
             StringExp *se = static_cast<StringExp *>(e);
 
             size_t nameLen = se->len;
-#if LDC_LLVM_VER >= 305
             if (global.params.targetTriple.isWindowsGNUEnvironment())
-#else
-            if (global.params.targetTriple.getOS() == llvm::Triple::MinGW32)
-#endif
             {
                 if (nameLen > 4 &&
                     !memcmp(static_cast<char*>(se->string) + nameLen - 4, ".lib", 4))
@@ -508,14 +504,9 @@ public:
                 }
             }
 
-    #if LDC_LLVM_VER >= 303
             // With LLVM 3.3 or later we can place the library name in the object
             // file. This seems to be supported only on Windows.
-#if LDC_LLVM_VER >= 305
             if (global.params.targetTriple.isWindowsMSVCEnvironment())
-#else
-            if (global.params.targetTriple.getOS() == llvm::Triple::Win32)
-#endif
             {
                 llvm::SmallString<24> LibName(llvm::StringRef(static_cast<const char *>(se->string), nameLen));
 
@@ -539,7 +530,6 @@ public:
 #endif
             }
             else
-    #endif
             {
                 size_t const n = nameLen + 3;
                 char *arg = static_cast<char *>(mem.xmalloc(n));

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -204,10 +204,8 @@ ldc::DIType ldc::DIBuilder::CreateEnumType(Type *type)
         LineNumber,
         getTypeBitSize(T), // size (bits)
         getABITypeAlign(T)*8, // align (bits)
-        DBuilder.getOrCreateArray(subscripts) // subscripts
-#if LDC_LLVM_VER >= 302
-        , CreateTypeDescription(te->sym->memtype, false)
-#endif
+        DBuilder.getOrCreateArray(subscripts), // subscripts
+        CreateTypeDescription(te->sym->memtype, false)
     );
 }
 
@@ -353,11 +351,7 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type)
     // if we don't know the aggregate's size, we don't know enough about it
     // to provide debug info. probably a forward-declared struct?
     if (sd->sizeok == SIZEOKnone)
-#if LDC_LLVM_VER >= 304
         return DBuilder.createUnspecifiedType(sd->toChars());
-#else
-        return llvm::DICompositeType(NULL);
-#endif
 
     // elements
 #if LDC_LLVM_VER >= 306
@@ -383,15 +377,11 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type)
                                         : llvm::dwarf::DW_TAG_class_type;
 #if LDC_LLVM_VER >= 307
     ir->diCompositeType = DBuilder.createReplaceableCompositeType(
-#elif LDC_LLVM_VER >= 305
-    ir->diCompositeType = DBuilder.createReplaceableForwardDecl(
 #else
-    ir->diCompositeType = DBuilder.createForwardDecl(
+    ir->diCompositeType = DBuilder.createReplaceableForwardDecl(
 #endif
                                                            tag, name,
-#if LDC_LLVM_VER >= 302
                                                            CU,
-#endif
                                                            file, linnum);
 
     if (!sd->isInterfaceDeclaration()) // plain interfaces don't have one
@@ -446,9 +436,7 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type)
            getTypeBitSize(T), // size in bits
            getABITypeAlign(T)*8, // alignment in bits
            DIFlags::FlagFwdDecl, // flags
-#if LDC_LLVM_VER >= 303
            derivedFrom, // DerivedFrom
-#endif
            elemsArray
         );
     }
@@ -495,7 +483,7 @@ ldc::DIType ldc::DIBuilder::CreateArrayType(Type *type)
         0, // What here?
 #if LDC_LLVM_VER >= 307
         nullptr, // DerivedFrom
-#elif LDC_LLVM_VER >= 303
+#else
         llvm::DIType(), // DerivedFrom
 #endif
         DBuilder.getOrCreateArray(elems)
@@ -538,11 +526,7 @@ ldc::DIType ldc::DIBuilder::CreateSArrayType(Type *type)
 ldc::DIType ldc::DIBuilder::CreateAArrayType(Type *type)
 {
     // FIXME: Implement
-#if LDC_LLVM_VER >= 304
     return DBuilder.createUnspecifiedType(type->toChars());
-#else
-    return llvm::DIType(NULL);
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -591,11 +575,7 @@ ldc::DISubroutineType ldc::DIBuilder::CreateDelegateType(Type *type)
     llvm::SmallVector<llvm::Value*, 16> Elts;
 #endif
     Elts.push_back(
-#if LDC_LLVM_VER >= 304
         DBuilder.createUnspecifiedType(type->toChars())
-#else
-        llvm::DIType(NULL)
-#endif
     );
 #if LDC_LLVM_VER >= 307
     llvm::DITypeRefArray EltTypeArray = DBuilder.getOrCreateTypeArray(Elts);
@@ -624,11 +604,7 @@ ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type* type,
     }
 
     if (t->ty == Tvoid || t->ty == Tnull)
-#if LDC_LLVM_VER >= 304
         return DBuilder.createUnspecifiedType(t->toChars());
-#else
-        return llvm::DIType(NULL);
-#endif
     else if (t->isintegral() || t->isfloating())
     {
         if (t->ty == Tvector)
@@ -677,12 +653,10 @@ void ldc::DIBuilder::EmitCompileUnit(Module *m)
     if (global.params.targetTriple.isWindowsMSVCEnvironment())
         IR->module.addModuleFlag(llvm::Module::Warning, "CodeView", 1);
 #endif
-#if LDC_LLVM_VER >= 304
     // Metadata without a correct version will be stripped by UpgradeDebugInfo.
     IR->module.addModuleFlag(llvm::Module::Warning, "Debug Info Version", llvm::DEBUG_METADATA_VERSION);
 
     CUNode =
-#endif
     DBuilder.createCompileUnit(
         global.params.symdebug == 2 ? llvm::dwarf::DW_LANG_C
                                     : llvm::dwarf::DW_LANG_D,
@@ -693,9 +667,6 @@ void ldc::DIBuilder::EmitCompileUnit(Module *m)
         llvm::StringRef(), // Flags TODO
         1 // Runtime Version TODO
     );
-#if LDC_LLVM_VER < 304
-    CUNode = DBuilder.getCU();
-#endif
 }
 
 ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd)
@@ -932,13 +903,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
     ldc::DILocalVariable debugVariable;
     unsigned Flags = 0;
     if (isThisPtr)
-    {
-#if LDC_LLVM_VER >= 302
         Flags |= DIFlags::FlagArtificial | DIFlags::FlagObjectPointer;
-#else
-        Flags |= DIFlags::FlagArtificial;
-#endif
-    }
 
 #if LDC_LLVM_VER < 306
     if (addr.empty()) {
@@ -1038,9 +1003,7 @@ ldc::DIGlobalVariable ldc::DIBuilder::EmitGlobalVariable(llvm::GlobalVariable *l
         GetCU(), // context
 #endif
         vd->toChars(), // name
-#if LDC_LLVM_VER >= 303
         mangle(vd), // linkage name
-#endif
         CreateFile(vd->loc), // file
         vd->loc.linnum, // line num
         CreateTypeDescription(vd->type, false), // type

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -10,30 +10,11 @@
 #ifndef LDC_GEN_DIBUILDER_H
 #define LDC_GEN_DIBUILDER_H
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/DataLayout.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DIBuilder.h"
-#else
-#include "llvm/DebugInfo.h"
-#include "llvm/DIBuilder.h"
-#endif
-#else
-#if LDC_LLVM_VER == 302
-#include "llvm/DataLayout.h"
-#include "llvm/DebugInfo.h"
-#include "llvm/DIBuilder.h"
-#else
-#include "llvm/Constants.h"
-#include "llvm/Type.h"
-#include "llvm/Analysis/DebugInfo.h"
-#include "llvm/Analysis/DIBuilder.h"
-#include "llvm/Target/TargetData.h"
-#endif
-#endif
 
 #include "gen/tollvm.h"
 #include "mars.h"
@@ -53,19 +34,11 @@ namespace llvm {
     class LLVMContext;
 
 // Only for the OpXXX templates, see below.
-#if LDC_LLVM_VER >= 302
     class DataLayout;
-#else
-    class TargetData;
-#endif
 }
 
 // Only for the OpXXX templates, see below.
-#if LDC_LLVM_VER >= 302
 extern const llvm::DataLayout* gDataLayout;
-#else
-extern const llvm::TargetData* gDataLayout;
-#endif
 
 namespace ldc {
 
@@ -81,7 +54,7 @@ typedef llvm::DIScope* DIScope;
 typedef llvm::DISubroutineType* DISubroutineType;
 typedef llvm::DISubprogram* DISubprogram;
 typedef llvm::DICompileUnit* DICompileUnit;
-#elif LDC_LLVM_VER >= 304
+#else
 typedef llvm::DIType DIType;
 typedef llvm::DIFile DIFile;
 typedef llvm::DIGlobalVariable DIGlobalVariable;
@@ -91,19 +64,9 @@ typedef llvm::DIDescriptor DIScope;
 typedef llvm::DICompositeType DISubroutineType;
 typedef llvm::DISubprogram DISubprogram;
 typedef llvm::DICompileUnit DICompileUnit;
-#else
-typedef llvm::DIType DIType;
-typedef llvm::DIFile DIFile;
-typedef llvm::DIGlobalVariable DIGlobalVariable;
-typedef llvm::DIVariable DILocalVariable;
-typedef llvm::DILexicalBlock DILexicalBlock;
-typedef llvm::DIDescriptor DIScope;
-typedef llvm::DISubprogram DISubprogram;
-typedef llvm::DIType DISubroutineType;
-typedef llvm::DICompileUnit DICompileUnit;
-#endif
 #if LDC_LLVM_VER == 306
 typedef llvm::DIExpression DIExpression;
+#endif
 #endif
 
 class DIBuilder

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -34,16 +34,8 @@
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Intrinsics.h"
-#else
-#include "llvm/Intrinsics.h"
-#endif
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/CFG.h"
-#else
-#include "llvm/Support/CFG.h"
-#endif
 #include <iostream>
 
 llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype, Type* nesttype,
@@ -102,10 +94,8 @@ llvm::FunctionType* DtoFunctionType(Type* type, IrFuncTy &irFty, Type* thistype,
     {
         // Add the this pointer for member functions
         AttrBuilder attrBuilder;
-#if LDC_LLVM_VER >= 303
         if (isCtor)
             attrBuilder.add(LDC_ATTRIBUTE(Returned));
-#endif
         newIrFty.arg_this = new IrFuncTyArg(thistype, thistype->toBasetype()->ty == Tstruct, attrBuilder);
         ++nextLLArgIdx;
     }
@@ -788,7 +778,6 @@ void DtoDefineFunction(FuncDeclaration* fd)
     {
         func->addFnAttr(LDC_ATTRIBUTE(UWTable));
     }
-#if LDC_LLVM_VER >= 303
     if (opts::sanitize != opts::None) {
         // Set the required sanitizer attribute.
         if (opts::sanitize == opts::AddressSanitizer) {
@@ -803,7 +792,6 @@ void DtoDefineFunction(FuncDeclaration* fd)
             func->addFnAttr(LDC_ATTRIBUTE(SanitizeThread));
         }
     }
-#endif
 
     llvm::BasicBlock* beginbb = llvm::BasicBlock::Create(gIR->context(), "", func);
 

--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -18,11 +18,7 @@
 
 IRState* gIR = 0;
 llvm::TargetMachine* gTargetMachine = 0;
-#if LDC_LLVM_VER >= 302
 const llvm::DataLayout* gDataLayout = 0;
-#else
-const llvm::TargetData* gDataLayout = 0;
-#endif
 TargetABI* gABI = 0;
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -26,11 +26,7 @@
 #include <sstream>
 #include <vector>
 #include "llvm/ADT/StringMap.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/CallSite.h"
-#else
-#include "llvm/Support/CallSite.h"
-#endif
 
 namespace llvm {
     class LLVMContext;
@@ -43,11 +39,7 @@ struct TargetABI;
 
 extern IRState* gIR;
 extern llvm::TargetMachine* gTargetMachine;
-#if LDC_LLVM_VER >= 302
 extern const llvm::DataLayout* gDataLayout;
-#else
-extern const llvm::TargetData* gDataLayout;
-#endif
 extern TargetABI* gABI;
 
 class TypeFunction;
@@ -185,13 +177,11 @@ struct IRState
     llvm::StringMap<llvm::GlobalVariable*> stringLiteral2ByteCache;
     llvm::StringMap<llvm::GlobalVariable*> stringLiteral4ByteCache;
 
-#if LDC_LLVM_VER >= 303
     /// Vector of options passed to the linker as metadata in object file.
 #if LDC_LLVM_VER >= 306
     llvm::SmallVector<llvm::Metadata *, 5> LinkerMetadataArgs;
 #else
     llvm::SmallVector<llvm::Value *, 5> LinkerMetadataArgs;
-#endif
 #endif
 };
 

--- a/gen/llvm.h
+++ b/gen/llvm.h
@@ -18,7 +18,6 @@
 #ifndef LDC_GEN_LLVM_H
 #define LDC_GEN_LLVM_H
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Type.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Constants.h"
@@ -31,41 +30,11 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/DebugInfo.h"
-#else
-#include "llvm/DebugInfo.h"
-#endif
-#else
-#include "llvm/Type.h"
-#include "llvm/DerivedTypes.h"
-#include "llvm/Constants.h"
-#include "llvm/IntrinsicInst.h"
-#include "llvm/CallingConv.h"
-#include "llvm/GlobalVariable.h"
-#include "llvm/Function.h"
-#include "llvm/Module.h"
-#include "llvm/Value.h"
-#include "llvm/Attributes.h"
-#if LDC_LLVM_VER == 302
-#include "llvm/DataLayout.h"
-#include "llvm/IRBuilder.h"
-#include "llvm/DebugInfo.h"
-#else
-#include "llvm/Target/TargetData.h"
-#include "llvm/Analysis/DebugInfo.h"
-#include "llvm/Support/IRBuilder.h"
-#endif
-#endif
-
 
 #include "gen/llvmcompat.h"
 
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/CallSite.h"
-#else
-#include "llvm/Support/CallSite.h"
-#endif
 
 using llvm::IRBuilder;
 

--- a/gen/llvmcompat.h
+++ b/gen/llvmcompat.h
@@ -24,22 +24,12 @@
 #error "Please specify value for LDC_LLVM_VER."
 #endif
 
-#if LDC_LLVM_VER >= 302
 #define ADDRESS_SPACE 0
-#else
-#define ADDRESS_SPACE
-#endif
-
-#if LDC_LLVM_VER < 302
-#define LLVM_OVERRIDE
-#define llvm_move(value) (value)
-#endif
 
 #ifndef __has_feature
 # define __has_feature(x) 0
 #endif
 
-#if LDC_LLVM_VER >= 305
 #if __has_feature(cxx_override_control) \
     || (defined(_MSC_VER) && _MSC_VER >= 1700)
 #define LLVM_OVERRIDE override
@@ -59,8 +49,6 @@
 #define llvm_move(value) (::std::move(value))
 #else
 #define llvm_move(value) (value)
-#endif
-
 #endif
 
 #endif

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -37,7 +37,6 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <stack>
 
-#if LDC_LLVM_VER >= 302
 #include "llvm/Support/CommandLine.h"
 
 llvm::cl::opt<llvm::GlobalVariable::ThreadLocalMode> clThreadModel("fthread-model",
@@ -53,7 +52,6 @@ llvm::cl::opt<llvm::GlobalVariable::ThreadLocalMode> clThreadModel("fthread-mode
         clEnumValN(llvm::GlobalVariable::LocalExecTLSModel, "local-exec",
                    "Local exec TLS model"),
         clEnumValEnd));
-#endif
 
 Type *getTypeInfoType(Type *t, Scope *sc);
 
@@ -1781,7 +1779,6 @@ llvm::GlobalVariable* getOrCreateGlobal(Loc& loc, llvm::Module& module,
         return existing;
     }
 
-#if LDC_LLVM_VER >= 302
     // Use a command line option for the thread model.
     // On PPC there is only local-exec available - in this case just ignore the
     // command line.
@@ -1793,10 +1790,6 @@ llvm::GlobalVariable* getOrCreateGlobal(Loc& loc, llvm::Module& module,
             : llvm::GlobalVariable::NotThreadLocal;
     return new llvm::GlobalVariable(module, type, isConstant, linkage,
                                     init, name, 0, tlsModel);
-#else
-    return new llvm::GlobalVariable(module, type, isConstant, linkage,
-                                    init, name, 0, isThreadLocal);
-#endif
 }
 
 FuncDeclaration* getParentFunc(Dsymbol* sym, bool stopOnStatic)

--- a/gen/logger.cpp
+++ b/gen/logger.cpp
@@ -17,18 +17,10 @@
 #include <iostream>
 #include <string>
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/GlobalValue.h"
-#else
-#include "llvm/GlobalValue.h"
-#endif
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_os_ostream.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/Value.h"
-#else
-#include "llvm/Assembly/Writer.h"
-#endif
 
 #include "gen/logger.h"
 #include "gen/irstate.h"
@@ -44,11 +36,7 @@ void Stream::writeValue(std::ostream& OS, const llvm::Value& V) {
     // still get their initializers printed)
     llvm::raw_os_ostream raw(OS);
     if (llvm::isa<llvm::Constant>(V) && !llvm::isa<llvm::GlobalValue>(V))
-#if LDC_LLVM_VER >= 305
         V.printAsOperand(raw, true, &gIR->module);
-#else
-        llvm::WriteAsOperand(raw, &V, true, &gIR->module);
-#endif
     else
         V.print(raw);
 }

--- a/gen/metadata.h
+++ b/gen/metadata.h
@@ -15,11 +15,7 @@
 #define LDC_GEN_METADATA_H
 
 // MDNode was moved into its own header, and contains Value*s
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Metadata.h"
-#else
-#include "llvm/Metadata.h"
-#endif
 typedef llvm::Value MDNodeField;
 
 #define METADATA_LINKAGE_TYPE  llvm::GlobalValue::WeakODRLinkage

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -41,24 +41,11 @@
 #include "ir/irtype.h"
 #include "ir/irvar.h"
 #include "llvm/Support/CommandLine.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/Verifier.h"
-#else
-#include "llvm/Analysis/Verifier.h"
-#endif
 #include "llvm/LinkAllPasses.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DataLayout.h"
-#else
-#include "llvm/Module.h"
-#if LDC_LLVM_VER == 302
-#include "llvm/DataLayout.h"
-#else
-#include "llvm/Target/TargetData.h"
-#endif
-#endif
 
 #if _AIX || __sun
 #include <alloca.h>

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -18,11 +18,7 @@
 #include "gen/logger.h"
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/InlineAsm.h"
-#else
-#include "llvm/InlineAsm.h"
-#endif
 #include <cassert>
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -181,12 +177,8 @@ void DtoDefineNakedFunction(FuncDeclaration* fd)
     else if (isWin)
     {
         std::string fullMangle;
-#if LDC_LLVM_VER >= 305
         if ( global.params.targetTriple.isWindowsGNUEnvironment() 
              && !global.params.targetTriple.isArch64Bit() )
-#else
-        if (global.params.targetTriple.getOS() == llvm::Triple::MinGW32)
-#endif
         {
             fullMangle = "_";
         }

--- a/gen/optimizer.h
+++ b/gen/optimizer.h
@@ -18,7 +18,6 @@
 // For llvm::CodeGenOpt::Level
 #include "llvm/Support/CodeGen.h"
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/Support/CommandLine.h"
 
 namespace opts {
@@ -27,7 +26,6 @@ enum SanitizerCheck { None, AddressSanitizer, MemorySanitizer, ThreadSanitizer }
 
 extern llvm::cl::opt<SanitizerCheck> sanitize;
 }
-#endif
 
 namespace llvm { class Module; }
 

--- a/gen/passes/StripExternals.cpp
+++ b/gen/passes/StripExternals.cpp
@@ -19,11 +19,7 @@
 
 #include "Passes.h"
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Module.h"
-#else
-#include "llvm/Module.h"
-#endif
 #include "llvm/Pass.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Compiler.h"

--- a/gen/programs.cpp
+++ b/gen/programs.cpp
@@ -29,10 +29,8 @@ static std::string findProgramByName(const std::string& name)
 #if LDC_LLVM_VER >= 306
     llvm::ErrorOr<std::string> res = llvm::sys::findProgramByName(name);
     return res ? res.get() : std::string();
-#elif LDC_LLVM_VER >= 304
-    return llvm::sys::FindProgramByName(name);
 #else
-    return llvm::sys::Program::FindProgramByName(name).str();
+    return llvm::sys::FindProgramByName(name);
 #endif
 }
 

--- a/gen/rttibuilder.h
+++ b/gen/rttibuilder.h
@@ -16,11 +16,7 @@
 #define LDC_GEN_RTTIBUILDER_H
 
 #include "llvm/ADT/SmallVector.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Constant.h"
-#else
-#include "llvm/Constant.h"
-#endif
 
 class AggregateDeclaration;
 class ClassDeclaration;

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -25,16 +25,8 @@
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/CFG.h"
-#else
-#include "llvm/Support/CFG.h"
-#endif
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/InlineAsm.h"
-#else
-#include "llvm/InlineAsm.h"
-#endif
 #include <fstream>
 #include <math.h>
 #include <stdio.h>
@@ -740,9 +732,7 @@ public:
             if ((*it)->var) {
                 llvm::Value* ehPtr = irs->func()->getOrCreateEhPtrSlot();
 
-#if LDC_LLVM_VER >= 305
                 if (!global.params.targetTriple.isWindowsMSVCEnvironment())
-#endif
                 {
                     // ehPtr is a pointer to _d_exception, which has a reference
                     // to the Throwable object at offset 0.

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -456,13 +456,9 @@ errorCmpxchg:
                 fatal();
             }
         }
-#if LDC_LLVM_VER >= 305
         LLValue* ret = p->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering), llvm::AtomicOrdering(atomicOrdering));
         // Use the same quickfix as for dragonegg - see r210956
         ret = p->ir->CreateExtractValue(ret, 0);
-#else
-        LLValue* ret = p->ir->CreateAtomicCmpXchg(ptr, cmp, val, llvm::AtomicOrdering(atomicOrdering));
-#endif
         llvm::Value* retVal = ret;
         if (retVal->getType() != retTy)
             retVal = DtoAllocaDump(retVal, exp3->type);
@@ -974,21 +970,13 @@ DValue* DtoCallFunction(Loc& loc, Type* resulttype, DValue* fnval, Expressions* 
     }
 
     // set calling convention and parameter attributes
-#if LDC_LLVM_VER >= 303
     llvm::AttributeSet attrlist = attrs.toNativeSet();
-#else
-    llvm::AttrListPtr attrlist = attrs.toNativeSet();
-#endif
     if (dfnval && dfnval->func)
     {
         LLFunction* llfunc = llvm::dyn_cast<LLFunction>(dfnval->val);
         if (llfunc && llfunc->isIntrinsic()) // override intrinsic attrs
         {
-#if LDC_LLVM_VER >= 302
             attrlist = llvm::Intrinsic::getAttributes(gIR->context(), static_cast<llvm::Intrinsic::ID>(llfunc->getIntrinsicID()));
-#else
-            attrlist = llvm::Intrinsic::getAttributes(static_cast<llvm::Intrinsic::ID>(llfunc->getIntrinsicID()));
-#endif
         }
         else
         {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -453,20 +453,12 @@ LLConstant* DtoConstFP(Type* t, longdouble value)
         uint64_t bits[] = { 0, 0 };
         bits[0] = *reinterpret_cast<uint64_t*>(&value);
         bits[1] = *reinterpret_cast<uint16_t*>(reinterpret_cast<uint64_t*>(&value) + 1);
-#if LDC_LLVM_VER >= 303
         return LLConstantFP::get(gIR->context(), APFloat(APFloat::x87DoubleExtended, APInt(80, 2, bits)));
-#else
-        return LLConstantFP::get(gIR->context(), APFloat(APInt(80, 2, bits)));
-#endif
     } else if(llty == LLType::getPPC_FP128Ty(gIR->context())) {
         uint64_t bits[] = {0, 0};
         bits[0] = *reinterpret_cast<uint64_t*>(&value);
         bits[1] = *reinterpret_cast<uint16_t*>(reinterpret_cast<uint64_t*>(&value) + 1);
-#if LDC_LLVM_VER >= 303
         return LLConstantFP::get(gIR->context(), APFloat(APFloat::PPCDoubleDouble, APInt(128, 2, bits)));
-#else
-        return LLConstantFP::get(gIR->context(), APFloat(APInt(128, 2, bits)));
-#endif
     }
 
     llvm_unreachable("Unknown floating point type encountered");

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -7,13 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/Constants.h"
-#include "llvm/DerivedTypes.h"
-#endif
 #include "llvm/ADT/SmallString.h"
 #ifndef NDEBUG
 #include "llvm/Support/raw_ostream.h"

--- a/ir/irforw.h
+++ b/ir/irforw.h
@@ -47,11 +47,7 @@ namespace llvm
     class Constant;
     class ConstantStruct;
     class ConstantArray;
-#if LDC_LLVM_VER >= 302
     class DataLayout;
-#else
-    class TargetData;
-#endif
     class Type;
     class StructType;
     class ArrayType;

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -439,29 +439,13 @@ IrFunction::IrFunction(FuncDeclaration* fd) {
 }
 
 void IrFunction::setNeverInline() {
-#if LDC_LLVM_VER >= 303
     assert(!func->getAttributes().hasAttribute(llvm::AttributeSet::FunctionIndex, llvm::Attribute::AlwaysInline) && "function can't be never- and always-inline at the same time");
     func->addFnAttr(llvm::Attribute::NoInline);
-#elif LDC_LLVM_VER == 302
-    assert(!func->getFnAttributes().hasAttribute(llvm::Attributes::AlwaysInline) && "function can't be never- and always-inline at the same time");
-    func->addFnAttr(llvm::Attributes::NoInline);
-#else
-    assert(!func->hasFnAttr(llvm::Attribute::AlwaysInline) && "function can't be never- and always-inline at the same time");
-    func->addFnAttr(llvm::Attribute::NoInline);
-#endif
 }
 
 void IrFunction::setAlwaysInline() {
-#if LDC_LLVM_VER >= 303
     assert(!func->getAttributes().hasAttribute(llvm::AttributeSet::FunctionIndex, llvm::Attribute::NoInline) && "function can't be never- and always-inline at the same time");
     func->addFnAttr(llvm::Attribute::AlwaysInline);
-#elif LDC_LLVM_VER == 302
-    assert(!func->getFnAttributes().hasAttribute(llvm::Attributes::NoInline) && "function can't be never- and always-inline at the same time");
-    func->addFnAttr(llvm::Attributes::AlwaysInline);
-#else
-    assert(!func->hasFnAttr(llvm::Attribute::NoInline) && "function can't be never- and always-inline at the same time");
-    func->addFnAttr(llvm::Attribute::AlwaysInline);
-#endif
 }
 
 llvm::AllocaInst* IrFunction::getOrCreateEhPtrSlot() {

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -7,13 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
-#else
-#include "llvm/DerivedTypes.h"
-#include "llvm/LLVMContext.h"
-#endif
 #include "mars.h"
 #include "mtype.h"
 #include "gen/irstate.h"
@@ -76,14 +71,7 @@ static inline llvm::Type* getReal80Type(llvm::LLVMContext& ctx)
     bool const anyX86 = (a == llvm::Triple::x86) || (a == llvm::Triple::x86_64);
 
     // only x86 has 80bit float - but no support with MS C Runtime!
-    if (anyX86 &&
-#if LDC_LLVM_VER >= 305
-        !global.params.targetTriple.isWindowsMSVCEnvironment()
-#else
-        !(global.params.targetTriple.getOS() == llvm::Triple::Win32)
-#endif
-        )
-
+    if (anyX86 && !global.params.targetTriple.isWindowsMSVCEnvironment())
         return llvm::Type::getX86_FP80Ty(ctx);
 
     return llvm::Type::getDoubleTy(ctx);

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -9,11 +9,7 @@
 
 #include "ir/irtypeaggr.h"
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/DerivedTypes.h"
-#endif
 
 #include "aggregate.h"
 #include "init.h"

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -12,13 +12,7 @@
 
 #include "ir/irtype.h"
 #include "llvm/ADT/ArrayRef.h"
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/DebugInfo.h"
-#elif LDC_LLVM_VER >= 302
-#include "llvm/DebugInfo.h"
-#else
-#include "llvm/Analysis/DebugInfo.h"
-#endif
 #include <map>
 #include <vector>
 

--- a/ir/irtypeclass.cpp
+++ b/ir/irtypeclass.cpp
@@ -7,11 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/DerivedTypes.h"
-#endif
 
 #include "aggregate.h"
 #include "declaration.h"

--- a/ir/irtypeclass.h
+++ b/ir/irtypeclass.h
@@ -15,11 +15,7 @@
 #define __LDC_IR_IRTYPECLASS_H__
 
 #include "ir/irtypeaggr.h"
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/DerivedTypes.h"
-#endif
 
 template <typename TYPE> struct Array;
 typedef Array<class FuncDeclaration *> FuncDeclarations;

--- a/ir/irtypefunction.cpp
+++ b/ir/irtypefunction.cpp
@@ -7,11 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/DerivedTypes.h"
-#endif
 #include "mtype.h"
 
 #include "gen/irstate.h"

--- a/ir/irtypestruct.cpp
+++ b/ir/irtypestruct.cpp
@@ -9,11 +9,7 @@
 
 #include "ir/irtypestruct.h"
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/DerivedTypes.h"
-#else
-#include "llvm/DerivedTypes.h"
-#endif
 
 #include "aggregate.h"
 #include "declaration.h"

--- a/ir/irvar.h
+++ b/ir/irvar.h
@@ -15,19 +15,8 @@
 #ifndef LDC_IR_IRVAR_H
 #define LDC_IR_IRVAR_H
 
-#if LDC_LLVM_VER >= 303
 #include "llvm/IR/Type.h"
-#else
-#include "llvm/Type.h"
-#endif
-
-#if LDC_LLVM_VER >= 305
 #include "llvm/IR/DebugInfo.h"
-#elif LDC_LLVM_VER >= 302
-#include "llvm/DebugInfo.h"
-#else
-#include "llvm/Analysis/DebugInfo.h"
-#endif
 
 struct IrFuncTyArg;
 class VarDeclaration;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -267,29 +267,6 @@ macro(dc input_d d_flags output_dir output_suffix outlist_o outlist_bc)
         list(APPEND ${outlist_bc} ${output_bc})
     endif()
 
-    # We hit a few known bugs in older LLVM versions when building the unit
-    # tests with full optimizations. Downgrade the optimization flags for those
-    # specific files so we can at least test the rest of them.
-    set(cur_d_flags ${d_flags})
-    if("${cur_d_flags}" MATCHES "-unittest")
-        if(${LDC_LLVM_VER} EQUAL 301 AND "${input_d}" MATCHES "std/exception.d" AND
-            ${HOST_BITNESS} EQUAL 64)
-            # Building the std.exception tests on x86_64 triggers an infinite
-            # recursion in scalar evolution on LLVM 3.1 (only), see the list of
-            # known LLVM bugs for details.
-            string(REPLACE "-O3" "-O1" cur_d_flags "${cur_d_flags}")
-        elseif(${LDC_LLVM_VER} LESS 303 AND "${input_d}" MATCHES "std/range.d")
-            # Building the std.range tests triggers an assertion error on
-            # every LLVM release before 3.3. See PR15608.
-            string(REPLACE "-O3" "-O1" cur_d_flags "${cur_d_flags}")
-        elseif(${LDC_LLVM_VER} LESS 304 AND "${input_d}" MATCHES "rt/util/container/array.d")
-            # Building the rt.util.container.array tests triggers a bug in the
-            # jump threading pass on every LLVM release before 3.4.
-            # See PR17621.
-            string(REPLACE "-O3" "-O1" cur_d_flags "${cur_d_flags}")
-        endif()
-    endif()
-
     # Compile
     if(BUILD_BC_LIBS)
         set(outfiles ${output_o} ${output_bc})
@@ -302,7 +279,7 @@ macro(dc input_d d_flags output_dir output_suffix outlist_o outlist_bc)
     add_custom_command(
         OUTPUT
             ${outfiles}
-        COMMAND ${LDC_EXE} ${dc_flags} -c -I${RUNTIME_DIR}/src -I${RUNTIME_DIR}/src/gc ${input_d} -of${output_o} ${cur_d_flags}
+        COMMAND ${LDC_EXE} ${dc_flags} -c -I${RUNTIME_DIR}/src -I${RUNTIME_DIR}/src/gc ${input_d} -of${output_o} ${d_flags}
         WORKING_DIRECTORY ${PROJECT_PARENT_DIR}
         DEPENDS ${input_d}
                 ${LDC_EXE}

--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -19,9 +19,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Path.h"
 #include "llvm/TableGen/Record.h"
-#if LDC_LLVM_VER < 302
-#include "llvm/TableGen/TableGenAction.h"
-#endif
 #include <algorithm>
 #include <assert.h>
 #include <map>
@@ -201,16 +198,6 @@ bool emit(raw_ostream& os, RecordKeeper& records)
     return false;
 }
 
-#if LDC_LLVM_VER < 302
-struct ActionImpl : TableGenAction
-{
-    bool operator()(raw_ostream& os, RecordKeeper& records)
-    {
-        return emit(os, records);
-    }
-};
-#endif
-
 int main(int argc, char** argv)
 {
     if(argc != 3)
@@ -221,9 +208,7 @@ int main(int argc, char** argv)
 
     llvm::SmallString<128> file(LLVM_INTRINSIC_TD_PATH);
     sys::path::append(file, "llvm");
-#if LDC_LLVM_VER >= 303
     sys::path::append(file, "IR");
-#endif
     sys::path::append(file, "Intrinsics.td");
 
     string iStr = string("-I=") + string(LLVM_INTRINSIC_TD_PATH);
@@ -236,10 +221,5 @@ int main(int argc, char** argv)
 
     cl::ParseCommandLineOptions(args2.size(), &args2[0]);
     arch = argv[2];
-#if LDC_LLVM_VER >= 302
     return TableGenMain(argv[0], emit);
-#else
-    ActionImpl act;
-    return TableGenMain(argv[0], act);
-#endif
 }


### PR DESCRIPTION
This allows to clean up the code a little.

**Warning**: I haven't double-checked it yet. :]