### PR TITLE
[WIP] Speed up semantic analysis using a tree in addition to an array

### DIFF
--- a/ddmd/arraytypes.d
+++ b/ddmd/arraytypes.d
@@ -51,3 +51,5 @@ alias GotoCaseStatements = Array!(GotoCaseStatement);
 alias ReturnStatements = Array!(ReturnStatement);
 alias GotoStatements = Array!(GotoStatement);
 alias TemplateInstances = Array!(TemplateInstance);
+
+version(IN_LLVM) alias DsymbolsAT = ArrayTree!(Dsymbol);

--- a/ddmd/arraytypes.h
+++ b/ddmd/arraytypes.h
@@ -68,4 +68,8 @@ typedef Array<class GotoStatement *> GotoStatements;
 
 typedef Array<class TemplateInstance *> TemplateInstances;
 
+#if IN_LLVM
+typedef ArrayTree<class Dsymbol *> DsymbolsAT;
+#endif
+
 #endif

--- a/ddmd/dsymbol.d
+++ b/ddmd/dsymbol.d
@@ -502,6 +502,22 @@ public:
         return b;
     }
 
+version(IN_LLVM)
+{
+    /*************************************
+     * Do syntax copy of an array-tree of Dsymbol's.
+     */
+    final static DsymbolsAT* arraySyntaxCopy(DsymbolsAT* a)
+    {
+        DsymbolsAT* b = null;
+        if (a)
+        {
+            b = new DsymbolsAT(arraySyntaxCopy(a.getArrayPtr));
+        }
+        return b;
+    }
+}
+
     Identifier getIdent()
     {
         return ident;
@@ -876,6 +892,13 @@ public:
     /*****************************************
      * Same as Dsymbol::oneMember(), but look at an array of Dsymbols.
      */
+version(IN_LLVM)
+{
+    final static bool oneMembers(DsymbolsAT* members, Dsymbol* ps, Identifier ident)
+    {
+        return oneMembers(members.getArrayPtr(), ps, ident);
+    }
+}
     final static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
     {
         //printf("Dsymbol::oneMembers() %d\n", members ? members.dim : 0);
@@ -1229,7 +1252,10 @@ public:
 extern (C++) class ScopeDsymbol : Dsymbol
 {
 public:
-    Dsymbols* members;      // all Dsymbol's in this scope
+    version(IN_LLVM)
+        DsymbolsAT* members;    // all Dsymbol's in this scope
+    else
+        Dsymbols* members;    // all Dsymbol's in this scope
     DsymbolTable symtab;    // members[] sorted into table
 
 private:
@@ -1594,6 +1620,14 @@ public:
             *pn = n; // update index
         return result;
     }
+version(IN_LLVM)
+{
+    /// Ditto
+    extern (D) static int _foreach(Scope* sc, DsymbolsAT* members, scope ForeachDg dg, size_t* pn = null)
+    {
+        return _foreach(sc, members.getArrayPtr(), dg, pn);
+    }
+}
 
     override final ScopeDsymbol isScopeDsymbol()
     {

--- a/ddmd/dsymbol.h
+++ b/ddmd/dsymbol.h
@@ -299,7 +299,11 @@ public:
 class ScopeDsymbol : public Dsymbol
 {
 public:
-    Dsymbols *members;          // all Dsymbol's in this scope
+    #if IN_LLVM
+        DsymbolsAT *members;    // all Dsymbol's in this scope
+    #else
+        Dsymbols *members;      // all Dsymbol's in this scope
+    #endif
     DsymbolTable *symtab;       // members[] sorted into table
 
 private:

--- a/ddmd/nspace.d
+++ b/ddmd/nspace.d
@@ -32,7 +32,10 @@ public:
         super(ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident->toChars());
         this.loc = loc;
-        this.members = members;
+        version(IN_LLVM)
+            this.members = DsymbolsAT.convert(members);
+        else
+            this.members = members;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/ddmd/parse.d
+++ b/ddmd/parse.d
@@ -264,7 +264,7 @@ public:
         //nextToken();              // start up the scanner
     }
 
-    Dsymbols* parseModule()
+    DsymbolsAT* parseModule()
     {
         const(char)* comment = token.blockComment;
         bool isdeprecated = false;
@@ -372,12 +372,12 @@ public:
             error(token.loc, "unrecognized declaration");
             goto Lerr;
         }
-        return decldefs;
+        return DsymbolsAT.convert(decldefs);
     Lerr:
         while (token.value != TOKsemicolon && token.value != TOKeof)
             nextToken();
         nextToken();
-        return new Dsymbols();
+        return new DsymbolsAT(null);
     }
 
     Dsymbols* parseDeclDefs(int once, Dsymbol* pLastDecl = null, PrefixAttributes* pAttrs = null)
@@ -2750,6 +2750,9 @@ public:
         else if (token.value == TOKlcurly)
         {
             //printf("enum definition\n");
+version(IN_LLVM)
+            e.members = new DsymbolsAT(null);
+else
             e.members = new Dsymbols();
             nextToken();
             const(char)* comment = token.blockComment;
@@ -2917,7 +2920,12 @@ public:
                 return new AnonDeclaration(loc, anon == 2, decl);
             }
             else
-                a.members = decl;
+            {
+                version(IN_LLVM)
+                    a.members = DsymbolsAT.convert(decl);
+                else
+                    a.members = decl;
+            }
         }
         else
         {
@@ -7779,6 +7787,9 @@ public:
                 if (token.value != TOKrcurly)
                     error("class member expected");
                 nextToken();
+version(IN_LLVM)
+                cd.members = DsymbolsAT.convert(decl);
+else
                 cd.members = decl;
             }
             Expression e = new NewAnonClassExp(loc, thisexp, newargs, cd, arguments);

--- a/ddmd/root/array.h
+++ b/ddmd/root/array.h
@@ -363,4 +363,95 @@ struct Array
 #endif
 };
 
