### PR TITLE
Re-enable core.internal.convert unit tests

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -709,19 +709,13 @@ endmacro()
 function(add_tests d_files runner name_suffix)
     foreach(file ${d_files})
         file_to_module_name(${file} module)
-        if("${module}" STREQUAL "core.internal.convert")
-            # Exclude unit tests for now, as they fail due to a CTFE vs. runtime
-            # issue with floating point numbers. See the discussion on GitHub
-            # pull request #770. To be revisited after 0.15.0 is out.
-        else()
-            add_test(NAME "${module}${name_suffix}"
-                WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-                COMMAND ${runner}-test-runner${name_suffix} ${module}
-            )
-            set_tests_properties("${module}${name_suffix}" PROPERTIES
-                DEPENDS build-${runner}-test-runner${name_suffix}
-            )
-        endif()
+        add_test(NAME "${module}${name_suffix}"
+            WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+            COMMAND ${runner}-test-runner${name_suffix} ${module}
+        )
+        set_tests_properties("${module}${name_suffix}" PROPERTIES
+            DEPENDS build-${runner}-test-runner${name_suffix}
+	)
     endforeach()
 endfunction()
 function(add_runtime_tests name_suffix)


### PR DESCRIPTION
Update druntime submodule with cherry-picked core.internal.convert upstream changes and start running its unit test again.

This should resolve issue #788.