### PR TITLE
Support Gentoo CHOST triple

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -271,6 +271,11 @@ static FloatABI::Type getARMFloatABI(const llvm::Triple &triple,
     return FloatABI::Soft;
 
   default:
+    if (triple.getVendorName().startswith("hardfloat"))
+      return FloatABI::Hard;
+    if (triple.getVendorName().startswith("softfloat"))
+      return FloatABI::SoftFP;
+
     switch (triple.getEnvironment()) {
     case llvm::Triple::GNUEABIHF:
       return FloatABI::Hard;


### PR DESCRIPTION
The Gentoo CHOST triple differs from the normalized triple used by
LLVM. See https://wiki.gentoo.org/wiki/CHOST for details.

This results in a failure to detect the used float ABI. The vendor
field can be hardfloat or softfloat in order to indicate the float
ABI. This is the only way to specify the hardfloat ABI because the
C library value gnueabihf is not supported.

This commit adds a check for vendor names hardfloat and softfloat.