### PR TITLE
[WIP] Ensure that the sync object is mutable in a `synchronize(obj) {...}` statement.

### DIFF
--- a/ddmd/statement.d
+++ b/ddmd/statement.d
@@ -4831,6 +4831,29 @@ public:
                 exp = new CastExp(loc, exp, t);
                 exp = exp.semantic(sc);
             }
+
+            version(IN_LLVM)
+            {
+                /+ Semantic checking is skipped for the calls to _d_monitorenter/exit below,
+                 + however they may write to the __monitor ptr of the object (argument type is mutable Object).
+                 + Ensure here that the synchronization object is mutable.
+                 +/
+                if (!exp.type.isMutable())
+                {
+                    if ( sc.func.isInvariantDeclaration()
+                        && ( (exp.op == TOKthis) || ((exp.op == TOKvar) && (cast(VarExp)exp).var.isThisDeclaration()) ) )
+                    {
+                        // Explicitly allow `synchronized invariant() { }` for now.
+                        // Also allow the equivalent: `invariant() { synchronized(this) {} }`.
+                    }
+                    else
+                    {
+                        error("LDC only supports synchronize on a mutable object, not on '%s' of type '%s'", exp.toChars(), exp.type.toChars());
+                        return new ErrorStatement();
+                    }
+                }
+            }
+
             version (all)
             {
                 /* Rewrite as:

--- a/tests/fail_compilation/immutable_synchronize.d
+++ b/tests/fail_compilation/immutable_synchronize.d
@@ -1,0 +1,22 @@
+// RUN: not %ldc %s -c -o- 2>&1 | FileCheck %s
+
+class A {}
+
+void foo()
+{
+  {
+    A a;
+// CHECK-NOT: immutable_synchronize.d(10):
+    synchronized(a) {}
+  }
+  {
+    const A a;
+// CHECK: immutable_synchronize.d(15): Error: {{.*}} synchronize on a mutable object, not on 'a' of type 'const(A)'
+    synchronized(a) {}
+  }
+  {
+    immutable A a;
+// CHECK: immutable_synchronize.d(20): Error: {{.*}} synchronize on a mutable object, not on 'a' of type 'immutable(A)'
+    synchronized(a) {}
+  }
+}


### PR DESCRIPTION
See https://github.com/D-Programming-Language/dmd/pull/5564

Also see LTS PR: https://github.com/ldc-developers/ldc/pull/1384

Depends on Phobos PR: https://github.com/ldc-developers/phobos/pull/30
