### PR TITLE
Add LDC-specific traits for CTFE information about the target machine.

### DIFF
--- a/ddmd/hooks.d
+++ b/ddmd/hooks.d
@@ -10,7 +10,10 @@ module ddmd.hooks;
 import ddmd.dscope;
 import ddmd.expression;
 
+import gen.ldctraits;
+
+/// Returns `null` when the __trait was not recognized.
 Expression semanticTraitsHook(TraitsExp e, Scope* sc)
 {
-    return null;
+    return semanticTraitsLDC(e, sc);
 }

--- a/ddmd/hooks.d
+++ b/ddmd/hooks.d
@@ -1,0 +1,16 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2016 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Distributed under the Boost Software License, Version 1.0.
+// http://www.boost.org/LICENSE_1_0.txt
+
+module ddmd.hooks;
+
+import ddmd.dscope;
+import ddmd.expression;
+
+Expression semanticTraitsHook(TraitsExp e, Scope* sc)
+{
+    return null;
+}

--- a/ddmd/idgen.d
+++ b/ddmd/idgen.d
@@ -393,6 +393,10 @@ Msgtable[] msgtable =
     { "LDC_global_crt_ctor" },
     { "LDC_global_crt_dtor" },
     { "LDC_extern_weak" },
+
+    // IN_LLVM: LDC-specific traits.
+    { "targetCPU" },
+    { "targetHasFeature" },
 ];
 
 

--- a/ddmd/traits.d
+++ b/ddmd/traits.d
@@ -27,6 +27,7 @@ import ddmd.expression;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.hdrgen;
+import ddmd.hooks;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.mtype;
@@ -1190,6 +1191,10 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.getPointerBitmap)
     {
         return pointerBitmap(e);
+    }
+    if (Expression ret = semanticTraitsHook(e, sc))
+    {
+        return ret;
     }
 
     extern (D) void* trait_search_fp(const(char)* seed, ref int cost)

--- a/gen/ldctraits.cpp
+++ b/gen/ldctraits.cpp
@@ -1,0 +1,56 @@
+//===-- ldctraits.cpp -----------------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/irstate.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+
+// TODO: move this to a D interfacing helper file
+struct Dstring {
+  const char *ptr;
+  size_t len;
+};
+
+Dstring traitsGetTargetCPU() {
+  auto cpu = gTargetMachine->getTargetCPU();
+  return {cpu.data(), cpu.size()};
+}
+
+bool traitsTargetHasFeature(Dstring feature) {
+#if LDC_LLVM_VER < 307
+  // LLVM below 3.7 does not provide the necessary means to obtain the needed information,
+  // return the safe "feature not enabled".
+  return false;
+#else
+  auto feat = llvm::StringRef(feature.ptr, feature.len);
+
+  // This is a work-around to a missing interface in LLVM to query whether a
+  // feature is set.
+
+  // Copy MCSubtargetInfo so we can modify it.
+  llvm::MCSubtargetInfo mcinfo = *gTargetMachine->getMCSubtargetInfo();
+  auto savedFeatbits = mcinfo.getFeatureBits();
+
+  // Nothing will change if the feature string is not recognized or if the
+  // feature is disabled.
+  {
+    auto newFeatbits = mcinfo.ApplyFeatureFlag(("-" + feat).str());
+    if (savedFeatbits == newFeatbits) {
+      return false;
+    }
+    mcinfo.setFeatureBits(savedFeatbits);
+  }
+  {
+    // Now that unrecognized feature strings are excluded,
+    // nothing will change iff the feature and its implied features are enabled.
+    auto newFeatbits = mcinfo.ApplyFeatureFlag(("+" + feat).str());
+    return savedFeatbits == newFeatbits;
+  }
+#endif
+}

--- a/gen/ldctraits.d
+++ b/gen/ldctraits.d
@@ -1,0 +1,77 @@
+//===-- gen/ldctraits.d - LDC-specific __traits handling ----------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//
+//===----------------------------------------------------------------------===//
+
+module gen.ldctraits;
+
+import ddmd.arraytypes;
+import ddmd.dscope;
+import ddmd.dtemplate;
+import ddmd.expression;
+import ddmd.errors;
+import ddmd.mtype;
+import ddmd.id;
+
+// TODO: move this to a D interfacing helper file
+extern(C++) struct Dstring
+{
+  const(char)* ptr;
+  size_t len;
+};
+
+extern(C++) Dstring traitsGetTargetCPU();
+extern(C++) bool traitsTargetHasFeature(Dstring feature);
+
+Expression semanticTraitsLDC(TraitsExp e, Scope* sc)
+{
+    size_t arg_count = e.args ? e.args.dim : 0;
+
+    if (e.ident == Id.targetCPU)
+    {
+        if (arg_count != 0)
+        {
+            e.warning("ignoring arguments for __traits %s", e.ident.toChars());
+        }
+
+        auto cpu = traitsGetTargetCPU();
+        auto se = new StringExp(e.loc, cast(void*)cpu.ptr, cpu.len);
+        return se.semantic(sc);
+    }
+    if (e.ident == Id.targetHasFeature)
+    {
+        if (arg_count != 1)
+        {
+            e.error("__traits %s expects one argument, not %u", e.ident.toChars(), cast(uint)arg_count);
+            return new ErrorExp();
+        }
+
+        auto ex = isExpression((*e.args)[0]);
+        if (!ex)
+        {
+            e.error("expression expected as argument of __traits %s", e.ident.toChars());
+            return new ErrorExp();
+        }
+        ex = ex.ctfeInterpret();
+
+        StringExp se = ex.toStringExp();
+        if (!se || se.len == 0)
+        {
+            e.error("string expected as argument of __traits %s instead of %s", e.ident.toChars(), ex.toChars());
+            return new ErrorExp();
+        }
+
+        se = se.toUTF8(sc);
+        auto featureFound = traitsTargetHasFeature(Dstring(se.toPtr(), se.len));
+        return new IntegerExp(e.loc, featureFound ? 1 : 0, Type.tbool);
+    }
+    return null;
+}

