### PR TITLE
install from package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ version supporting it.
 Installation
 ------------
 
+### From a pre-built package
+
+Some Linux and OS X package managers include recent versions of LDC, so
+manually installing it might not be necessary. For several platforms,
+there are also stand-alone binary builds available at the
+[GitHub release page](https://github.com/ldc-developers/ldc/releases).
+
+| Distribution | Command               |
+| ------------ | --------------------- |
+| Arch Linux   | `pacman -S ldc`       |
+| Debian       | `apt-get install ldc` |
+| Fedora       | `yum install ldc`     |
+| Gentoo       | `layman -a ldc`       |
+| HomeBrew     | `brew install ldc`    |
+| Ubuntu       | `apt-get install ldc` |
+
+### Building from source
+
 In-depth material on building and installing LDC and the standard
 libraries, including experimental instructions for running LDC on
 Windows, is available on the project wiki at
@@ -42,12 +60,6 @@ are up to date:
 
     $ cd ldc
     $ git submodule update --recursive --init
-
-Some Linux and OS X package managers include recent versions of LDC, so
-manually installing it might not be necessary. For several platforms,
-there are also stand-alone binary builds available at the
-[GitHub release page](https://github.com/ldc-developers/ldc/releases).
-
 
 Contact
 -------


### PR DESCRIPTION
Hi all,

I think it's quite convenient to show the users for which distribution a package is available.
Moreover it would be quite nice if on the [dlang download page](http://dlang.org/download.html) a user would be redirected to these installation instructions (e.g. then
https://github.com/ldc-developers/ldc/README.md#using-a-package) instead of the Github releases page.

PS: Did I miss a distro (you probably know this better)?