### PR TITLE
Tests: use -mtriple= instead of without equals sign.

### DIFF
--- a/tests/codegen/attr_fastmath_x86.d
+++ b/tests/codegen/attr_fastmath_x86.d
@@ -2,7 +2,7 @@
 
 // REQUIRES: target_X86
 
-// RUN: %ldc -mtriple x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
+// RUN: %ldc -mtriple=x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
 
 import ldc.attributes;
 

--- a/tests/codegen/attr_target_x86.d
+++ b/tests/codegen/attr_target_x86.d
@@ -3,8 +3,8 @@
 // REQUIRES: atleast_llvm307
 // REQUIRES: target_X86
 
-// RUN: %ldc -O -c -mcpu=i386 -mtriple i386-linux-gnu -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
-// RUN: %ldc -O -c -mcpu=i386 -mtriple i386-linux-gnu -output-s -of=%t.s %s && FileCheck %s  --check-prefix ASM < %t.s
+// RUN: %ldc -O -c -mcpu=i386 -mtriple=i386-linux-gnu -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
+// RUN: %ldc -O -c -mcpu=i386 -mtriple=i386-linux-gnu -output-s -of=%t.s %s && FileCheck %s  --check-prefix ASM < %t.s
 
 import ldc.attributes;
 

--- a/tests/codegen/inlineIR_math.d
+++ b/tests/codegen/inlineIR_math.d
@@ -3,7 +3,7 @@
 // REQUIRES: target_X86
 
 // RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
-// RUN: %ldc -mtriple x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
+// RUN: %ldc -mtriple=x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
 
 import ldc.attributes;
 pragma(LDC_inline_ir) R inlineIR(string s, R, P...)(P);


### PR DESCRIPTION
If I understand correctly, the "official" way of setting target triple is with an equals sign.
This PR fixes that in the tests.