### PR TITLE
[Travis] Make sure we test at least one build with an C++-buildable LDC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       d: ldc
       env: LLVM_CONFIG="llvm-config-3.7" OPTS="-DMULTILIB=ON"
     - os: linux
-      d: ldc
+      d: ldc-0.17.1
       env: LLVM_CONFIG="llvm-config-3.6" OPTS="-DBUILD_SHARED_LIBS=ON"
     - os: linux
       d: dmd


### PR DESCRIPTION
To test that there is a bootstrapping sequence with 1 intermediate C++-based D compiler
(instead of having to hop several compiler versions due to D features used that are not available in the C++-based version).