### PR TITLE
fix tilde expansion

### DIFF
--- a/dmd2/root/filename.c
+++ b/dmd2/root/filename.c
@@ -96,6 +96,21 @@ Strings *FileName::splitPath(const char *path)
             while (isspace((utf8_t)*p))         // skip leading whitespace
                 p++;
             buf.reserve(strlen(p) + 1); // guess size of path
+
+#if POSIX
+           if (*p == '~') // Only replace tilde on first char
+           {
+               if (*(p+1) == '/') // and only if next char is path separator
+               {
+                   char *home = getenv("HOME");
+                   if (home)
+                       buf.writestring(home);
+               } else
+                   buf.writestring("~");
+           }
+#endif
+
+
             for (; ; p++)
             {
                 c = *p;
@@ -124,18 +139,6 @@ Strings *FileName::splitPath(const char *path)
 
                     case '\r':
                         continue;       // ignore carriage returns
-
-#if POSIX
-                    case '~':
-                    {
-                        char *home = getenv("HOME");
-                        if (home)
-                            buf.writestring(home);
-                        else
-                            buf.writestring("~");
-                        continue;
-                    }
-#endif
 
 #if 0
                     case ' ':


### PR DESCRIPTION
While building the debian package for 0.17.0~beta1 (for various reasons beta versions need to be prefixed with ~ so that they get superceeded by normal releases) the build failed. Tracking down the issue revealed that tilde expansion is done wrong in dmd, breaking the build. According the POSIX spec, tilde expansion can occur only in the beginning of the path and only if the next char is a path separator, so I took the liberty of fixing a patch, which fixes the debian package build -which is now being uploaded in unstable.

Feel free to make any modifications in case I have missed something.
