### PR TITLE
Remove gratuitous extra leading underscore for x86 abi mangling of D symbols

### DIFF
--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -67,7 +67,7 @@ struct X86TargetABI : TargetABI {
       if (global.params.targetTriple->isOSWindows()) {
         // Prepend a 0x1 byte to keep LLVM from adding the usual
         // "@<paramsize>" stdcall suffix.
-        return ("\1_" + name).str();
+        return ("\1" + name).str();
       }
       return name;
     }


### PR DESCRIPTION
If this underscore is not needed, I'd rather remove it. Because of this extra underscore, some work with mangled names requires extra special case for Win32. (I ran into this during PGO work)