### PR TITLE
Use build host D real type [was ARM/AArch64 updates to master (support 64-bit/128-bit real type)]

### DIFF
--- a/ddmd/root/port.d
+++ b/ddmd/root/port.d
@@ -84,20 +84,6 @@ extern (C++) struct Port
         static __gshared bool yl2xp1_supported = false;
     }
     static __gshared real snan;
-    static this()
-    {
-        /*
-         * Use a payload which is different from the machine NaN,
-         * so that uninitialised variables can be
-         * detected even if exceptions are disabled.
-         */
-        ushort* us = cast(ushort*)&snan;
-        us[0] = 0;
-        us[1] = 0;
-        us[2] = 0;
-        us[3] = 0xA000;
-        us[4] = 0x7FFF;
-    }
 
     static bool isNan(double r)
     {
@@ -114,9 +100,11 @@ extern (C++) struct Port
         return a % b;
     }
 
-    static real fequal(real a, real b)
+    static bool fequal(real a, real b)
     {
-        return memcmp(&a, &b, 10) == 0;
+        // don't compare pad bytes in extended precision
+        enum sz = (real.mant_dig == 64) ? 10 : real.sizeof;
+        return memcmp(&a, &b, sz) == 0;
     }
 
     static int memicmp(const char* s1, const char* s2, size_t n)


### PR DESCRIPTION
master builds on ARM and phobos hello world works.  Now need to get ARM tests working, starting by putting 64-bit real support back in root/port.d.

Note there is more stuff in previous port.c C++ version that needs to move up to D version, such as supporting big endian.

edit: this has morphed into something simpler - just use real type of the build host D compiler.  It is needed on all the non-x86 hosts until real type cross-compiling is supported.