### PR TITLE
propagate "nothrow" to LLVM IR

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -470,10 +470,6 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   // add func to IRFunc
   irFunc->func = func;
 
-  // function attributes
-  if (f->isnothrow)
-    func->setDoesNotThrow();
-
   // parameter attributes
   if (!DtoIsIntrinsic(fdecl)) {
     applyParamAttrsToLLFunc(f, getIrFunc(fdecl)->irFty, func);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -470,6 +470,10 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   // add func to IRFunc
   irFunc->func = func;
 
+  // function attributes
+  if (f->isnothrow)
+    func->setDoesNotThrow();
+
   // parameter attributes
   if (!DtoIsIntrinsic(fdecl)) {
     applyParamAttrsToLLFunc(f, getIrFunc(fdecl)->irFty, func);

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -843,7 +843,7 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
                        numFormalParams);
 
   // call the function
-  LLCallSite call = gIR->func()->scopes->callOrInvoke(callable, args);
+  LLCallSite call = gIR->func()->scopes->callOrInvoke(callable, args, "", tf->isnothrow);
 
   // get return value
   const int sretArgIndex =
@@ -988,8 +988,6 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
   } else {
     call.setCallingConv(callconv);
   }
-  attrlist = attrlist.addAttributes(
-      gIR->context(), llvm::AttributeSet::FunctionIndex, call.getAttributes());
   call.setAttributes(attrlist);
 
   // Special case for struct constructor calls: For temporaries, using the

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -988,6 +988,8 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
   } else {
     call.setCallingConv(callconv);
   }
+  attrlist = attrlist.addAttributes(
+      gIR->context(), llvm::AttributeSet::FunctionIndex, call.getAttributes());
   call.setAttributes(attrlist);
 
   // Special case for struct constructor calls: For temporaries, using the


### PR DESCRIPTION
I noticed that "nothrow" was never propageted to the LLVM function object, causing these function to still be "invoked" instead of "called". I guess adding this can reduce code bloat quite a bit for functions with cleanup code.

Maybe omitting it was a deliberate choice? It can change the way exceptions are caught, because no landing pads are generated if the try block is known to be "nothrow". This shows in the unittest of lifetime.d: https://github.com/ldc-developers/druntime/blob/ldc/src/rt/lifetime.d#L2439 which now fails. I think the test is wrong here.