### PR TITLE
Win64 ABI: Rewrite magic __c_long_double struct as double

### DIFF
--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -227,4 +227,31 @@ struct ExplicitByvalRewrite : ABIRewrite {
   }
 };
 
+//////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Rewrites the magic core.stdc.config.__c_long_double struct (used for MSVC++
+ * mangling) to a double.
+ */
+struct MSVCLongDoubleRewrite : ABIRewrite {
+  LLValue *get(Type *dty, LLValue *v) override {
+    return DtoAllocaDump(v, dty, ".MSVCLongDoubleRewrite_dump");
+  }
+
+  void getL(Type *, LLValue *v, LLValue *lval) override {
+    storeToMemory(v, lval);
+  }
+
+  LLValue *put(DValue *dv) override {
+    assert(dv->getType()->toBasetype()->ty == Tstruct);
+    LLValue *address = dv->getLVal();
+    return loadFromMemory(address, LLType::getDoubleTy(gIR->context()),
+                          ".MSVCLongDoubleRewrite_putResult");
+  }
+
+  LLType *type(Type *, LLType *) override {
+    return LLType::getDoubleTy(gIR->context());
+  }
+};
+
 #endif

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -21,7 +21,6 @@
 #include "gen/tollvm.h"
 
 struct MIPS64TargetABI : TargetABI {
-  IntegerRewrite integerRewrite;
   const bool Is64Bit;
 
   explicit MIPS64TargetABI(const bool Is64Bit) : Is64Bit(Is64Bit) {}
@@ -54,12 +53,6 @@ struct MIPS64TargetABI : TargetABI {
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
     // FIXME
-  }
-
-  // Returns true if the D type can be bit-cast to an integer of the same size.
-  bool canRewriteAsInt(Type *t) {
-    const unsigned size = t->size();
-    return size == 1 || size == 2 || size == 4 || (Is64Bit && size == 8);
   }
 };
 

