### PR TITLE
Enable MSVC EH for Win64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,16 +17,24 @@ os: Visual Studio 2015
 environment:
   matrix:
     - APPVEYOR_JOB_CONFIG: Debug
+      APPVEYOR_JOB_ARCH:   x64
     - APPVEYOR_JOB_CONFIG: Release
+      APPVEYOR_JOB_ARCH:   x64
+    - APPVEYOR_JOB_CONFIG: Debug
+      APPVEYOR_JOB_ARCH:   x86
+    - APPVEYOR_JOB_CONFIG: Release
+      APPVEYOR_JOB_ARCH:   x86
 
 matrix:
   allow_failures:
     - APPVEYOR_JOB_CONFIG: Release
+    - APPVEYOR_JOB_ARCH: x86
 
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
-  - call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64 )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 )
   # Print environment info
   - set
   - msbuild /version
@@ -46,15 +54,16 @@ install:
   - cd libconfig
   - git checkout 7585cf6
   - cd ..
-  ## Download & extract LLVM source
-  #- ps: Start-FileDownload 'http://llvm.org/pre-releases/3.7.0/rc3/llvm-3.7.0rc3.src.tar.xz' -FileName 'llvm.src.tar.xz'
-  #- 7z x llvm.src.tar.xz -so | 7z x -si -ttar > nul
-  #- ren llvm-3.7.0rc3.src llvm
-  # Download a pre-built LLVM & extract
-  - ps: Start-FileDownload 'https://dl.dropboxusercontent.com/s/5cok3dvmohtduy6/llvm-x64-release.7z?dl=0' -FileName 'llvm-x64.7z'
-  - md llvm-x64
-  - cd llvm-x64
-  - 7z x ..\llvm-x64.7z > nul
+  # Download a pre-built LLVM (CMAKE_BUILD_TYPE=Release) & extract
+  - ps: |
+        If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/37fhk1z2k8b03d4/LLVM-a5b740a-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+        } Else {
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/ne10suiupnzy041/LLVM-a5b740a-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+        }
+  - md llvm-%APPVEYOR_JOB_ARCH%
+  - cd llvm-%APPVEYOR_JOB_ARCH%
+  - 7z x ..\llvm-%APPVEYOR_JOB_ARCH%.7z > nul
   - cd ..
   # Download & install Ninja
   - ps: Start-FileDownload 'https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
@@ -71,19 +80,18 @@ install:
   - 7z x ..\libcurl.zip > nul
   - cd ..
   # Copy libcurl.dll to final LDC installation directory and add to PATH
-  - md ldc-x64
-  - md ldc-x64\bin
-  - copy libcurl\dmd2\windows\bin64\libcurl.dll ldc-x64\bin
-  - set PATH=c:\projects\ldc-x64\bin;%PATH%
+  - md ldc-%APPVEYOR_JOB_ARCH% && md ldc-%APPVEYOR_JOB_ARCH%\bin
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( copy libcurl\dmd2\windows\bin64\libcurl.dll ldc-x64\bin )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( copy libcurl\dmd2\windows\bin\libcurl.dll ldc-x86\bin )
+  - set PATH=c:\projects\ldc-%APPVEYOR_JOB_ARCH%\bin;%PATH%
   # Install lit
   - python -m pip install lit
   - python -c "import lit; lit.main();" --version
   # Download & extract DMD
   - ps: Start-FileDownload 'http://downloads.dlang.org/releases/2015/dmd.2.069.2.windows.7z' -FileName 'dmd2.7z'
   - 7z x dmd2.7z > nul
-  - set PATH=%PATH%;c:\projects\dmd2\windows\bin
-  - set DC=c:\projects\dmd2\windows\bin\dmd.exe
-  - dmd --version
+  - set DMD=c:\projects\dmd2\windows\bin\dmd.exe
+  - c:\projects\dmd2\windows\bin\dmd.exe --version
 
 #---------------------------------#
 #       build configuration       #
@@ -92,19 +100,16 @@ install:
 before_build:
   - cd c:\projects
   # Build libconfig
-  - msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64
-  ## Generate build files for LLVM, build & install
-  #- md ninja-llvm
-  #- cd ninja-llvm
-  #- cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\llvm-x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_APPEND_VC_REV=ON ..\llvm
-  #- ninja install
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=x64 )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( msbuild libconfig\lib\libconfig.vcxproj /p:Configuration=ReleaseStatic /p:Platform=Win32 )
 
 build_script:
   - cd c:\projects
   # Generate build files for LDC
   - md ninja-ldc
   - cd ninja-ldc
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x86 -DLLVM_ROOT_DIR=c:/projects/llvm-x86 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/ReleaseStatic/libconfig.lib ..\ldc )
   # Build LDC, druntime and phobos
   - ninja -j2
 
@@ -115,9 +120,9 @@ after_build:
             echo 'Preparing artifact...'
             cd c:\projects\ninja-ldc
             ninja install > $null
-            copy bin\ldc2.pdb ..\ldc-x64\bin
-            cd ..\ldc-x64
-            (gc etc\ldc2.conf).replace('C:/projects/ldc-x64/', '%%ldcbinarypath%%/../') | sc etc\ldc2.conf
+            copy bin\ldc2.pdb "..\ldc-$Env:APPVEYOR_JOB_ARCH\bin"
+            cd "..\ldc-$Env:APPVEYOR_JOB_ARCH"
+            (gc etc\ldc2.conf).replace("C:/projects/ldc-$Env:APPVEYOR_JOB_ARCH/", '%%ldcbinarypath%%/../') | sc etc\ldc2.conf
             $artifactFilename = "LDC-Win64-master-$Env:APPVEYOR_BUILD_NUMBER.7z"
             7z a "..\$artifactFilename" * > $null
             cd ..
@@ -133,7 +138,7 @@ test_script:
   - bin\ldc2 -version
   # Compile, link & execute a hello-world program
   - ps: 'echo "import std.stdio; void main() { writeln(""Hello world!""); }" > hello.d'
-  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( bin\ldc2 -g hello.d ) else ( bin\ldc2 hello.d )
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( bin\ldc2 -g -link-debuglib hello.d ) else ( bin\ldc2 -O3 -release hello.d )
   - hello.exe
   # Compile the druntime & phobos unit tests
   - set TEST_SUFFIX=unittest
@@ -164,3 +169,4 @@ deploy:
   on:
     branch: master
     APPVEYOR_JOB_CONFIG: Debug
+    APPVEYOR_JOB_ARCH:   x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,17 +18,16 @@ environment:
   matrix:
     - APPVEYOR_JOB_CONFIG: Debug
       APPVEYOR_JOB_ARCH:   x64
-    - APPVEYOR_JOB_CONFIG: Release
-      APPVEYOR_JOB_ARCH:   x64
     - APPVEYOR_JOB_CONFIG: Debug
       APPVEYOR_JOB_ARCH:   x86
+    - APPVEYOR_JOB_CONFIG: Release
+      APPVEYOR_JOB_ARCH:   x64
     - APPVEYOR_JOB_CONFIG: Release
       APPVEYOR_JOB_ARCH:   x86
 
 matrix:
   allow_failures:
     - APPVEYOR_JOB_CONFIG: Release
-    - APPVEYOR_JOB_ARCH: x86
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -57,9 +56,9 @@ install:
   # Download a pre-built LLVM (CMAKE_BUILD_TYPE=Release) & extract
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/una5bc049qw92k4/LLVM-dbe4385-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/gsgyy2k3nw7c8jc/LLVM-fa4edb6-x64.7z?dl=0' -FileName 'llvm-x64.7z'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/3xj7gllo0sg9901/LLVM-dbe4385-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/txrug8g1707bc59/LLVM-fa4edb6-x86.7z?dl=0' -FileName 'llvm-x86.7z'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%
@@ -123,7 +122,7 @@ after_build:
             copy bin\ldc2.pdb "..\ldc-$Env:APPVEYOR_JOB_ARCH\bin"
             cd "..\ldc-$Env:APPVEYOR_JOB_ARCH"
             (gc etc\ldc2.conf).replace("C:/projects/ldc-$Env:APPVEYOR_JOB_ARCH/", '%%ldcbinarypath%%/../') | sc etc\ldc2.conf
-            $artifactFilename = "LDC-Win64-master-$Env:APPVEYOR_BUILD_NUMBER.7z"
+            $artifactFilename = "LDC-master-$Env:APPVEYOR_BUILD_NUMBER-$Env:APPVEYOR_JOB_ARCH.7z"
             7z a "..\$artifactFilename" * > $null
             cd ..
             Push-AppveyorArtifact $artifactFilename
@@ -146,12 +145,17 @@ test_script:
   # (pre-build some modules serially - those known to require lots of memory)
   - ninja -j1 runtime\std\algorithm\searching-%TEST_SUFFIX%.obj runtime\std\algorithm\setops-%TEST_SUFFIX%.obj runtime\std\array-%TEST_SUFFIX%.obj runtime\std\conv-%TEST_SUFFIX%.obj runtime\std\datetime-%TEST_SUFFIX%.obj runtime\std\range\package-%TEST_SUFFIX%.obj runtime\std\range\primitives-%TEST_SUFFIX%.obj runtime\std\regex\internal\tests-%TEST_SUFFIX%.obj runtime\std\string-%TEST_SUFFIX%.obj runtime\std\traits-%TEST_SUFFIX%.obj
   - ninja -j2 druntime-ldc-%TEST_SUFFIX% phobos2-ldc-%TEST_SUFFIX%
