### PR TITLE
CMake: Use appropriate DMD flags for CMAKE_BUILD_TYPE=RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,14 +111,16 @@ endif()
 # Setup D compiler flags and linker flags for phobos (system linker) etc. We use
 # DMD syntax for all the flags so we can work with both DMD and LDMD.
 set(DDMD_DFLAGS "-wi")
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-    append("-g" DDMD_DFLAGS)
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    append("-g -link-debuglib" DDMD_FLAGS)
+elseif(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+    append("-g -O -inline -release" DDMD_DFLAGS)
 else()
     # Default to a Release build type
     append("-O -inline -release" DDMD_DFLAGS)
 endif()
 
-if(WIN32)
+if(MSVC)
     if(${D_COMPILER_ID} STREQUAL "DigitalMars")
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
             message(STATUS "Let DMD output 64bit object files")
@@ -129,7 +131,6 @@ if(WIN32)
         endif()
     endif()
 endif()
-
 
 append("-J${PROJECT_SOURCE_DIR}/${DDMDFE_PATH}" DDMD_DFLAGS) # Needed for importing text files
 string(STRIP "${DDMD_DFLAGS}" DDMD_DFLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,26 @@ if(MSVC)
             message(STATUS "Let DMD output 32bit COFF object files")
             append("-m32mscoff" DDMD_DFLAGS)
         endif()
+
+        if(MSVC_VERSION GREATER 1800) # VS 2015+
+            append("-Llegacy_stdio_definitions.lib" DDMD_DFLAGS)
+        endif()
+    endif()
+
+    # LDC and LDMD are both linked against the dynamic MSVC runtime by
+    # default (due to default CMAKE_C[XX]_FLAGS_*).
+    # Host DMD/LDMD will default to linking against the static MSVC runtime.
+    # So disable some default libs based on CMAKE_C_FLAGS_RELEASE.
+    if(CMAKE_C_FLAGS_RELEASE MATCHES "(^| )[/-]MD( |$)")
+        append("-L/DEFAULTLIB:msvcrt -L/NODEFAULTLIB:libcmt" DDMD_DFLAGS)
+        if(MSVC_VERSION GREATER 1800) # VS 2015+
+            append("-L/NODEFAULTLIB:libvcruntime" DDMD_DFLAGS)
+        endif()
+    else()
+        append("-L/DEFAULTLIB:libcmt -L/NODEFAULTLIB:msvcrt" DDMD_DFLAGS)
+        if(MSVC_VERSION GREATER 1800) # VS 2015+
+            append("-L/NODEFAULTLIB:vcruntime" DDMD_DFLAGS)
+        endif()
     endif()
 endif()
 
@@ -574,11 +594,11 @@ set(tempVar "")
 FOREACH(f ${LDC_LINKERFLAG_LIST})
       append("-L${f}" tempVar)
 ENDFOREACH(f)
-if(WIN32)
+if(MSVC)
     # Issue 1297
     # The default system-allocated stack size is 8MB on Linux and Mac, but only 1MB on Windows
     # Set LDC's stack to 8MB also on Windows:
-    append("-L/STACK:8388608 -L/DEFAULTLIB:msvcrt -L/NODEFAULTLIB:libcmt legacy_stdio_definitions.lib" tempVar)
+    append("-L/STACK:8388608" tempVar)
 else()
     append("-L-lstdc++" tempVar)
 endif()
@@ -701,7 +721,7 @@ add_subdirectory(tests)
 install(PROGRAMS ${LDC_EXE_FULL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(PROGRAMS ${LDMD_EXE_FULL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 if(${BUILD_SHARED})
-    # For now, only install libldc if explicitely building the shared library.
+    # For now, only install libldc if explicitly building the shared library.
     # While it might theoretically be possible to use LDC as a static library
     # as well, for the time being this just bloats the normal packages.
     install(TARGETS ${LDC_LIB} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Hopefully generating the .pdb again for AppVeyor.