### PR TITLE
Remove TupleDeclaration.semantic3

### DIFF
--- a/ddmd/declaration.d
+++ b/ddmd/declaration.d
@@ -489,27 +489,6 @@ public:
         return false;
     }
 
-version(IN_LLVM)
-{
-    override void semantic3(Scope *sc)
-    {
-        //printf("TupleDeclaration::semantic3((%s)\n", toChars());
-        for (size_t i = 0; i < objects.dim; i++)
-        {   RootObject o = (*objects)[i];
-            if (o.dyncast() == DYNCAST_EXPRESSION)
-            {
-                Expression e = cast(Expression)o;
-                if (e.op == TOKdsymbol)
-                {
-                    DsymbolExp ve = cast(DsymbolExp)e;
-                    Declaration d = ve.s.isDeclaration();
-                    d.semantic3(sc);
-                }
-            }
-        }
-    }
-}
-
     override inout(TupleDeclaration) isTupleDeclaration() inout
     {
         return this;


### PR DESCRIPTION
It was added ages ago to work around an issue with tuples not being
expanded in function arguments and/or variable declarations, but
it doesn't seem to be required anymore.