### PR TITLE
fix building against LLVM master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,9 +83,9 @@ install:
   # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/gsgyy2k3nw7c8jc/LLVM-fa4edb6-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/ey99b8e7bpbpt9o/LLVM-20ebcfc-x64.7z?dl=0' -FileName 'llvm-x64.7z'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/txrug8g1707bc59/LLVM-fa4edb6-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/ggsdfwdfrlr26mj/LLVM-20ebcfc-x86.7z?dl=0' -FileName 'llvm-x86.7z'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -96,7 +96,11 @@ MipsABI::Type getMipsABI() {
 #endif
     if (dl.getPointerSizeInBits() == 64)
       return MipsABI::N64;
+#if LDC_LLVM_VER >= 309
+    else if (dl.getLargestLegalIntTypeSizeInBits() == 64)
+#else
     else if (dl.getLargestLegalIntTypeSize() == 64)
+#endif
       return MipsABI::N32;
     else
       return MipsABI::O32;


### PR DESCRIPTION
`getLargestLegalIntTypeSize` has just been renamed `getLargestLegalIntTypeSizeInBits`.
This needs another workaround to support both versions for LLVM 3.9 until the build servers have been updated.