### PR TITLE
Lit tests on Windows x86 now PASS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,12 @@ set( LLVM_TOOLS_DIR  ${LLVM_ROOT_DIR}/bin                  )
 set( LDC2_BIN_DIR    ${PROJECT_BINARY_DIR}/bin             )
 set( TESTS_IR_DIR    ${CMAKE_CURRENT_SOURCE_DIR}           )
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set( DEFAULT_TARGET_BITS 64 )
+else()
+    set( DEFAULT_TARGET_BITS 32 )
+endif()
+
 configure_file(lit.site.cfg.in lit.site.cfg )
 configure_file(runlit.py       runlit.py    COPYONLY)
 

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -1,5 +1,8 @@
 // RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
+// Fails on Windows_x86, see https://github.com/ldc-developers/ldc/issues/1356
+// XFAIL: Windows_x86
+
 align(32) struct Outer { int a; }
 struct Inner { align(32) int a; }
 

--- a/tests/codegen/hashed_mangling.d
+++ b/tests/codegen/hashed_mangling.d
@@ -15,9 +15,9 @@ extern (C) int externCfunctions_are_not_hashed_externCfunctions_are_not_hashed_e
 
 auto s(T)(T t)
 {
-    // HASH90-DAG: define{{.*}} @_D3one3two5three8__T1sTiZ1sFNaNbNiNfiZS3one3two5three8__T1sTiZ1sFiZ13__T6ResultTiZ6Result
-    // HASH90-DAG: define{{.*}} @_D3one3two5three3L1633_699ccf279a146992d539ca3ca16e22e11sZ
-    // HASH90-DAG: define{{.*}} @_D3one3two5three3L2333_5ee632e10b6f09e8f541a143266bdf226Result3fooZ
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three8__T1sTiZ1sFNaNbNiNfiZS3one3two5three8__T1sTiZ1sFiZ13__T6ResultTiZ6Result
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L1633_699ccf279a146992d539ca3ca16e22e11sZ
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L2333_5ee632e10b6f09e8f541a143266bdf226Result3fooZ
     struct Result(T)
     {
         void foo(){}
@@ -29,8 +29,8 @@ auto klass(T)(T t)
 {
     class Result(T)
     {
-        // HASH90-DAG: define{{.*}} @_D3one3two5three12__T5klassTiZ5klassFiZ13__T6ResultTiZ6Result3fooMFZv
-        // HASH90-DAG: define{{.*}} @_D3one3two5three3L3433_46a82aac733d8a4b3588d7fa8937aad66Result3fooZ
+        // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three12__T5klassTiZ5klassFiZ13__T6ResultTiZ6Result3fooMFZv
+        // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L3433_46a82aac733d8a4b3588d7fa8937aad66Result3fooZ
         void foo(){}
     }
     return new Result!int();

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -10,6 +10,7 @@ config.test_source_root = "@TESTS_IR_DIR@"
 config.llvm_tools_dir   = "@LLVM_TOOLS_DIR@"
 config.llvm_version     = @LDC_LLVM_VER@
 config.llvm_targetsstr  = "@LLVM_TARGETS_TO_BUILD@"
+config.default_target_bits = @DEFAULT_TARGET_BITS@
 
 config.name = 'LDC'
 
@@ -43,6 +44,10 @@ config.available_features.add(platform.system())
 # Examples: 'target_X86', 'target_ARM', 'target_PowerPC', 'target_AArch64'
 for t in config.llvm_targetsstr.split(';'):
     config.available_features.add('target_' + t)
+
+# Add a specific feature for Windows x86 testing
+if (platform.system() == 'Windows') and (config.default_target_bits == 32):
+    config.available_features.add('Windows_x86')
 
 config.target_triple = '(unused)'
 


### PR DESCRIPTION
Fixes the failing symbol hashing test.
Marks align.d test as an expected failure on Windows x86, see #1356 
