### PR TITLE
Implement cent/ucent data types.

### DIFF
--- a/dmd2/builtin.c
+++ b/dmd2/builtin.c
@@ -120,8 +120,12 @@ static inline int getBitsizeOfType(Loc loc, Type *type)
       case Tuns16: return 16;
       case Tint128:
       case Tuns128:
+#if WANT_CENT
+        return 128;
+#else
           error(loc, "cent/ucent not supported");
           break;
+#endif
       default:
           error(loc, "unsupported type");
           break;
@@ -281,8 +285,20 @@ Expression *eval_bswap(Loc loc, FuncDeclaration *fd, Expressions *arguments)
     #define BYTEMASK  0x00FF00FF00FF00FFLL
     #define SHORTMASK 0x0000FFFF0000FFFFLL
     #define INTMASK 0x00000000FFFFFFFFLL
+#if WANT_CENT
+    #define LONGMASK 0xFFFFFFFFFFFFFFFFLL
+#endif
     switch (type->toBasetype()->ty)
     {
+      case Tint128:
+      case Tuns128:
+#if WANT_CENT
+          // swap high and low uints
+          n = ((n >> 64) & LONGMASK) | ((n & LONGMASK) << 64);
+#else
+          error(loc, "cent/ucent not supported");
+          break;
+#endif
       case Tint64:
       case Tuns64:
           // swap high and low uints
@@ -295,10 +311,6 @@ Expression *eval_bswap(Loc loc, FuncDeclaration *fd, Expressions *arguments)
       case Tuns16:
           // swap adjacent ubytes
           n = ((n >> 8 ) & BYTEMASK)  | ((n & BYTEMASK) << 8 );
-          break;
-      case Tint128:
-      case Tuns128:
-          error(loc, "cent/ucent not supported");
           break;
       default:
           error(loc, "unsupported type");

--- a/dmd2/constfold.c
+++ b/dmd2/constfold.c
@@ -648,6 +648,16 @@ UnionExp Shr(Type *type, Expression *e1, Expression *e2)
                 value = (d_uns64)(value) >> count;
                 break;
 
+#if WANT_CENT
+        case Tint128:
+                value = (d_int128)(value) >> count;
+                break;
+
+        case Tuns128:
+                value = (d_uns128)(value) >> count;
+                break;
+#endif
+
         case Terror:
                 new(&ue) ErrorExp();
                 return ue;
@@ -690,10 +700,22 @@ UnionExp Ushr(Type *type, Expression *e1, Expression *e2)
                 value = (value & 0xFFFFFFFF) >> count;
                 break;
 
+#if WANT_CENT
+        case Tint64:
+        case Tuns64:
+                value = (value & 0xFFFFFFFFFFFFFFFF) >> count;
+                break;
+
+        case Tint128:
+        case Tuns128:
+                value = (d_uns128)(value) >> count;
+                break;
+#else
         case Tint64:
         case Tuns64:
                 value = (d_uns64)(value) >> count;
                 break;
+#endif
 
         case Terror:
                 new(&ue) ErrorExp();
@@ -1257,6 +1279,10 @@ L1:
                 case Tuns32:    result = (d_uns32)r;    break;
                 case Tint64:    result = (d_int64)r;    break;
                 case Tuns64:    result = (d_uns64)r;    break;
+#if WANT_CENT
+                case Tint128:   result = (d_int128)r;   break;
+                case Tuns128:   result = (d_uns128)r;   break;
+#endif
                 default:
                     assert(0);
             }

--- a/dmd2/ctfeexpr.c
+++ b/dmd2/ctfeexpr.c
@@ -1127,6 +1127,17 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
             case Tuns64:
                 result = (d_uns64)(value) >> count;
                 break;
+
+#if WANT_CENT
+            case Tint128:
+                result = (d_int128)(value) >> count;
+                break;
+
+            case Tuns128:
+                result = (d_uns128)(value) >> count;
+                break;
+#endif
+
             default:
                 assert(0);
         }
@@ -1160,10 +1171,22 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
                 result = (value & 0xFFFFFFFF) >> count;
                 break;
 
