### PR TITLE
MSVC: Limit debug info symbol names to ~64k

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,8 +105,6 @@ build_script:
   - md ninja-ldc
   - cd ninja-ldc
   - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
-  # Work around LDC issue #930
-  - ps: (gc build.ninja).replace('runtime/std/string-unittest-debug.obj -w -d -g -link-debuglib -unittest', 'runtime/std/string-unittest-debug.obj -w -d -link-debuglib -unittest') | sc build.ninja
   # Build LDC, druntime and phobos
   - ninja -j2
 


### PR DESCRIPTION
A limitation of the MS linker/COFF format and enforced by LLVM.
Fixes issue #930.