### PR TITLE
Run semantic on Type::tvalist.

### DIFF
--- a/dmd2/func.c
+++ b/dmd2/func.c
@@ -1497,7 +1497,11 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (f->linkage == LINKd || (f->parameters && Parameter::dim(f->parameters)))
             {
                 // Declare _argptr
+#if IN_LVVM
+                Type *t = Type::tvalist->semantic(loc, sc);
+#else
                 Type *t = Type::tvalist;
+#endif
                 argptr = new VarDeclaration(Loc(), t, Id::_argptr, NULL);
                 argptr->storage_class |= STCtemp;
                 argptr->semantic(sc2);

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -111,8 +111,7 @@ struct AArch64TargetABI : TargetABI {
     // using TypeIdentifier here is a bit wonky but works, as long as the name
     // is actually available in the scope (this is what DMD does, so if a better
     // solution is found there, this should be adapted).
-    return (new TypeIdentifier(Loc(), Identifier::idPool("__va_list_tag")))
-        ->pointerTo();
+    return (new TypeIdentifier(Loc(), Identifier::idPool("__va_list")));
   }
 };
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -882,7 +882,7 @@ void DtoDefineFunction(FuncDeclaration *fd) {
     // D varargs: prepare _argptr and _arguments
     if (f->linkage == LINKd && f->varargs == 1) {
       // allocate _argptr (of type core.stdc.stdarg.va_list)
-      LLValue *argptrmem = DtoAlloca(Type::tvalist, "_argptr_mem");
+      LLValue *argptrmem = DtoAlloca(Type::tvalist->semantic(fd->loc, fd->scope), "_argptr_mem");
       irFunc->_argptr = argptrmem;
 
       // initialize _argptr with a call to the va_start intrinsic


### PR DESCRIPTION
This is required to resolve the type for AAPCS/AAPCS64.
Up to now it was not necessary because only char* was used.
AAPCS/AAPCS64 use a special extern(C++) struct __va_list.