### PR TITLE
Fix explicit alignment of local variables

### DIFF
--- a/dmd2/parse.c
+++ b/dmd2/parse.c
@@ -4067,6 +4067,12 @@ L2:
                     new TemplateDeclaration(loc, ident, tpl, NULL, a2, 0);
                 s = tempdecl;
             }
+            if (structalign != 0)
+            {
+                Dsymbols *ax = new Dsymbols();
+                ax->push(s);
+                s = new AlignDeclaration(structalign, ax);
+            }
             if (link != linkage)
             {
                 Dsymbols *ax = new Dsymbols();

--- a/tests/ir/align.d
+++ b/tests/ir/align.d
@@ -1,4 +1,4 @@
-// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 align(32) struct Outer { int a; }
 struct Inner { align(32) int a; }
@@ -6,11 +6,29 @@ struct Inner { align(32) int a; }
 void main() {
   static Outer globalOuter;
   static Inner globalInner;
-  // LLVM: constant %align.Outer_init zeroinitializer, align 32
-  // LLVM: constant %align.Inner_init zeroinitializer, align 32
+  // CHECK: constant %align.Outer_init zeroinitializer, align 32
+  // CHECK: constant %align.Inner_init zeroinitializer, align 32
 
   Outer outer;
   Inner inner;
-  // LLVM: %outer = alloca %align.Outer, align 32
-  // LLVM: %inner = alloca %align.Inner, align 32
+  // CHECK: %outer = alloca %align.Outer, align 32
+  // CHECK: %inner = alloca %align.Inner, align 32
+
+  align(16) byte byte16;
+  // CHECK: %byte16 = alloca i8, align 16
+  align(64) Outer outer64;
+  // CHECK: %outer64 = alloca %align.Outer, align 64
+  align(128) Inner inner128;
+  // CHECK: %inner128 = alloca %align.Inner, align 128
+
+  alias Byte8 = align(8) byte;
+  Byte8 byte8;
+  // Can aliases contain align(x) ?
+  // C HECK: %byte8 = alloca i8, align 8
+  // C HECK: %byte8 = alloca i8, align 1
+
+  align(16) Outer outeroverride;
+  // Yet undecided if align() should override type alignment:
+  // C HECK: %outeroverride = alloca %align.Outer, align 16
+  // C HECK: %outeroverride = alloca %align.Outer, align 32
 }


### PR DESCRIPTION
This fixes the remaining problem of issue #1154, explicit (overriding) alignment of local variables.

It's the first time I look at the parser code, so please review carefully.
What it looks like to me is that the attributes found on line 3804 are forgotten and not applied to normal local variables without initializers (the last part of the function). So I added code that applies the AlignDeclaration to the declaration, following a pattern found elsewhere in this function. Perhaps we also need to add the other attributes (except linkage?):
```C++
        if (storage_class)
        {
            Dsymbol *s = new StorageClassDeclaration(storage_class, a);
            a = new Dsymbols();
            a->push(s);
        }
        if (structalign != 0)
        {
            Dsymbol *s = new AlignDeclaration(structalign, a);
            a = new Dsymbols();
            a->push(s);
        }
        if (udas)
        {
            Dsymbol *s = new UserAttributeDeclaration(udas, a);
            a = new Dsymbols();
            a->push(s);
        }
``` 

@kinke: this was fun to figure out :) hope you haven't been working on it too.