+#if WANT_CENT
+            case Tint64:
+            case Tuns64:
+                result = (value & 0xFFFFFFFFFFFFFFFF) >> count;
+                break;
+
+            case Tint128:
+            case Tuns128:
+                result = (d_uns128)(value) >> count;
+                break;
+#else
             case Tint64:
             case Tuns64:
                 result = (d_uns64)(value) >> count;
                 break;
+#endif
 
             default:
                 assert(0);

--- a/dmd2/expression.c
+++ b/dmd2/expression.c
@@ -2941,6 +2941,10 @@ void IntegerExp::normalize()
         case Tuns32:        value = (d_uns32) value;        break;
         case Tint64:        value = (d_int64) value;        break;
         case Tuns64:        value = (d_uns64) value;        break;
+#if WANT_CENT
+        case Tint128:       value = (d_int128) value;       break;
+        case Tuns128:       value = (d_uns128) value;       break;
+#endif
         case Tpointer:
             if (Target::ptrsize == 4)
                 value = (d_uns32) value;

--- a/dmd2/globals.h
+++ b/dmd2/globals.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "longdouble.h"
+#include "int128.h"
 #include "outbuffer.h"
 #include "filename.h"
 
@@ -294,6 +295,11 @@ struct Global
 
 extern Global global;
 
+#if WANT_CENT
+typedef uint128_t dinteger_t;
+typedef int128_t sinteger_t;
+typedef uint128_t uinteger_t;
+#else
 // Because int64_t and friends may be any integral type of the
 // correct size, we have to explicitly ask for the correct
 // integer type to get the correct mangling with ddmd
@@ -310,6 +316,7 @@ typedef unsigned long long dinteger_t;
 typedef long long sinteger_t;
 typedef unsigned long long uinteger_t;
 #endif
+#endif
 
 typedef int8_t                  d_int8;
 typedef uint8_t                 d_uns8;
@@ -319,6 +326,10 @@ typedef int32_t                 d_int32;
 typedef uint32_t                d_uns32;
 typedef int64_t                 d_int64;
 typedef uint64_t                d_uns64;
+#if WANT_CENT
+typedef int128_t                d_int128;
+typedef uint128_t               d_uns128;
+#endif
 
 typedef float                   d_float32;
 typedef double                  d_float64;

--- a/dmd2/hdrgen.c
+++ b/dmd2/hdrgen.c
@@ -2182,6 +2182,24 @@ public:
                     buf->printf("%lluLU", v);
                     break;
 
+#if WANT_CENT
+                case Tint128: {
+                    char buffer[42];
+                    sprintf_i128(buffer, v);
+                    assert(strlen(buffer) < sizeof(buffer));
+                    buf->writestring(buffer);
+                    }
+                    break;
+
+                case Tuns128: {
+                    char buffer[42];
+                    sprintf_u128(buffer, v);
+                    assert(strlen(buffer) < sizeof(buffer));
+                    buf->writestring(buffer);
+                    }
+                    break;
+#endif
+
                 case Tbool:
                     buf->writestring(v ? "true" : "false");
                     break;

--- a/dmd2/mtype.c
+++ b/dmd2/mtype.c
@@ -317,11 +317,13 @@ unsigned Type::alignsize()
 
 Type *Type::semantic(Loc loc, Scope *sc)
 {
+#if !WANT_CENT
     if (ty == Tint128 || ty == Tuns128)
     {
         error(loc, "cent and ucent types not implemented");
         return terror;
     }
+#endif
 
     return merge();
 }
@@ -2494,6 +2496,10 @@ uinteger_t Type::sizemask()
         case Tuns32:    m = 0xFFFFFFFFUL;               break;
         case Tint64:
         case Tuns64:    m = 0xFFFFFFFFFFFFFFFFULL;      break;
+#if WANT_CENT
+        case Tint128:
+        case Tuns128:   m = UINT128C(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFFFFULL); break;
+#endif
         default:
                 assert(0);
     }