--- a/tests/semantic/target_traits.d
+++ b/tests/semantic/target_traits.d
@@ -1,0 +1,57 @@
+// Tests LDC-specific target __traits
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mcpu=haswell -d-version=CPU_HASWELL -c %s
+// RUN: %ldc -mcpu=pentium -mattr=+fma -d-version=ATTR_FMA -c %s
+// RUN: %ldc -mcpu=pentium -mattr=+fma,-sse -d-version=ATTR_FMA_MINUS_SSE -c %s
+
+// Important: LLVM's default CPU selection already enables some features (like sse3)
+
+// Querying feature information is only available from LLVM 3.7.
+// Below 3.7, __traits(targetHasFeature,...) should always return false.
+version (LDC_LLVM_305)
+{
+}
+else version (LDC_LLVM_306)
+{
+}
+else
+{
+    version = HASFEATURE;
+}
+
+void main()
+{
+    version (CPU_HASWELL)
+    {
+        static assert(__traits(targetCPU) == "haswell");
+        version (HASFEATURE)
+        {
+            static assert(__traits(targetHasFeature, "sse3"));
+            static assert(__traits(targetHasFeature, "sse4.1"));
+        }
+        static assert(!__traits(targetHasFeature, "sse4"));
+        static assert(!__traits(targetHasFeature, "sse4a"));
+        static assert(!__traits(targetHasFeature, "unrecognized feature"));
+    }
+    version (ATTR_FMA)
+    {
+        version (HASFEATURE)
+        {
+            static assert(__traits(targetHasFeature, "sse"));
+            static assert(__traits(targetHasFeature, "sse2"));
+            static assert(__traits(targetHasFeature, "sse3"));
+            static assert(__traits(targetHasFeature, "sse4.1"));
+            static assert(__traits(targetHasFeature, "fma"));
+            static assert(__traits(targetHasFeature, "avx"));
+        }
+        static assert(!__traits(targetHasFeature, "avx2"));
+        static assert(!__traits(targetHasFeature, "unrecognized feature"));
+    }
+    version (ATTR_FMA_MINUS_SSE)
+    {
+        // All implied features must be enabled for targetHasFeature to return true
+        static assert(!__traits(targetHasFeature, "fma"));
+    }
+}

--- a/tests/semantic/target_traits_diag.d
+++ b/tests/semantic/target_traits_diag.d
@@ -1,0 +1,22 @@
+// Tests diagnostics of __traits(targetCPU) and __traits(targetHasFeature, ...)
+
+// RUN: not %ldc -c -w %s 2>&1 | FileCheck %s
+
+void main()
+{
+// CHECK: Warning: ignoring arguments for __traits targetCPU
+    enum a = __traits(targetCPU, 1);
+
+// CHECK: Error: __traits targetHasFeature expects one argument, not 0
+    enum b = __traits(targetHasFeature);
+// CHECK: Error: __traits targetHasFeature expects one argument, not 2
+    enum c = __traits(targetHasFeature, "fma", 1);
+// CHECK: Error: expression expected as argument of __traits targetHasFeature
+    enum d = __traits(targetHasFeature, main);
+// CHECK: Error: string expected as argument of __traits targetHasFeature instead of 1
+    enum e = __traits(targetHasFeature, 1);
+
+// CHECK: '-夜畔' is not a recognized feature for this target (ignoring feature)
+    enum f = __traits(targetHasFeature, "夜畔");
+}
+


### PR DESCRIPTION
Edit: updated to current state of the PR.  (removed `__traits(targetFeatures)`)

This adds the following LDC-specific traits:
```D
__traits(targetCPU) == "broadwell"
__traits(targetHasFeature, "sse2") == bool
```

Example usage:
```D
import std.stdio;
void main() {
  writeln("CPU = ", __traits(targetCPU));
  writeln("Has 'sse3' = ", __traits(targetHasFeature, "sse3"));
  writeln("Has 'sse4' = ", __traits(targetHasFeature, "sse4"));
  writeln("Has 'sse4.1' = ", __traits(targetHasFeature, "sse4.1"));
}
```
Outputs on my machine:
```
❯ ../bin/ldc2 -wi -mcpu=native -run ../../tests/codegen/target_traits.d
CPU = haswell
Has 'sse3' = true
Has 'sse4' = false
Has 'sse4.1' = true
```