+#if IN_LLVM
+template <typename TYPE>
+class ArrayTree
+{
+  private:
+    Array<TYPE>* array;
+    void* tree;
+
+  public:
+    static bool fastSearch; // Enable sub-linear lookup
+
+    // The bindings to this D class are intentionally exposing only part of the functionality
+
+    // Disallow C++ construction
+    ArrayTree() = delete;
+
+    ~ArrayTree()
+    {
+        array = nullptr;
+        tree = nullptr;
+    }
+
+    size_t dim()
+    {
+        return array->dim;
+    }
+
+    TYPE& operator[] (d_size_t index)
+    {
+        return (*array)[index];
+    }
+
+    void push(TYPE a); // mangling is broken with 2.070
+    void push(void* a);
+
+#if IN_LLVM
+    // Define members and types like std::vector
+    typedef size_t size_type;
+
+    size_type size()
+    {
+        return array->size();
+    }
+
+    bool empty()
+    {
+        return array->empty();
+    }
+
+    TYPE front()
+    {
+        return array->front();
+    }
+
+    TYPE back()
+    {
+        return array->back();
+    }
+
+    void push_back(TYPE a)
+    {
+        push(a);
+    }
+
+    typedef TYPE *iterator;
+    typedef std::reverse_iterator<iterator> reverse_iterator;
+
+    iterator begin()
+    {
+        return array->begin();
+    }
+
+    iterator end()
+    {
+        return array->end();
+    }
+
+    reverse_iterator rbegin()
+    {
+        return array->rbegin();
+    }
+
+    reverse_iterator rend()
+    {
+        return array->rend();
+    }
+
+#endif
+};
+#endif
+
 #endif

--- a/ddmd/template.h
+++ b/ddmd/template.h
@@ -88,6 +88,10 @@ public:
     const char *intrinsicName;
 #endif
 
+#if IN_LLVM
+    TemplateDeclaration(Loc loc, Identifier *id, TemplateParameters *parameters,
+        Expression *constraint, DsymbolsAT *decldefs, bool ismixin = false, bool literal = false);
+#endif
     TemplateDeclaration(Loc loc, Identifier *id, TemplateParameters *parameters,
         Expression *constraint, Dsymbols *decldefs, bool ismixin = false, bool literal = false);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/ddmd/traits.d
+++ b/ddmd/traits.d
@@ -1161,7 +1161,10 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                     }
                 }
             }