@@ -3033,6 +3039,10 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tuns32:        ivalue = 0xFFFFFFFFUL;  goto Livalue;
             case Tint64:        ivalue = 0x7FFFFFFFFFFFFFFFLL;  goto Livalue;
             case Tuns64:        ivalue = 0xFFFFFFFFFFFFFFFFULL; goto Livalue;
+#if WANT_CENT
+            case Tint128:       ivalue = INT128C(0x7FFFFFFFFFFFFFFFLL, 0xFFFFFFFFFFFFFFFFULL);   goto Livalue;
+            case Tuns128:       ivalue = UINT128C(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL); goto Livalue;
+#endif
             case Tbool:         ivalue = 1;             goto Livalue;
             case Tchar:         ivalue = 0xFF;          goto Livalue;
             case Twchar:        ivalue = 0xFFFFUL;      goto Livalue;
@@ -3061,6 +3071,10 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tuns32:        ivalue = 0;                     goto Livalue;
             case Tint64:        ivalue = (-9223372036854775807LL-1LL);  goto Livalue;
             case Tuns64:        ivalue = 0;             goto Livalue;
+#if WANT_CENT
+            case Tint128:       ivalue = INT128C(0x8000000000000000LL, 0x0LL); goto Livalue;
+            case Tuns128:       ivalue = 0;             goto Livalue;
+#endif
             case Tbool:         ivalue = 0;             goto Livalue;
             case Tchar:         ivalue = 0;             goto Livalue;
             case Twchar:        ivalue = 0;             goto Livalue;

