### PR TITLE
[cmake] Allow specification of D_COMPILER on CMake cmdline.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ include(CheckIncludeFile)
 include(CheckLibraryExists)
 include(CheckCXXCompilerFlag)
 
+# The script currently only supports the DMD-style commandline interface
+if (NOT D_COMPILER_DMD_COMPAT)
+    message(FATAL_ERROR "We currently only support building using a D compiler with a DMD-compatible commandline interface. (try 'ldmd2' or 'gdmd')")
+endif()
+
 #
 # Locate LLVM.
 #

--- a/cmake/Modules/FindDCompiler.cmake
+++ b/cmake/Modules/FindDCompiler.cmake
@@ -1,6 +1,6 @@
 # Find a D compiler!
 #
-# use environment variable DMD first if defined by user, next use a list of common compiler executables.
+# Use variable D_COMPILER first if defined by user, then try the environment variable DMD, next use a list of common compiler executables.
 #
 # The following variables are defined:
 #  D_COMPILER_FOUND          - true if a D compiler was found
@@ -8,20 +8,29 @@
 #  D_COMPILER_FLAGS    - D compiler flags (could be passed in the DMD environment variable)
 #  D_COMPILER_ID       = {"DigitalMars", "LDMD", "LDC", "GDC"}
 #  D_COMPILER_VERSION_STRING - String containing the compiler version, e.g. "DMD64 D Compiler v2.070.2"
+#  D_COMPILER_DMD_COMPAT - true if the D compiler cmdline interface is compatible with DMD
 
 
 set(D_COMPILER_FOUND "FALSE")
 
-set(COMMON_D_COMPILERS "ldmd2" "dmd")
+set(COMMON_D_COMPILERS "ldmd2" "dmd" "gdmd")
 set(COMMON_D_COMPILER_PATHS "/usr/bin" "/usr/local/bin" "C:\\d\\dmd2\\windows\\bin")
 
-if($ENV{DMD} MATCHES ".+")
+if (D_COMPILER)
+    get_filename_component(D_COMPILER ${D_COMPILER} PROGRAM PROGRAM_ARGS D_COMPILER_FLAGS_ENV_INIT CACHE)
+    if(D_COMPILER_FLAGS_ENV_INIT)
+        set(D_COMPILER_FLAGS "${D_COMPILER_FLAGS_ENV_INIT}" CACHE STRING "Default flags for D compiler")
+    endif()
+    if(NOT EXISTS ${D_COMPILER})
+        message(FATAL_ERROR "Could not find compiler set in variable D_COMPILER: ${D_COMPILER}.")
+    endif()
+elseif($ENV{DMD} MATCHES ".+")
     get_filename_component(D_COMPILER $ENV{DMD} PROGRAM PROGRAM_ARGS D_COMPILER_FLAGS_ENV_INIT CACHE)
     if(D_COMPILER_FLAGS_ENV_INIT)
         set(D_COMPILER_FLAGS "${D_COMPILER_FLAGS_ENV_INIT}" CACHE STRING "Default flags for D compiler")
     endif()
     if(NOT EXISTS ${D_COMPILER})
-        message(FATAL_ERROR "Could not find compiler set in environment variable $ENV{DMD}.")
+        message(FATAL_ERROR "Could not find compiler set in environment variable DMD: $ENV{DMD}.")
     endif()
 else()
     # "NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH" is necessary, otherwise CMake will find the compiler in the install prefix path!
@@ -35,12 +44,19 @@ if (D_COMPILER)
     get_filename_component(__D_COMPILER_NAME ${D_COMPILER} NAME_WE)
     if (__D_COMPILER_NAME STREQUAL "dmd")
         set(D_COMPILER_ID "DigitalMars")
+        set(D_COMPILER_DMD_COMPAT "TRUE")
     elseif (__D_COMPILER_NAME STREQUAL "ldmd2")
         set(D_COMPILER_ID "LDMD")
+        set(D_COMPILER_DMD_COMPAT "TRUE")
     elseif (__D_COMPILER_NAME STREQUAL "ldc2")
         set(D_COMPILER_ID "LDC")
+        set(D_COMPILER_DMD_COMPAT "FALSE")
     elseif (__D_COMPILER_NAME STREQUAL "gdc")
         set(D_COMPILER_ID "GDC")
+        set(D_COMPILER_DMD_COMPAT "FALSE")
+    elseif (__D_COMPILER_NAME STREQUAL "gdmd")
+        set(D_COMPILER_ID "GDMD")
+        set(D_COMPILER_DMD_COMPAT "TRUE")
     endif()
 
     # Older versions of ldmd do not have --version cmdline option, but the error message still contains the version info in the first line.
@@ -56,5 +72,5 @@ if (D_COMPILER_FOUND)
     message(STATUS "Found D compiler ${D_COMPILER}, with default flags '${D_COMPILER_FLAGS}'")
     message(STATUS "D compiler version: ${D_COMPILER_VERSION_STRING}")
 else()
-    message(FATAL_ERROR "Did not find D compiler! Try setting the 'DMD' environment variable.")
+    message(FATAL_ERROR "Did not find D compiler! Try setting the 'D_COMPILER' variable or 'DMD' environment variable.")
 endif()


### PR DESCRIPTION
Use with `cmake -DD_COMPILER=ldmd2`. Resolves issue #1320