### PR TITLE
AppVeyor: Use a slightly older LLVM build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,9 +83,9 @@ install:
   # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/undoy42t6ax7jcl/LLVM-r270356-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/4bzfyd0npnya4y1/LLVM-d06ea8a-x64.7z?dl=0' -FileName 'llvm-x64.7z'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/r6ru8qnx6b2z17y/LLVM-r270356-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/m94gi730rvsmvrl/LLVM-d06ea8a-x86.7z?dl=0' -FileName 'llvm-x86.7z'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%


### PR DESCRIPTION
3 days old and free of the MS (CodeView) debug info regression shown by `runnable\opover2.d` on Win64 when using `-enable-inlining`.