### PR TITLE
For `LDC_inline_ir` functions: instantiate a new "alwaysinline" function for each call

### DIFF
--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -1,99 +1,170 @@
 #include "gen/inlineir.h"
-#include "gen/llvmhelpers.h"
 
+#include "ddmd/expression.h"
+#include "ddmd/mtype.h"
+#include "gen/attributes.h"
+#include "gen/llvmhelpers.h"
 #include "declaration.h"
 #include "template.h"
 #include "gen/irstate.h"
+#include "gen/logger.h"
 #include "gen/tollvm.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/Linker/Linker.h"
 
-llvm::Function *DtoInlineIRFunction(FuncDeclaration *fdecl) {
-  const char *mangled_name = mangleExact(fdecl);
+namespace {
+
+/// Adds the idol's function attributes to the wannabe
+void copyFnAttributes(llvm::Function *wannabe, llvm::Function *idol) {
+  auto attrSet = idol->getAttributes();
+  auto fnAttrSet = attrSet.getFnAttributes();
+  wannabe->addAttributes(llvm::AttributeSet::FunctionIndex, fnAttrSet);
+}
+} // anonymous namespace
+
+DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
+                        Expressions *arguments) {
+  IF_LOG Logger::println("DtoInlineIRExpr @ %s", loc.toChars());
+  LOG_SCOPE;
+
+  // Generate a random new function name. Because the inlineIR function is
+  // always inlined, this name does not escape the current compiled module; not
+  // even at -O0.
+  static size_t namecounter = 0;
+  std::string mangled_name = "inline.ir." + std::to_string(namecounter++);
   TemplateInstance *tinst = fdecl->parent->isTemplateInstance();
   assert(tinst);
 
-  Objects &objs = tinst->tdtypes;
-  assert(objs.dim == 3);
+  // 1. Define the inline function (define a new function for each call)
+  {
 
-  Expression *a0 = isExpression(objs[0]);
-  assert(a0);
-  StringExp *strexp = a0->toStringExp();
-  assert(strexp);
-  assert(strexp->sz == 1);
-  std::string code(strexp->toPtr(), strexp->numberOfCodeUnits());
+    Objects &objs = tinst->tdtypes;
+    assert(objs.dim == 3);
 
-  Type *ret = isType(objs[1]);
-  assert(ret);
+    Expression *a0 = isExpression(objs[0]);
+    assert(a0);
+    StringExp *strexp = a0->toStringExp();
+    assert(strexp);
+    assert(strexp->sz == 1);
+    std::string code(strexp->toPtr(), strexp->numberOfCodeUnits());
 
-  Tuple *a2 = isTuple(objs[2]);
-  assert(a2);
-  Objects &arg_types = a2->objects;
+    Type *ret = isType(objs[1]);
+    assert(ret);
 
-  std::string str;
-  llvm::raw_string_ostream stream(str);
-  stream << "define " << *DtoType(ret) << " @" << mangled_name << "(";
+    Tuple *a2 = isTuple(objs[2]);
+    assert(a2);
+    Objects &arg_types = a2->objects;
 
-  for (size_t i = 0;;) {
-    Type *ty = isType(arg_types[i]);
-    // assert(ty);
-    if (!ty) {
-      error(tinst->loc, "All parameters of a template defined with pragma "
-                        "llvm_inline_ir, except for the first one, should be "
-                        "types");
-      fatal();
+    std::string str;
+    llvm::raw_string_ostream stream(str);
+    stream << "define " << *DtoType(ret) << " @" << mangled_name << "(";
+
+    for (size_t i = 0;;) {
+      Type *ty = isType(arg_types[i]);
+      // assert(ty);
+      if (!ty) {
+        error(tinst->loc, "All parameters of a template defined with pragma "
+                          "LDC_inline_ir, except for the first one, should be "
+                          "types");
+        fatal();
+      }
+      stream << *DtoType(ty);
+
+      i++;
+      if (i >= arg_types.dim) {
+        break;
+      }
+
+      stream << ", ";
     }
-    stream << *DtoType(ty);
 
-    i++;
-    if (i >= arg_types.dim) {
-      break;
+    if (ret->ty == Tvoid) {
+      code.append("\nret void");
     }
 
-    stream << ", ";
-  }
+    stream << ")\n{\n" << code << "\n}";
 
-  if (ret->ty == Tvoid) {
-    code.append("\nret void");
-  }
-
-  stream << ")\n{\n" << code << "\n}";
-
-  llvm::SMDiagnostic err;
+    llvm::SMDiagnostic err;
 
 #if LDC_LLVM_VER >= 306
-  std::unique_ptr<llvm::Module> m =
-      llvm::parseAssemblyString(stream.str().c_str(), err, gIR->context());
+    std::unique_ptr<llvm::Module> m =
+        llvm::parseAssemblyString(stream.str().c_str(), err, gIR->context());
 #else
-  llvm::Module *m = llvm::ParseAssemblyString(stream.str().c_str(), NULL, err,
-                                              gIR->context());
+    llvm::Module *m = llvm::ParseAssemblyString(stream.str().c_str(), NULL, err,
+                                                gIR->context());
 #endif
 
-  std::string errstr = err.getMessage();
-  if (errstr != "") {
-    error(tinst->loc,
+    std::string errstr = err.getMessage();
+    if (errstr != "") {
+      error(
+          tinst->loc,
           "can't parse inline LLVM IR:\n%s\n%s\n%s\nThe input string was: \n%s",
           err.getLineContents().str().c_str(),
           (std::string(err.getColumnNo(), ' ') + '^').c_str(), errstr.c_str(),
           stream.str().c_str());
-  }
+    }
 
 #if LDC_LLVM_VER >= 308
-  llvm::Linker(gIR->module).linkInModule(std::move(m));
+    llvm::Linker(gIR->module).linkInModule(std::move(m));
 #elif LDC_LLVM_VER >= 306
-  llvm::Linker(&gIR->module).linkInModule(m.get());
+    llvm::Linker(&gIR->module).linkInModule(m.get());
 #else
-  std::string errstr2 = "";
-  llvm::Linker(&gIR->module).linkInModule(m, &errstr2);
-  if (errstr2 != "")
-    error(tinst->loc, "Error when linking in llvm inline ir: %s",
-          errstr2.c_str());
+    std::string errstr2 = "";
+    llvm::Linker(&gIR->module).linkInModule(m, &errstr2);
+    if (errstr2 != "")
+      error(tinst->loc, "Error when linking in llvm inline ir: %s",
+            errstr2.c_str());
 #endif
+  }
 
-  LLFunction *fun = gIR->module.getFunction(mangled_name);
-  setLinkage({LLGlobalValue::LinkOnceODRLinkage, supportsCOMDAT()}, fun);
-  fun->addFnAttr(LLAttribute::AlwaysInline);
-  return fun;
+  // 2. Call the function that was just defined and return the returnvalue
+  {
+    llvm::Function *fun = gIR->module.getFunction(mangled_name);
+
+    // Apply some parent function attributes to the inlineIR function too. This
+    // is needed e.g. when the parent function has "unsafe-fp-math"="true"
+    // applied.
+    {
+      assert(!gIR->functions.empty() && "Inline ir outside function");
+      auto enclosingFunc = gIR->topfunc();
+      assert(enclosingFunc);
+      copyFnAttributes(fun, enclosingFunc);
+    }
+
+    fun->setLinkage(llvm::GlobalValue::PrivateLinkage);
+    fun->addFnAttr(llvm::Attribute::AlwaysInline);
+    fun->setCallingConv(llvm::CallingConv::C);
+
+    // Build the runtime arguments
+    size_t n = arguments->dim;
+    llvm::SmallVector<llvm::Value *, 8> args;
+    args.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+      args.push_back(toElem((*arguments)[i])->getRVal());
+    }
+
+    llvm::Value *rv = gIR->ir->CreateCall(fun, args);
+
+    // work around missing tuple support for users of the return value
+    Type *type = fdecl->type->nextOf()->toBasetype();
+    if (type->ty == Tstruct) {
+      // make a copy
+      llvm::Value *mem = DtoAlloca(type, ".__ir_tuple_ret");
+
+      TypeStruct *ts = static_cast<TypeStruct *>(type);
+      size_t n = ts->sym->fields.dim;
+      for (size_t i = 0; i < n; i++) {
+        llvm::Value *v = gIR->ir->CreateExtractValue(rv, i, "");
+        llvm::Value *gep = DtoGEPi(mem, 0, i);
+        DtoStore(v, gep);
+      }
+
+      return new DVarValue(fdecl->type->nextOf(), mem);
+    }
+
+    // return call as im value
+    return new DImValue(fdecl->type->nextOf(), rv);
+  }
 }

--- a/gen/inlineir.h
+++ b/gen/inlineir.h
@@ -14,11 +14,17 @@
 #ifndef LDC_GEN_INLINEIR_H
 #define LDC_GEN_INLINEIR_H
 
+#include "ddmd/arraytypes.h"
+
+class DValue;
 class FuncDeclaration;
+struct Loc;
+
 namespace llvm {
 class Function;
 }
 
-llvm::Function *DtoInlineIRFunction(FuncDeclaration *fdecl);
+DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
+                        Expressions *arguments);
 
 #endif

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1634,6 +1634,10 @@ DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl) {
       // TODO: Is this needed? If so, what about other intrinsics?
       error(loc, "special ldc inline asm is not a normal function");
       fatal();
+    } else if (fdecl->llvmInternal == LLVMinline_ir) {
+      // TODO: Is this needed? If so, what about other intrinsics?
+      error(loc, "special ldc inline ir is not a normal function");
+      fatal();
     }
     DtoResolveFunction(fdecl);
     return new DFuncValue(fdecl, fdecl->llvmInternal != LLVMva_arg

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -17,6 +17,7 @@
 #include "gen/coverage.h"
 #include "gen/dvalue.h"
 #include "gen/functions.h"
+#include "gen/inlineir.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
@@ -874,6 +875,10 @@ public:
       if (FuncDeclaration *fd = ve->var->isFuncDeclaration()) {
         if (fd->llvmInternal == LLVMinline_asm) {
           result = DtoInlineAsmExpr(e->loc, fd, e->arguments);
+          return;
+        }
+        if (fd->llvmInternal == LLVMinline_ir) {
+          result = DtoInlineIRExpr(e->loc, fd, e->arguments);
           return;
         }
       }

--- a/tests/codegen/inlineIR_math.d
+++ b/tests/codegen/inlineIR_math.d
@@ -1,0 +1,106 @@
+// Tests inlineIR + math optimizations
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
+// RUN: %ldc -mtriple x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
+
+import ldc.attributes;
+pragma(LDC_inline_ir) R inlineIR(string s, R, P...)(P);
+
+
+// Test that internal @inline.ir.*" functions for the inlined IR pieces are always inlined and are not present as a global symbol
+// LLVM-NOT: @inline.ir.
+// LLVM-NOT: alwaysinline
+
+
+// inlineIR should inherit the enclosing function attributes, thus preserving the enclosing function attributes after inlining.
+// LLVM-LABEL: define{{.*}} @dot
+// LLVM-SAME: #[[UNSAFEFPMATH:[0-9]+]]
+// ASM-LABEL: dot:
+@llvmAttr("unsafe-fp-math", "true")
+extern (C) double dot(double[] a, double[] b)
+{
+    double s = 0;
+
+// ASM: vfmadd{{[123][123][123]}}pd
+    foreach (size_t i; 0 .. a.length)
+    {
+        s = inlineIR!(`%p = fmul fast double %0, %1
+                       %r = fadd fast double %p, %2
+                       ret double %r`, double)(a[i], b[i], s);
+    }
+    return s;
+}
+
+// LLVM-LABEL: define{{.*}} @features
+// LLVM-SAME: #[[FEAT:[0-9]+]]
+@target("fma")
+extern (C) double features(double[] a, double[] b)
+{
+    double s = 0;
+    foreach (size_t i; 0 .. a.length)
+    {
+        s = inlineIR!(`%p = fmul fast double %0, %1
+                       %r = fadd fast double %p, %2
+                       ret double %r`, double)(a[i], b[i], s);
+    }
+    return s;
+}
+
+// Test that inlineIR works when calling function has special attributes defined for its parameters
+// LLVM-LABEL: define{{.*}} @dot160
+// ASM-LABEL: dot160:
+@llvmAttr("unsafe-fp-math", "false") // needed because of an LLVM bug: see the discussion at GH #1438
+extern (C) double dot160(double[160] a, double[160] b)
+{
+    double s = 0;
+
+// ASM-NOT: vfmadd
+    foreach (size_t i; 0 .. a.length)
+    {
+        s = inlineIR!(`%p = fmul fast double %0, %1
+                       %r = fadd fast double %p, %2
+                       ret double %r`, double)(a[i], b[i], s);
+    }
+    return s;
+}
+
+// Test inlineIR alias defined outside any function
+alias inlineIR!(`%p = fmul fast double %0, %1
+                 %r = fadd fast double %p, %2
+                 ret double %r`,
+                 double, double, double, double) muladd;
+
+// LLVM-LABEL: define{{.*}} @aliasInlineUnsafe
+// LLVM-SAME: #[[UNSAFEFPMATH2:[0-9]+]]
+// ASM-LABEL: aliasInlineUnsafe:
+@llvmAttr("unsafe-fp-math", "true")
+extern (C) double aliasInlineUnsafe(double[] a, double[] b)
+{
+    double s = 0;
+
+// ASM: vfmadd{{[123][123][123]}}pd
+    foreach (size_t i; 0 .. a.length)
+    {
+        s = muladd(a[i], b[i], s);
+    }
+    return s;
+}
+
+// LLVM-LABEL: define{{.*}} @aliasInlineSafe
+// ASM-LABEL: aliasInlineSafe:
+@llvmAttr("unsafe-fp-math", "false") // needed because of an LLVM bug: see the discussion at GH #1438
+extern (C) double aliasInlineSafe(double[] a, double[] b)
+{
+    double s = 0;
+
+// ASM-NOT: vfmadd{{[123][123][123]}}pd
+    foreach (size_t i; 0 .. a.length)
+    {
+        s = muladd(a[i], b[i], s);
+    }
+    return s;
+}
+
+// LLVM-DAG: attributes #[[UNSAFEFPMATH]] ={{.*}} "unsafe-fp-math"="true"
+// LLVM-DAG: attributes #[[UNSAFEFPMATH2]] ={{.*}} "unsafe-fp-math"="true"
+// LLVM-DAG: attributes #[[FEAT]] ={{.*}} "target-features"="+fma"


### PR DESCRIPTION
This is the current behavior for inline ASM too.

When certain attributes are applied to the calling function, like "unsafe-fp-math", the inlined inlineIR function has to have the same attributes otherwise the calling function attribute will be reset to the safe merge of the two: "false". Because the same inlineIR function can be called in different functions using an alias definition, a new function (with possibly different attributes) has to be instantiated upon every call.

Related GH issue #1438