-  # Execute the unit tests; exclude dmd-testsuite for now
-  - set CTEST_SUFFIX=-E "-debug|testsuite"
-  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug -E testsuite)
+  # Execute the unit tests
+  - set CTEST_SUFFIX=-E "-debug|dmd-testsuite|lit-tests"
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug -E "dmd-testsuite|lit-tests")
   - ctest --output-on-failure %CTEST_SUFFIX%
-  # Execute the LLVM IR tests
-  - ctest --output-on-failure -R lit-tests
+  # Execute the LLVM IR tests (excluded for Debug x86 job due to LDC issue #1356)
+  - ps: |
+        If ($Env:APPVEYOR_JOB_CONFIG -eq 'Debug' -And $Env:APPVEYOR_JOB_ARCH -eq 'x86') {
+        } Else {
+            ctest --output-on-failure -R lit-tests
+        }
+  # Exclude dmd-testsuite for now
 
 #---------------------------------#
 #     deployment configuration    #
@@ -159,14 +163,13 @@ test_script:
 
 deploy:
   release: 'LDC Win64 master'
-  description: "Latest successful Win64 CI builds of branch 'master'"
+  description: "Latest successful Windows CI builds of branch 'master'"
   provider: GitHub
   auth_token:
     secure: qnbD8agL9mr0SFvy/sMkR2E29oQQ427T5zYwVVZkjRS3IZ361tG+9jlSiyEkyULy
-  artifact: LDC-Win64-master-$(APPVEYOR_BUILD_NUMBER).7z
+  artifact: LDC-master-$(APPVEYOR_BUILD_NUMBER)-$(APPVEYOR_JOB_ARCH).7z
   draft: true
   prerelease: true
   on:
     branch: master
     APPVEYOR_JOB_CONFIG: Debug
-    APPVEYOR_JOB_ARCH:   x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,7 @@ install:
   - 7z x ..\make.7z > nul
   - bin\make --version
   - cd ..
-  # Download a pre-built LLVM (CMAKE_BUILD_TYPE=Release) & extract
+  # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
             Start-FileDownload 'https://dl.dropboxusercontent.com/s/gsgyy2k3nw7c8jc/LLVM-fa4edb6-x64.7z?dl=0' -FileName 'llvm-x64.7z'
@@ -162,16 +162,13 @@ test_script:
   - set CTEST_SUFFIX=-E "-debug|dmd-testsuite|lit-tests"
   - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug -E "dmd-testsuite|lit-tests")
   - ctest --output-on-failure %CTEST_SUFFIX%
-  # Execute the LLVM IR tests (excluded for Debug x86 job due to LDC issue #1356)
-  - ps: |
-        If ($Env:APPVEYOR_JOB_CONFIG -eq 'Debug' -And $Env:APPVEYOR_JOB_ARCH -eq 'x86') {
-        } Else {
-            ctest --output-on-failure -R lit-tests
-        }
-  # Execute dmd-testsuite, but ignore failures for now
+  # Execute the LLVM IR tests; ignore failures for x86 jobs due to LDC issue #1356
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( ctest --output-on-failure -R lit-tests || set ERRORLEVEL=0)
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( ctest --output-on-failure -R lit-tests )
+  # Execute dmd-testsuite
   - if "%APPVEYOR_JOB_ARCH%"=="x64" ( set OS=Win_64) else ( set OS=Win_32)
-  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( ctest --verbose -R dmd-testsuite-debug || set ERRORLEVEL=0)
-  - if "%APPVEYOR_JOB_CONFIG%"=="Release" ( ctest --verbose -R dmd-testsuite -E -debug || set ERRORLEVEL=0)
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( ctest --verbose -R dmd-testsuite-debug )
+  - if "%APPVEYOR_JOB_CONFIG%"=="Release" ( ctest --verbose -R dmd-testsuite -E -debug )
 
 #---------------------------------#
 #     deployment configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -146,12 +146,12 @@ test_script:
   # (pre-build some modules serially - those known to require lots of memory)
   - ninja -j1 runtime\std\algorithm\searching-%TEST_SUFFIX%.obj runtime\std\algorithm\setops-%TEST_SUFFIX%.obj runtime\std\array-%TEST_SUFFIX%.obj runtime\std\conv-%TEST_SUFFIX%.obj runtime\std\datetime-%TEST_SUFFIX%.obj runtime\std\range\package-%TEST_SUFFIX%.obj runtime\std\range\primitives-%TEST_SUFFIX%.obj runtime\std\regex\internal\tests-%TEST_SUFFIX%.obj runtime\std\string-%TEST_SUFFIX%.obj runtime\std\traits-%TEST_SUFFIX%.obj
   - ninja -j2 druntime-ldc-%TEST_SUFFIX% phobos2-ldc-%TEST_SUFFIX%
-  # Execute the LLVM IR tests
-  - ctest --output-on-failure -R lit-tests
   # Execute the unit tests; exclude dmd-testsuite for now
   - set CTEST_SUFFIX=-E "-debug|testsuite"
   - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( set CTEST_SUFFIX=-R -debug -E testsuite)
   - ctest --output-on-failure %CTEST_SUFFIX%
+  # Execute the LLVM IR tests
+  - ctest --output-on-failure -R lit-tests
 
 #---------------------------------#
 #     deployment configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,14 +32,6 @@ matrix:
 # scripts that are called at very beginning, before repo cloning
 init:
   - git config --global core.autocrlf input
-  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64 )
-  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 )
-  # Print environment info
-  - set
-  - msbuild /version
-  - cl
-  - cmake --version
-  - python --version
 
 # scripts that run after cloning repository
 install:
@@ -53,6 +45,45 @@ install:
   - cd libconfig
   - git checkout 7585cf6
   - cd ..
+  # dmd-testsuite: Merge `windows` branch
+  - cd ldc\tests\d2\dmd-testsuite
+  - git merge origin/windows
+  - cd ..\..\..\..
+  # Download & extract libcurl
+  - ps: Start-FileDownload 'http://d.darktech.org/libcurl-7.47.0-WinSSL-zlib-x86-x64.zip' -FileName 'libcurl.zip'
+  - md libcurl
+  - cd libcurl
+  - 7z x ..\libcurl.zip > nul
+  - cd ..
+  # Copy libcurl.dll to final LDC installation directory and add to PATH
+  - md ldc-%APPVEYOR_JOB_ARCH% && md ldc-%APPVEYOR_JOB_ARCH%\bin
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( copy libcurl\dmd2\windows\bin64\libcurl.dll ldc-x64\bin )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( copy libcurl\dmd2\windows\bin\libcurl.dll ldc-x86\bin )
+  - set PATH=%CD%\ldc-%APPVEYOR_JOB_ARCH%\bin;%PATH%
+  # Download & extract Ninja
+  - ps: Start-FileDownload 'https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
+  - md ninja
+  - cd ninja
+  - 7z x ..\ninja.zip > nul
+  - ninja --version
+  - cd ..
+  # Install lit
+  - python --version
+  - python -m pip install lit
+  - python -c "import lit; lit.main();" --version
+  # Download & extract DMD
+  - ps: Start-FileDownload 'http://downloads.dlang.org/releases/2015/dmd.2.069.2.windows.7z' -FileName 'dmd2.7z'
+  - 7z x dmd2.7z > nul
+  - set DMD=%CD%\dmd2\windows\bin\dmd.exe
+  - dmd2\windows\bin\dmd.exe --version
+  # Download & extract GNU make + utils (for dmd-testsuite)
+  - bash --version
+  - ps: Start-FileDownload 'https://dl.dropboxusercontent.com/s/d0cqmxf9arbjn27/make-3.81.7z?dl=0' -FileName 'make.7z'
+  - md make
+  - cd make
+  - 7z x ..\make.7z > nul
+  - bin\make --version
+  - cd ..
   # Download a pre-built LLVM (CMAKE_BUILD_TYPE=Release) & extract
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
@@ -64,33 +95,15 @@ install:
   - cd llvm-%APPVEYOR_JOB_ARCH%
   - 7z x ..\llvm-%APPVEYOR_JOB_ARCH%.7z > nul
   - cd ..