-            collectUnitTests(sds.members);
+            version(IN_LLVM)
+                collectUnitTests(sds.members.getArrayPtr());
+            else
+                collectUnitTests(sds.members);
         }
         auto te = new TupleExp(e.loc, exps);
         return te.semantic(sc);

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -147,6 +147,11 @@ cl::opt<bool, true>
                    cl::desc("Do not emit code that uses the red zone."),
                    cl::location(global.params.disableRedZone), cl::init(false));
 
+cl::opt<bool> fastMemberSearch(
+    "fast-member-search",
+    cl::desc("Enables faster module member lookup during semantic analysis at "
+             "the cost of more memory usage."), cl::init(false));
+
 // DDoc options
 static cl::opt<bool, true> doDdoc("D", cl::desc("Generate documentation"),
                                   cl::location(global.params.doDocComments));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -48,6 +48,7 @@ extern cl::opt<bool> output_ll;
 extern cl::opt<bool> output_s;
 extern cl::opt<cl::boolOrDefault> output_o;
 extern cl::opt<bool, true> disableRedZone;
+extern cl::opt<bool> fastMemberSearch;
 extern cl::opt<std::string> ddocDir;
 extern cl::opt<std::string> ddocFile;
 extern cl::opt<std::string> jsonFile;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -353,6 +353,9 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
     }
   }
 
+  // Set search/memory behavior of DsymbolsAT
+  DsymbolsAT::fastSearch = opts::fastMemberSearch;
+
   // Negated options
   global.params.link = !compileOnly;
   global.params.obj = !dontWriteObj;

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -543,7 +543,7 @@ static ClassFlags::Type build_classinfo_flags(ClassDeclaration *cd) {
   }
   for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass) {
     if (pc->members) {
-      for (size_t i = 0; i < pc->members->dim; i++) {
+      for (size_t i = 0; i < pc->members->dim(); i++) {
         Dsymbol *sm = (*pc->members)[i];
         // printf("sm = %s %s\n", sm->kind(), sm->toChars());
         if (sm->hasPointers()) {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1028,8 +1028,8 @@ DValue *DtoDeclarationExp(Dsymbol *declaration) {
     }
   } else if (TemplateMixin *m = declaration->isTemplateMixin()) {
     Logger::println("TemplateMixin");
-    for (unsigned i = 0; i < m->members->dim; ++i) {
-      Dsymbol *mdsym = static_cast<Dsymbol *>(m->members->data[i]);
+    for (unsigned i = 0; i < m->members->dim(); ++i) {
+      Dsymbol *mdsym = (*m->members)[i];
       DtoDeclarationExp(mdsym);
     }
   } else if (TupleDeclaration *tupled = declaration->isTupleDeclaration()) {

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -695,7 +695,7 @@ void codegenModule(IRState *irs, Module *m, bool emitFullModuleInfo) {
   }
 
   // process module members
-  for (unsigned k = 0; k < m->members->dim; k++) {
+  for (unsigned k = 0; k < m->members->dim(); k++) {
     Dsymbol *dsym = (*m->members)[k];
     assert(dsym);
     Declaration_codegen(dsym);
@@ -771,7 +771,7 @@ static void genModuleInfo(Module *m, bool emitFullModuleInfo) {
   llvm::ArrayType *localClassesTy = nullptr;
   ClassDeclarations aclasses;
   // printf("members->dim = %d\n", members->dim);
-  for (size_t i = 0; i < m->members->dim; i++) {
+  for (size_t i = 0; i < m->members->dim(); i++) {
     (*m->members)[i]->addLocalClass(&aclasses);
   }
   // fill inits

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -123,7 +123,7 @@ TypeInfoDeclaration *getOrCreateTypeInfoDeclaration(Type *torig, Scope *sc) {
       {
         // Find module that will go all the way to an object file
         Module *m = sc->module->importedFrom;
-        m->members->push(t->vtinfo);
+        m->members->push((void*)t->vtinfo);
 
         semanticTypeInfo(sc, t);
       } else // if in obj generation pass


### PR DESCRIPTION
Adds a tree to the members array to speed up the operation: "is this pointer already in the member array?" It speeds up semantic analysis on a testcase by about 25%.
Because the extra data structure is not necessary (ordered access seems needed so the array has to stay) it is optional (`-fast-member-search`) to save memory on memory-constrained systems.
I've tried to keep FE changes to a minimum.