--- a/gen/abi-ppc64.cpp
+++ b/gen/abi-ppc64.cpp
@@ -58,7 +58,7 @@ struct PPC64TargetABI : TargetABI {
     Type *ty = arg.type->toBasetype();
 
     if (ty->ty == Tstruct || ty->ty == Tsarray) {
-      if (canRewriteAsInt(ty)) {
+      if (canRewriteAsInt(ty, Is64Bit)) {
         if (!IntegerRewrite::isObsoleteFor(arg.ltype)) {
           arg.rewrite = &integerRewrite;
           arg.ltype = integerRewrite.type(arg.type, arg.ltype);
@@ -77,12 +77,6 @@ struct PPC64TargetABI : TargetABI {
             .addAlignment(byvalRewrite.alignment(arg.type));
       }
     }
-  }
-
-  // Returns true if the D type can be bit-cast to an integer of the same size.
-  bool canRewriteAsInt(Type *t) {
-    const unsigned size = t->size();
-    return size == 1 || size == 2 || size == 4 || (Is64Bit && size == 8);
   }
 };
 

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -38,26 +38,9 @@ private:
   IntegerRewrite integerRewrite;
   MSVCLongDoubleRewrite longDoubleRewrite;
 
-  // Returns true if the D type is an aggregate:
-  // * struct
-  // * static/dynamic array
-  // * delegate
-  // * complex number
-  static bool isAggregate(Type *t) {
-    TY ty = t->ty;
-    return ty == Tstruct || ty == Tsarray ||
-           /*ty == Tarray ||*/ ty == Tdelegate || t->iscomplex();
-  }
-
   static bool isMagicCppLongDoubleStruct(Type *t) {
     return t->ty == Tstruct &&
            static_cast<TypeStruct *>(t)->sym->ident == Id::__c_long_double;
-  }
-
-  // Returns true if the D type can be bit-cast to an integer of the same size.
-  static bool canRewriteAsInt(Type *t) {
-    unsigned size = t->size();
-    return size == 1 || size == 2 || size == 4 || size == 8;
   }
 
   static bool realIs80bits() {
@@ -92,8 +75,7 @@ public:
     //   (incl. 2x32-bit cfloat) are returned in a register (RAX, or
     //   XMM0 for single float/ifloat/double/idouble)
     // * all other types are returned via struct-return (sret)
-    return (rt->ty == Tstruct &&
-            !(static_cast<TypeStruct *>(rt))->sym->isPOD()) ||
+    return (rt->ty == Tstruct && !isPOD(rt, tf->linkage)) ||
            isPassedWithByvalSemantics(rt);
   }
 

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -33,45 +33,40 @@
 #include <utility>
 
 struct Win64TargetABI : TargetABI {
+private:
   ExplicitByvalRewrite byvalRewrite;
   IntegerRewrite integerRewrite;
   MSVCLongDoubleRewrite longDoubleRewrite;
 
-  bool returnInArg(TypeFunction *tf) override;
-
-  bool passByVal(Type *t) override;
-
-  bool passThisBeforeSret(TypeFunction *tf) override;
-
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override;
-
-  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override;
-
-private:
   // Returns true if the D type is an aggregate:
   // * struct
   // * static/dynamic array
   // * delegate
   // * complex number
-  bool isAggregate(Type *t) {
+  static bool isAggregate(Type *t) {
     TY ty = t->ty;
     return ty == Tstruct || ty == Tsarray ||
            /*ty == Tarray ||*/ ty == Tdelegate || t->iscomplex();
   }
 
+  static bool isMagicCppLongDoubleStruct(Type *t) {
+    return t->ty == Tstruct &&
+           static_cast<TypeStruct *>(t)->sym->ident == Id::__c_long_double;
+  }
+
   // Returns true if the D type can be bit-cast to an integer of the same size.
-  bool canRewriteAsInt(Type *t) {
+  static bool canRewriteAsInt(Type *t) {
     unsigned size = t->size();
     return size == 1 || size == 2 || size == 4 || size == 8;
   }
 
-  bool realIs80bits() {
+  static bool realIs80bits() {
     return !global.params.targetTriple.isWindowsMSVCEnvironment();
   }
 
   // Returns true if the D type is passed byval (the callee getting a pointer
   // to a dedicated hidden copy).
-  bool isPassedWithByvalSemantics(Type *t) {
+  static bool isPassedWithByvalSemantics(Type *t) {
     return
         // * aggregates which can NOT be rewritten as integers
         //   (size > 64 bits or not a power of 2)
@@ -79,87 +74,91 @@ private:
         // * 80-bit real and ireal
         (realIs80bits() && (t->ty == Tfloat80 || t->ty == Timaginary80));
   }
+
+public:
+  bool returnInArg(TypeFunction *tf) override {
+    if (tf->isref) {
+      return false;
+    }
+
+    Type *rt = tf->next->toBasetype();
+
+    // * let LLVM return 80-bit real/ireal on the x87 stack, for DMD compliance
+    if (realIs80bits() && (rt->ty == Tfloat80 || rt->ty == Timaginary80)) {
+      return false;
+    }
+
+    // * all POD types <= 64 bits and of a size that is a power of 2
+    //   (incl. 2x32-bit cfloat) are returned in a register (RAX, or
+    //   XMM0 for single float/ifloat/double/idouble)
+    // * all other types are returned via struct-return (sret)
+    return (rt->ty == Tstruct &&
+            !(static_cast<TypeStruct *>(rt))->sym->isPOD()) ||
+           isPassedWithByvalSemantics(rt);
+  }
+
+  bool passByVal(Type *t) override {
+    // LLVM's byval attribute is not compatible with the Win64 ABI
+    return false;
+  }
+
+  bool passThisBeforeSret(TypeFunction *tf) override {
+    // required by MSVC++
+    return tf->linkage == LINKcpp;
+  }
+
+  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+    // return value
+    if (!fty.ret->byref && fty.ret->type->toBasetype()->ty != Tvoid) {
+      rewriteArgument(fty, *fty.ret);
+    }
+
+    // explicit parameters
+    for (auto arg : fty.args) {
+      if (!arg->byref) {
+        rewriteArgument(fty, *arg);
+      }
+    }
+
+    // extern(D): reverse parameter order for non variadics, for DMD-compliance
+    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+      fty.reverseParams = true;
+    }
+  }
+
+  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
+    Type *t = arg.type->toBasetype();
+
+    if (isPassedWithByvalSemantics(t)) {
+      // these types are passed byval:
+      // the caller allocates a copy and then passes a pointer to the copy
+      arg.rewrite = &byvalRewrite;
+
+      // the copy is treated as a local variable of the callee
+      // hence add the NoAlias and NoCapture attributes
+      arg.attrs.clear()
+          .add(LLAttribute::NoAlias)
+          .add(LLAttribute::NoCapture)
+          .addAlignment(byvalRewrite.alignment(arg.type));
+    } else if (isMagicCppLongDoubleStruct(t)) {
+      arg.rewrite = &longDoubleRewrite;
+    } else if (isAggregate(t) && canRewriteAsInt(t) &&
+               !IntegerRewrite::isObsoleteFor(arg.ltype)) {
+      arg.rewrite = &integerRewrite;
+    }
+
+    if (arg.rewrite) {
+      LLType *originalLType = arg.ltype;
+      arg.ltype = arg.rewrite->type(arg.type, arg.ltype);
+
+      IF_LOG {
+        Logger::println("Rewriting argument type %s", t->toChars());
+        LOG_SCOPE;
+        Logger::cout() << *originalLType << " => " << *arg.ltype << '\n';
+      }
+    }
+  }
 };
 
 // The public getter for abi.cpp
 TargetABI *getWin64TargetABI() { return new Win64TargetABI; }
-
-bool Win64TargetABI::returnInArg(TypeFunction *tf) {
-  if (tf->isref) {
-    return false;
-  }
-
-  Type *rt = tf->next->toBasetype();
-
-  // * let LLVM return 80-bit real/ireal on the x87 stack, for DMD compliance
-  if (realIs80bits() && (rt->ty == Tfloat80 || rt->ty == Timaginary80)) {
-    return false;
-  }
-
-  // * all POD types <= 64 bits and of a size that is a power of 2
-  //   (incl. 2x32-bit cfloat) are returned in a register (RAX, or
-  //   XMM0 for single float/ifloat/double/idouble)
-  // * all other types are returned via struct-return (sret)
-  return (rt->ty == Tstruct &&
-          !(static_cast<TypeStruct *>(rt))->sym->isPOD()) ||
-         isPassedWithByvalSemantics(rt);
-}
-
-bool Win64TargetABI::passByVal(Type *t) { return false; }
-
-bool Win64TargetABI::passThisBeforeSret(TypeFunction *tf) {
-  return tf->linkage == LINKcpp;
-}
-
-void Win64TargetABI::rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) {
-  // RETURN VALUE
-  if (!fty.ret->byref && fty.ret->type->toBasetype()->ty != Tvoid) {
-    rewriteArgument(fty, *fty.ret);
-  }
-
-  // EXPLICIT PARAMETERS
-  for (auto arg : fty.args) {
-    if (!arg->byref) {
-      rewriteArgument(fty, *arg);
-    }
-  }
-
-  // extern(D): reverse parameter order for non variadics, for DMD-compliance
-  if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
-    fty.reverseParams = true;
-  }
-}
-
-void Win64TargetABI::rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) {
-  Type *t = arg.type->toBasetype();
-
-  if (isPassedWithByvalSemantics(t)) {
-    // these types are passed byval:
-    // the caller allocates a copy and then passes a pointer to the copy
-    arg.rewrite = &byvalRewrite;
-
-    // the copy is treated as a local variable of the callee
-    // hence add the NoAlias and NoCapture attributes
-    arg.attrs.clear()
-        .add(LLAttribute::NoAlias)
-        .add(LLAttribute::NoCapture)
-        .addAlignment(byvalRewrite.alignment(arg.type));
-  } else if (t->ty == Tstruct &&
-             static_cast<TypeStruct *>(t)->sym->ident == Id::__c_long_double) {
-    arg.rewrite = &longDoubleRewrite;
-  } else if (isAggregate(t) && canRewriteAsInt(t) &&
-             !IntegerRewrite::isObsoleteFor(arg.ltype)) {
-    arg.rewrite = &integerRewrite;
-  }
-
-  if (arg.rewrite) {
-    LLType *originalLType = arg.ltype;
-    arg.ltype = arg.rewrite->type(arg.type, arg.ltype);
-
-    IF_LOG {
-      Logger::println("Rewriting argument type %s", t->toChars());
-      LOG_SCOPE;
-      Logger::cout() << *originalLType << " => " << *arg.ltype << '\n';
-    }
-  }
-}

