### PR TITLE
Fix mangling error on AArch64 platform.

### DIFF
--- a/ddmd/cppmangle.d
+++ b/ddmd/cppmangle.d
@@ -648,7 +648,12 @@ version(IN_LLVM) {
                 c = 'd';
                 break;
             case Tfloat80:
+version(IN_LLVM) {
+                // There is no platform which uses __float128 for real.
+                c = 'e';
+} else {
                 c = (Target.realsize - Target.realpad == 16) ? 'g' : 'e';
+}
                 break;
             case Tbool:
                 c = 'b';


### PR DESCRIPTION
There is no platform which uses `__float128` for `real` data type.
On AArch64 the wrong mangling is choosen. Just remove support for
`__float128`.