-  # Download & install Ninja
-  - ps: Start-FileDownload 'https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip' -FileName 'ninja.zip'
-  - md ninja
-  - cd ninja
-  - 7z x ..\ninja.zip > nul
-  - cd ..
-  - set PATH=c:\projects\ninja;%PATH%
-  - ninja --version
-  # Download & extract libcurl
-  - ps: Start-FileDownload 'http://d.darktech.org/libcurl-7.47.0-WinSSL-zlib-x86-x64.zip' -FileName 'libcurl.zip'
-  - md libcurl
-  - cd libcurl
-  - 7z x ..\libcurl.zip > nul
-  - cd ..
-  # Copy libcurl.dll to final LDC installation directory and add to PATH
-  - md ldc-%APPVEYOR_JOB_ARCH% && md ldc-%APPVEYOR_JOB_ARCH%\bin
-  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( copy libcurl\dmd2\windows\bin64\libcurl.dll ldc-x64\bin )
-  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( copy libcurl\dmd2\windows\bin\libcurl.dll ldc-x86\bin )
-  - set PATH=c:\projects\ldc-%APPVEYOR_JOB_ARCH%\bin;%PATH%
-  # Install lit
-  - python -m pip install lit
-  - python -c "import lit; lit.main();" --version
-  # Download & extract DMD
-  - ps: Start-FileDownload 'http://downloads.dlang.org/releases/2015/dmd.2.069.2.windows.7z' -FileName 'dmd2.7z'
-  - 7z x dmd2.7z > nul
-  - set DMD=c:\projects\dmd2\windows\bin\dmd.exe
-  - c:\projects\dmd2\windows\bin\dmd.exe --version
+  # Set environment variables
+  - set PATH=%CD%\ninja;%CD%\make\bin;%PATH%
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64 )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 )
+  # Print environment info
+  - set
+  - msbuild /version
+  - cl
+  - cmake --version
 
 #---------------------------------#
 #       build configuration       #
@@ -155,7 +168,10 @@ test_script:
         } Else {
             ctest --output-on-failure -R lit-tests
         }
-  # Exclude dmd-testsuite for now
+  # Execute dmd-testsuite, but ignore failures for now
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( set OS=Win_64) else ( set OS=Win_32)
+  - if "%APPVEYOR_JOB_CONFIG%"=="Debug" ( ctest --verbose -R dmd-testsuite-debug || set ERRORLEVEL=0)
+  - if "%APPVEYOR_JOB_CONFIG%"=="Release" ( ctest --verbose -R dmd-testsuite -E -debug || set ERRORLEVEL=0)
 
 #---------------------------------#
 #     deployment configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,9 +57,9 @@ install:
   # Download a pre-built LLVM (CMAKE_BUILD_TYPE=Release) & extract
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/37fhk1z2k8b03d4/LLVM-a5b740a-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/una5bc049qw92k4/LLVM-dbe4385-x64.7z?dl=0' -FileName 'llvm-x64.7z'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/ne10suiupnzy041/LLVM-a5b740a-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/3xj7gllo0sg9901/LLVM-dbe4385-x86.7z?dl=0' -FileName 'llvm-x86.7z'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -109,6 +109,19 @@ public:
     }
   }
 
+  void rewriteVarargs(IrFuncTy &fty,
+                      std::vector<IrFuncTyArg *> &args) override {
+    for (auto arg : args) {
+      rewriteArgument(fty, *arg);
+
+      if (arg->rewrite == &byvalRewrite) {
+        // mark the vararg as being passed byref to prevent DtoCall() from
+        // passing the dereferenced pointer, i.e., just pass the pointer
+        arg->byref = true;
+      }
+    }
+  }
+
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
     Type *t = arg.type->toBasetype();
 

--- a/gen/attributes.cpp
+++ b/gen/attributes.cpp
@@ -29,6 +29,11 @@ AttrBuilder &AttrBuilder::add(LLAttribute attribute) {
   return *this;
 }
 
