### PR TITLE
[AppVeyor] Use LDC for Debug x86 build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       D_COMPILER:          ldc
     - APPVEYOR_JOB_CONFIG: Debug
       APPVEYOR_JOB_ARCH:   x86
-      D_COMPILER:          dmd
+      D_COMPILER:          ldc
     - APPVEYOR_JOB_CONFIG: Release
       APPVEYOR_JOB_ARCH:   x64
       D_COMPILER:          dmd


### PR DESCRIPTION
This is to check whether the appveyor debug x86 failure in closure.d is fixed by using LDC instead of DMD.