### PR TITLE
Support ARM AAPCS style va_list for C++ mangling

### DIFF
--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -139,6 +139,20 @@ struct ArmTargetABI : TargetABI {
       }
     }
   }
+
+  void vaCopy(LLValue *pDest, LLValue *src) {
+    // simply bitcopy src over dest.  src is __va_list*, so need load
+    auto srcval = DtoLoad(src);
+    DtoStore(srcval, pDest);
+  }
+
+  Type *vaListType() override {
+    // We need to pass the actual va_list type for correct mangling. Simply
+    // using TypeIdentifier here is a bit wonky but works, as long as the name
+    // is actually available in the scope (this is what DMD does, so if a better
+    // solution is found there, this should be adapted).
+    return (new TypeIdentifier(Loc(), Identifier::idPool("__va_list")));
+  }
 };
 
 TargetABI *getArmTargetABI() { return new ArmTargetABI; }


### PR DESCRIPTION
AAPCS defines va_list as a std::__va_list struct, which is needed to interface with C++.   This builds on @redstar 's recent change for AArch64 which has a similar situation, although AAPCS __va_list is not as complicated.  With this, test runnable/cppa passes.

Needs to be pulled with ldc-developers/druntime#64.

Now runnable/test42.d will need a fix for ARM because va_list is no longer a simple pointer.  Coming in the next few days.