--- a/gen/abi-win64.h
+++ b/gen/abi-win64.h
@@ -15,7 +15,7 @@
 #ifndef __LDC_GEN_ABI_WIN64_H__
 #define __LDC_GEN_ABI_WIN64_H__
 
-#include "gen/abi.h"
+struct TargetABI;
 
 TargetABI *getWin64TargetABI();
 

--- a/gen/abi-x86-64.h
+++ b/gen/abi-x86-64.h
@@ -16,9 +16,6 @@
 #define LDC_GEN_ABI_X86_64_H
 
 struct TargetABI;
-namespace llvm {
-class Type;
-}
 
 TargetABI *getX86_64TargetABI();
 

--- a/gen/abi-x86.h
+++ b/gen/abi-x86.h
@@ -15,6 +15,7 @@
 #define LDC_GEN_ABI_X86_H
 
 struct TargetABI;
+
 TargetABI *getX86TargetABI();
 
 #endif

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -54,17 +54,17 @@ struct ABIRewrite {
 protected:
   /***** Static Helpers *****/
 
-  // Returns the address of a D value, storing it to memory first if need be.
+  /// Returns the address of a D value, storing it to memory first if need be.
   static llvm::Value *getAddressOf(DValue *v);
 
-  // Stores a LL value to a specified memory address. The element type of the
-  // provided pointer doesn't need to match the value type (=> suited for
-  // bit-casting).
+  /// Stores a LL value to a specified memory address. The element type of the
+  /// provided pointer doesn't need to match the value type (=> suited for
+  /// bit-casting).
   static void storeToMemory(llvm::Value *rval, llvm::Value *address);
 
-  // Loads a LL value of a specified type from memory. The element type of the
-  // provided pointer doesn't need to match the value type (=> suited for
-  // bit-casting).
+  /// Loads a LL value of a specified type from memory. The element type of the
+  /// provided pointer doesn't need to match the value type (=> suited for
+  /// bit-casting).
   static llvm::Value *loadFromMemory(llvm::Value *address, llvm::Type *asType,
                                      const char *name = ".bitcast_result");
 };
