### PR TITLE
Update druntime and remove additional VS2015 .lib from config file

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -193,11 +193,6 @@ endif()
 # Create configuration files.
 #
 
-# Add a lib required by VS 2015+ when building LDC with VS 2015+.
-if(MSVC AND (MSVC_VERSION GREATER 1800))
-    set(ADDITIONAL_DEFAULT_LDC_SWITCHES ",\n        \"-Llegacy_stdio_definitions.lib\"")
-endif()
-
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of
 # fat binaries. Other Posixen might need to be added here.


### PR DESCRIPTION
The required lib is now referenced as defaultlib in druntime's `msvc.c` if druntime is built with VS 2015, see https://github.com/ldc-developers/druntime/pull/47.