### PR TITLE
Ensure that the sync object is mutable in a `synchronize(obj) {...}` statement.

### DIFF
--- a/dmd2/statement.c
+++ b/dmd2/statement.c
@@ -4435,7 +4435,17 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
             exp = new CastExp(loc, exp, t);
             exp = exp->semantic(sc);
         }
-
+#if IN_LLVM
+        /* Semantic checking is skipped for the calls to _d_monitorenter/exit below,
+         * however they may write to the __monitor ptr of the object (argument type is mutable Object).
+         * Ensure here that the synchronization object is mutable.
+         */
+        if (!exp->type->isMutable())
+        {
+            error("LDC only supports synchronize on a mutable object, not on '%s' of type '%s'", exp->toChars(), exp->type->toChars());
+            return new ErrorStatement();
+        }
+#endif
 #if 1
         /* Rewrite as:
          *  auto tmp = exp;


### PR DESCRIPTION
See https://github.com/D-Programming-Language/dmd/pull/5564

(Let's do better than DMD and kill this bug asap ;))