@@ -124,24 +124,48 @@ struct TargetABI {
   virtual void rewriteVarargs(IrFuncTy &fty, std::vector<IrFuncTyArg *> &args);
   virtual void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) {}
 
-  // Prepares a va_start intrinsic call.
-  // Input:  pointer to passed ap argument (va_list*)
-  // Output: value to be passed to LLVM's va_start intrinsic (void*)
+  /// Prepares a va_start intrinsic call.
+  ///
+  /// Input:  pointer to passed ap argument (va_list*)
+  /// Output: value to be passed to LLVM's va_start intrinsic (void*)
   virtual llvm::Value *prepareVaStart(llvm::Value *pAp);
 
-  // Implements the va_copy intrinsic.
-  // Input: pointer to dest argument (va_list*) and src argument (va_list)
+  /// Implements the va_copy intrinsic.
+  ///
+  /// Input: pointer to dest argument (va_list*) and src argument (va_list)
   virtual void vaCopy(llvm::Value *pDest, llvm::Value *src);
 
-  // Prepares a va_arg intrinsic call.
-  // Input:  pointer to passed ap argument (va_list*)
-  // Output: value to be passed to LLVM's va_arg intrinsic (void*)
+  /// Prepares a va_arg intrinsic call.
+  ///
+  /// Input:  pointer to passed ap argument (va_list*)
+  /// Output: value to be passed to LLVM's va_arg intrinsic (void*)
   virtual llvm::Value *prepareVaArg(llvm::Value *pAp);
 
   /// Returns the D type to be used for va_list.
   ///
   /// Must match the alias in druntime.
   virtual Type *vaListType();
