### PR TITLE
Fix non-x86 __traits compiles for dmd inline asm

### DIFF
--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -133,7 +133,10 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
     err = true;
   }
   if (err) {
-    fatal();
+    if (!global.gag) {
+      fatal();
+    }
+    return s;
   }
 
   // puts(toChars());


### PR DESCRIPTION
Allow asm statement to be tested in a __traits compiles check without fataling for those targets that don't support dmd style inline asm.  Without this, a compile could exit(1) mysteriously without any error messages.

Fixes runnable/testsafe.d on ARM and probably all other non-X86 targets.
