### PR TITLE
Refactor DVarValue handling; fix dumping ToElemVisitor result to stack slot

### DIFF
--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -130,9 +130,8 @@ public:
 
   DVarValue *isVar() override { return this; }
 
-  VarDeclaration *var;
-
 protected:
+  VarDeclaration *var;
   llvm::Value *val;
 };
 

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -61,6 +61,16 @@ public:
 
   virtual bool isLVal() { return false; }
 
+  /// Returns true iff the value can be accessed at the end of the entry basic
+  /// block of the current function, in the sense that it is either not derived
+  /// from an llvm::Instruction (but from a global, constant, etc.) or that
+  /// instruction is part of the entry basic block.
+  ///
+  /// In other words, whatever value the result of getLVal()/getRVal() might be
+  /// derived from then certainly dominates uses in all other basic blocks of
+  /// the function.
+  virtual bool definedInFuncEntryBB() = 0;
+
   virtual DImValue *isIm() { return nullptr; }
   virtual DConstValue *isConst() { return nullptr; }
   virtual DNullValue *isNull() { return nullptr; }
@@ -87,6 +97,8 @@ public:
     return val;
   }
 
+  bool definedInFuncEntryBB() override;
+
   DImValue *isIm() override { return this; }
 
 protected:
@@ -99,6 +111,8 @@ public:
   DConstValue(Type *t, llvm::Constant *con) : DValue(t), c(con) {}
 
   llvm::Value *getRVal() override;
+
+  bool definedInFuncEntryBB() override { return true; }
 
   DConstValue *isConst() override { return this; }
 
@@ -129,6 +143,8 @@ public:
   /// Illegal to call on any other value.
   llvm::Value *getRefStorage();
 
+  bool definedInFuncEntryBB() override;
+
   DVarValue *isVar() override { return this; }
 
 protected:
@@ -144,6 +160,8 @@ public:
 
   llvm::Value *getRVal() override;
 
+  bool definedInFuncEntryBB() override;
+
   DSliceValue *isSlice() override { return this; }
 
   llvm::Value *len;
@@ -158,6 +176,8 @@ public:
   DFuncValue(FuncDeclaration *fd, llvm::Value *v, llvm::Value *vt = nullptr);
 
   llvm::Value *getRVal() override;
+
+  bool definedInFuncEntryBB() override;
 
   DFuncValue *isFunc() override { return this; }
 

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -112,11 +112,14 @@ public:
   DNullValue *isNull() override { return this; }
 };
 
-// variable d-value
+/// This is really a misnomer, DVarValue represents generic lvalues, which
+/// might or might not come from variable declarations.
+// TODO: Rename this, probably remove getLVal() from parent since this is the
+// only lvalue. The isSpecialRefVar case should probably also be its own
+// subclass.
 class DVarValue : public DValue {
 public:
-  DVarValue(Type *t, VarDeclaration *vd, llvm::Value *llvmValue);
-  DVarValue(Type *t, llvm::Value *llvmValue);
+  DVarValue(Type *t, llvm::Value *llvmValue, bool isSpecialRefVar = false);
 
   bool isLVal() override { return true; }
   llvm::Value *getLVal() override;
@@ -124,13 +127,13 @@ public:
 
   /// Returns the underlying storage for special internal ref variables.
   /// Illegal to call on any other value.
-  virtual llvm::Value *getRefStorage();
+  llvm::Value *getRefStorage();
 
   DVarValue *isVar() override { return this; }
 
 protected:
-  VarDeclaration *var;
-  llvm::Value *val;
+  llvm::Value *const val;
+  bool const isSpecialRefVar;
 };
 
 // slice d-value

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -35,7 +35,6 @@ class DImValue;
 class DConstValue;
 class DNullValue;
 class DVarValue;
-class DFieldValue;
 class DFuncValue;
 class DSliceValue;
 
@@ -66,7 +65,6 @@ public:
   virtual DConstValue *isConst() { return nullptr; }
   virtual DNullValue *isNull() { return nullptr; }
   virtual DVarValue *isVar() { return nullptr; }
-  virtual DFieldValue *isField() { return nullptr; }
   virtual DSliceValue *isSlice() { return nullptr; }
   virtual DFuncValue *isFunc() { return nullptr; }
 
@@ -133,13 +131,6 @@ public:
 protected:
   VarDeclaration *var;
   llvm::Value *val;
-};
-
-// field d-value
-class DFieldValue : public DVarValue {
-public:
-  DFieldValue(Type *t, llvm::Value *llvmValue) : DVarValue(t, llvmValue) {}
-  DFieldValue *isField() override { return this; }
 };
 
 // slice d-value

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -9,11 +9,7 @@
 
 #include "gen/llvmhelpers.h"
 #include "expression.h"
-#include "id.h"
-#include "init.h"
-#include "mars.h"
-#include "module.h"
-#include "template.h"
+#include "gen/abi.h"
 #include "gen/arrays.h"
 #include "gen/classes.h"
 #include "gen/complex.h"