+AttrBuilder &AttrBuilder::add(llvm::StringRef A, llvm::StringRef V) {
+  builder.addAttribute(A, V);
+  return *this;
+}
+
 AttrBuilder &AttrBuilder::remove(LLAttribute attribute) {
   // never remove 'None' explicitly
   if (attribute) {

--- a/gen/attributes.cpp
+++ b/gen/attributes.cpp
@@ -29,11 +29,6 @@ AttrBuilder &AttrBuilder::add(LLAttribute attribute) {
   return *this;
 }
 
-AttrBuilder &AttrBuilder::add(llvm::StringRef A, llvm::StringRef V) {
-  builder.addAttribute(A, V);
-  return *this;
-}
-
 AttrBuilder &AttrBuilder::remove(LLAttribute attribute) {
   // never remove 'None' explicitly
   if (attribute) {

--- a/gen/attributes.h
+++ b/gen/attributes.h
@@ -27,7 +27,6 @@ public:
   AttrBuilder &add(LLAttribute attribute);
   AttrBuilder &remove(LLAttribute attribute);
   AttrBuilder &merge(const AttrBuilder &other);
-  AttrBuilder &add(llvm::StringRef A, llvm::StringRef V = llvm::StringRef());
 
   AttrBuilder &addAlignment(unsigned alignment);
   AttrBuilder &addByVal(unsigned alignment);

--- a/gen/attributes.h
+++ b/gen/attributes.h
@@ -27,6 +27,7 @@ public:
   AttrBuilder &add(LLAttribute attribute);
   AttrBuilder &remove(LLAttribute attribute);
   AttrBuilder &merge(const AttrBuilder &other);
+  AttrBuilder &add(llvm::StringRef A, llvm::StringRef V = llvm::StringRef());
 
   AttrBuilder &addAlignment(unsigned alignment);
   AttrBuilder &addByVal(unsigned alignment);

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -645,25 +645,15 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
 
   ldc::DIFile file(CreateFile(fd->loc));
 
-  std::string mangledName(getIrFunc(fd)->func->getName());
-
   // Create subroutine type
   ldc::DISubroutineType DIFnType =
     CreateFunctionType(static_cast<TypeFunction *>(fd->type));
 
-  llvm::StringRef displayName = fd->toPrettyChars();
-  // Mimic DMD for MSVC display names > ~64k: simply cut them off
-  constexpr size_t MSVC_MAX_DISPLAY_NAME_LENGTH = 0xffd8;
-  if (global.params.targetTriple->isWindowsMSVCEnvironment() &&
-      displayName.size() > MSVC_MAX_DISPLAY_NAME_LENGTH) {
-    displayName = displayName.substr(0, MSVC_MAX_DISPLAY_NAME_LENGTH);
-  }
-
   // FIXME: duplicates?
   return DBuilder.createFunction(
       CU,                                 // context
-      displayName,                        // name
-      mangledName,                        // linkage name
+      fd->toPrettyChars(),                // name
+      getIrFunc(fd)->func->getName(),     // linkage name
       file,                               // file
       fd->loc.linnum,                     // line no
       DIFnType,                           // type
@@ -701,22 +691,22 @@ ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
   // Create subroutine type (thunk has same type as wrapped function)
   ldc::DISubroutineType DIFnType = CreateFunctionType(fd->type);
 
-  std::string name(fd->toPrettyChars());
+  std::string name = fd->toPrettyChars();
   name.append(".__thunk");
 
   // FIXME: duplicates?
   return DBuilder.createFunction(
-      CU,                                      // context
-      name,                                    // name
-      Thunk->getName(),                        // linkage name
-      file,                                    // file
-      fd->loc.linnum,                          // line no
-      DIFnType,                                // type
-      fd->protection.kind == PROTprivate,      // is local to unit
-      true,                                    // isdefinition
-      fd->loc.linnum,                          // FIXME: scope line
-      DIFlags::FlagPrototyped,                 // Flags
-      isOptimizationEnabled()                  // isOptimized
+      CU,                                 // context
+      name,                               // name
+      Thunk->getName(),                   // linkage name
+      file,                               // file
+      fd->loc.linnum,                     // line no
+      DIFnType,                           // type
+      fd->protection.kind == PROTprivate, // is local to unit
+      true,                               // isdefinition
+      fd->loc.linnum,                     // FIXME: scope line
+      DIFlags::FlagPrototyped,            // Flags
+      isOptimizationEnabled()             // isOptimized
 #if LDC_LLVM_VER < 308
       ,
       getIrFunc(fd)->func

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -645,6 +645,8 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
 
   ldc::DIFile file(CreateFile(fd->loc));
 
+  std::string mangledName(getIrFunc(fd)->func->getName());
+
   // Create subroutine type
   ldc::DISubroutineType DIFnType =
     CreateFunctionType(static_cast<TypeFunction *>(fd->type));
@@ -661,7 +663,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
   return DBuilder.createFunction(
       CU,                                 // context
       displayName,                        // name
-      mangleExact(fd),                    // linkage name
+      mangledName,                        // linkage name
       file,                               // file
       fd->loc.linnum,                     // line no
       DIFnType,                           // type

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -647,7 +647,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
 
   // Create subroutine type
   ldc::DISubroutineType DIFnType =
-      CreateFunctionType(static_cast<TypeFunction *>(fd->type));
+    CreateFunctionType(static_cast<TypeFunction *>(fd->type));
 
   llvm::StringRef displayName = fd->toPrettyChars();
   // Mimic DMD for MSVC display names > ~64k: simply cut them off
@@ -670,6 +670,51 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
       fd->loc.linnum,                     // FIXME: scope line
       DIFlags::FlagPrototyped,            // Flags
       isOptimizationEnabled()             // isOptimized
+#if LDC_LLVM_VER < 308
+      ,
+      getIrFunc(fd)->func
+#endif
+      );
+}
+
+ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
+                                            FuncDeclaration *fd) {
+  if (!global.params.symdebug) {
+#if LDC_LLVM_VER >= 307
+    return nullptr;
+#else
+    return llvm::DISubprogram();
+#endif
+  }
+
+  Logger::println("Thunk to dwarf subprogram");
+  LOG_SCOPE;
+
+  ldc::DICompileUnit CU(GetCU());
+  assert(CU &&
+         "Compilation unit missing or corrupted in DIBuilder::EmitThunk");
+
+  ldc::DIFile file(CreateFile(fd->loc));
+
+  // Create subroutine type (thunk has same type as wrapped function)
+  ldc::DISubroutineType DIFnType = CreateFunctionType(fd->type);
+
+  std::string name(fd->toPrettyChars());
+  name.append(".__thunk");
+
+  // FIXME: duplicates?
+  return DBuilder.createFunction(
+      CU,                                      // context
+      name,                                    // name
+      Thunk->getName(),                        // linkage name
+      file,                                    // file
+      fd->loc.linnum,                          // line no
+      DIFnType,                                // type
+      fd->protection.kind == PROTprivate,      // is local to unit
+      true,                                    // isdefinition
+      fd->loc.linnum,                          // FIXME: scope line
+      DIFlags::FlagPrototyped,                 // Flags
+      isOptimizationEnabled()                  // isOptimized
 #if LDC_LLVM_VER < 308
       ,
       getIrFunc(fd)->func

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -99,6 +99,13 @@ public:
   /// \returns        the Dwarf subprogram global.
   DISubprogram EmitSubProgram(FuncDeclaration *fd); // FIXME
 
+  /// \brief Emit the Dwarf subprogram global for a thunk.
+  /// \param Thunk    llvm::Function pointer.
+  /// \param fd       The function wrapped by this thunk.
+  /// \returns        the Dwarf subprogram global.
+  DISubprogram EmitThunk(llvm::Function *Thunk,
+                              FuncDeclaration *fd); // FIXME
+
   /// \brief Emit the Dwarf subprogram global for a module ctor.
   /// This is used for generated functions like moduleinfoctors,
   /// module ctors/dtors and unittests.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -79,12 +79,8 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
       newIrFty.arg_sret = new IrFuncTyArg(
           rt, true,
           AttrBuilder().add(LLAttribute::StructRet).add(LLAttribute::NoAlias));
-      const unsigned alignment = DtoAlignment(rt);
-      if (alignment &&
-          // FIXME: LLVM inliner issues for std.bitmanip and std.uni on Win64
-          !global.params.targetTriple->isOSMSVCRT()) {
+      if (unsigned alignment = DtoAlignment(rt))
         newIrFty.arg_sret->attrs.addAlignment(alignment);
-      }
       rt = Type::tvoid;
       ++nextLLArgIdx;
     } else {

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -182,6 +182,12 @@ struct IRState {
 #else
   llvm::SmallVector<llvm::Value *, 5> LinkerMetadataArgs;
 #endif
+
+#if LDC_LLVM_VER >= 308
+  // MS C++ compatible type descriptors
+  llvm::DenseMap<size_t, llvm::StructType *> TypeDescriptorTypeMap;
+  llvm::DenseMap<llvm::Constant *, llvm::GlobalVariable *> TypeDescriptorMap;
+#endif
 };
 
 void Statement_toIR(Statement *s, IRState *irs);

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -187,7 +187,6 @@ struct IRState {
   // MS C++ compatible type descriptors
   llvm::DenseMap<size_t, llvm::StructType *> TypeDescriptorTypeMap;
   llvm::DenseMap<llvm::Constant *, llvm::GlobalVariable *> TypeDescriptorMap;
-  llvm::GlobalVariable *SkipCleanupVar = nullptr;
 #endif
 };
 

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -187,6 +187,7 @@ struct IRState {
   // MS C++ compatible type descriptors
   llvm::DenseMap<size_t, llvm::StructType *> TypeDescriptorTypeMap;
   llvm::DenseMap<llvm::Constant *, llvm::GlobalVariable *> TypeDescriptorMap;
+  llvm::GlobalVariable *SkipCleanupVar = nullptr;
 #endif
 };
 

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -1,0 +1,265 @@
+//===-- ms-cxx-helper.cpp -------------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/ms-cxx-helper.h"
+#include "gen/llvm.h"
+#include "gen/llvmhelpers.h"
+#include "gen/irstate.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+
+#if LDC_LLVM_VER >= 308
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/IR/CFG.h"
+
+llvm::BasicBlock *getUnwindDest(llvm::Instruction *I) {
+  if (auto II = llvm::dyn_cast<llvm::InvokeInst> (I))
+    return II->getUnwindDest();
+  else if (auto CSI = llvm::dyn_cast<llvm::CatchSwitchInst> (I))
+    return CSI->getUnwindDest();
+  else if (auto CRPI = llvm::dyn_cast<llvm::CleanupReturnInst> (I))
+    return CRPI->getUnwindDest();
+  return nullptr;
+}
+
+void mapFunclet(llvm::Instruction *I, llvm::ValueToValueMapTy &VMap, llvm::Value *funclet) {
+  if (auto II = llvm::dyn_cast<llvm::InvokeInst> (I)) {
+    auto bundle = II->getOperandBundle(llvm::LLVMContext::OB_funclet);
+    if (bundle)
+      VMap[bundle->Inputs[0].get()] = funclet;
+  } else if (auto CI = llvm::dyn_cast<llvm::CallInst> (I)) {
+    auto bundle = CI->getOperandBundle(llvm::LLVMContext::OB_funclet);
+    if (bundle)
+      VMap[bundle->Inputs[0].get()] = funclet;
+  }
+}
+
+// return all basic blocks that are reachable from bb, but don't pass through
+// ebb and don't follow unwinding target
+void findSuccessors(std::vector<llvm::BasicBlock *> &blocks,
+                    llvm::BasicBlock *bb, llvm::BasicBlock *ebb) {
+  blocks.push_back(bb);
+  if (bb != ebb) {
+    assert(bb->getTerminator());
+    for (size_t pos = 0; pos < blocks.size(); ++pos) {
+      bb = blocks[pos];
+      if (auto term = bb->getTerminator()) {
+        llvm::BasicBlock *unwindDest = getUnwindDest(term);
+        unsigned cnt = term->getNumSuccessors();
+        for (unsigned s = 0; s < cnt; s++) {
+          llvm::BasicBlock *succ = term->getSuccessor(s);
+          if (succ != ebb && succ != unwindDest &&
+              std::find(blocks.begin(), blocks.end(), succ) == blocks.end()) {
+            blocks.push_back(succ);
+          }
+        }
+      }
+    }
+    blocks.push_back(ebb);
+  }
+}
+
+// remap values in all instructions of all blocks
+void remapBlocks(std::vector<llvm::BasicBlock *> &blocks,
+                 llvm::ValueToValueMapTy &VMap, llvm::BasicBlock *unwindTo,
+                 llvm::Value *funclet) {
+  for (llvm::BasicBlock *bb : blocks)
+    for (llvm::BasicBlock::iterator I = bb->begin(); I != bb->end(); ++I) {
+      //if (funclet)
+      //  mapFunclet(&*I, VMap, funclet);
+      llvm::RemapInstruction(&*I, VMap, llvm::RF_IgnoreMissingEntries |
+                             llvm::RF_NoModuleLevelChanges);
+    }
+}
+
+void remapBlocksValue(std::vector<llvm::BasicBlock *> &blocks,
+                      llvm::Value *from, llvm::Value *to) {
+  llvm::ValueToValueMapTy VMap;
+  VMap[from] = to;
+  remapBlocks(blocks, VMap, nullptr, nullptr);
+}
+
+// make a copy of all srcblocks, mapping values to clones and redirect srcTarget
+// to continueWith
+void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
+                 std::vector<llvm::BasicBlock *> &blocks,
+                 llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
+                 llvm::Value *funclet) {
+  llvm::ValueToValueMapTy VMap;
+  // map the terminal branch to the new target
+  if (continueWith)
+    if (auto term = srcblocks.back()->getTerminator())
+      if (auto succ = term->getSuccessor(0))
+        VMap[succ] = continueWith;
+
+  for (size_t b = 0; b < srcblocks.size(); b++) {
+    llvm::BasicBlock *bb = srcblocks[b];
+    llvm::Function* F = bb->getParent();
+
+    auto nbb = llvm::BasicBlock::Create(bb->getContext());
+    // Loop over all instructions, and copy them over.
+    for (auto II = bb->begin(), IE = bb->end(); II != IE; ++II) {
+      llvm::Instruction *Inst = &*II;
+      llvm::Instruction *newInst = nullptr;
+      if (funclet && !llvm::isa<llvm::DbgInfoIntrinsic>(Inst)) {
+        if (auto IInst = llvm::dyn_cast<llvm::InvokeInst> (Inst)) {
+          newInst = llvm::InvokeInst::Create(
+            IInst, llvm::OperandBundleDef("funclet", funclet));
+        } else if (auto CInst = llvm::dyn_cast<llvm::CallInst> (Inst)) {
+          newInst = llvm::CallInst::Create(
+            CInst, llvm::OperandBundleDef("funclet", funclet));
+        }
+      }
+      if (!newInst)
+        newInst = Inst->clone();
+
+      nbb->getInstList().push_back(newInst);
+      VMap[Inst] = newInst; // Add instruction map to value.
+      if (unwindTo)
+        if (auto dest = getUnwindDest(Inst))
+          VMap[dest] = unwindTo;
+    }
+    nbb->insertInto(F, continueWith);
+    VMap[bb] = nbb;
+    blocks.push_back(nbb);
+  }
+
+  remapBlocks(blocks, VMap, unwindTo, funclet);
+}
+
+// copy from clang/.../MicrosoftCXXABI.cpp
+
+// 5 routines for constructing the llvm types for MS RTTI structs.
+llvm::StructType *getTypeDescriptorType(IRState &irs,
+                                        llvm::Constant *classInfoPtr,
+                                        llvm::StringRef TypeInfoString) {
+  llvm::SmallString<256> TDTypeName("rtti.TypeDescriptor");
+  TDTypeName += llvm::utostr(TypeInfoString.size());
+  llvm::StructType *&TypeDescriptorType =
+      irs.TypeDescriptorTypeMap[TypeInfoString.size()];
+  if (TypeDescriptorType)
+    return TypeDescriptorType;
+  auto int8Ty = LLType::getInt8Ty(gIR->context());
+  llvm::Type *FieldTypes[] = {
+      classInfoPtr->getType(), // CGM.Int8PtrPtrTy,
+      getPtrToType(int8Ty),    // CGM.Int8PtrTy,
+      llvm::ArrayType::get(int8Ty, TypeInfoString.size() + 1)};
+  TypeDescriptorType =
+      llvm::StructType::create(gIR->context(), FieldTypes, TDTypeName);
+  return TypeDescriptorType;
+}
+
+llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
+
+  auto classInfoPtr = getIrAggr(cd, true)->getClassInfoSymbol();
+  llvm::GlobalVariable *&Var = irs.TypeDescriptorMap[classInfoPtr];
+  if (Var)
+    return Var;
+
+  // first character skipped in debugger output, so we add 'D' as prefix
+  std::string TypeNameString = "D";
+  TypeNameString.append(cd->toPrettyChars());
+  std::string TypeDescName = TypeNameString + "@TypeDescriptor";
+
+  // Declare and initialize the TypeDescriptor.
+  llvm::Constant *Fields[] = {
+      classInfoPtr, // VFPtr
+      llvm::ConstantPointerNull::get(
+          LLType::getInt8PtrTy(gIR->context())), // Runtime data
+      llvm::ConstantDataArray::getString(gIR->context(), TypeNameString)};
+  llvm::StructType *TypeDescriptorType =
+      getTypeDescriptorType(irs, classInfoPtr, TypeNameString);
+  Var = new llvm::GlobalVariable(
+      gIR->module, TypeDescriptorType, /*Constant=*/false,
+      LLGlobalVariable::InternalLinkage, // getLinkageForRTTI(Type),
+      llvm::ConstantStruct::get(TypeDescriptorType, Fields), TypeDescName);
+  return Var;
+}
+
+#if 0
+// currently unused, information built at runtime ATM
+llvm::StructType *BaseClassDescriptorType;
+llvm::StructType *ClassHierarchyDescriptorType;
+llvm::StructType *CompleteObjectLocatorType;
+
+bool isImageRelative() {
+  return global.params.targetTriple.isArch64Bit();
+}
+
+llvm::Type *getImageRelativeType(llvm::Type *PtrType) {
+  if (!isImageRelative())
+    return PtrType;
+  return LLType::getInt32Ty(gIR->context());
+}
+
+llvm::StructType *getClassHierarchyDescriptorType();
+
+llvm::StructType *getBaseClassDescriptorType() {
+  if (BaseClassDescriptorType)
+    return BaseClassDescriptorType;
+  auto intTy = LLType::getInt32Ty(gIR->context());
+  auto int8Ty = LLType::getInt8Ty(gIR->context());
+  llvm::Type *FieldTypes[] = {
+    getImageRelativeType(getPtrToType(int8Ty)),
+    intTy,
+    intTy,
+    intTy,
+    intTy,
+    intTy,
+    getImageRelativeType(getClassHierarchyDescriptorType()->getPointerTo()),
+  };
+  BaseClassDescriptorType = llvm::StructType::create(
+    gIR->context(), FieldTypes, "rtti.BaseClassDescriptor");
+  return BaseClassDescriptorType;
+}
+
+llvm::StructType *getClassHierarchyDescriptorType() {
+  if (ClassHierarchyDescriptorType)
+    return ClassHierarchyDescriptorType;
+  // Forward-declare RTTIClassHierarchyDescriptor to break a cycle.
+  ClassHierarchyDescriptorType = llvm::StructType::create(
+    gIR->context(), "rtti.ClassHierarchyDescriptor");
+  auto intTy = LLType::getInt32Ty(gIR->context());
+  llvm::Type *FieldTypes[] = {
+    intTy,
+    intTy,
+    intTy,
+    getImageRelativeType(
+      getBaseClassDescriptorType()->getPointerTo()->getPointerTo()),
+  };
+  ClassHierarchyDescriptorType->setBody(FieldTypes);
+  return ClassHierarchyDescriptorType;
+}
+
+llvm::StructType *getCompleteObjectLocatorType() {
+  if (CompleteObjectLocatorType)
+    return CompleteObjectLocatorType;
+  CompleteObjectLocatorType = llvm::StructType::create(
+    gIR->context(), "rtti.CompleteObjectLocator");
+  auto intTy = LLType::getInt32Ty(gIR->context());
+  auto int8Ty = LLType::getInt8Ty(gIR->context());
+  llvm::Type *FieldTypes[] = {
+    intTy,
+    intTy,
+    intTy,
+    getImageRelativeType(getPtrToType(int8Ty)),
+    getImageRelativeType(getClassHierarchyDescriptorType()->getPointerTo()),
+    getImageRelativeType(CompleteObjectLocatorType),
+  };
+  llvm::ArrayRef<llvm::Type *> FieldTypesRef(FieldTypes);
+  if (!isImageRelative())
+    FieldTypesRef = FieldTypesRef.drop_back();
+  CompleteObjectLocatorType->setBody(FieldTypesRef);
+  return CompleteObjectLocatorType;
+}
+#endif
+
+#endif // LDC_LLVM_VER >= 308

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -102,16 +102,10 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
         if (auto IInst = llvm::dyn_cast<llvm::InvokeInst> (Inst)) {
           auto invoke = llvm::InvokeInst::Create(
             IInst, llvm::OperandBundleDef("funclet", funclet));
-          // do not replace functions in optimizer, they lose the "funclet" token
-          invoke->addAttribute(llvm::AttributeSet::FunctionIndex,
-                               llvm::Attribute::NoBuiltin);
           newInst = invoke;
         } else if (auto CInst = llvm::dyn_cast<llvm::CallInst> (Inst)) {
           auto call = llvm::CallInst::Create(
               CInst, llvm::OperandBundleDef("funclet", funclet));
-          // do not replace functions in optimizer, they lose the "funclet" token
-          call->addAttribute(llvm::AttributeSet::FunctionIndex,
-                             llvm::Attribute::NoBuiltin);
           newInst = call;
         }
       }

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -187,16 +187,6 @@ llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
   return Var;
 }
 
-llvm::GlobalVariable *getSkipCleanupVar(IRState &irs) {
-  if (!irs.SkipCleanupVar) {
-    auto int1Ty = LLType::getInt1Ty(gIR->context());
-    irs.SkipCleanupVar = new llvm::GlobalVariable(
-        gIR->module, int1Ty, false, LLGlobalVariable::ExternalLinkage,
-        nullptr, "_d_skipCleanup");
-  }
-  return irs.SkipCleanupVar;
-}
-
 #if 0
 // currently unused, information built at runtime ATM
 llvm::StructType *BaseClassDescriptorType;

--- a/gen/ms-cxx-helper.h
+++ b/gen/ms-cxx-helper.h
@@ -17,6 +17,8 @@ llvm::StructType *getTypeDescriptorType(IRState &irs,
                                         llvm::StringRef TypeInfoString);
 llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd);
 
+llvm::GlobalVariable *getSkipCleanupVar(IRState &irs);
+
 void findSuccessors(std::vector<llvm::BasicBlock *> &blocks,
                     llvm::BasicBlock *bb, llvm::BasicBlock *ebb);
 

--- a/gen/ms-cxx-helper.h
+++ b/gen/ms-cxx-helper.h
@@ -28,4 +28,6 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
                  llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
                  llvm::Value *funclet);
 
