### PR TITLE
fix issue #1473: ICE when implementing extern(C++) interfaces

### DIFF
--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -548,8 +548,9 @@ LLConstant *IrAggr::getClassInfoInterfaces() {
 
   // create and apply initializer
   LLConstant *arr = LLConstantArray::get(array_type, constants);
-  classInterfacesArray->setInitializer(arr);
-  setLinkage(cd, classInterfacesArray);
+  auto ciarr = getInterfaceArraySymbol();
+  ciarr->setInitializer(arr);
+  setLinkage(cd, ciarr);
 
   // return null, only baseclass provide interfaces
   if (cd->vtblInterfaces->dim == 0) {
@@ -563,9 +564,9 @@ LLConstant *IrAggr::getClassInfoInterfaces() {
 
   LLConstant *ptr = llvm::ConstantExpr::getGetElementPtr(
 #if LDC_LLVM_VER >= 307
-      isaPointer(classInterfacesArray)->getElementType(),
+      isaPointer(ciarr)->getElementType(),
 #endif
-      classInterfacesArray, idxs, true);
+      ciarr, idxs, true);
 
   // return as a slice
   return DtoConstSlice(DtoConstSize_t(cd->vtblInterfaces->dim), ptr);

--- a/ir/irtypeclass.h
+++ b/ir/irtypeclass.h
@@ -80,6 +80,8 @@ protected:
 
   /// Builds a vtable type given the type of the first entry and an array
   /// of all entries.
+  /// If first is nullptr for C++ interfaces, the vtbl_array will be added
+  /// as is without replacing the first entry.
   std::vector<llvm::Type *> buildVtblType(Type *first,
                                           FuncDeclarations *vtbl_array);
 


### PR DESCRIPTION
The vtbl still contained the class info entry for C++ interfaces.