### PR TITLE
Add new attribute visualcppmangle.

### DIFF
--- a/ddmd/aggregate.h
+++ b/ddmd/aggregate.h
@@ -178,6 +178,9 @@ public:
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+#if IN_LLVM
+    bool cppmangleAsClass;      // true if this struct should be mangled as class (VS only)
+#endif
 
     StructDeclaration(Loc loc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -273,6 +276,9 @@ public:
     bool cpp;                           // true if this is a C++ interface
     bool isscope;                       // true if this is a scope class
     bool isabstract;                    // true if abstract class
+#if IN_LLVM
+    bool cppmangleAsStruct;             // true if this class should be mangled as struct (VS only)
+#endif
     int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving
     Objc_ClassDeclaration objc;

--- a/ddmd/attrib.d
+++ b/ddmd/attrib.d
@@ -1529,6 +1529,24 @@ extern (C++) static uint setMangleOverride(Dsymbol s, char* sym)
         s.isDeclaration().mangleOverride = sym;
         return 1;
     }
+//version(IN_LLVM) {
+    else if (s.isStructDeclaration() || s.isClassDeclaration())
+    {
+        bool asClass = !strcmp(sym, "class");
+        bool asStruct = !strcmp(sym, "struct");
+        if (!(asClass || asStruct))
+            return 0;
+        if (StructDeclaration sd = s.isStructDeclaration())
+        {
+            sd.cppmangleAsClass = asClass;
+        }
+        else if (ClassDeclaration cd = s.isClassDeclaration())
+        {
+            cd.cppmangleAsStruct = asStruct;
+        }
+        return 1;
+    }
+//}
     else
         return 0;
 }

--- a/ddmd/cppmangle.d
+++ b/ddmd/cppmangle.d
@@ -30,6 +30,7 @@ import ddmd.target;
 import ddmd.tokens;
 import ddmd.visitor;
 version(IN_LLVM) {
+    import ddmd.dclass;
     import ddmd.errors;
     import gen.llvmhelpers;
 }
@@ -1281,7 +1282,12 @@ static if (IN_LLVM || TARGET_WINDOS)
                 if (type.sym.isUnionDeclaration())
                     buf.writeByte('T');
                 else
+version(IN_LLVM) {
+                    StructDeclaration sd = (cast(TypeStruct)type).sym;
+                    buf.writeByte(sd.cppmangleAsClass ? 'V' : 'U');
+} else {
                     buf.writeByte('U');
+}
                 mangleIdent(type.sym);
             }
             flags &= ~IS_NOT_TOP_TYPE;
@@ -1348,7 +1354,12 @@ static if (IN_LLVM || TARGET_WINDOS)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleModifier(type);
+version(IN_LLVM) {
+            ClassDeclaration cd = (cast(TypeClass)type).sym;
+            buf.writeByte(cd.cppmangleAsStruct ? 'U' : 'V');
+} else {
             buf.writeByte('V');
+}
             mangleIdent(type.sym);
             flags &= ~IS_NOT_TOP_TYPE;
             flags &= ~IGNORE_CONST;

--- a/ddmd/dclass.d
+++ b/ddmd/dclass.d
@@ -213,6 +213,10 @@ public:
     bool cpp;           // true if this is a C++ interface
     bool isscope;       // true if this is a scope class
     bool isabstract;    // true if abstract class
+    version (IN_LLVM)
+    {
+        bool cppmangleAsStruct; // true if this class should be mangled as struct (VS only)
+    }
     int inuse;          // to prevent recursive attempts
     Baseok baseok;      // set the progress of base classes resolving
 

--- a/ddmd/dstruct.d
+++ b/ddmd/dstruct.d
@@ -248,6 +248,10 @@ public:
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+    version (IN_LLVM)
+    {
+        bool cppmangleAsClass;// true if this struct should be mangled as class (VS only)
+    }
 
     final extern (D) this(Loc loc, Identifier id)
     {


### PR DESCRIPTION
This attribute allows to influence the C++ mangling for VS. This is
necessary because VS has different manglings for structs and classes.
gcc uses the same mangling instead.