### PR TITLE
Base implicit executable filename on first object file name

### DIFF
--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -62,26 +62,21 @@ static std::string getOutputName(bool const sharedLib) {
   // Output name is inferred.
   std::string result;
 
-  // try root module name
-  if (Module::rootModule) {
+  if (global.params.objfiles->dim) {
+    result = FileName::removeExt(global.params.objfiles->data[0]);
+  } else if (Module::rootModule) {
     result = Module::rootModule->toChars();
-  } else if (global.params.objfiles->dim) {
-    result = FileName::removeExt(
-        static_cast<const char *>(global.params.objfiles->data[0]));
   } else {
     result = "a.out";
   }
+
+  bool isWindows = global.params.targetTriple.isOSWindows();
   if (sharedLib) {
-    std::string libExt = std::string(".") + global.dll_ext;
-    if (!endsWith(result, libExt)) {
-      if (global.params.targetTriple.getOS() != llvm::Triple::Win32) {
-        result = "lib" + result + libExt;
-      } else {
-        result.append(libExt);
-      }
+    result.append(std::string(".") + global.dll_ext);
+    if (!isWindows) {
+        result = "lib" + result;
     }
-  } else if (global.params.targetTriple.isOSWindows() &&
-             !endsWith(result, ".exe")) {
+  } else if (isWindows) {
     result.append(".exe");
   }
 


### PR DESCRIPTION
And only then on an optional root module name. This should mimic DMD behavior (I haven't checked its source though) and so makes sure LDMD is compatible in this regard.

E.g., when compiling a module `a.d` stating `module tst;` to an executable without providing an explicit output file name, the executable will now be called `a[.exe]` instead of `tst[.exe]`.