### PR TITLE
cmake: Detect if llvm assertions enabled

### DIFF
--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -151,6 +151,7 @@ else()
     llvm_set(HOST_TARGET host-target)
     llvm_set(INCLUDE_DIRS includedir true)
     llvm_set(ROOT_DIR prefix true)
+    llvm_set(ENABLE_ASSERTIONS assertion-mode)
 
     if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-2][\\.0-9A-Za-z]*")
         # Versions below 3.3 do not support components objcarcopts, option


### PR DESCRIPTION
Set cmake var LLVM_ENABLE_ASSERTIONS based on llvm-config --assertion-mode.

This is a solution to #1250.

This option isn't in a build I have of llvm 3.4 but it is in my 3.5.1 build.  Does LDC support older LLVM than 3.5.1?