--- a/dmd2/parse.c
+++ b/dmd2/parse.c
@@ -784,12 +784,21 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                 if (token.value == TOKlparen)
                 {
                     nextToken();
+#if WANT_CENT
+                    if (token.value == TOKint32v && token.uns128value > 0)
+                    {
+                        if (token.uns128value & (token.uns128value - 1))
+                            error("align(%s) must be a power of 2", token.toChars());
+                        n = (unsigned)token.uns128value;
+                    }
+#else
                     if (token.value == TOKint32v && token.uns64value > 0)
                     {
                         if (token.uns64value & (token.uns64value - 1))
                             error("align(%s) must be a power of 2", token.toChars());
                         n = (unsigned)token.uns64value;
                     }
+#endif
                     else
                     {
                         error("positive integer expected, not %s", token.toChars());
@@ -868,8 +877,13 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                     nextToken();
                     if (token.value == TOKidentifier)
                         s = new DebugSymbol(token.loc, token.ident);
+#if WANT_CENT
+                    else if (token.value == TOKint32v || token.value == TOKint64v || token.value == TOKint128v)
+                        s = new DebugSymbol(token.loc, (unsigned)token.uns128value);
+#else
                     else if (token.value == TOKint32v || token.value == TOKint64v)
                         s = new DebugSymbol(token.loc, (unsigned)token.uns64value);
+#endif
                     else
                     {
                         error("identifier or integer expected, not %s", token.toChars());
@@ -892,8 +906,13 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                     nextToken();
                     if (token.value == TOKidentifier)
                         s = new VersionSymbol(token.loc, token.ident);
+#if WANT_CENT
+                    else if (token.value == TOKint32v || token.value == TOKint64v || token.value == TOKint128v)
+                        s = new VersionSymbol(token.loc, (unsigned)token.uns128value);
+#else
                     else if (token.value == TOKint32v || token.value == TOKint64v)
                         s = new VersionSymbol(token.loc, (unsigned)token.uns64value);
+#endif
                     else
                     {
                         error("identifier or integer expected, not %s", token.toChars());
@@ -1394,8 +1413,13 @@ Condition *Parser::parseDebugCondition()
 
         if (token.value == TOKidentifier)
             id = token.ident;
+#if WANT_CENT
+        else if (token.value == TOKint32v || token.value == TOKint64v || token.value == TOKint128v)
+            level = (unsigned)token.uns128value;
+#else
         else if (token.value == TOKint32v || token.value == TOKint64v)
             level = (unsigned)token.uns64value;
+#endif
         else
             error("identifier or integer expected, not %s", token.toChars());
         nextToken();
@@ -1428,8 +1452,13 @@ Condition *Parser::parseVersionCondition()
          */
         if (token.value == TOKidentifier)
             id = token.ident;
+#if WANT_CENT
+        else if (token.value == TOKint32v || token.value == TOKint64v || token.value == TOKint128v)
+            level = (unsigned)token.uns128value;
+#else
         else if (token.value == TOKint32v || token.value == TOKint64v)
             level = (unsigned)token.uns64value;
+#endif
         else if (token.value == TOKunittest)
             id = Identifier::idPool(Token::toChars(TOKunittest));
         else if (token.value == TOKassert)
@@ -3625,8 +3654,13 @@ void Parser::parseStorageClasses(StorageClass &storage_class, LINK &link, unsign
                 if (token.value == TOKlparen)
                 {
                     nextToken();
+#if WANT_CENT
+                    if (token.value == TOKint32v && token.uns128value > 0)
+                        structalign = (unsigned)token.uns128value;
+#else
                     if (token.value == TOKint32v && token.uns64value > 0)
                         structalign = (unsigned)token.uns64value;
+#endif
                     else
                     {
                         error("positive integer expected, not %s", token.toChars());
@@ -6612,6 +6646,37 @@ Expression *Parser::parsePrimaryExp()
             nextToken();
             break;
 
+#if WANT_CENT
+        case TOKint32v:
+	    e = new IntegerExp(loc, (d_int32)token.int128value, Type::tint32);
+            nextToken();
+            break;
+
+        case TOKuns32v:
+	    e = new IntegerExp(loc, (d_uns32)token.uns128value, Type::tuns32);
+            nextToken();
+            break;
+
+        case TOKint64v:
+            e = new IntegerExp(loc, (d_int64)token.int128value, Type::tint64);
+            nextToken();
+            break;
+
+        case TOKuns64v:
+            e = new IntegerExp(loc, (d_uns64)token.uns128value, Type::tuns64);
+            nextToken();
+            break;
+
+        case TOKint128v:
+            e = new IntegerExp(loc, token.int128value, Type::tint128);
+            nextToken();
+            break;
+
+        case TOKuns128v:
+            e = new IntegerExp(loc, token.uns128value, Type::tuns128);
+            nextToken();
+            break;
+#else
         case TOKint32v:
             e = new IntegerExp(loc, (d_int32)token.int64value, Type::tint32);
             nextToken();
@@ -6631,6 +6696,7 @@ Expression *Parser::parsePrimaryExp()
             e = new IntegerExp(loc, token.uns64value, Type::tuns64);
             nextToken();
             break;
+#endif
 
         case TOKfloat32v:
             e = new RealExp(loc, token.float80value, Type::tfloat32);
@@ -6707,6 +6773,22 @@ Expression *Parser::parsePrimaryExp()
             nextToken();
             break;
 
+#if WANT_CENT
+        case TOKcharv:
+	    e = new IntegerExp(loc, (d_uns8)token.uns128value, Type::tchar);
+            nextToken();
+            break;
+
+        case TOKwcharv:
+	    e = new IntegerExp(loc, (d_uns16)token.uns128value, Type::twchar);
+            nextToken();
+            break;
+
+        case TOKdcharv:
+	    e = new IntegerExp(loc, (d_uns32)token.uns128value, Type::tdchar);
+            nextToken();
+            break;
+#else
         case TOKcharv:
             e = new IntegerExp(loc, (d_uns8)token.uns64value, Type::tchar);
             nextToken();
@@ -6721,6 +6803,7 @@ Expression *Parser::parsePrimaryExp()
             e = new IntegerExp(loc, (d_uns32)token.uns64value, Type::tdchar);
             nextToken();
             break;
+#endif
 
         case TOKstring:
         case TOKxstring:

--- a/dmd2/root/int128.c
+++ b/dmd2/root/int128.c
@@ -1,0 +1,58 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/int128.c
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "int128.h"
+
+#if WANT_CENT
+// see http://stackoverflow.com/question/11656241/how-to-print-uint128-t-number-using-gcc
+#ifndef UINT64_MAX
+#define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
+#endif
+
+#define INT128_MIN INT128C(0x8000000000000000ULL, 0x0000000000000000ULL)
+
+#define P10_UINT64 10000000000000000000ULL
+
+void sprintf_u128(char *buffer, uint128_t u128)
+{
+    if (u128 > UINT64_MAX)
+    {
+        uint128_t leading = u128 / P10_UINT64;
+        uint64_t trailing = u128 % P10_UINT64;
+        sprintf_u128(buffer, leading);
+        sprintf(&buffer[strlen(buffer)], "%.19llu", trailing);
+    }
+    else
+    {
+         sprintf(buffer,"%llu",(uint64_t) u128);
+    }
+}
+
+void sprintf_i128(char *buffer, int128_t i128)
+{
+    if (i128 == INT128_MIN)
+        strcpy(buffer, "-170141183460469231731687303715884105728");
+    else
+    {
+        if (i128 < 0)
+        {
+            *buffer++ = '-';
+            i128 = -i128;
+        }
+        sprintf_u128(buffer, (uint128_t) i128);
+    }
+}
+
+#endif

--- a/dmd2/root/int128.h
+++ b/dmd2/root/int128.h
@@ -1,0 +1,30 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/int128.h
+ */
+
+#ifndef DMD_INT128_H
+#define DMD_INT128_H
+
+#define WANT_CENT __GNUC__
+
+#if WANT_CENT
+typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
+
+// 128bit literals are not supported
+#define INT128C(hi,lo) ((((int128_t)hi)<<64)|lo)
+#define UINT128C(hi,lo) ((((uint128_t)hi)<<64)|lo)
+
+void sprintf_i128(char* buffer, int128_t v);
+void sprintf_u128(char* buffer, uint128_t v);
+
+#endif
+
+#endif // DMD_INT128_H

--- a/dmd2/tokens.c
+++ b/dmd2/tokens.c
@@ -58,6 +58,34 @@ const char *Token::toChars()
     const char *p = &buffer[0];
     switch (value)
     {
+#if WANT_CENT
+        case TOKint32v:
+            sprintf(&buffer[0],"%d",(d_int32)int128value);
+            break;
+
+        case TOKuns32v:
+        case TOKcharv:
+        case TOKwcharv:
+        case TOKdcharv:
+            sprintf(&buffer[0],"%uU",(d_uns32)uns128value);
+            break;
+
+        case TOKint64v:
+            sprintf(&buffer[0],"%lldL",(longlong)int128value);
+            break;
+
+        case TOKuns64v:
+            sprintf(&buffer[0],"%lluUL",(ulonglong)uns128value);
+            break;
+
+        case TOKint128v:
+            sprintf_i128(&buffer[0], int128value);
+            break;
+
+        case TOKuns128v:
+            sprintf_u128(&buffer[0], uns128value);
+            break;
+#else
         case TOKint32v:
             sprintf(&buffer[0],"%d",(d_int32)int64value);
             break;
@@ -76,6 +104,7 @@ const char *Token::toChars()
         case TOKuns64v:
             sprintf(&buffer[0],"%lluUL",(ulonglong)uns64value);
             break;
+#endif
 
         case TOKfloat32v:
             ld_sprint(&buffer[0], 'g', float80value);

--- a/dmd2/tokens.h
+++ b/dmd2/tokens.h
@@ -201,8 +201,13 @@ struct Token
     union
     {
         // Integers
+#if WANT_CENT
+        d_int128 int128value;
+        d_uns128 uns128value;
+#else
         d_int64 int64value;
         d_uns64 uns64value;
+#endif
 
         // Floats
         d_float80 float80value;


### PR DESCRIPTION
This is a first try at implementing the data types cent and ucent.
All changes are wrapped in #if WANT_CENT .. #endif. It takes
advantage of the GCC builtin type __int128 and is currently only
enabled if compiled with gcc.

As soon as this is stable it should go upstream, too.