### PR TITLE
Do not use global.params.is<OS>

### DIFF
--- a/dmd2/globals.h
+++ b/dmd2/globals.h
@@ -80,13 +80,15 @@ struct Param
 #endif
     bool is64bit;       // generate 64 bit code
     bool isLP64;        // generate code for LP64
+#if !IN_LLVM
     bool isLinux;       // generate code for linux
     bool isOSX;         // generate code for Mac OSX
+#endif
     bool isWindows;     // generate code for Windows
+#if !IN_LLVM
     bool isFreeBSD;     // generate code for FreeBSD
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
-#if !IN_LLVM
     bool mscoff;        // for Win32: write COFF object files instead of OMF
     char useDeprecated; // 0: don't allow use of deprecated features
                         // 1: silently allow use of deprecated features

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -212,7 +212,7 @@ void CodeGenerator::emit(Module *m) {
 
     // On Linux, strongly define the excecutabe BSS bracketing symbols in
     // the main module for druntime use (see rt.sections_linux).
-    if (global.params.isLinux) {
+    if (global.params.targetTriple.isOSLinux()) {
       emitSymbolAddrGlobal(ir_->module, "__bss_start", "_d_execBssBegAddr");
       emitSymbolAddrGlobal(ir_->module, "_end", "_d_execBssEndAddr");
     }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -972,12 +972,7 @@ int main(int argc, char **argv) {
   {
     llvm::Triple triple = llvm::Triple(gTargetMachine->getTargetTriple());
     global.params.targetTriple = triple;
-    global.params.isLinux = triple.getOS() == llvm::Triple::Linux;
-    global.params.isOSX = triple.isMacOSX();
     global.params.isWindows = triple.isOSWindows();
-    global.params.isFreeBSD = triple.getOS() == llvm::Triple::FreeBSD;
-    global.params.isOpenBSD = triple.getOS() == llvm::Triple::OpenBSD;
-    global.params.isSolaris = triple.getOS() == llvm::Triple::Solaris;
     global.params.isLP64 = gDataLayout->getPointerSizeInBits() == 64;
     global.params.is64bit = triple.isArch64Bit();
   }

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -26,7 +26,7 @@ struct X86TargetABI : TargetABI {
   IntegerRewrite integerRewrite;
 
   X86TargetABI()
-      : isOSX(global.params.isOSX),
+      : isOSX(global.params.targetTriple.isMacOSX()),
         isMSVC(global.params.targetTriple.isWindowsMSVCEnvironment()) {
     using llvm::Triple;
     auto os = global.params.targetTriple.getOS();

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -935,7 +935,16 @@ static void genModuleInfo(Module *m, bool emitFullModuleInfo) {
   b.finalize(moduleInfoSym->getType()->getPointerElementType(), moduleInfoSym);
   moduleInfoSym->setLinkage(llvm::GlobalValue::ExternalLinkage);
 
-  if (global.params.isLinux || global.params.isFreeBSD) {
+  if (global.params.targetTriple.isOSLinux() || global.params.targetTriple.isOSFreeBSD() ||
+#if LDC_LLVM_VER > 305
+      global.params.targetTriple.isOSNetBSD() || global.params.targetTriple.isOSOpenBSD() ||
+      global.params.targetTriple.isOSDragonFly()
+#else
+      global.params.targetTriple.getOS() == llvm::Triple::NetBSD ||
+      global.params.targetTriple.getOS() == llvm::Triple::OpenBSD ||
+      global.params.targetTriple.getOS() == llvm::Triple::DragonFly
+#endif
+     ) {
     if (emitFullModuleInfo) {
       build_dso_registry_calls(mangle(m), moduleInfoSym);
     } else {

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -652,7 +652,16 @@ static void buildRuntimeModule() {
       {objectTy});
 
   // void _d_dso_registry(CompilerDSOData* data)
-  if (global.params.isLinux || global.params.isFreeBSD) {
+  if (global.params.targetTriple.isOSLinux() || global.params.targetTriple.isOSFreeBSD() ||
+#if LDC_LLVM_VER > 305
+      global.params.targetTriple.isOSNetBSD() || global.params.targetTriple.isOSOpenBSD() ||
+      global.params.targetTriple.isOSDragonFly()
+#else
+      global.params.targetTriple.getOS() == llvm::Triple::NetBSD ||
+      global.params.targetTriple.getOS() == llvm::Triple::OpenBSD ||
+      global.params.targetTriple.getOS() == llvm::Triple::DragonFly
+#endif
+     ) {
     llvm::StringRef fname("_d_dso_registry");
 
     LLType *LLvoidTy = LLType::getVoidTy(gIR->context());


### PR DESCRIPTION
This PR replaces the few uses of `global.params.is<OS>` with
`global.params.targetTriple.isOS<OS>()`. This avoids adding a new
boolean for each supported OS.
It also defines all xBSD-type OS as using the dso-registry.

Only `global.params.isWindows` is not replaced because it is used by the frontend code.