### PR TITLE
Extend DtoBitCast() to support aggregate values.

### DIFF
--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -204,8 +204,7 @@ public:
             returnValue =
                 LLConstant::getNullValue(irs->mainFunc->getReturnType());
           } else {
-            returnValue = irs->ir->CreateBitCast(
-                returnValue, irs->topfunc()->getReturnType());
+            returnValue = DtoBitCast(returnValue, irs->topfunc()->getReturnType());
           }
 
           IF_LOG Logger::cout() << "return value after cast: " << *returnValue

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -503,8 +503,14 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const char *name) {
   if (v->getType() == t) {
     return v;
   }
-  assert(!isaStruct(t));
-  return gIR->ir->CreateBitCast(v, t, name);
+  if (isaStruct(t) || isaStruct(v)) {
+    // A bitcast is not allowed for aggregate types. In this case
+    // store the value in memory and reload it.
+    return DtoLoad(DtoAllocaDump(v, t, 0, ".bitcast_dump"));
+  }
+  else {
+    return gIR->ir->CreateBitCast(v, t, name);
+  }
 }
 
 LLConstant *DtoBitCast(LLConstant *v, LLType *t) {


### PR DESCRIPTION
The LLVM instruction bitcast works only on non-aggregate values and types.
As long as struct are stored in memory there is no problem. But if the
struct has integral size (e.g. only an int member) then the value is not
necessarily stored in memory. Nevertheless there may be the need to cast
this value to a different type.
DtoBitCast() is extended to store and reload the value with differnt types
in this case.

This functionality is used to fix issue #1211.