### PR TITLE
[AppVeyor] Use LLVM snapshot build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,16 +80,16 @@ install:
   - 7z x ..\make.7z > nul
   - bin\make --version
   - cd ..
-  # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
+  # Download & install an LLVM snapshot build
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/gsgyy2k3nw7c8jc/LLVM-fa4edb6-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'http://llvm.org/pre-releases/win-snapshots/LLVM-3.9.0-r268238-win64.exe' -FileName 'llvm-x64.exe'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/txrug8g1707bc59/LLVM-fa4edb6-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'http://llvm.org/pre-releases/win-snapshots/LLVM-3.9.0-r268238-win32.exe' -FileName 'llvm-x86.exe'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%
-  - 7z x ..\llvm-%APPVEYOR_JOB_ARCH%.7z > nul
+  - 7z x ..\llvm-%APPVEYOR_JOB_ARCH%.exe
   - cd ..
   # Set environment variables
   - set PATH=%CD%\ninja;%CD%\make\bin;%PATH%
@@ -116,8 +116,8 @@ build_script:
   # Generate build files for LDC
   - md ninja-ldc
   - cd ninja-ldc
-  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLLVM_ROOT_DIR=c:/projects/llvm-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc )
-  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x86 -DLLVM_ROOT_DIR=c:/projects/llvm-x86 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/ReleaseStatic/libconfig.lib ..\ldc )
+  - if "%APPVEYOR_JOB_ARCH%"=="x64" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x64 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/x64/ReleaseStatic/libconfig.lib ..\ldc )
+  - if "%APPVEYOR_JOB_ARCH%"=="x86" ( cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=c:\projects\ldc-x86 -DLIBCONFIG_INCLUDE_DIR=c:/projects/libconfig/lib -DLIBCONFIG_LIBRARY=c:/projects/libconfig/lib/ReleaseStatic/libconfig.lib ..\ldc )
   # Build LDC, druntime and phobos
   - ninja -j2
 


### PR DESCRIPTION
Created a PR to see if this works.

Use LLVM snapshot build installers on AppVeyor, so LLVM is up-to-date with LLVM trunk without the need for us to build it ourselves.
