### PR TITLE
Windows: Move the prepending of 0x1 to C++ mangled functions from frontend to the backend.

### DIFF
--- a/ddmd/cppmangle.d
+++ b/ddmd/cppmangle.d
@@ -1356,9 +1356,6 @@ static if (IN_LLVM || TARGET_WINDOS)
 
         const(char)* mangleOf(Dsymbol s)
         {
-version(IN_LLVM) {
-            buf.writeByte('\01'); // disable further mangling by the backend
-}
             VarDeclaration vd = s.isVarDeclaration();
             FuncDeclaration fd = s.isFuncDeclaration();
             if (vd)

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -93,7 +93,17 @@ struct TargetABI {
   /// Using this function at a stage where the name could be user-visible is
   /// almost certainly a mistake; it is intended to e.g. prepend '\1' where
   /// disabling the LLVM-internal name mangling/postprocessing is required.
-  virtual std::string mangleForLLVM(llvm::StringRef name, LINK l) {
+  virtual std::string mangleFunctionForLLVM(std::string name, LINK l) {
+    return name;
+  }
+
+  /// Applies any rewrites that might be required to accurately reproduce the
+  /// passed variable name on LLVM given a specific D linkage.
+  ///
+  /// Using this function at a stage where the name could be user-visible is
+  /// almost certainly a mistake; it is intended to e.g. prepend '\1' where
+  /// the LLVM-internal postprocessing of prepending a '_' must be disabled.
+  virtual std::string mangleVariableForLLVM(std::string name, LINK l) {
     return name;
   }
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -21,6 +21,7 @@
 #include "gen/llvmcompat.h"
 #include "gen/logger.h"
 #include "gen/nested.h"
+#include "gen/mangling.h"
 #include "gen/pragma.h"
 #include "gen/runtime.h"
 #include "gen/tollvm.h"
@@ -831,7 +832,7 @@ void DtoResolveVariable(VarDeclaration *vd) {
     if (gIR->dmodule) {
       vd->ir->setInitialized();
     }
-    std::string llName(mangle(vd));
+    std::string llName(getMangledName(vd));
 
     // Since the type of a global must exactly match the type of its
     // initializer, we cannot know the type until after we have emitted the

--- a/gen/mangling.cpp
+++ b/gen/mangling.cpp
@@ -108,7 +108,17 @@ std::string getMangledName(FuncDeclaration *fdecl, LINK link) {
     mangledName = "_D" + hashedName + "Z";
   }
 
-  return gABI->mangleForLLVM(mangledName, link);
+  // TODO: Cache the result?
+
+  return gABI->mangleFunctionForLLVM(std::move(mangledName), link);
+}
+
+std::string getMangledName(VarDeclaration *vd) {
+  // TODO: is hashing of variable names necessary?
+
+  // TODO: Cache the result?
+
+  return gABI->mangleVariableForLLVM(mangle(vd), vd->linkage);
 }
 
 std::string getMangledInitSymbolName(AggregateDeclaration *aggrdecl) {
@@ -123,7 +133,7 @@ std::string getMangledInitSymbolName(AggregateDeclaration *aggrdecl) {
 
   ret += "6__initZ";
 
-  return ret;
+  return gABI->mangleVariableForLLVM(std::move(ret), LINKd);
 }
 
 std::string getMangledVTableSymbolName(AggregateDeclaration *aggrdecl) {
@@ -138,7 +148,7 @@ std::string getMangledVTableSymbolName(AggregateDeclaration *aggrdecl) {
 
   ret += "6__vtblZ";
 
-  return ret;
+  return gABI->mangleVariableForLLVM(std::move(ret), LINKd);
 }
 
 std::string getMangledClassInfoSymbolName(AggregateDeclaration *aggrdecl) {
@@ -157,5 +167,5 @@ std::string getMangledClassInfoSymbolName(AggregateDeclaration *aggrdecl) {
     ret += "7__ClassZ";
   }
 
-  return ret;
+  return gABI->mangleVariableForLLVM(std::move(ret), LINKd);
 }

--- a/gen/mangling.h
+++ b/gen/mangling.h
@@ -17,10 +17,12 @@
 #include <string>
 #include "ddmd/globals.h"
 
-class FuncDeclaration;
 class AggregateDeclaration;
+class FuncDeclaration;
+class VarDeclaration;
 
 std::string getMangledName(FuncDeclaration *fdecl, LINK link);
+std::string getMangledName(VarDeclaration *vd);
 
 std::string getMangledInitSymbolName(AggregateDeclaration *aggrdecl);
 std::string getMangledVTableSymbolName(AggregateDeclaration *aggrdecl);

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -187,7 +187,7 @@ static llvm::Function *build_module_function(
   LLFunctionType *fnTy = LLFunctionType::get(LLType::getVoidTy(gIR->context()),
                                              std::vector<LLType *>(), false);
 
-  std::string const symbolName = gABI->mangleForLLVM(name, LINKd);
+  std::string const symbolName = gABI->mangleFunctionForLLVM(name, LINKd);
   assert(gIR->module.getFunction(symbolName) == NULL);
   llvm::Function *fn = llvm::Function::Create(
       fnTy, llvm::GlobalValue::InternalLinkage, symbolName, &gIR->module);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -674,7 +674,7 @@ static void buildRuntimeModule() {
   // void invariant._d_invariant(Object o)
   createFwdDecl(
       LINKd, voidTy,
-      {gABI->mangleForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd)},
+      {gABI->mangleFunctionForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd)},
       {objectTy});
 
   // void _d_dso_registry(CompilerDSOData* data)

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1889,7 +1889,7 @@ public:
       Logger::println("calling class invariant");
       llvm::Function *fn = getRuntimeFunction(
           e->loc, gIR->module,
-          gABI->mangleForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd)
+          gABI->mangleFunctionForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd)
               .c_str());
       LLValue *arg =
           DtoBitCast(cond->getRVal(), fn->getFunctionType()->getParamType(0));

--- a/tests/codegen/mangling_gh1519.d
+++ b/tests/codegen/mangling_gh1519.d
@@ -1,0 +1,33 @@
+// Test for Github issue 1519
+
+// Check that .mangleof strings do not contain any char 0x01.
+// LDC may prepend 0x01 to prevent LLVM from modifying the symbol name, but it should not appear in user code.
+
+// RUN: %ldc -c %s
+
+extern (C) void fooC()
+{
+}
+
+extern (C++) void fooCpp()
+{
+}
+
+extern (D) void fooD()
+{
+}
+
+void aliasTemplate(alias F)()
+{
+    F();
+}
+
+void main()
+{
+    import std.algorithm;
+
+    static assert(all!"a != '\1'"(fooC.mangleof));
+    static assert(all!"a != '\1'"(fooCpp.mangleof));
+    static assert(all!"a != '\1'"(fooD.mangleof));
+    static assert(all!"a != '\1'"(aliasTemplate!fooCpp.mangleof));
+}


### PR DESCRIPTION
This removes the 0x1 byte from `.mangleof` accessible from user code.
Resolves issue #1519