### PR TITLE
[AppVeyor] Update LLVM to r271875

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,9 +102,9 @@ install:
   # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/4bzfyd0npnya4y1/LLVM-d06ea8a-x64.7z?dl=0' -FileName 'llvm-x64.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/972u4dhwif3xh6x/LLVM-r271875-x64.7z?dl=0' -FileName 'llvm-x64.7z'
         } Else {
-            Start-FileDownload 'https://dl.dropboxusercontent.com/s/m94gi730rvsmvrl/LLVM-d06ea8a-x86.7z?dl=0' -FileName 'llvm-x86.7z'
+            Start-FileDownload 'https://dl.dropboxusercontent.com/s/k0h72r6zzhc6t6b/LLVM-r271875-x86.7z?dl=0' -FileName 'llvm-x86.7z'
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%


### PR DESCRIPTION
See https://github.com/ldc-developers/ldc/pull/1506 for discussion about a Windows PDB issue with recent LLVM versions. Should be fixed at this LLVM rev.