@@ -29,10 +25,14 @@
 #include "gen/tollvm.h"
 #include "gen/typeinf.h"
 #include "gen/uda.h"
-#include "gen/abi.h"
+#include "id.h"
+#include "init.h"
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
 #include "ir/irtypeaggr.h"
+#include "mars.h"
+#include "module.h"
+#include "template.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
@@ -659,7 +659,7 @@ DValue *DtoCast(Loc &loc, DValue *val, Type *to) {
       // Do nothing, the types will match up anyway.
       return new DImValue(to, val->getRVal());
     }
-    // fall-through
+  // fall-through
   default:
     error(loc, "invalid cast from '%s' to '%s'", val->getType()->toChars(),
           to->toChars());

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -16,11 +16,11 @@
 #ifndef LDC_GEN_LLVMHELPERS_H
 #define LDC_GEN_LLVMHELPERS_H
 
-#include "mtype.h"
-#include "statement.h"
 #include "gen/dvalue.h"
 #include "gen/llvm.h"
 #include "ir/irfuncty.h"
+#include "mtype.h"
+#include "statement.h"
 
 // dynamic memory helpers
 LLValue *DtoNew(Loc &loc, Type *newtype);
@@ -256,5 +256,12 @@ DValue *toElem(Expression *e);
 DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
 LLConstant *toConstElem(Expression *e, IRState *p);
+
+/// Creates a DVarValue for the given VarDeclaration.
+///
+/// If the storage is not given explicitly, the declaration is expected to be
+/// already resolved, and the value from the associated IrVar will be used.
+DValue *makeVarDValue(Type *type, VarDeclaration *vd,
+                      llvm::Value *storage = nullptr);
 
 #endif

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1304,25 +1304,20 @@ public:
                          e->type->toChars());
     LOG_SCOPE;
 
-    // this is the new slicing code, it's different in that a full slice will no
-    // longer retain the original pointer.
-    // but this was broken if there *was* no original pointer, ie. a slice of a
-    // slice...
-    // now all slices have *both* the 'len' and 'ptr' fields set to != null.
-
     // value being sliced
     LLValue *elen = nullptr;
     LLValue *eptr;
     DValue *v = toElem(e->e1);
 
-    // handle pointer slicing
     Type *etype = e->e1->type->toBasetype();
     if (etype->ty == Tpointer) {
+      // pointer slicing
       assert(e->lwr);
       eptr = v->getRVal();
     }
-    // array slice
+
     else {
+      // array slice
       eptr = DtoArrayPtr(v);
     }
 
