### PR TITLE
Allow different configurations in the ldc2.conf

### DIFF
--- a/driver/configfile.cpp
+++ b/driver/configfile.cpp
@@ -158,7 +158,7 @@ bool ConfigFile::locate() {
   return false;
 }
 
-bool ConfigFile::read(const char *explicitConfFile) {
+bool ConfigFile::read(const char *explicitConfFile, const char* section) {
   // explicitly provided by user in command line?
   if (explicitConfFile) {
     const std::string clPath = explicitConfFile;
@@ -188,14 +188,21 @@ bool ConfigFile::read(const char *explicitConfFile) {
     return false;
   }
 
+  config_setting_t *root = nullptr;
+  if (section && *section)
+    root = config_lookup(cfg, section);
+
   // make sure there's a default group
-  config_setting_t *root = config_lookup(cfg, "default");
+  if (!root) {
+    section = "default";
+    root = config_lookup(cfg, section);
+  }
   if (!root) {
     std::cerr << "no default settings in configuration file" << std::endl;
     return false;
   }
   if (!config_setting_is_group(root)) {
-    std::cerr << "default is not a group" << std::endl;
+    std::cerr << section << " is not a group" << std::endl;
     return false;
   }
 

--- a/driver/configfile.h
+++ b/driver/configfile.h
@@ -27,7 +27,7 @@ public:
 public:
   ConfigFile();
 
-  bool read(const char *explicitConfFile);
+  bool read(const char *explicitConfFile, const char* section);
 
   s_iterator switches_begin() { return switches.begin(); }
   s_iterator switches_end() { return switches.end(); }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -297,6 +297,23 @@ static const char *tryGetExplicitConfFile(int argc, char **argv) {
   return nullptr;
 }
 
+static llvm::Triple tryGetExplicitTriple(int argc, char **argv) {
+  llvm::Triple triple(llvm::sys::getDefaultTargetTriple());
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "-m32") == 0) {
+      triple = triple.get32BitArchVariant();
+    } else if (strcmp(argv[i], "-m64") == 0) {
+      triple = triple.get64BitArchVariant();
+    } else if (strcmp(argv[i], "-mtriple=") == 0) {
+      triple = llvm::Triple(llvm::Triple::normalize(argv[i] + 9));
+    } else if (strcmp(argv[i], "-march=") == 0) {
+      std::string errorMsg; // ignore error, will show up later anyway
+      lookupTarget(argv[i] + 7, triple, errorMsg); 
+    }
+  }
+  return triple;
+}
+
 /// Parses switches from the command line, any response files and the global
 /// config file and sets up global.params accordingly.
 ///
@@ -323,8 +340,9 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
 
   ConfigFile cfg_file;
   const char *explicitConfFile = tryGetExplicitConfFile(argc, argv);
+  std::string cfg_triple = tryGetExplicitTriple(argc, argv).getTriple();
   // just ignore errors for now, they are still printed
-  cfg_file.read(explicitConfFile);
+  cfg_file.read(explicitConfFile, cfg_triple.c_str());
   final_args.insert(final_args.end(), cfg_file.switches_begin(),
                     cfg_file.switches_end());
 

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -32,6 +32,8 @@ enum Type { Unknown, O32, N32, N64, EABI };
 }
 
 namespace llvm {
+class Triple;
+class Target;
 class TargetMachine;
 }
 
@@ -56,5 +58,9 @@ llvm::TargetMachine *createTargetMachine(
  * for Mips).
  */
 MipsABI::Type getMipsABI();
+
+// Looks up a target based on an arch name and a target triple.
+const llvm::Target *lookupTarget(const std::string &arch, llvm::Triple &triple,
+                                 std::string &errorMsg);
 
 #endif // LDC_DRIVER_TARGET_H


### PR DESCRIPTION
This allows selecting the configuration group by target triple extracted from the command line.

This allows using the same installation for both 32-bit and 64-bit builds on Windows by just having different lib folders. Not sure how this is done on other platforms...