### PR TITLE
DtoCast: Handle struct repainting

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -62,8 +62,7 @@ Type *getTypeInfoType(Type *t, Scope *sc);
 
 LLValue *DtoNew(Loc &loc, Type *newtype) {
   // get runtime function
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_allocmemoryT");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_allocmemoryT");
   // get type info
   LLConstant *ti = DtoTypeInfoOf(newtype);
   assert(isaPointer(ti));
@@ -83,16 +82,14 @@ LLValue *DtoNewStruct(Loc &loc, TypeStruct *newtype) {
 }
 
 void DtoDeleteMemory(Loc &loc, DValue *ptr) {
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_delmemory");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_delmemory");
   LLValue *lval = (ptr->isLVal() ? ptr->getLVal() : makeLValue(loc, ptr));
   gIR->CreateCallOrInvoke(
       fn, DtoBitCast(lval, fn->getFunctionType()->getParamType(0)));
 }
 
 void DtoDeleteStruct(Loc &loc, DValue *ptr) {
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_delstruct");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_delstruct");
   LLValue *lval = (ptr->isLVal() ? ptr->getLVal() : makeLValue(loc, ptr));
   gIR->CreateCallOrInvoke(
       fn, DtoBitCast(lval, fn->getFunctionType()->getParamType(0)),
@@ -101,24 +98,21 @@ void DtoDeleteStruct(Loc &loc, DValue *ptr) {
 }
 
 void DtoDeleteClass(Loc &loc, DValue *inst) {
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_delclass");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_delclass");
   LLValue *lval = (inst->isLVal() ? inst->getLVal() : makeLValue(loc, inst));
   gIR->CreateCallOrInvoke(
       fn, DtoBitCast(lval, fn->getFunctionType()->getParamType(0)));
 }
 
 void DtoDeleteInterface(Loc &loc, DValue *inst) {
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_delinterface");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_delinterface");
   LLValue *lval = (inst->isLVal() ? inst->getLVal() : makeLValue(loc, inst));
   gIR->CreateCallOrInvoke(
       fn, DtoBitCast(lval, fn->getFunctionType()->getParamType(0)));
 }
 
 void DtoDeleteArray(Loc &loc, DValue *arr) {
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_delarray_t");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_delarray_t");
   llvm::FunctionType *fty = fn->getFunctionType();
 
   // the TypeInfo argument must be null if the type has no dtor
@@ -182,8 +176,7 @@ llvm::AllocaInst *DtoRawAlloca(LLType *lltype, size_t alignment,
 
 LLValue *DtoGcMalloc(Loc &loc, LLType *lltype, const char *name) {
   // get runtime function
-  llvm::Function *fn =
-      getRuntimeFunction(loc, gIR->module, "_d_allocmemory");
+  llvm::Function *fn = getRuntimeFunction(loc, gIR->module, "_d_allocmemory");
   // parameters
   LLValue *size = DtoConstSize_t(getTypeAllocSize(lltype));
   // call runtime allocator
@@ -1373,7 +1366,6 @@ LLValue *makeLValue(Loc &loc, DValue *value) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void callPostblit(Loc &loc, Expression *exp, LLValue *val) {
-
   Type *tb = exp->type->toBasetype();
   if ((exp->op == TOKvar || exp->op == TOKdotvar || exp->op == TOKstar ||
        exp->op == TOKthis || exp->op == TOKindex) &&

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -499,7 +499,7 @@ void DtoAlignedStore(LLValue *src, LLValue *dst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoBitCast(LLValue *v, LLType *t, const char *name) {
+LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
   if (v->getType() == t) {
     return v;
   }

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -100,7 +100,7 @@ void DtoStore(LLValue *src, LLValue *dst);
 void DtoVolatileStore(LLValue *src, LLValue *dst);
 void DtoStoreZextI8(LLValue *src, LLValue *dst);
 void DtoAlignedStore(LLValue *src, LLValue *dst);
-LLValue *DtoBitCast(LLValue *v, LLType *t, const char *name = "");
+LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name = "");
 LLConstant *DtoBitCast(LLConstant *v, LLType *t);
 LLValue *DtoInsertValue(LLValue *aggr, LLValue *v, unsigned idx,
                         const char *name = "");


### PR DESCRIPTION
Previously, we would just ignore such casts altogether, leading to problems down the road when we would actually load the alloca/… for the source struct.

Fixes #1211.