### PR TITLE
More (or less) Objective-C Stuff

### DIFF
--- a/ddmd/globals.d
+++ b/ddmd/globals.d
@@ -200,6 +200,7 @@ struct Param
         OUTPUTFLAG output_o;
         bool useInlineAsm;
         bool verbose_cg;
+        bool hasObjectiveC;
 
         // target stuff
         const(void)* targetTriple; // const llvm::Triple*

--- a/ddmd/globals.h
+++ b/ddmd/globals.h
@@ -199,6 +199,7 @@ struct Param
     OUTPUTFLAG output_o;
     bool useInlineAsm;
     bool verbose_cg;
+    bool hasObjectiveC;
 
     const llvm::Triple *targetTriple;
 

--- a/ddmd/objc.d
+++ b/ddmd/objc.d
@@ -145,13 +145,21 @@ struct Objc_FuncDeclaration
 // MARK: semantic
 extern (C++) void objc_ClassDeclaration_semantic_PASSinit_LINKobjc(ClassDeclaration cd)
 {
-    cd.objc.objc = true;
+    if (global.params.hasObjectiveC)
+        cd.objc.objc = true;
+    else
+        cd.error("Objective-C classes not supported");
 }
 
 extern (C++) void objc_InterfaceDeclaration_semantic_objcExtern(InterfaceDeclaration id, Scope* sc)
 {
     if (sc.linkage == LINKobjc)
-        id.objc.objc = true;
+    {
+        if (global.params.hasObjectiveC)
+            id.objc.objc = true;
+        else
+            id.error("Objective-C interfaces not supported");
+    }
 }
 
 // MARK: semantic

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -766,7 +766,6 @@ static void registerPredefinedTargetVersions() {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
     VersionCondition::addPredefinedGlobalIdent("OSX");
-    VersionCondition::addPredefinedGlobalIdent("D_ObjectiveC");
     VersionCondition::addPredefinedGlobalIdent(
         "darwin"); // For backwards compatibility.
     VersionCondition::addPredefinedGlobalIdent("Posix");
@@ -832,6 +831,10 @@ static void registerPredefinedVersions() {
   }
 
   registerPredefinedTargetVersions();
+
+  if (global.params.hasObjectiveC) {
+    VersionCondition::addPredefinedGlobalIdent("D_ObjectiveC");
+  }
 
   // Pass sanitizer arguments to linker. Requires clang.
   if (opts::sanitize == opts::AddressSanitizer) {
@@ -999,6 +1002,7 @@ int main(int argc, char **argv) {
     global.params.isWindows = triple->isOSWindows();
     global.params.isLP64 = gDataLayout->getPointerSizeInBits() == 64;
     global.params.is64bit = triple->isArch64Bit();
+    global.params.hasObjectiveC = objc_isSupported(*triple);
   }
 
   // allocate the target abi
@@ -1023,8 +1027,8 @@ int main(int argc, char **argv) {
   Module::_init();
   Target::_init();
   Expression::_init();
-  objc_init();
   builtin_init();
+  objc_init();
   initTraitsStringTable();
 
   // Build import search path

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -289,8 +289,12 @@ llvm::FunctionType *DtoFunctionType(FuncDeclaration *fdecl) {
     dnest = Type::tvoid->pointerTo();
   }
 
-  if (fdecl->objc.selector) {
+  if (fdecl->linkage == LINKobjc && dthis) {
+    if (fdecl->objc.selector) {
       hasSel = true;
+    } else if (ClassDeclaration *cd = fdecl->parent->isClassDeclaration()) {
+      fdecl->error("Objective-C @selector is missing");
+    }
   }
 
   LLFunctionType *functype = DtoFunctionType(

--- a/gen/objcgen.h
+++ b/gen/objcgen.h
@@ -18,8 +18,10 @@ class Type;
 struct ObjcSelector;
 namespace llvm {
 class GlobalVariable;
+class Triple;
 }
 
+bool objc_isSupported(const llvm::Triple &triple);
 void objc_init();
 const char *objc_getMsgSend(Type *ret, bool hasHiddenArg);
 void objc_Module_genmoduleinfo_classes();

--- a/gen/objcgen.h
+++ b/gen/objcgen.h
@@ -1,14 +1,28 @@
+//===-- gen/objcgen.cpp -----------------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions for generating Objective-C method calls.
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef LDC_GEN_OBJCGEN_H
 #define LDC_GEN_OBJCGEN_H
 
-#include "gen/llvm.h"
-
 class Type;
 struct ObjcSelector;
+namespace llvm {
+class GlobalVariable;
+}
 
 void objc_init();
-const char* objc_getMsgSend(Type *ret, bool hasHiddenArg);
+const char *objc_getMsgSend(Type *ret, bool hasHiddenArg);
 void objc_Module_genmoduleinfo_classes();
-LLGlobalVariable *objc_getMethVarRef(const ObjcSelector &sel);
+llvm::GlobalVariable *objc_getMethVarRef(const ObjcSelector &sel);
 
 #endif // LDC_GEN_OBJCGEN_H


### PR DESCRIPTION
Experiment with letting LLVM generate image info based on module flags.  Probably the way to go.

I am not sure if doing pull requests or pushing directly to objc-wip branch is best.  I imagine incremental improvements over the next week or so.

Are we supposed to make -m32 x86 work too?  I noticed test suite Makefile only enables objc tests for 64-bit.

edit:  dmd -m32 doesn't make a working objc call.  In ldc, I got it to work by using the fragile ABI section names with -m32.  Is there any reason not to support x86?