### PR TITLE
buildRuntimeModule: Always create _d_dso_registry forward decl (small cleanup)

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -652,34 +652,23 @@ static void buildRuntimeModule() {
       {objectTy});
 
   // void _d_dso_registry(CompilerDSOData* data)
-  if (global.params.targetTriple.isOSLinux() || global.params.targetTriple.isOSFreeBSD() ||
-#if LDC_LLVM_VER > 305
-      global.params.targetTriple.isOSNetBSD() || global.params.targetTriple.isOSOpenBSD() ||
-      global.params.targetTriple.isOSDragonFly()
-#else
-      global.params.targetTriple.getOS() == llvm::Triple::NetBSD ||
-      global.params.targetTriple.getOS() == llvm::Triple::OpenBSD ||
-      global.params.targetTriple.getOS() == llvm::Triple::DragonFly
-#endif
-     ) {
-    llvm::StringRef fname("_d_dso_registry");
+  llvm::StringRef fname("_d_dso_registry");
 
-    LLType *LLvoidTy = LLType::getVoidTy(gIR->context());
-    LLType *LLvoidPtrPtrTy = getPtrToType(getPtrToType(LLvoidTy));
-    LLType *moduleInfoPtrPtrTy =
-        getPtrToType(getPtrToType(DtoType(Module::moduleinfo->type)));
+  LLType *LLvoidTy = LLType::getVoidTy(gIR->context());
+  LLType *LLvoidPtrPtrTy = getPtrToType(getPtrToType(LLvoidTy));
+  LLType *moduleInfoPtrPtrTy =
+      getPtrToType(getPtrToType(DtoType(Module::moduleinfo->type)));
 
-    llvm::StructType *dsoDataTy =
-        llvm::StructType::get(DtoSize_t(),        // version
-                              LLvoidPtrPtrTy,     // slot
-                              moduleInfoPtrPtrTy, // _minfo_beg
-                              moduleInfoPtrPtrTy, // _minfo_end
-                              NULL);
+  llvm::StructType *dsoDataTy =
+      llvm::StructType::get(DtoSize_t(),        // version
+                            LLvoidPtrPtrTy,     // slot
+                            moduleInfoPtrPtrTy, // _minfo_beg
+                            moduleInfoPtrPtrTy, // _minfo_end
+                            NULL);
 
-    llvm::Type *types[] = {getPtrToType(dsoDataTy)};
-    llvm::FunctionType *fty = llvm::FunctionType::get(LLvoidTy, types, false);
-    llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
-  }
+  llvm::Type *types[] = {getPtrToType(dsoDataTy)};
+  llvm::FunctionType *fty = llvm::FunctionType::get(LLvoidTy, types, false);
+  llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
 
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The added overhead for Windows et al. is utterly insignificant
compared to all the other typically unused declarations that
will be created by this, and copy/pasting the long condition
(see d072bdf) is error-prone. The alternative would have been
to factor the check out into a predicate function.