### PR TITLE
AArch64: This platform uses IEEE 128-bit floats.

### DIFF
--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -406,6 +406,14 @@ LLConstant *DtoConstFP(Type *t, longdouble value) {
     return LLConstantFP::get(gIR->context(), APFloat(APFloat::x87DoubleExtended,
                                                      APInt(80, 2, bits)));
   }
+  if (llty == LLType::getFP128Ty(gIR->context())) {
+    uint64_t bits[] = { 0, 0 };
+    bits[0] = *reinterpret_cast<uint64_t *>(&value);
+    bits[1] =
+      *reinterpret_cast<uint16_t *>(reinterpret_cast<uint64_t *>(&value) + 1);
+    return LLConstantFP::get(
+      gIR->context(), APFloat(APFloat::IEEEquad, APInt(128, 2, bits)));
+  }
   if (llty == LLType::getPPC_FP128Ty(gIR->context())) {
     uint64_t bits[] = {0, 0};
     bits[0] = *reinterpret_cast<uint64_t *>(&value);

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -48,10 +48,19 @@ namespace {
 llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
   llvm::Triple::ArchType const a = global.params.targetTriple.getArch();
   bool const anyX86 = (a == llvm::Triple::x86) || (a == llvm::Triple::x86_64);
+  bool const anyAarch64 = (a == llvm::Triple::aarch64) || (a == llvm::Triple::aarch64_be)
+#if LDC_LLVM_VER == 305
+                       || (a == llvm::Triple::arm64) || (a == llvm::Triple::arm64_be)
+#endif
+    ;
 
   // only x86 has 80bit float - but no support with MS C Runtime!
   if (anyX86 && !global.params.targetTriple.isWindowsMSVCEnvironment()) {
     return llvm::Type::getX86_FP80Ty(ctx);
+  }
+
+  if (anyAarch64) {
+    return llvm::Type::getFP128Ty(ctx);
   }
 
   return llvm::Type::getDoubleTy(ctx);


### PR DESCRIPTION
This adds the missing code paths.