### PR TITLE
fix runnable/interface2

### DIFF
--- a/ir/iraggr.h
+++ b/ir/iraggr.h
@@ -107,10 +107,11 @@ protected:
   /// ClassInfo initializer constant.
   llvm::Constant *constClassInfo = nullptr;
 
-  /// Map for mapping ClassDeclaration* to LLVM GlobalVariable.
-  using ClassGlobalMap = std::map<ClassDeclaration *, llvm::GlobalVariable *>;
+  using ClassGlobalMap = std::map<std::pair<ClassDeclaration *, size_t>, llvm::GlobalVariable *>;
 
-  /// Map from of interface vtbls implemented by this class.
+  /// Map from pairs of <interface vtbl,index> to global variable, implemented
+  /// by this class. The same interface can appear multiple times, so index is
+  /// another way to specify the thunk offset
   ClassGlobalMap interfaceVtblMap;
 
   /// Interface info array global.


### PR DESCRIPTION
Trying to fix the C++ interface casting I stumbled across a number of issues:
- casting didn't take full advantage of static type information
- I didn't really grasp the logic in DtoCastClass, so I changed it the to mimick the simpler one in dmd.
- caching vtbls didn't take the thunk offset into account
