### PR TITLE
Prepare DtoCallFunction() for runtime function calls

### DIFF
--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -216,6 +216,9 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
 ///
 DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
                         Expressions *arguments, LLValue *sretPointer = nullptr);
+DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
+                        const std::vector<DValue *> &argvals,
+                        LLValue *sretPointer = nullptr);
 
 Type *stripModifiers(Type *type, bool transitive = false);
 


### PR DESCRIPTION
By also taking `DValue*` args, not just `Expression*`s.