+bool isCatchSwitchBlock(llvm::BasicBlock* bb);
+
 #endif // LDC_GEN_MS_CXX_HELPER_H

--- a/gen/ms-cxx-helper.h
+++ b/gen/ms-cxx-helper.h
@@ -17,8 +17,6 @@ llvm::StructType *getTypeDescriptorType(IRState &irs,
                                         llvm::StringRef TypeInfoString);
 llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd);
 
-llvm::GlobalVariable *getSkipCleanupVar(IRState &irs);
-
 void findSuccessors(std::vector<llvm::BasicBlock *> &blocks,
                     llvm::BasicBlock *bb, llvm::BasicBlock *ebb);
 

--- a/gen/ms-cxx-helper.h
+++ b/gen/ms-cxx-helper.h
@@ -1,0 +1,31 @@
+//===-- ms-cxx-helper.h ---------------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_GEN_MS_CXX_HELPER_H
+#define LDC_GEN_MS_CXX_HELPER_H
+
+#include "gen/irstate.h"
+
+llvm::StructType *getTypeDescriptorType(IRState &irs,
+                                        llvm::Constant *classInfoPtr,
+                                        llvm::StringRef TypeInfoString);
+llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd);
+
+void findSuccessors(std::vector<llvm::BasicBlock *> &blocks,
+                    llvm::BasicBlock *bb, llvm::BasicBlock *ebb);
+
+void remapBlocksValue(std::vector<llvm::BasicBlock *> &blocks,
+                      llvm::Value *from, llvm::Value *to);
+
+void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
+                 std::vector<llvm::BasicBlock *> &blocks,
+                 llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
+                 llvm::Value *funclet);
+
+#endif // LDC_GEN_MS_CXX_HELPER_H

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -638,6 +638,11 @@ static void buildRuntimeModule() {
     }
   }
 
