### PR TITLE
Ensure strict evaluation order in slice expressions.

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1331,12 +1331,14 @@ public:
       assert(e->upr);
 
       // get bounds (make sure $ works)
+      // The lower bound expression must be fully evaluated to an RVal before
+      // evaluating the upper bound expression, because the lower bound
+      // expression might change value after evaluating the upper bound, e.g. in
+      // a statement like this: `auto a1 = values[offset .. offset += 2];`
       p->arrays.push_back(v);
-      DValue *lo = toElem(e->lwr);
-      DValue *up = toElem(e->upr);
+      LLValue *vlo = toElem(e->lwr)->getRVal();
+      LLValue *vup = toElem(e->upr)->getRVal();
       p->arrays.pop_back();
-      LLValue *vlo = lo->getRVal();
-      LLValue *vup = up->getRVal();
 
       const bool needCheckUpper =
           (etype->ty != Tpointer) && !e->upperIsInBounds;


### PR DESCRIPTION
Fixes a 2.070 testsuite bug that only manifests itself for 32bit compilation.
Code like this is bugged without this PR:
```D
uint[] values = [0,1,2,3,4];
size_t offset = 0;
auto a = values[offset .. offset+=2];
assert (a == [0,1] && offset == 2);
```
The type of `offset` is important. In the testsuite, the type is `uint`, such that for 64bit compilation the lowerbound expression `32bit offset` is converted to a 64bit value before evaluating the upperbound, hence it all works out OK for 64bit. For 32bit, no conversion is needed and the lowerbound expression is only fully evaluated after offset+=2.