### PR TITLE
Add @fastmath magic UDA

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -822,6 +822,13 @@ void DtoDefineFunction(FuncDeclaration *fd) {
   // assert(gIR->scopes.empty());
   gIR->scopes.push_back(IRScope(beginbb));
 
+  // Set the FastMath options for this function scope.
+#if LDC_LLVM_VER >= 308
+  gIR->scopes.back().builder.setFastMathFlags(irFunc->FMF);
+#else
+  gIR->scopes.back().builder.SetFastMathFlags(irFunc->FMF);
+#endif
+
   // create alloca point
   // this gets erased when the function is complete, so alignment etc does not
   // matter at all

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -496,7 +496,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
     }
   }
 
-  applyFuncDeclUDAs(fdecl, func);
+  applyFuncDeclUDAs(fdecl, irFunc);
 
   // main
   if (fdecl->isMain()) {

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -6,6 +6,7 @@
 #include "attrib.h"
 #include "declaration.h"
 #include "expression.h"
+#include "ir/irfunction.h"
 #include "module.h"
 
 #include "llvm/ADT/StringExtras.h"
@@ -211,9 +212,12 @@ void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar) {
   }
 }
 
-void applyFuncDeclUDAs(FuncDeclaration *decl, llvm::Function *func) {
+void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc) {
   if (!decl->userAttribDecl)
     return;
+
+  llvm::Function *func = irFunc->func;
+  assert(func);
 
   Expressions *attrs = decl->userAttribDecl->getAttributes();
   expandTuples(attrs);

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -16,6 +16,7 @@ namespace {
 /// Names of the attribute structs we recognize.
 namespace attr {
 const std::string llvmAttr = "llvmAttr";
+const std::string llvmFastMathFlag = "llvmFastMathFlag";
 const std::string section = "section";
 const std::string target = "target";
 const std::string weak = "_weak";
@@ -84,6 +85,12 @@ void checkStructElems(StructLiteralExp *sle, ArrayParam<Type *> elemTypes) {
   }
 }
 
+bool getBoolElem(StructLiteralExp *sle, size_t idx) {
+  auto arg = (*sle->elements)[idx];
+  return arg->toInteger() != 0;
+}
+
+/// Returns a null-terminated string
 const char *getStringElem(StructLiteralExp *sle, size_t idx) {
   auto arg = (*sle->elements)[idx];
   if (arg && arg->op == TOKstring) {
@@ -96,6 +103,7 @@ const char *getStringElem(StructLiteralExp *sle, size_t idx) {
   }
 }
 
+/// Returns a null-terminated string
 const char *getFirstElemString(StructLiteralExp *sle) {
   return getStringElem(sle, 0);
 }
@@ -110,6 +118,32 @@ void applyAttrLLVMAttr(StructLiteralExp *sle, llvm::Function *func) {
     func->addFnAttr(key);
   } else {
     func->addFnAttr(key, value);
+  }
+}
+
+// @llvmFastMathFlag("flag")
+void applyAttrLLVMFastMathFlag(StructLiteralExp *sle, IrFunction *irFunc) {
+  checkStructElems(sle, {Type::tstring});
+  llvm::StringRef value = getStringElem(sle, 0);
+
+  if (value == "clear") {
+    irFunc->FMF.clear();
+  } else if (value == "fast") {
+    irFunc->FMF.setUnsafeAlgebra();
+  } else if (value == "nnan") {
+    irFunc->FMF.setNoNaNs();
+  } else if (value == "ninf") {
+    irFunc->FMF.setNoInfs();
+  } else if (value == "nsz") {
+    irFunc->FMF.setNoSignedZeros();
+  } else if (value == "arcp") {
+    irFunc->FMF.setAllowReciprocal();
+  } else {
+    // `value` is a null-terminated returned from getStringElem so can be passed
+    // to warning("... %s ...").
+    sle->warning(
+        "ignoring unrecognized flag parameter '%s' for '@ldc.attributes.%s'",
+        value.data(), sle->sd->ident->string);
   }
 }
 
@@ -229,6 +263,8 @@ void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc) {
     auto name = sle->sd->ident->string;
     if (name == attr::llvmAttr) {
       applyAttrLLVMAttr(sle, func);
+    } else if (name == attr::llvmFastMathFlag) {
+      applyAttrLLVMFastMathFlag(sle, irFunc);
     } else if (name == attr::section) {
       applyAttrSection(sle, func);
     } else if (name == attr::target) {

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -18,12 +18,12 @@
 class Dsymbol;
 class FuncDeclaration;
 class VarDeclaration;
+struct IrFunction;
 namespace llvm {
-class Function;
 class GlobalVariable;
 }
 
-void applyFuncDeclUDAs(FuncDeclaration *decl, llvm::Function *func);
+void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc);
 void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar);
 
 bool hasWeakUDA(Dsymbol *sym);

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -607,7 +607,7 @@ llvm::BasicBlock *ScopeStack::emitLandingPad() {
   return beginBB;
 }
 
-IrFunction::IrFunction(FuncDeclaration *fd) {
+IrFunction::IrFunction(FuncDeclaration *fd) : FMF() {
   decl = fd;
 
   Type *t = fd->type->toBasetype();

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -519,6 +519,10 @@ struct IrFunction {
 
   IrFuncTy irFty;
 
+  /// Stores the FastMath options for this functions.
+  /// These are set e.g. by math related UDA's from ldc.attributes.
+  llvm::FastMathFlags FMF;
+
 private:
   llvm::AllocaInst *ehPtrSlot = nullptr;
   llvm::BasicBlock *resumeUnwindBlock = nullptr;

--- a/tests/codegen/attr_fastmath.d
+++ b/tests/codegen/attr_fastmath.d
@@ -1,0 +1,53 @@
+// Test @fastmath
+
+// RUN: %ldc -O0 -release -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import ldc.attributes;
+
+// CHECK-LABEL: define{{.*}} @notfast
+// CHECK-SAME: #[[ATTR_NOTFAST:[0-9]+]]
+extern (C) double notfast(double a, double b)
+{
+    @fastmath
+    double nested_fast(double a, double b)
+    {
+        return a * b;
+    }
+
+// CHECK-NOT: fmul fast
+    return a * b;
+}
+// CHECK-LABEL: define{{.*}} @{{.*}}nested_fast
+// CHECK: fmul fast
+
+
+// CHECK-LABEL: define{{.*}} @fast
+// CHECK-SAME: #[[ATTR_FAST:[0-9]+]]
+@fastmath
+extern (C) double fast(double a, double b)
+{
+    double c;
+
+    double nested_slow(double a, double b)
+    {
+        return a * b;
+    }
+
+    // Also test new scopes when generating the IR.
+    try {
+// CHECK: fmul fast
+        c += a * b;
+    }
+    catch
+    {
+// CHECK: fmul fast
+        return a * b;
+    }
+// CHECK: fmul fast
+    return c + a * b;
+}
+// CHECK-LABEL: define{{.*}} @{{.*}}nested_slow
+// CHECK-NOT: fmul fast
+
+// CHECK-DAG: attributes #[[ATTR_FAST]] ={{.*}} "unsafe-fp-math"="true"
+// CHECK-NOT: attributes #[[ATTR_NOTFAST]] ={{.*}} "unsafe-fp-math"="true"

--- a/tests/codegen/attr_fastmath_x86.d
+++ b/tests/codegen/attr_fastmath_x86.d
@@ -1,0 +1,21 @@
+// Test vectorized fused multiply-add in a simple dot product routine
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
+
+import ldc.attributes;
+
+// ASM-LABEL: dot:
+@fastmath
+extern (C) double dot(double[] a, double[] b)
+{
+    double s = 0;
+// ASM: vfmadd{{[123][123][123]}}pd
+    foreach (size_t i; 0 .. a.length)
+    {
+        s += a[i] * b[i];
+    }
+    return s;
+// ASM: ret
+}

--- a/tests/codegen/attr_llvmFMF.d
+++ b/tests/codegen/attr_llvmFMF.d
@@ -1,0 +1,57 @@
+// Test @ldc.attributes.llvmFastMathFlag UDA
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
+// RUN: %ldc -c -w -d-version=WARNING %s 2>&1 | FileCheck %s --check-prefix WARNING
+
+import ldc.attributes;
+
+version(WARNING)
+{
+    // WARNING: attr_llvmFMF.d(11): Warning: ignoring unrecognized flag parameter 'unrecognized' for '@ldc.attributes.llvmFastMathFlag'
+    @llvmFastMathFlag("unrecognized")
+    void foo() {}
+}
+
+// LLVM-LABEL: define{{.*}} @notfast
+// LLVM-SAME: #[[ATTR_NOTFAST:[0-9]+]]
+extern (C) double notfast(double a, double b)
+{
+    @llvmFastMathFlag("fast")
+    double nested_fast(double a, double b)
+    {
+        return a * b;
+    }
+
+// LLVM: fmul double
+    return a * b;
+}
+// LLVM-LABEL: define{{.*}} @{{.*}}nested_fast
+// LLVM: fmul fast double
+
+// LLVM-LABEL: define{{.*}} @{{.*}}nnan_arcp
+@llvmFastMathFlag("nnan")
+@llvmFastMathFlag("arcp")
+double nnan_arcp(double a, double b)
+{
+// LLVM: fmul nnan arcp double
+    return a * b;
+}
+
+// LLVM-LABEL: define{{.*}} @{{.*}}ninf_nsz
+@llvmFastMathFlag("ninf")
+@llvmFastMathFlag("nsz")
+double ninf_nsz(double a, double b)
+{
+// LLVM: fmul ninf nsz double
+    return a * b;
+}
+
+// LLVM-LABEL: define{{.*}} @{{.*}}cleared
+@llvmFastMathFlag("ninf")
+@llvmFastMathFlag("clear")
+double cleared(double a, double b)
+{
+// LLVM: fmul double
+    return a * b;
+}
+

--- a/tests/codegen/inlineIR_math.d
+++ b/tests/codegen/inlineIR_math.d
@@ -51,7 +51,6 @@ extern (C) double features(double[] a, double[] b)
 // Test that inlineIR works when calling function has special attributes defined for its parameters
 // LLVM-LABEL: define{{.*}} @dot160
 // ASM-LABEL: dot160:
-@llvmAttr("unsafe-fp-math", "false") // needed because of an LLVM bug: see the discussion at GH #1438
 extern (C) double dot160(double[160] a, double[160] b)
 {
     double s = 0;
@@ -89,8 +88,8 @@ extern (C) double aliasInlineUnsafe(double[] a, double[] b)
 }
 
 // LLVM-LABEL: define{{.*}} @aliasInlineSafe
+// LLVM-SAME: #[[UNSAFEFPMATH3:[0-9]+]]
 // ASM-LABEL: aliasInlineSafe:
-@llvmAttr("unsafe-fp-math", "false") // needed because of an LLVM bug: see the discussion at GH #1438
 extern (C) double aliasInlineSafe(double[] a, double[] b)
 {
     double s = 0;
@@ -105,4 +104,5 @@ extern (C) double aliasInlineSafe(double[] a, double[] b)
 
 // LLVM-DAG: attributes #[[UNSAFEFPMATH]] ={{.*}} "unsafe-fp-math"="true"
 // LLVM-DAG: attributes #[[UNSAFEFPMATH2]] ={{.*}} "unsafe-fp-math"="true"
+// LLVM-DAG: attributes #[[UNSAFEFPMATH3]] ={{.*}} "unsafe-fp-math"="false"
 // LLVM-DAG: attributes #[[FEAT]] ={{.*}} "target-features"="+fma"


### PR DESCRIPTION
Adds `@fastMath` that should enable aggressive math optimizations.

The attribute sets "fast" attributes on all floating point operations, ~~but does not set "unsafe-fp-math". I think it _should_ set "unsafe-fp-math" though.~~ and it sets unsafe-fp-math=true. This will also enable reassociation optimizations.  ~~(`@fastMath(false)` will do the opposite)~~