+  if (useMSVCEH()) {
+    createFwdDecl(LINKc, boolTy, {"_d_enter_cleanup"}, {voidPtrTy});
+    createFwdDecl(LINKc, voidTy, {"_d_leave_cleanup"}, {voidPtrTy});
+  }
+
   // void _d_eh_resume_unwind(ptr)
   createFwdDecl(LINKc, voidTy, {"_d_eh_resume_unwind"}, {voidPtrTy});
 

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -24,6 +24,7 @@
 #include "gen/llvmhelpers.h"
 #include "gen/logger.h"
 #include "gen/tollvm.h"
+#include "ir/irfunction.h"
 #include "ir/irtype.h"
 #include "ir/irtypefunction.h"
 #include "llvm/Bitcode/ReaderWriter.h"
@@ -620,9 +621,11 @@ static void buildRuntimeModule() {
   // int _d_eh_personality(...)
   {
     if (global.params.targetTriple->isWindowsMSVCEnvironment()) {
+      const char *fname =
+          useMSVCEH() ? "__CxxFrameHandler3" : "_d_eh_personality";
       // (ptr ExceptionRecord, ptr EstablisherFrame, ptr ContextRecord,
       //  ptr DispatcherContext)
-      createFwdDecl(LINKc, intTy, {"_d_eh_personality"},
+      createFwdDecl(LINKc, intTy, {fname},
                     {voidPtrTy, voidPtrTy, voidPtrTy, voidPtrTy});
     } else if (global.params.targetTriple->getArch() == llvm::Triple::arm) {
       // (int state, ptr ucb, ptr context)

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -647,7 +647,7 @@ static void buildRuntimeModule() {
 
     // Object _d_eh_enter_catch(ptr exception, ClassInfo catchType)
     createFwdDecl(LINKc, objectTy, {"_d_eh_enter_catch"},
-                  {voidPtrTy, classInfoTy}, {}, Attr_NoUnwind);
+                  {voidPtrTy, classInfoTy}, {});
   } else {
 
     // void _d_eh_resume_unwind(ptr)

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -639,16 +639,24 @@ static void buildRuntimeModule() {
   }
 
   if (useMSVCEH()) {
+    // _d_enter_cleanup(ptr frame)
     createFwdDecl(LINKc, boolTy, {"_d_enter_cleanup"}, {voidPtrTy});
+
+    // _d_leave_cleanup(ptr frame)
     createFwdDecl(LINKc, voidTy, {"_d_leave_cleanup"}, {voidPtrTy});
+
+    // Object _d_eh_enter_catch(ptr exception, ClassInfo catchType)
+    createFwdDecl(LINKc, objectTy, {"_d_eh_enter_catch"},
+                  {voidPtrTy, classInfoTy}, {}, Attr_NoUnwind);
+  } else {
+
+    // void _d_eh_resume_unwind(ptr)
+    createFwdDecl(LINKc, voidTy, {"_d_eh_resume_unwind"}, {voidPtrTy});
+
+    // Object _d_eh_enter_catch(ptr)
+    createFwdDecl(LINKc, objectTy, {"_d_eh_enter_catch"}, {voidPtrTy}, {},
+                  Attr_NoUnwind);
   }
-
-  // void _d_eh_resume_unwind(ptr)
-  createFwdDecl(LINKc, voidTy, {"_d_eh_resume_unwind"}, {voidPtrTy});
-
-  // Object _d_eh_enter_catch(ptr)
-  createFwdDecl(LINKc, objectTy, {"_d_eh_enter_catch"}, {voidPtrTy}, {},
-                Attr_NoUnwind);
 
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -724,7 +724,7 @@ public:
     if (var) {
       // alloca storage for the variable, it always needs a place on the stack
       // do not initialize, this will be done by the C++ exception handler
-      var->init = nullptr;
+      var->_init = nullptr;
 
       // redirect scope to avoid the generation of debug info before the
       // catchpad

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -741,11 +741,12 @@ public:
         cpyObj = exnObj;
         exnObj = DtoAlloca(var->type, "exnObj");
       }
-
       irs->scope() = save;
-
-    } else {
+    } else if (ctch->type) {
       // catch without var
+      exnObj = DtoAlloca(ctch->type, "exnObj");
+    } else {
+      // catch all
       exnObj = llvm::Constant::getNullValue(getVoidPtrType());
     }
 
@@ -773,9 +774,8 @@ public:
     }
     const auto enterCatchFn =
         getRuntimeFunction(Loc(), irs->module, "_d_eh_enter_catch");
-    auto throwableObj =
-        irs->ir->CreateCall(enterCatchFn, DtoBitCast(exnObj, getVoidPtrType()),
-                            {llvm::OperandBundleDef("funclet", catchpad)});
+    irs->ir->CreateCall(enterCatchFn, DtoBitCast(exnObj, getVoidPtrType()),
+                        {llvm::OperandBundleDef("funclet", catchpad)});
 
     // The code generator will extract the catch handler to funclets
     // so it needs to know the end of the code executed in the handler.

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -786,8 +786,7 @@ public:
       llvm::BasicBlock::Create(irs->context(), "catchhandler", irs->topfunc());
     llvm::CatchReturnInst::Create(catchpad, catchhandler, irs->scopebb());
     irs->scope() = IRScope(catchhandler);
-    irs->ir->CreateCall(enterCatchFn,
-                        {DtoBitCast(exnObj, getVoidPtrType()), clssInfo});
+    irs->CreateCallOrInvoke(enterCatchFn, DtoBitCast(exnObj, getVoidPtrType()), clssInfo);
 #else
     irs->ir->CreateCall(enterCatchFn,
                         {DtoBitCast(exnObj, getVoidPtrType()), clssInfo},

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -41,9 +41,8 @@ void Target::_init() {
   c_longsize = global.params.is64bit ? 8 : 4;
   c_long_doublesize = realsize;
 
-  // according to DMD, only for 32-bit MSVC++:
-  reverseCppOverloads = !global.params.is64bit &&
-                        global.params.targetTriple->isWindowsMSVCEnvironment();
+  // according to DMD, only for MSVC++:
+  reverseCppOverloads = global.params.targetTriple->isWindowsMSVCEnvironment();
 }
 
 /******************************

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -987,6 +987,10 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
   } else {
     call.setCallingConv(callconv);
   }
+  // merge in function attributes set in callOrInvoke
+  attrlist = attrlist.addAttributes(
+      gIR->context(), llvm::AttributeSet::FunctionIndex, call.getAttributes());
+
   call.setAttributes(attrlist);
 
   // Special case for struct constructor calls: For temporaries, using the

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -350,6 +350,11 @@ llvm::GlobalVariable *IrAggr::getInterfaceVtbl(BaseClass *b, bool new_instance,
       // function has.
       thunk->setUnnamedAddr(true);
 
+#if LDC_LLVM_VER >= 307
+      // thunks don't need exception handling themselves
+      thunk->setPersonalityFn(nullptr);
+#endif
+
       // create entry and end blocks
       llvm::BasicBlock *beginbb =
           llvm::BasicBlock::Create(gIR->context(), "", thunk);

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -355,10 +355,26 @@ llvm::GlobalVariable *IrAggr::getInterfaceVtbl(BaseClass *b, bool new_instance,
       thunk->setPersonalityFn(nullptr);
 #endif
 
+      // it is necessary to add debug information to the thunk
+      //  in case it is subject to inlining. See https://llvm.org/bugs/show_bug.cgi?id=26833
+      IF_LOG Logger::println("Doing function body for thunk to: %s", fd->toChars());
+
+      // create a dummy FuncDeclaration with enough information to satisfy the DIBuilder
+      FuncDeclaration *thunkFd = reinterpret_cast<FuncDeclaration *>(memcpy(
+          new char[sizeof(FuncDeclaration)], fd, sizeof(FuncDeclaration)));
+      thunkFd->ir = new IrDsymbol();
+      auto thunkFunc = getIrFunc(thunkFd, true); // create the IrFunction
+      gIR->functions.push_back(thunkFunc);
+
+      // debug info
+      thunkFunc->diSubprogram = gIR->DBuilder.EmitThunk(thunk, thunkFd);
+
       // create entry and end blocks
       llvm::BasicBlock *beginbb =
           llvm::BasicBlock::Create(gIR->context(), "", thunk);
       gIR->scopes.push_back(IRScope(beginbb));
+
+      gIR->DBuilder.EmitFuncStart(thunkFd);
 
       // Copy the function parameters, so later we can pass them to the
       // real function and set their names from the original function (the
@@ -381,6 +397,10 @@ llvm::GlobalVariable *IrAggr::getInterfaceVtbl(BaseClass *b, bool new_instance,
       thisArg = DtoGEP1(thisArg, DtoConstInt(-b->offset), true);
       thisArg = DtoBitCast(thisArg, targetThisType);
 
+      // all calls that might be subject to inlining into a caller with debug info
+      //  should have debug info, too
+      gIR->DBuilder.EmitStopPoint(fd->loc);
+
       // call the real vtbl function.
       llvm::CallSite call = gIR->ir->CreateCall(irFunc->func, args);
       call.setCallingConv(irFunc->func->getCallingConv());
@@ -393,8 +413,12 @@ llvm::GlobalVariable *IrAggr::getInterfaceVtbl(BaseClass *b, bool new_instance,
                                  beginbb);
       }
 
+      gIR->DBuilder.EmitFuncEnd(thunkFd);
+
       // clean up
       gIR->scopes.pop_back();
+
+      gIR->functions.pop_back();
     }
 
     constants.push_back(thunk);

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -364,6 +364,8 @@ llvm::GlobalVariable *IrAggr::getInterfaceVtbl(BaseClass *b, bool new_instance,
           new char[sizeof(FuncDeclaration)], fd, sizeof(FuncDeclaration)));
       thunkFd->ir = new IrDsymbol();
       auto thunkFunc = getIrFunc(thunkFd, true); // create the IrFunction
+      thunkFunc->func = thunk;
+      thunkFunc->type = irFunc->type;
       gIR->functions.push_back(thunkFunc);
 
       // debug info

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -34,8 +34,7 @@ CatchScope::CatchScope(llvm::Constant *classInfoPtr,
 
 bool useMSVCEH() {
 #if LDC_LLVM_VER >= 308
-  return global.params.targetTriple->isWindowsMSVCEnvironment() &&
-         !global.params.targetTriple->isArch64Bit();
+  return global.params.targetTriple->isWindowsMSVCEnvironment();
 #else
   return false;
 #endif

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -184,7 +184,6 @@ void executeCleanup(IRState *irs, CleanupScope &scope,
   scope.exitTargets.push_back(CleanupExitTarget(continueWith));
   scope.exitTargets.back().sourceBlocks.push_back(sourceBlock);
 }
-
 }
 
 ScopeStack::~ScopeStack() {
@@ -255,17 +254,6 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
   if (isCatchSwitchBlock(cleanupScopes[scope].beginBlock))
     return cleanupScopes[scope].beginBlock;
 
-  // when hitting a catch return instruction during cleanup,
-  //  just unwind to the corresponding catchswitch block instead
-  if (!cleanupScopes[scope].beginBlock->empty()) {
-    if (auto catchret = llvm::dyn_cast<llvm::CatchReturnInst>(
-      &cleanupScopes[scope].beginBlock->front())) {
-      llvm::BasicBlock* endcatch = nullptr;
-      auto catchpad = catchret->getCatchPad();
-      auto catchswitch = catchpad->getCatchSwitch();
-      return catchswitch->getUnwindDest();
-    }
-  }
 
   // each cleanup block is bracketed by a pair of cleanuppad/cleanupret
   // instructions, any unwinding should also just continue at the next

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -251,6 +251,7 @@ void ScopeStack::runCleanupCopies(CleanupCursor sourceScope,
 
 llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
                                             llvm::BasicBlock *unwindTo) {
+  // a catch switch never needs to be cloned and is an unwind target itself
   if (isCatchSwitchBlock(cleanupScopes[scope].beginBlock))
     return cleanupScopes[scope].beginBlock;
 
@@ -287,10 +288,10 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
 
   llvm::BasicBlock *cleanupret =
       llvm::BasicBlock::Create(irs->context(), "cleanupret", irs->topfunc());
-
   llvm::CleanupReturnInst::Create(cleanuppad, unwindTo, cleanupret);
+
   auto copybb = executeCleanupCopying(irs, cleanupScopes[scope], cleanupbb,
-                                       cleanupret, unwindTo, cleanuppad);
+                                      cleanupret, unwindTo, cleanuppad);
   llvm::BranchInst::Create(copybb, cleanupbb);
   return cleanupbb;
 }

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -34,8 +34,8 @@ CatchScope::CatchScope(llvm::Constant *classInfoPtr,
 
 bool useMSVCEH() {
 #if LDC_LLVM_VER >= 308
-  return global.params.targetTriple.isWindowsMSVCEnvironment() &&
-         !global.params.targetTriple.isArch64Bit();
+  return global.params.targetTriple->isWindowsMSVCEnvironment() &&
+         !global.params.targetTriple->isArch64Bit();
 #else
   return false;
 #endif

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -273,7 +273,7 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
   //
   // cleanuppad:
   //   %0 = cleanuppad within %funclet[]
-  //   %frame = alloca(byte[16])
+  //   %frame = nullptr
   //   if (!_d_enter_cleanup(%frame)) br label %cleanupret 
   //                                  else br label %copy
   //
@@ -292,12 +292,9 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
   llvm::BasicBlock *cleanupret =
       llvm::BasicBlock::Create(irs->context(), "cleanupret", irs->topfunc());
 
-  // allocate some space on the stack where _d_enter_cleanup can place an exception frame
-  auto int8Ty = LLType::getInt8Ty(gIR->context());
-  auto frametype = llvm::ArrayType::get(int8Ty, 16);
-  auto frameai = DtoRawAlloca(frametype, 0, "cleanup.frame");
-  auto frame =
-      new llvm::BitCastInst(frameai, getPtrToType(int8Ty), "", cleanupbb);
+  // preparation to allocate some space on the stack where _d_enter_cleanup 
+  //  can place an exception frame (but not done here)
+  auto frame = getNullPtr(getVoidPtrType());
 
   auto endFn = getRuntimeFunction(Loc(), irs->module, "_d_leave_cleanup");
   llvm::CallInst::Create(endFn, frame,

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -267,6 +267,49 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
     }
   }
 
+#if 1
+  // translate cleanup to catch-all-rethrow:
+  // %switch = catchswitch within %funclet [label %catch] unwind to %unwindTo
+  llvm::BasicBlock *cleanupbb =
+    llvm::BasicBlock::Create(irs->context(), "cleanuppad", irs->topfunc());
+  auto catchswitch =
+    llvm::CatchSwitchInst::Create(getFuncletToken(), unwindTo, 1, "", cleanupbb);
+
+  // %catch = catchpad within %switch [nullptr, 0, &caughtObject]
+  llvm::BasicBlock *catchpadbb =
+    llvm::BasicBlock::Create(irs->context(), "cleanupcatch", irs->topfunc());
+  int flags = 64; // just mimicking clang here
+  LLValue* nulltype = llvm::Constant::getNullValue(getVoidPtrType());
+  LLValue* excptObj = irs->func()->getOrCreateEhPtrSlot();
+  LLValue *args[] = { nulltype, DtoConstUint(flags), excptObj };
+  auto catchpad = llvm::CatchPadInst::Create(
+      catchswitch, llvm::ArrayRef<LLValue *>(args), "", catchpadbb);
+  catchswitch->addHandler(catchpadbb);
+
+
+  llvm::BasicBlock *cleanupret =
+      llvm::BasicBlock::Create(irs->context(), "cleanupret", irs->topfunc());
+  const auto resumeFn =
+      getRuntimeFunction(Loc(), irs->module, "_d_eh_resume_unwind");
+  auto excptn = new llvm::LoadInst(excptObj, "excptn", cleanupret);
+  if (unwindTo) {
+    llvm::BasicBlock *unreachable =
+      llvm::BasicBlock::Create(irs->context(), "unreachable", irs->topfunc());
+    new llvm::UnreachableInst(irs->context(), unreachable);
+    llvm::InvokeInst::Create(resumeFn, unreachable, unwindTo, excptn,
+                             {llvm::OperandBundleDef("funclet", catchpad)}, "",
+                             cleanupret);
+  } else {
+    llvm::CallInst::Create(resumeFn, excptn,
+                           {llvm::OperandBundleDef("funclet", catchpad)}, "",
+                           cleanupret);
+    new llvm::UnreachableInst(irs->context(), cleanupret);
+  }
+
+  auto copybb = executeCleanupCopying(irs, cleanupScopes[scope], catchpadbb,
+                                      cleanupret, unwindTo, catchpad);
+  llvm::BranchInst::Create(copybb, catchpadbb);
+#else
   // each cleanup block is bracketed by a pair of cleanuppad/cleanupret
   // instructions, any unwinding should also just continue at the next
   // cleanup block, e.g.:
@@ -293,6 +336,7 @@ llvm::BasicBlock *ScopeStack::runCleanupPad(CleanupCursor scope,
   auto copybb = executeCleanupCopying(irs, cleanupScopes[scope], cleanupbb,
                                       cleanupret, unwindTo, cleanuppad);
   llvm::BranchInst::Create(copybb, cleanupbb);
+#endif
   return cleanupbb;
 }
 #endif
@@ -510,12 +554,14 @@ llvm::BasicBlock *ScopeStack::emitLandingPadMSVCEH(CleanupCursor scope) {
     currentFunction->setPersonalityFn(personalityFn);
   }
 
+#if 0
   // WinEHPrepare pass fails after optimizations, so disable these for now
   if (!currentFunction->getFnAttribute("disable-tail-calls")
       .isStringAttribute()) {
     currentFunction->addFnAttr("disable-tail-calls", "true");
     currentFunction->addFnAttr(llvm::Attribute::NoInline);
   }
+#endif
 
   if (scope == 0)
     return runCleanupPad(scope, nullptr);

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -416,7 +416,6 @@ llvm::CallSite ScopeStack::callOrInvoke(llvm::Value *callee, const T &args,
 #endif
 
   if (doesNotThrow || (cleanupScopes.empty() && catchScopes.empty())) {
-L_call:
     llvm::CallInst *call = irs->ir->CreateCall(callee, args,
 #if LDC_LLVM_VER >= 308
                                                BundleList, 
@@ -429,8 +428,6 @@ L_call:
   }
 
   llvm::BasicBlock* landingPad = getLandingPad();
-  if (!landingPad)
-    goto L_call;
 
   llvm::BasicBlock *postinvoke = llvm::BasicBlock::Create(
       irs->context(), "postinvoke", irs->topfunc(), landingPad);

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -425,12 +425,6 @@ L_call:
     if (calleeFn) {
       call->setAttributes(calleeFn->getAttributes());
     }
-#if LDC_LLVM_VER >= 308
-    if (!BundleList.empty())
-      // do not replace functions in optimizer, they lose the "funclet" token
-      call->addAttribute(llvm::AttributeSet::FunctionIndex,
-                         llvm::Attribute::NoBuiltin);
-#endif
     return call;
   }
 
@@ -449,12 +443,6 @@ L_call:
   if (calleeFn) {
     invoke->setAttributes(calleeFn->getAttributes());
   }
-#if LDC_LLVM_VER >= 308
-  if (!BundleList.empty())
-    // do not replace functions in optimizer, they lose the "funclet" token
-    invoke->addAttribute(llvm::AttributeSet::FunctionIndex,
-                         llvm::Attribute::NoBuiltin);
-#endif
 
   irs->scope() = IRScope(postinvoke);
   return invoke;

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -425,6 +425,12 @@ L_call:
     if (calleeFn) {
       call->setAttributes(calleeFn->getAttributes());
     }
+#if LDC_LLVM_VER >= 308
+    if (!BundleList.empty())
+      // do not replace functions in optimizer, they lose the "funclet" token
+      call->addAttribute(llvm::AttributeSet::FunctionIndex,
+                         llvm::Attribute::NoBuiltin);
+#endif
     return call;
   }
 
@@ -443,6 +449,12 @@ L_call:
   if (calleeFn) {
     invoke->setAttributes(calleeFn->getAttributes());
   }
+#if LDC_LLVM_VER >= 308
+  if (!BundleList.empty())
+    // do not replace functions in optimizer, they lose the "funclet" token
+    invoke->addAttribute(llvm::AttributeSet::FunctionIndex,
+                         llvm::Attribute::NoBuiltin);
+#endif
 
   irs->scope() = IRScope(postinvoke);
   return invoke;

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -251,6 +251,7 @@ public:
 
   size_t currentCatchScope() { return catchScopes.size(); }
 
+#if LDC_LLVM_VER >= 308
   /// MSVC: catch and cleanup code is emitted as funclets and need
   /// to be referenced from inner pads and calls
   void pushFunclet(llvm::Value *funclet) {
@@ -268,6 +269,7 @@ public:
     return funclets.empty() ? llvm::ConstantTokenNone::get(irs->context())
                             : funclets.back();
   }
+#endif
 
   /// Registers a loop statement to be used as a target for break/continue
   /// statements in the current scope.

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -10,13 +10,14 @@ static Inner globalInner;
 
 Outer passAndReturnOuterByVal(Outer arg) { return arg; }
 // CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
-// CHECK-SAME: %align.Outer* noalias sret align 32 %.sret_arg
+/* the 32-bit x86 ABI substitutes the sret attribute by inreg */
+// CHECK-SAME: %align.Outer* {{noalias sret|inreg noalias}} align 32 %.sret_arg
 /* how the arg is passed by value is ABI-specific, but the pointer must be aligned */
 // CHECK-SAME: align 32 %
 
 Inner passAndReturnInnerByVal(Inner arg) { return arg; }
 // CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
-// CHECK-SAME: %align.Inner* noalias sret align 32 %.sret_arg
+// CHECK-SAME: %align.Inner* {{noalias sret|inreg noalias}} align 32 %.sret_arg
 // CHECK-SAME: align 32 %
 
 void main() {
@@ -48,11 +49,11 @@ void main() {
 
   outer = passAndReturnOuterByVal(outer);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
-  // CHECK-SAME: %align.Outer* noalias sret align 32 %.rettmp
+  // CHECK-SAME: %align.Outer* {{noalias sret|inreg noalias}} align 32 %.rettmp
   // CHECK-SAME: align 32 %
 
   inner = passAndReturnInnerByVal(inner);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
-  // CHECK-SAME: %align.Inner* noalias sret align 32 %.rettmp1
+  // CHECK-SAME: %align.Inner* {{noalias sret|inreg noalias}} align 32 %.rettmp1
   // CHECK-SAME: align 32 %
 }

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -10,14 +10,13 @@ static Inner globalInner;
 
 Outer passAndReturnOuterByVal(Outer arg) { return arg; }
 // CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
-/* no sret align attributes for MSVC targets at the moment */
-// C HECK-SAME: %align.Outer* noalias sret align 32 %.sret_arg
+// CHECK-SAME: %align.Outer* noalias sret align 32 %.sret_arg
 /* how the arg is passed by value is ABI-specific, but the pointer must be aligned */
 // CHECK-SAME: align 32 %
 
 Inner passAndReturnInnerByVal(Inner arg) { return arg; }
 // CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
-// C HECK-SAME: %align.Inner* noalias sret align 32 %.sret_arg
+// CHECK-SAME: %align.Inner* noalias sret align 32 %.sret_arg
 // CHECK-SAME: align 32 %
 
 void main() {
@@ -49,11 +48,11 @@ void main() {
 
   outer = passAndReturnOuterByVal(outer);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
-  // C HECK-SAME: %align.Outer* noalias sret align 32 %.rettmp
+  // CHECK-SAME: %align.Outer* noalias sret align 32 %.rettmp
   // CHECK-SAME: align 32 %
 
   inner = passAndReturnInnerByVal(inner);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
-  // C HECK-SAME: %align.Inner* noalias sret align 32 %.rettmp1
+  // CHECK-SAME: %align.Inner* noalias sret align 32 %.rettmp1
   // CHECK-SAME: align 32 %
 }

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -9,14 +9,14 @@ static Inner globalInner;
 // CHECK: constant %align.Inner_init zeroinitializer, align 32
 
 Outer passAndReturnOuterByVal(Outer arg) { return arg; }
-// CHECK: define void @_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
+// CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
 /* no sret align attributes for MSVC targets at the moment */
 // C HECK-SAME: %align.Outer* noalias sret align 32 %.sret_arg
 /* how the arg is passed by value is ABI-specific, but the pointer must be aligned */
 // CHECK-SAME: align 32 %
 
 Inner passAndReturnInnerByVal(Inner arg) { return arg; }
-// CHECK: define void @_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
+// CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
 // C HECK-SAME: %align.Inner* noalias sret align 32 %.sret_arg
 // CHECK-SAME: align 32 %
 
@@ -48,12 +48,12 @@ void main() {
   // CHECK: %.rettmp{{.*}} = alloca %align.Inner, align 32
 
   outer = passAndReturnOuterByVal(outer);
-  // CHECK: call void @_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
+  // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
   // C HECK-SAME: %align.Outer* noalias sret align 32 %.rettmp
   // CHECK-SAME: align 32 %
 
   inner = passAndReturnInnerByVal(inner);
-  // CHECK: call void @_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
+  // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
   // C HECK-SAME: %align.Inner* noalias sret align 32 %.rettmp1
   // CHECK-SAME: align 32 %
 }

--- a/tests/codegen/attributes.d
+++ b/tests/codegen/attributes.d
@@ -9,7 +9,7 @@ import ldc.attributes;
 // CHECK-DAG: @{{.*}}mySectionedGlobali ={{.*}} section ".mySection"
 @(section(".mySection")) int mySectionedGlobal;
 
-// CHECK-DAG: define void @{{.*}}sectionedfoo{{.*}} section "funcSection"
+// CHECK-DAG: define{{.*}} void @{{.*}}sectionedfoo{{.*}} section "funcSection"
 @(section("funcSection")) void sectionedfoo() {}
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
Enable @rainers #1168 for Win64 too and add x86 AppVeyor jobs.
Requires https://github.com/ldc-developers/druntime/pull/65 and a post-3.8 LLVM (Rainer's work has uncovered a few LLVM bugs whose near-instant fixes didn't make it into 3.8 final).