@@ -1383,8 +1378,7 @@ public:
     // no bounds or full slice -> just convert to slice
     else {
       assert(e->e1->type->toBasetype()->ty != Tpointer);
-      // if the sliceee is a static array, we use the length of that as DMD
-      // seems
+      // if the slicee is a static array, we use the length of that as DMD seems
       // to give contrary inconsistent sizesin some multidimensional static
       // array cases.
       // (namely default initialization, int[16][16] arr; -> int[256] arr = 0;)

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2279,7 +2279,7 @@ public:
 
     p->scope() = IRScope(condend);
     if (retPtr) {
-      result = new DVarValue(e->type, DtoLoad(retPtr));
+      result = new DVarValue(e->type, retPtr, true);
     } else {
       result = new DConstValue(e->type, getNullValue(DtoMemType(dtype)));
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1051,11 +1051,6 @@ public:
     }
 
     DValue *v = toElem(e->e1, true);
-    if (v->isField()) {
-      Logger::println("is field");
-      result = v;
-      return;
-    }
     if (DFuncValue *fv = v->isFunc()) {
       Logger::println("is func");
       // Logger::println("FuncDeclaration");

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -318,12 +318,9 @@ public:
 
     result = DtoDeclarationExp(e->declaration);
 
-    if (result) {
-      if (DVarValue *varValue = result->isVar()) {
-        VarDeclaration *vd = varValue->var;
-        if (!vd->isDataseg() && vd->edtor && !vd->noscope) {
-          pushVarDtorCleanup(p, vd);
-        }
+    if (auto vd = e->declaration->isVarDeclaration()) {
+      if (!vd->isDataseg() && vd->edtor && !vd->noscope) {
+        pushVarDtorCleanup(p, vd);
       }
     }
   }
@@ -1794,10 +1791,12 @@ public:
       if (tc->sym->isInterfaceDeclaration()) {
         DtoDeleteInterface(e->loc, dval);
         onstack = true;
-      } else if (DVarValue *vv = dval->isVar()) {
-        if (vv->var && vv->var->onstack) {
-          DtoFinalizeClass(e->loc, dval->getRVal());
-          onstack = true;
+      } else if (e->e1->op == TOKvar) {
+        if (auto vd = static_cast<VarExp *>(e->e1)->var->isVarDeclaration()) {
+          if (vd->onstack) {
+            DtoFinalizeClass(e->loc, dval->getRVal());
+            onstack = true;
+          }
         }
       }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -156,7 +156,9 @@ static void write_struct_literal(Loc loc, LLValue *mem, StructDeclaration *sd,
     }
 
     // get a pointer to this field
-    DVarValue field(vd->type, vd, DtoIndexAggregate(mem, sd, vd));
+    assert(!isSpecialRefVar(vd) && "Code not expected to handle special ref "
+                                   "vars, although it can easily be made to.");
+    DVarValue field(vd->type, DtoIndexAggregate(mem, sd, vd));
 
     // store the initializer there
     DtoAssign(loc, &field, val, TOKconstruct, true);
@@ -1143,9 +1145,10 @@ public:
     if (e->cachedLvalue) {
       Logger::println("using cached lvalue");
       LLValue *V = e->cachedLvalue;
-      VarDeclaration *vd = e->var->isVarDeclaration();
-      assert(vd);
-      result = new DVarValue(e->type, vd, V);
+      assert(!isSpecialRefVar(e->var->isVarDeclaration()) &&
+             "Code not expected to handle special ref vars, although it can "
+             "easily be made to.");
+      result = new DVarValue(e->type, V);
       return;
     }
 
@@ -1178,7 +1181,7 @@ public:
       }
 
       // Logger::cout() << "mem: " << *arrptr << '\n';
-      result = new DVarValue(e->type, vd, arrptr);
+      result = new DVarValue(e->type, arrptr);
     } else if (FuncDeclaration *fdecl = e->var->isFuncDeclaration()) {
       DtoResolveFunction(fdecl);
 
@@ -1240,7 +1243,10 @@ public:
         Logger::println("normal this exp");
         v = p->func()->thisArg;
       }
-      result = new DVarValue(e->type, vd, v);
+      assert(!isSpecialRefVar(vd) && "Code not expected to handle special ref "
+                                     "vars, although it can easily be made "
+                                     "to.");
+      result = new DVarValue(e->type, v);
     } else {
       llvm_unreachable("No VarDeclaration in ThisExp.");
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -9,14 +9,6 @@
 
 #include "attrib.h"
 #include "enum.h"
-#include "hdrgen.h"
-#include "id.h"
-#include "init.h"
-#include "mtype.h"
-#include "module.h"
-#include "port.h"
-#include "rmem.h"
-#include "template.h"
 #include "gen/aa.h"
 #include "gen/abi.h"
 #include "gen/arrays.h"
@@ -37,9 +29,17 @@
 #include "gen/tollvm.h"
 #include "gen/typeinf.h"
 #include "gen/warnings.h"
+#include "hdrgen.h"
+#include "id.h"
+#include "init.h"
 #include "ir/irfunction.h"
 #include "ir/irtypeclass.h"
 #include "ir/irtypestruct.h"
+#include "module.h"
+#include "mtype.h"
+#include "port.h"
+#include "rmem.h"
+#include "template.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ManagedStatic.h"
 #include <fstream>
@@ -100,14 +100,17 @@ static void write_struct_literal(Loc loc, LLValue *mem, StructDeclaration *sd,
     Expression *expr = (index < nexprs) ? exprs[index] : nullptr;
 
     if (vd->overlapped && !expr) {
-      // In case of an union (overlapped field), we can't simply use the default initializer.
+      // In case of an union (overlapped field), we can't simply use the default
+      // initializer.
       // Consider the type union U7727A1 { int i; double d; } and
       // the declaration U7727A1 u = { d: 1.225 };
       // The loop will first visit variable i and then d. Since d has an
-      // explicit initializer, we must use this one. We should therefore skip union fields
+      // explicit initializer, we must use this one. We should therefore skip
+      // union fields
       // with no explicit initializer.
-      IF_LOG Logger::println("skipping overlapped field without init expr: %s %s (+%u)", vd->type->toChars(),
-                             vd->toChars(), vd->offset);
+      IF_LOG Logger::println(
+          "skipping overlapped field without init expr: %s %s (+%u)",
+          vd->type->toChars(), vd->toChars(), vd->offset);
       continue;
     }
 
@@ -1899,8 +1902,9 @@ public:
     // struct invariants
     else if (global.params.useInvariants && condty->ty == Tpointer &&
              condty->nextOf()->ty == Tstruct &&
-             (invdecl = static_cast<TypeStruct *>(condty->nextOf())
-                            ->sym->inv) != nullptr) {
+             (invdecl =
+                  static_cast<TypeStruct *>(condty->nextOf())->sym->inv) !=
+                 nullptr) {
       Logger::print("calling struct invariant");
       DtoResolveFunction(invdecl);
       DFuncValue invfunc(invdecl, getIrFunc(invdecl)->func, cond->getRVal());


### PR DESCRIPTION
See the commit descriptions for details (most changes are just refactorings).

Fixes #1294 (both by avoiding the issue, as well as fixing potentially undiscovered similar issues by tackling the root cause).