### PR TITLE
Change initialization of IrDsymbol.irData.

### DIFF
--- a/ir/irdsymbol.cpp
+++ b/ir/irdsymbol.cpp
@@ -23,7 +23,9 @@ void IrDsymbol::resetAll() {
   }
 }
 
-IrDsymbol::IrDsymbol() { list.push_back(this); }
+IrDsymbol::IrDsymbol() : irData(nullptr) {
+  list.push_back(this);
+}
 
 IrDsymbol::IrDsymbol(const IrDsymbol &s) {
   list.push_back(this);

--- a/ir/irdsymbol.h
+++ b/ir/irdsymbol.h
@@ -83,7 +83,7 @@ private:
   friend IrField *getIrField(VarDeclaration *decl, bool create);
 
   union {
-    void *irData = nullptr;
+    void *irData;
     IrModule *irModule;
     IrAggr *irAggr;
     IrFunction *irFunc;


### PR DESCRIPTION
This fixes an assertion failure on Linux/AArch64 (Ubuntu) and on
Linux/PPC64 (RedHat).