### PR TITLE
Implement ARM AAPCS ABI and other ARM fixes

### DIFF
--- a/gen/abi-arm.h
+++ b/gen/abi-arm.h
@@ -1,0 +1,21 @@
+//===-- gen/abi-arm.h - ARM ABI description -------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// The ABI implementation used for ARM targets.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_GEN_ABI_ARM_H
+#define LDC_GEN_ABI_ARM_H
+
+struct TargetABI;
+
+TargetABI *getArmTargetABI();
+
+#endif

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -12,6 +12,7 @@
 #include "id.h"
 #include "gen/abi-generic.h"
 #include "gen/abi-aarch64.h"
+#include "gen/abi-arm.h"
 #include "gen/abi-mips64.h"
 #include "gen/abi-ppc64.h"
 #include "gen/abi-win64.h"
@@ -96,6 +97,113 @@ LLValue *ABIRewrite::loadFromMemory(LLValue *address, LLType *asType,
 }
 
 //////////////////////////////////////////////////////////////////////////////
+
+// A Homogeneous Floating-point Aggregate (HFA) is an ARM/AArch64 concept that
+// consists of up to 4 of same floating point type.  D floats of same size are
+// considered as same (e.g. ifloat and float are same).  It is the aggregate
+// final data layout that matters so nested structs, unions, and sarrays can
+// result in an HFA.
+//
+// simple HFAs: struct F1 {float f;}  struct D4 {double a,b,c,d;}
+// interesting HFA: struct {F1[2] vals; float weight;}
+
+namespace {
+bool isNestedHFA(const TypeStruct *t, d_uns64 &floatSize, int &num,
+                 uinteger_t adim) {
+  // Used internally by isHFA() to check struct recursively for HFA-ness.
+  // Return true if struct 't' is part of an HFA where 'floatSize' is sizeof
+  // the float and 'num' is number of these floats so far.  On return, 'num'
+  // is updated to the total number of floats in the HFA.  Set 'floatSize'
+  // to 0 discover the sizeof the float.  When struct 't' is part of an
+  // sarray, 'adim' is the dimension of that array, otherwise it is 1.
+  VarDeclarations fields = t->sym->fields;
+
+  // HFA can't contains an empty struct
+  if (fields.dim == 0)
+    return false;
+
+  // Accumulate number of floats in HFA
+  int n;
+
+  // For unions, need to find field with most floats
+  int maxn = num;
+
+  for (size_t i = 0; i < fields.dim; ++i) {
+    Type *field = fields[i]->type;
+
+    // reset to initial num floats (all union fields are at offset 0)
+    if (fields[i]->offset == 0)
+      n = num;
+
+    // reset dim to dimension of sarray we are in (will be 1 if not)
+    uinteger_t dim = adim;
+
+    // Field is an array.  Process the arrayof type and multiply dim by
+    // array dim.  Note that empty arrays immediately exclude this struct
+    // from HFA status.
+    if (field->ty == Tsarray) {
+      TypeSArray *array = (TypeSArray *)field;
+      if (array->dim->toUInteger() == 0)
+        return false;
+      field = array->nextOf();
+      dim *= array->dim->toUInteger();
+    }
+
+    if (field->ty == Tstruct) {
+      if (!isNestedHFA((TypeStruct *)field, floatSize, n, dim))
+        return false;
+    } else if (field->isfloating()) {
+      d_uns64 sz = field->size();
+      n += dim;
+
+      if (field->iscomplex()) {
+        sz /= 2; // complex is 2 floats, adjust sz
+        n += dim;
+      }
+
+      if (floatSize == 0) // discovered floatSize
+        floatSize = sz;
+      else if (sz != floatSize) // different float size, reject
+        return false;
+
+      if (n > 4)
+        return false; // too many floats for HFA, reject
+    } else {
+      return false; // reject all other types
+    }
+
+    if (n > maxn)
+      maxn = n;
+  }
+
+  num = maxn;
+  return true;
+}
+}
+
+bool TargetABI::isHFA(TypeStruct *t, llvm::Type **rewriteType) {
+  d_uns64 floatSize = 0;
+  int num = 0;
+
+  if (isNestedHFA(t, floatSize, num, 1)) {
+    if (rewriteType) {
+      llvm::Type *floatType = nullptr;
+      switch (floatSize) {
+      case 4:
+        floatType = llvm::Type::getFloatTy(gIR->context());
+        break;
+      case 8:
+        floatType = llvm::Type::getDoubleTy(gIR->context());
+        break;
+      default:
+        llvm_unreachable("Unexpected size for float type");
+      }
+      *rewriteType = LLArrayType::get(floatType, num);
+    }
+    return true;
+  }
+  return false;
+}
 
 bool TargetABI::isAggregate(Type *t) {
   TY ty = t->toBasetype()->ty;
@@ -235,6 +343,9 @@ TargetABI *TargetABI::getTarget() {
   case llvm::Triple::aarch64:
   case llvm::Triple::aarch64_be:
     return getAArch64TargetABI();
+  case llvm::Triple::arm:
+  case llvm::Triple::thumb:
+    return getArmTargetABI();
   default:
     Logger::cout() << "WARNING: Unknown ABI, guessing...\n";
     return new UnknownTargetABI;

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -23,6 +23,7 @@
 
 class Type;
 class TypeFunction;
+class TypeStruct;
 struct IrFuncTy;
 struct IrFuncTyArg;
 class DValue;
@@ -148,8 +149,14 @@ struct TargetABI {
   /// Must match the alias in druntime.
   virtual Type *vaListType();
 
-protected:
   /***** Static Helpers *****/
+
+  /// Check if struct 't' is a Homogeneous Floating-point Aggregate (HFA)
+  /// consisting of up to 4 of same floating point type.  If so, optionally
+  /// produce the rewriteType: an array of that floating point type
+  static bool isHFA(TypeStruct *t, llvm::Type **rewriteType = nullptr);
+
+protected:
 
   /// Returns true if the D type is an aggregate:
   /// * struct


### PR DESCRIPTION
This is the bulk of the AAPCS (Procedure Call Standard for the ARM Architecture) used for C interop.  This will be used for both arm and thumb target triples.  The extern(D) ABI tries to follows the AAPCS with a few exceptions.
