### PR TITLE
Implement rudimentary support for @ldc.attributes.target("...")

### DIFF
--- a/tests/ir/attr_target_x86.d
+++ b/tests/ir/attr_target_x86.d
@@ -1,0 +1,62 @@
+// Tests @target attribute for x86
+
+// REQUIRES: atleast_llvm307
+
+// RUN: %ldc -O -c -mcpu=i386 -mtriple i386-linux-gnu -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
+// RUN: %ldc -O -c -mcpu=i386 -mtriple i386-linux-gnu -output-s -of=%t.s %s && FileCheck %s  --check-prefix ASM < %t.s
+
+import ldc.attributes;
+
+// LLVM-LABEL: define{{.*}} void @{{.*}}foo
+// ASM-LABEL: _D15attr_target_x863fooFPfPffZv:
+void foo(float *A, float* B, float K) {
+    for (int i = 0; i < 128; ++i)
+        A[i] *= B[i] + K;
+// ASM-NOT: addps
+}
+
+// LLVM-LABEL: define{{.*}} void @{{.*}}foo_sse
+// LLVM-SAME: #[[SSE:[0-9]+]]
+// ASM-LABEL: _D15attr_target_x867foo_sseFPfPffZv:
+@(target("sse"))
+void foo_sse(float *A, float* B, float K) {
+    for (int i = 0; i < 128; ++i)
+        A[i] *= B[i] + K;
+// ASM: addps
+}
+
+// Make sure that no-sse overrides sse (attribute sorting). Also tests multiple @target attribs.
+// LLVM-LABEL: define{{.*}} void @{{.*}}foo_nosse
+// LLVM-SAME: #[[NOSSE:[0-9]+]]
+// ASM-LABEL: _D15attr_target_x869foo_nosseFPfPffZv:
+@(target("no-sse\n  , \tsse  "))
+void foo_nosse(float *A, float* B, float K) {
+    for (int i = 0; i < 128; ++i)
+        A[i] *= B[i] + K;
+// ASM-NOT: addps
+}
+// LLVM-LABEL: define{{.*}} void @{{.*}}bar_nosse
+// LLVM-SAME: #[[NOSSE]]
+// ASM-LABEL: _D15attr_target_x869bar_nosseFPfPffZv:
+@(target("sse"))
+@(target("  no-sse"))
+void bar_nosse(float *A, float* B, float K) {
+    for (int i = 0; i < 128; ++i)
+        A[i] *= B[i] + K;
+// ASM-NOT: addps
+}
+
+// LLVM-LABEL: define{{.*}} void @{{.*}}haswell
+// LLVM-SAME: #[[HSW:[0-9]+]]
+// ASM-LABEL: _D15attr_target_x867haswellFPfPffZv:
+@(target("arch=haswell "))
+void haswell(float *A, float* B, float K) {
+    for (int i = 0; i < 128; ++i)
+        A[i] *= B[i] + K;
+// ASM: vaddps
+}
+
+
+// LLVM-DAG: attributes #[[SSE]] = {{.*}} "target-features"="+sse"
+// LLVM-DAG: attributes #[[NOSSE]] = {{.*}} "target-features"="+sse,-sse"
+// LLVM-DAG: attributes #[[HSW]] = {{.*}} "target-cpu"="haswell"


### PR DESCRIPTION
The implementation is rudimentary, but I think it works well enough.
The string passed to target(...) is not checked, and so the user has to be careful in specifying valid options. LLVM does warn on invalid options.
One significant difference with clang is that for the string "sse4.1", this PR will set "target-features" to "+sse4.1", whereas clang will set a long list of features "sse,sse2,sse3,ssse3,sse4.1" and more. From simple testcases, it appears this is not needed for LLVM to do the right thing.
Clang has an elaborate implementation that deals with x86's options, see clang/lib/basic/Targets.cpp. Perhaps that functionality can be moved into LLVM; if not, we will have to copy that code (and keep it up-to-date with the latest microarchitecture...).