### PR TITLE
OS X - default OS to macosx instead of darwin

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -741,6 +741,7 @@ static void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("Posix");
     break;
   case llvm::Triple::Darwin:
+  case llvm::Triple::MacOSX:
     VersionCondition::addPredefinedGlobalIdent("OSX");
     VersionCondition::addPredefinedGlobalIdent(
         "darwin"); // For backwards compatibility.

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -420,6 +420,11 @@ llvm::TargetMachine *createTargetMachine(
   if (targetTriple.empty()) {
     triple = llvm::Triple(llvm::sys::getDefaultTargetTriple());
 
+    // We only support OSX, so darwin should really be macosx.
+    if (triple.getOS() == llvm::Triple::Darwin) {
+      triple.setOS(llvm::Triple::MacOSX);
+    }
+
     // Handle -m32/-m64.
     if (sizeof(void *) == 4 && bitness == ExplicitBitness::M64) {
       triple = triple.get64BitArchVariant();


### PR DESCRIPTION
Not mean to be the end all as other darwin targets are coming along.  But this makes everything better with Xcode 7.  In particular, OS X ld in Xcode 7 warns when default LLVM triple with OS darwin is used because the darwin default version (x86_64-apple-darwin14.5.0 on my box) is greater than OS X version.  More work has to be done for specifying OS min versions and such.  Hope this is ok for now.

For background: http://forum.dlang.org/post/avnefmjkfgqbfiapibfv@forum.dlang.org