+
+protected:
+  /***** Static Helpers *****/
+
+  /// Returns true if the D type is an aggregate:
+  /// * struct
+  /// * static/dynamic array
+  /// * delegate
+  /// * complex number
+  static bool isAggregate(Type *t);
+
+  /// The frontend uses magic structs to express the variable-sized C types
+  /// ((unsigned) long, long double) for C++ mangling purposes.
+  static bool isMagicCppStruct(Type *t);
+
+  /// Returns true if the D struct type is a Plain-Old-Datatype for the given
+  /// linkage.
+  static bool isPOD(Type *t, LINK l);
+
+  /// Returns true if the D type can be bit-cast to an integer of the same size.
+  static bool canRewriteAsInt(Type *t, bool include64bit = true);
 };
 
 #endif

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -189,37 +189,39 @@ public:
       return;
     }
 
-    if (decl->members && decl->symtab) {
-      DtoResolveStruct(decl);
-      decl->ir.setDefined();
+    if (!(decl->members && decl->symtab)) {
+      return;
+    }
 
-      for (auto m : *decl->members) {
-        m->accept(this);
-      }
+    DtoResolveStruct(decl);
+    decl->ir.setDefined();
 
-      // Define the __initZ symbol.
-      IrAggr *ir = getIrAggr(decl);
-      llvm::GlobalVariable *initZ = ir->getInitSymbol();
-      initZ->setInitializer(ir->getDefaultInit());
-      LinkageWithCOMDAT lwc = DtoLinkage(decl);
-      initZ->setLinkage(lwc.first);
-      if (lwc.second) {
-        SET_COMDAT(initZ, gIR->module);
-      }
+    for (auto m : *decl->members) {
+      m->accept(this);
+    }
 
-      // emit typeinfo
-      DtoTypeInfoOf(decl->type);
+    // Define the __initZ symbol.
+    IrAggr *ir = getIrAggr(decl);
+    llvm::GlobalVariable *initZ = ir->getInitSymbol();
+    initZ->setInitializer(ir->getDefaultInit());
+    LinkageWithCOMDAT lwc = DtoLinkage(decl);
+    initZ->setLinkage(lwc.first);
+    if (lwc.second) {
+      SET_COMDAT(initZ, gIR->module);
+    }
 
-      // Emit __xopEquals/__xopCmp/__xtoHash.
-      if (decl->xeq && decl->xeq != decl->xerreq) {
-        decl->xeq->accept(this);
-      }
-      if (decl->xcmp && decl->xcmp != decl->xerrcmp) {
-        decl->xcmp->accept(this);
-      }
-      if (decl->xhash) {
-        decl->xhash->accept(this);
-      }
+    // emit typeinfo
+    DtoTypeInfoOf(decl->type);
+
+    // Emit __xopEquals/__xopCmp/__xtoHash.
+    if (decl->xeq && decl->xeq != decl->xerreq) {
+      decl->xeq->accept(this);
+    }
+    if (decl->xcmp && decl->xcmp != decl->xerrcmp) {
+      decl->xcmp->accept(this);
+    }
+    if (decl->xhash) {
+      decl->xhash->accept(this);
     }
   }
 


### PR DESCRIPTION
Another positive side-effect of #1168.

To be complemented by https://github.com/D-Programming-Language/druntime/pull/1443.