### PR TITLE
add testcase for issue 1481

### DIFF
--- a/tests/codegen/cpp_interface.d
+++ b/tests/codegen/cpp_interface.d
@@ -1,0 +1,5 @@
+// RUN: %ldc -c %s
+
+extern(C++) interface XUnknown {}
+class ComObject : XUnknown {}
+class DComObject : ComObject {}


### PR DESCRIPTION
Lit tests still don't run locally for me, so better try them in a PR.

Any idea what's wrong here:
```
Start testing: May 14 08:24 Romance Summer Time
----------------------------------------------------------
1909/1909 Testing: lit-tests
1909/1909 Test: lit-tests
Command: "C:/l/Python27/python.exe" "runlit.py" "-v" "."
Directory: C:/s/d/ldc/ninja-ldc/tests
"lit-tests" start time: May 14 08:24 Romance Summer Time
Output:
----------------------------------------------------------
-- Testing: 9 tests, 8 threads --
FAIL: LDC :: codegen/cpp_interface.d (1 of 9)
******************** TEST 'LDC :: codegen/cpp_interface.d' FAILED ********************
Script:
--
C:/s/d/ldc/ninja-ldc/bin/ldc2 -c C:\s\d\ldc\ldc\tests\codegen\cpp_interface.d
--
Exit Code: 127

Command Output (stdout):
--
Command 0: "C:/s/d/ldc/ninja-ldc/bin/ldc2" "-c" "C:\s\d\ldc\ldc\tests\codegen\cpp_interface.d"
Command 0 Result: 127
Command 0 Output:


Command 0 Stderr:
Could not create process due to [Error 193] %1 is not a valid Win32 application
```