### PR TITLE
LLVM 3.9: llvm::Reloc::Default was removed.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -279,10 +279,14 @@ cl::opt<std::string>
 
 cl::opt<llvm::Reloc::Model> mRelocModel(
     "relocation-model", cl::desc("Relocation model"),
+#if LDC_LLVM_VER < 309
     cl::init(llvm::Reloc::Default),
+#endif
     cl::values(
+#if LDC_LLVM_VER < 309
         clEnumValN(llvm::Reloc::Default, "default",
                    "Target default relocation model"),
+#endif
         clEnumValN(llvm::Reloc::Static, "static", "Non-relocatable code"),
         clEnumValN(llvm::Reloc::PIC_, "pic",
                    "Fully relocatable, position independent code"),

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -15,6 +15,9 @@
 #ifndef LDC_DRIVER_TARGET_H
 #define LDC_DRIVER_TARGET_H
 
+#if LDC_LLVM_VER >= 309
+#include "llvm/ADT/Optional.h"
+#endif
 #include "llvm/Support/CodeGen.h"
 #include <string>
 #include <vector>
@@ -44,7 +47,12 @@ class TargetMachine;
 llvm::TargetMachine *createTargetMachine(
     std::string targetTriple, std::string arch, std::string cpu,
     std::vector<std::string> attrs, ExplicitBitness::Type bitness,
-    FloatABI::Type floatABI, llvm::Reloc::Model relocModel,
+    FloatABI::Type floatABI,
+#if LDC_LLVM_VER >= 309
+    llvm::Optional<llvm::Reloc::Model> relocModel,
+#else
+    llvm::Reloc::Model relocModel,
+#endif
     llvm::CodeModel::Model codeModel, llvm::CodeGenOpt::Level codeGenOptLevel,
     bool noFramePointerElim, bool noLinkerStripDead);
 


### PR DESCRIPTION
The value is now optional as there is nothing like a default relocation.