### PR TITLE
Avoiding directives that split up parts of statements.

### DIFF
--- a/dmd2/statement.c
+++ b/dmd2/statement.c
@@ -5117,6 +5117,7 @@ Statement *GotoStatement::semantic(Scope *sc)
 
 bool GotoStatement::checkLabel()
 {
+    int error_msg;
     if (!label->statement)
     {
         error("label '%s' is undefined", label->toChars());
@@ -5140,10 +5141,11 @@ bool GotoStatement::checkLabel()
     }
 
 #if !IN_LLVM
-    if (label->statement->tf != tf)
+    error_msg = (label->statement->tf != tf);
 #else
-    if (label->statement && label->statement->tf != tf)
+    error_msg = (label->statement && label->statement->tf != tf);
 #endif
+    if (error_msg)
     {
         error("cannot goto in or out of finally block");
         return true;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.

I noticed that the project uses this types of directives only in a few places by running my tool. I'm willing to contribute by removing those issues if it is important to the project.