### PR TITLE
Fix C++ declarations causing link errors

### DIFF
--- a/ddmd/dsymbol.h
+++ b/ddmd/dsymbol.h
@@ -190,7 +190,7 @@ public:
     char *toChars();
     virtual char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc& getLoc();
-    char *locToChars();
+    const char *locToChars();
     bool equals(RootObject *o);
     bool isAnonymous();
     void error(Loc loc, const char *format, ...);

--- a/ddmd/mtype.h
+++ b/ddmd/mtype.h
@@ -788,7 +788,7 @@ public:
     structalign_t alignment();
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
-    bool isZeroInit(Loc loc) const;
+    bool isZeroInit(Loc loc) /*const*/;
     bool isAssignable();
     bool isBoolean() const;
     bool needsDestruction() const;


### PR DESCRIPTION
These are the symbols that caused actual link errors on Windows, but there are actually a lot more places in the headers that are wrong (i.e. adding const to an override does not override in C++, but creates a new vtable slot (if virtual)). This should be fixed in general upstream.