### PR TITLE
Enable the DDMD overides for memory allocation when LDC+@weak is detected

### DIFF
--- a/ddmd/root/rmem.d
+++ b/ddmd/root/rmem.d
@@ -163,7 +163,22 @@ else
         goto L1;
     }
 
-    version(DigitalMars)
+    version (DigitalMars)
+    {
+        enum OVERRIDE_MEMALLOC = true;
+    }
+    else version (LDC)
+    {
+        // Memory allocation functions gained weak linkage when the @weak attribute was introduced.
+        import ldc.attributes;
+        enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
+    }
+    else
+    {
+        enum OVERRIDE_MEMALLOC = false;
+    }
+
+    static if (OVERRIDE_MEMALLOC)
     {
         extern (C) void* _d_allocmemory(size_t m_size)
         {


### PR DESCRIPTION
~~Important: this should be merged *after* druntime has been updated with @weak for the memory allocation functions (otherwise LDC-master will not be able to build itself).
See https://github.com/ldc-developers/ldc/pull/1413~~

The change will become effective once LDC 0.17.2 (yet unreleased, assuming #1413 will be merged) is used.
Edit: so this means that our current CI systems do not use the `OVERRIDE_MEMALLOC=true` path.