### PR TITLE
LLVM 3.9: Function getGlobalContext() was removed.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -67,6 +67,10 @@
 // in traits.c
 void initTraitsStringTable();
 
+// FIXME: In this file and in ir/irtype.cpp a global LLVM context is used.
+//        This functionality was removed in LLVM 3.9.
+llvm::LLVMContext TheGlobalContext;
+
 using namespace opts;
 
 extern void getenv_setargv(const char *envvar, int *pargc, char ***pargv);
@@ -1258,7 +1262,7 @@ int main(int argc, char **argv) {
 
   // Generate one or more object/IR/bitcode files.
   if (global.params.obj && !modules.empty()) {
-    ldc::CodeGenerator cg(llvm::getGlobalContext(), singleObj);
+    ldc::CodeGenerator cg(TheGlobalContext, singleObj);
 
     for (unsigned i = 0; i < modules.dim; i++) {
       Module *const m = modules[i];

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -17,7 +17,8 @@
 #include "ir/irtype.h"
 
 // These functions use llvm::getGlobalContext() as they are invoked before gIR
-// is set.
+// is set. See note in driver/main.cpp.
+extern llvm::LLVMContext TheGlobalContext;
 
 IrType::IrType(Type *dt, LLType *lt) : dtype(dt), type(lt) {
   assert(dt && "null D Type");
@@ -68,7 +69,7 @@ llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
 }
 
 llvm::Type *IrTypeBasic::basic2llvm(Type *t) {
-  llvm::LLVMContext &ctx = llvm::getGlobalContext();
+  llvm::LLVMContext &ctx = TheGlobalContext;
 
   switch (t->ty) {
   case Tvoid:
@@ -135,7 +136,7 @@ IrTypePointer *IrTypePointer::get(Type *dt) {
 
   LLType *elemType;
   if (dt->ty == Tnull) {
-    elemType = llvm::Type::getInt8Ty(llvm::getGlobalContext());
+    elemType = llvm::Type::getInt8Ty(TheGlobalContext);
   } else {
     elemType = DtoMemType(dt->nextOf());
 
@@ -186,7 +187,7 @@ IrTypeArray *IrTypeArray::get(Type *dt) {
   // just as for pointers.
   if (!dt->ctype) {
     llvm::Type *types[] = {DtoSize_t(), llvm::PointerType::get(elemType, 0)};
-    LLType *at = llvm::StructType::get(llvm::getGlobalContext(), types, false);
+    LLType *at = llvm::StructType::get(TheGlobalContext, types, false);
     dt->ctype = new IrTypeArray(dt, at);
   }
 


### PR DESCRIPTION
There are only two files in LDC which used the global context.
This PR is a hack to compile LDC with LLVM 3.9.