### PR TITLE
core.atomic: Fix atomicOp template constraint for -de

### DIFF
--- a/tests/ir/atomicrmw.d
+++ b/tests/ir/atomicrmw.d
@@ -1,4 +1,4 @@
-// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -c -de -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 import core.atomic;
 


### PR DESCRIPTION
RMW operations on shared values have been deprecated for quite
some while, but since the test suite is not built with -de, this
has not been caught.

GitHub: Fixes #1454.