### PR TITLE
Optimize ABIRewrite system for lvalues

### DIFF
--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -50,11 +50,11 @@ struct AArch64TargetABI : TargetABI {
       // non-HFA and messes up register selection
       if (isHFA((TypeStruct *)retTy, &fty.ret->ltype)) {
         fty.ret->rewrite = &hfaToArray;
-        fty.ret->ltype = hfaToArray.type(fty.ret->type, fty.ret->ltype);
+        fty.ret->ltype = hfaToArray.type(fty.ret->type);
       }
       else {
         fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type, fty.ret->ltype);
+        fty.ret->ltype = integerRewrite.type(fty.ret->type);
       }
     }
 
@@ -75,11 +75,11 @@ struct AArch64TargetABI : TargetABI {
       // non-HFA and messes up register selection
       if (ty->ty == Tstruct && isHFA((TypeStruct *)ty, &arg.ltype)) {
         arg.rewrite = &hfaToArray;
-        arg.ltype = hfaToArray.type(arg.type, arg.ltype);
+        arg.ltype = hfaToArray.type(arg.type);
       }
       else {
         arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type, arg.ltype);
+        arg.ltype = compositeToArray64.type(arg.type);
       }
     }
   }

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -77,7 +77,7 @@ struct ArmTargetABI : TargetABI {
         fty.ret->rewrite = &hfaToArray;
       } else {
         fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type, fty.ret->ltype);
+        fty.ret->ltype = integerRewrite.type(fty.ret->type);
       }
     }
 
@@ -111,10 +111,10 @@ struct ArmTargetABI : TargetABI {
         arg.rewrite = &hfaToArray;
       } else if (DtoAlignment(ty) <= 4) {
         arg.rewrite = &compositeToArray32;
-        arg.ltype = compositeToArray32.type(arg.type, arg.ltype);
+        arg.ltype = compositeToArray32.type(arg.type);
       } else {
         arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type, arg.ltype);
+        arg.ltype = compositeToArray64.type(arg.type);
       }
     }
   }

--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -97,9 +97,8 @@ struct RemoveStructPadding : ABIRewrite {
     return lval;
   }
 
-  /// return the transformed type for this rewrite
-  LLType *type(Type *dty, LLType *t) override {
-    return DtoUnpaddedStructType(dty->toBasetype());
+  LLType *type(Type *t) override {
+    return DtoUnpaddedStructType(t->toBasetype());
   }
 };
 
@@ -166,7 +165,7 @@ struct IntegerRewrite : ABIRewrite {
     return DtoAllocaDump(v, dty, ".IntegerRewrite_dump");
   }
 
-  LLType *type(Type *t, LLType *) override { return getIntegerType(t->size()); }
+  LLType *type(Type *t) override { return getIntegerType(t->size()); }
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -211,7 +210,7 @@ struct ExplicitByvalRewrite : ABIRewrite {
     return DtoBitCast(v, DtoPtrToType(dty));
   }
 
-  LLType *type(Type *dty, LLType *t) override { return DtoPtrToType(dty); }
+  LLType *type(Type *t) override { return DtoPtrToType(t); }
 
   unsigned alignment(Type *dty) const {
     return std::max(minAlignment, DtoAlignment(dty));
@@ -230,7 +229,7 @@ struct HFAToArray : ABIRewrite {
   LLValue *put(DValue *dv) override {
     Type *dty = dv->getType();
     Logger::println("rewriting HFA %s -> as array", dty->toChars());
-    LLType *t = type(dty, nullptr);
+    LLType *t = type(dty);
     return DtoLoad(DtoBitCast(dv->getRVal(), getPtrToType(t)));
   }
 
@@ -239,12 +238,12 @@ struct HFAToArray : ABIRewrite {
     return DtoAllocaDump(v, dty, ".HFAToArray_dump");
   }
 
-  LLType *type(Type *dty, LLType *) override {
-    assert(dty->ty == Tstruct);
+  LLType *type(Type *t) override {
+    assert(t->ty == Tstruct);
     LLType *floatArrayType = nullptr;
-    if (TargetABI::isHFA((TypeStruct *)dty, &floatArrayType, maxFloats))
+    if (TargetABI::isHFA((TypeStruct *)t, &floatArrayType, maxFloats))
       return floatArrayType;
-    llvm_unreachable("Type dty should be an HFA");
+    llvm_unreachable("Type t should be an HFA");
   }
 };
 
@@ -255,7 +254,7 @@ struct CompositeToArray64 : ABIRewrite {
   LLValue *put(DValue *dv) override {
     Type *dty = dv->getType();
     Logger::println("rewriting %s -> as i64 array", dty->toChars());
-    LLType *t = type(dty, nullptr);
+    LLType *t = type(dty);
     return DtoLoad(DtoBitCast(dv->getRVal(), getPtrToType(t)));
   }
 
@@ -264,7 +263,7 @@ struct CompositeToArray64 : ABIRewrite {
     return DtoAllocaDump(v, dty, ".CompositeToArray64_dump");
   }
 
-  LLType *type(Type *t, LLType *) override {
+  LLType *type(Type *t) override {
     // An i64 array that will hold Type 't'
     size_t sz = (t->size() + 7) / 8;
     return LLArrayType::get(LLIntegerType::get(gIR->context(), 64), sz);
@@ -278,7 +277,7 @@ struct CompositeToArray32 : ABIRewrite {
   LLValue *put(DValue *dv) override {
     Type *dty = dv->getType();
     Logger::println("rewriting %s -> as i32 array", dty->toChars());
-    LLType *t = type(dty, nullptr);
+    LLType *t = type(dty);
     return DtoLoad(DtoBitCast(dv->getRVal(), getPtrToType(t)));
   }
 
@@ -287,7 +286,7 @@ struct CompositeToArray32 : ABIRewrite {
     return DtoAllocaDump(v, dty, ".CompositeToArray32_dump");
   }
 
-  LLType *type(Type *t, LLType *) override {
+  LLType *type(Type *t) override {
     // An i32 array that will hold Type 't'
     size_t sz = (t->size() + 3) / 4;
     return LLArrayType::get(LLIntegerType::get(gIR->context(), 32), sz);

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -68,13 +68,13 @@ struct PPCTargetABI : TargetABI {
       if (canRewriteAsInt(ty, Is64Bit)) {
         if (!IntegerRewrite::isObsoleteFor(arg.ltype)) {
           arg.rewrite = &integerRewrite;
-          arg.ltype = integerRewrite.type(arg.type, arg.ltype);
+          arg.ltype = integerRewrite.type(arg.type);
         }
       } else {
         // these types are passed byval:
         // the caller allocates a copy and then passes a pointer to the copy
         arg.rewrite = &byvalRewrite;
-        arg.ltype = byvalRewrite.type(arg.type, arg.ltype);
+        arg.ltype = byvalRewrite.type(arg.type);
 
         // the copy is treated as a local variable of the callee
         // hence add the NoAlias and NoCapture attributes

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -63,14 +63,14 @@ struct PPC64LETargetABI : TargetABI {
         if (retTy->ty == Tstruct &&
             isHFA((TypeStruct *)retTy, &fty.ret->ltype, 8)) {
           fty.ret->rewrite = &hfaToArray;
-          fty.ret->ltype = hfaToArray.type(fty.ret->type, fty.ret->ltype);
+          fty.ret->ltype = hfaToArray.type(fty.ret->type);
         } else if (canRewriteAsInt(retTy, true)) {
           fty.ret->rewrite = &integerRewrite;
-          fty.ret->ltype = integerRewrite.type(fty.ret->type, fty.ret->ltype);
+          fty.ret->ltype = integerRewrite.type(fty.ret->type);
         } else {
           fty.ret->rewrite = &compositeToArray64;
           fty.ret->ltype =
-              compositeToArray64.type(fty.ret->type, fty.ret->ltype);
+              compositeToArray64.type(fty.ret->type);
         }
       } else if (retTy->isintegral())
         fty.ret->attrs.add(retTy->isunsigned() ? LLAttribute::ZExt
@@ -90,13 +90,13 @@ struct PPC64LETargetABI : TargetABI {
     if (ty->ty == Tstruct || ty->ty == Tsarray) {
       if (ty->ty == Tstruct && isHFA((TypeStruct *)ty, &arg.ltype, 8)) {
         arg.rewrite = &hfaToArray;
-        arg.ltype = hfaToArray.type(arg.type, arg.ltype);
+        arg.ltype = hfaToArray.type(arg.type);
       } else if (canRewriteAsInt(ty, true)) {
         arg.rewrite = &integerRewrite;
-        arg.ltype = integerRewrite.type(arg.type, arg.ltype);
+        arg.ltype = integerRewrite.type(arg.type);
       } else {
         arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type, arg.ltype);
+        arg.ltype = compositeToArray64.type(arg.type);
       }
     } else if (ty->isintegral())
       arg.attrs.add(ty->isunsigned() ? LLAttribute::ZExt : LLAttribute::SExt);

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -145,7 +145,7 @@ public:
 
     if (arg.rewrite) {
       LLType *originalLType = arg.ltype;
-      arg.ltype = arg.rewrite->type(arg.type, arg.ltype);
+      arg.ltype = arg.rewrite->type(arg.type);
 
       IF_LOG {
         Logger::println("Rewriting argument type %s", t->toChars());

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -169,16 +169,6 @@ struct RegCount {
  * memory so that it's then readable as the other type (i.e., bit-casting).
  */
 struct X86_64_C_struct_rewrite : ABIRewrite {
-  LLValue *get(Type *dty, LLValue *v) override {
-    LLValue *address = DtoAllocaDump(v, dty, ".X86_64_C_struct_rewrite_dump");
-    LLType *type = DtoType(dty);
-    return loadFromMemory(address, type, ".X86_64_C_struct_rewrite_getResult");
-  }
-
-  void getL(Type *dty, LLValue *v, LLValue *lval) override {
-    storeToMemory(v, lval);
-  }
-
   LLValue *put(DValue *v) override {
     LLValue *address = getAddressOf(v);
 
@@ -186,6 +176,10 @@ struct X86_64_C_struct_rewrite : ABIRewrite {
     assert(abiTy && "Why are we rewriting a non-rewritten type?");
 
     return loadFromMemory(address, abiTy, ".X86_64_C_struct_rewrite_putResult");
+  }
+
+  LLValue *getLVal(Type *dty, LLValue *v) override {
+    return DtoAllocaDump(v, dty, ".X86_64_C_struct_rewrite_dump");
   }
 
   LLType *type(Type *dty, LLType *t) override { return getAbiType(dty); }
@@ -200,15 +194,9 @@ struct X86_64_C_struct_rewrite : ABIRewrite {
  * the ByVal LLVM attribute.
  */
 struct ImplicitByvalRewrite : ABIRewrite {
-  LLValue *get(Type *dty, LLValue *v) override {
-    return DtoLoad(v, ".ImplicitByvalRewrite_getResult");
-  }
-
-  void getL(Type *dty, LLValue *v, LLValue *lval) override {
-    DtoMemCpy(lval, v);
-  }
-
   LLValue *put(DValue *v) override { return getAddressOf(v); }
+
+  LLValue *getLVal(Type *dty, LLValue *v) override { return v; }
 
   LLType *type(Type *dty, LLType *t) override { return DtoPtrToType(dty); }
 };

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -182,7 +182,7 @@ struct X86_64_C_struct_rewrite : ABIRewrite {
     return DtoAllocaDump(v, dty, ".X86_64_C_struct_rewrite_dump");
   }
 
-  LLType *type(Type *dty, LLType *t) override { return getAbiType(dty); }
+  LLType *type(Type *t) override { return getAbiType(t); }
 };
 
 /**
@@ -198,7 +198,7 @@ struct ImplicitByvalRewrite : ABIRewrite {
 
   LLValue *getLVal(Type *dty, LLValue *v) override { return v; }
 
-  LLType *type(Type *dty, LLType *t) override { return DtoPtrToType(dty); }
+  LLType *type(Type *t) override { return DtoPtrToType(t); }
 };
 
 struct X86_64TargetABI : TargetABI {

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -126,7 +126,7 @@ struct X86TargetABI : TargetABI {
           !(externD && rt->ty == Tcomplex32) &&
           !integerRewrite.isObsoleteFor(fty.ret->ltype)) {
         fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type, fty.ret->ltype);
+        fty.ret->ltype = integerRewrite.type(fty.ret->type);
       }
     }
 
@@ -166,7 +166,7 @@ struct X86TargetABI : TargetABI {
           // rewrite aggregates as integers to make inreg work
           if (lastTy->ty == Tstruct || lastTy->ty == Tsarray) {
             last->rewrite = &integerRewrite;
-            last->ltype = integerRewrite.type(last->type, last->ltype);
+            last->ltype = integerRewrite.type(last->type);
             // undo byval semantics applied via passByVal() returning true
             last->byref = false;
             last->attrs.clear();

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -31,10 +31,8 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
-void ABIRewrite::getL(Type *dty, LLValue *v, LLValue *lval) {
-  LLValue *rval = get(dty, v);
-  assert(rval->getType() == lval->getType()->getContainedType(0));
-  DtoStore(rval, lval);
+llvm::Value *ABIRewrite::getRVal(Type *dty, LLValue *v) {
+  return DtoLoad(DtoBitCast(getLVal(dty, v), DtoType(dty)->getPointerTo()));
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -51,27 +51,6 @@ LLValue *ABIRewrite::getAddressOf(DValue *v) {
   return DtoAllocaDump(v, ".getAddressOf_dump");
 }
 
-void ABIRewrite::storeToMemory(LLValue *rval, LLValue *address) {
-  LLType *pointerType = address->getType();
-  assert(pointerType->isPointerTy());
-  LLType *pointeeType = pointerType->getPointerElementType();
-
-  LLType *rvalType = rval->getType();
-  if (rvalType != pointeeType) {
-    if (getTypeStoreSize(rvalType) > getTypeAllocSize(pointeeType)) {
-      // not enough allocated memory
-      LLValue *paddedDump = DtoAllocaDump(rval, 0, ".storeToMemory_paddedDump");
-      DtoMemCpy(address, paddedDump);
-      return;
-    }
-
-    address = DtoBitCast(address, getPtrToType(rvalType),
-                         ".storeToMemory_bitCastAddress");
-  }
-
-  DtoStore(rval, address);
-}
-
 LLValue *ABIRewrite::loadFromMemory(LLValue *address, LLType *asType,
                                     const char *name) {
   LLType *pointerType = address->getType();

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -39,16 +39,16 @@ class FunctionType;
 struct ABIRewrite {
   virtual ~ABIRewrite() = default;
 
-  /// get a rewritten value back to its original form
-  virtual llvm::Value *get(Type *dty, llvm::Value *v) = 0;
-
-  /// get a rewritten value back to its original form and store result in
-  /// provided lvalue
-  /// this one is optional and defaults to calling the one above
-  virtual void getL(Type *dty, llvm::Value *v, llvm::Value *lval);
-
-  /// put out rewritten value
+  /// Transforms the D argument to a suitable LL argument.
   virtual llvm::Value *put(DValue *v) = 0;
+
+  /// Transforms the LL parameter back and returns the address for the D
+  /// parameter.
+  virtual llvm::Value *getLVal(Type *dty, llvm::Value *v) = 0;
+
+  /// Transforms the LL parameter back and returns the value for the D
+  /// parameter.
+  virtual llvm::Value *getRVal(Type *dty, llvm::Value *v);
 
   /// should return the transformed type for this rewrite
   virtual llvm::Type *type(Type *dty, llvm::Type *t) = 0;

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -59,11 +59,6 @@ protected:
   /// Returns the address of a D value, storing it to memory first if need be.
   static llvm::Value *getAddressOf(DValue *v);
 
-  /// Stores a LL value to a specified memory address. The element type of the
-  /// provided pointer doesn't need to match the value type (=> suited for
-  /// bit-casting).
-  static void storeToMemory(llvm::Value *rval, llvm::Value *address);
-
   /// Loads a LL value of a specified type from memory. The element type of the
   /// provided pointer doesn't need to match the value type (=> suited for
   /// bit-casting).

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -35,7 +35,9 @@ class Value;
 class FunctionType;
 }
 
-// return rewrite rule
+/// Transforms function arguments and return values.
+/// This is needed to implement certain ABI aspects which LLVM doesn't get
+/// right by default.
 struct ABIRewrite {
   virtual ~ABIRewrite() = default;
 
@@ -48,10 +50,12 @@ struct ABIRewrite {
 
   /// Transforms the LL parameter back and returns the value for the D
   /// parameter.
+  /// Defaults to loading the lvalue returned by getLVal().
   virtual llvm::Value *getRVal(Type *dty, llvm::Value *v);
 
-  /// should return the transformed type for this rewrite
-  virtual llvm::Type *type(Type *dty, llvm::Type *t) = 0;
+  /// Returns the resulting LL type when transforming an argument of the
+  /// specified D type.
+  virtual llvm::Type *type(Type *t) = 0;
 
 protected:
   /***** Static Helpers *****/
@@ -60,7 +64,7 @@ protected:
   static llvm::Value *getAddressOf(DValue *v);
 
   /// Loads a LL value of a specified type from memory. The element type of the
-  /// provided pointer doesn't need to match the value type (=> suited for
+  /// provided pointer doesn't need to match the value type (=> suitable for
   /// bit-casting).
   static llvm::Value *loadFromMemory(llvm::Value *address, llvm::Type *asType,
                                      const char *name = ".bitcast_result");

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -660,6 +660,57 @@ void verifyScopedDestructionInClosure(FuncDeclaration* fd) {
   }
 }
 
+namespace {
+
+// Gives all explicit parameters storage and debug info.
+// All explicit D parameters are lvalues, just like regular local variables.
+void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
+  // Not all arguments are necessarily passed on the LLVM level
+  // (e.g. zero-member structs), so we need to keep track of the
+  // index in the IrFuncTy args array separately.
+  size_t llArgIdx = 0;
+
+  for (size_t i = 0; i < parameters.dim; ++i) {
+    auto *const vd = parameters[i];
+    IrParameter *irparam = getIrParameter(vd);
+
+    // vd->type (parameter) and irparam->arg->type (argument) don't always
+    // match.
+    // E.g., for a lazy parameter of type T, vd->type is T (with lazy storage
+    // class) while irparam->arg->type is the delegate type.
+    Type *const paramType = (irparam ? irparam->arg->type : vd->type);
+
+    if (!irparam) {
+      // This is a parameter that is not passed on the LLVM level.
+      // Create the param here and set it to a "dummy" alloca that
+      // we do not store to here.
+      irparam = getIrParameter(vd, true);
+      irparam->value = DtoAlloca(vd, vd->ident->toChars());
+    } else {
+      assert(irparam->value);
+
+      if (irparam->arg->byref) {
+        // The argument is an appropriate lvalue passed by reference.
+        // Use the passed pointer as parameter storage.
+        assert(irparam->value->getType() == DtoPtrToType(paramType));
+      } else {
+        // Let the ABI transform the parameter back to an lvalue.
+        irparam->value =
+            irFty.getParamLVal(paramType, llArgIdx, irparam->value);
+      }
+
+      irparam->value->setName(vd->ident->toChars());
+
+      ++llArgIdx;
+    }
+
+    if (global.params.symdebug)
+      gIR->DBuilder.EmitLocalVariable(irparam->value, vd, paramType);
+  }
+}
+
+} // anonymous namespace
+
 void DtoDefineFunction(FuncDeclaration *fd) {
   IF_LOG Logger::println("DtoDefineFunction(%s): %s", fd->toPrettyChars(),
                          fd->loc.toChars());
@@ -868,7 +919,7 @@ void DtoDefineFunction(FuncDeclaration *fd) {
 #endif
   }
 
-  // give the 'this' argument storage and debug info
+  // give the 'this' parameter (an lvalue) storage and debug info
   if (irFty.arg_this) {
     LLValue *thisvar = irFunc->thisArg;
     assert(thisvar);
@@ -893,46 +944,14 @@ void DtoDefineFunction(FuncDeclaration *fd) {
     gIR->DBuilder.EmitLocalVariable(thismem, fd->vthis, nullptr, true);
   }
 
-  // give the 'nestArg' storage
+  // give the 'nestArg' parameter (an lvalue) storage
   if (irFty.arg_nest) {
     irFunc->nestArg = DtoAllocaDump(irFunc->nestArg, 0, "nestedFrame");
   }
 
-  // give arguments storage and debug info
-  if (fd->parameters) {
-    // Not all arguments are necessarily passed on the LLVM level
-    // (e.g. zero-member structs), so we need to keep track of the
-    // index in the IrFuncTy args array separately.
-    size_t llArgIdx = 0;
-    for (size_t i = 0; i < fd->parameters->dim; ++i) {
-      auto *const vd = (*fd->parameters)[i];
-
-      IrParameter *irparam = getIrParameter(vd);
-      Type *debugInfoType = vd->type;
-      if (!irparam) {
-        // This is a parameter that is not passed on the LLVM level.
-        // Create the param here and set it to a "dummy" alloca that
-        // we do not store to here.
-        irparam = getIrParameter(vd, true);
-        irparam->value = DtoAlloca(vd, vd->ident->toChars());
-      } else {
-        if (!irparam->arg->byref) {
-          // let the abi transform the argument back first
-          LLValue *mem = irFty.getParamLVal(irparam->arg->type, llArgIdx, irparam->value);
-          mem->setName(vd->ident->toChars());
-
-          // set the arg var value to the alloca
-          irparam->value = mem;
-
-          debugInfoType = irparam->arg->type;
-        }
-        ++llArgIdx;
-      }
-
-      if (global.params.symdebug)
-        gIR->DBuilder.EmitLocalVariable(irparam->value, vd, debugInfoType);
-    }
-  }
+  // define all explicit parameters
+  if (fd->parameters)
+    defineParameters(irFty, *fd->parameters);
 
   {
     ScopeStack scopeStack(gIR);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -917,11 +917,9 @@ void DtoDefineFunction(FuncDeclaration *fd) {
         irparam->value = DtoAlloca(vd, vd->ident->toChars());
       } else {
         if (!irparam->arg->byref) {
-          // alloca a stack slot for this first class value arg
-          LLValue *mem = DtoAlloca(irparam->arg->type, vd->ident->toChars());
-
           // let the abi transform the argument back first
-          irFty.getParam(vd->type, llArgIdx, irparam->value, mem);
+          LLValue *mem = irFty.getParamLVal(irparam->arg->type, llArgIdx, irparam->value);
+          mem->setName(vd->ident->toChars());
 
           // set the arg var value to the alloca
           irparam->value = mem;

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -227,14 +227,14 @@ LLValue *DtoAllocaDump(LLValue *val, Type *asType, const char *name) {
 
 LLValue *DtoAllocaDump(LLValue *val, LLType *asType, int alignment,
                        const char *name) {
-  LLType *valType = i1ToI8(voidToI8(val->getType()));
-  asType = i1ToI8(voidToI8(asType));
+  LLType *memType = i1ToI8(voidToI8(val->getType()));
+  LLType *asMemType = i1ToI8(voidToI8(asType));
   LLType *allocaType =
-      (getTypeStoreSize(valType) <= getTypeAllocSize(asType) ? asType
-                                                             : valType);
+      (getTypeStoreSize(memType) <= getTypeAllocSize(asMemType) ? asMemType
+                                                                : memType);
   LLValue *mem = DtoRawAlloca(allocaType, alignment, name);
-  DtoStoreZextI8(val, DtoBitCast(mem, valType->getPointerTo()));
-  return DtoBitCast(mem, asType->getPointerTo());
+  DtoStoreZextI8(val, DtoBitCast(mem, memType->getPointerTo()));
+  return DtoBitCast(mem, asMemType->getPointerTo());
 }
 
 /******************************************************************************
@@ -1602,18 +1602,10 @@ DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl) {
         assert(type->ty == Tdelegate);
         return new DVarValue(type, getIrValue(vd));
       }
-      if (vd->isRef() || vd->isOut() || DtoIsInMemoryOnly(vd->type) ||
-          llvm::isa<llvm::AllocaInst>(getIrValue(vd))) {
-        assert(!isSpecialRefVar(vd) && "Code not expected to handle special "
-                                       "ref vars, although it can easily be "
-                                       "made to.");
-        return new DVarValue(type, getIrValue(vd));
-      }
-      if (llvm::isa<llvm::Argument>(getIrValue(vd))) {
-        return new DImValue(type, getIrValue(vd));
-      }
-      llvm_unreachable("Unexpected parameter value.");
-
+      assert(!isSpecialRefVar(vd) && "Code not expected to handle special "
+                                     "ref vars, although it can easily be "
+                                     "made to.");
+      return new DVarValue(type, getIrValue(vd));
     } else {
       Logger::println("a normal variable");
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1600,7 +1600,6 @@ DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl) {
       if (vd->storage_class & STClazy) {
         Logger::println("lazy parameter");
         assert(type->ty == Tdelegate);
-        return new DVarValue(type, getIrValue(vd));
       }
       assert(!isSpecialRefVar(vd) && "Code not expected to handle special "
                                      "ref vars, although it can easily be "

--- a/gen/structs.cpp
+++ b/gen/structs.cpp
@@ -168,7 +168,7 @@ void DtoPaddedStruct(Type *dty, LLValue *v, LLValue *lval) {
       // Nested structs are the only members that can contain padding
       DtoPaddedStruct(fields[i]->type, fieldval, fieldptr);
     } else {
-      DtoStore(fieldval, fieldptr);
+      DtoStoreZextI8(fieldval, fieldptr);
     }
   }
 }

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -900,13 +900,11 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
     // do ABI specific return value fixups
     if (storeReturnValueOnStack) {
       Logger::println("Storing return value to stack slot");
-      LLValue *mem = DtoAlloca(returntype);
-      irFty.getRet(returntype, retllval, mem);
-      retllval = mem;
+      retllval = irFty.getRetLVal(returntype, retllval);
       retValIsAlloca = true;
       storeReturnValueOnStack = false;
     } else {
-      retllval = irFty.getRet(returntype, retllval);
+      retllval = irFty.getRetRVal(returntype, retllval);
       storeReturnValueOnStack =
           (returnTy == Tstruct && !isaPointer(retllval)) ||
           (returnTy == Tsarray && isaArray(retllval));

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -111,12 +111,12 @@ struct IrFuncTy {
   void *tag = nullptr;
 
   llvm::Value *putRet(DValue *dval);
-  llvm::Value *getRet(Type *dty, llvm::Value *val);
-  void getRet(Type *dty, llvm::Value *val, llvm::Value *address);
+  llvm::Value *getRetRVal(Type *dty, llvm::Value *val);
+  llvm::Value *getRetLVal(Type *dty, llvm::Value *val);
 
   llvm::Value *putParam(size_t idx, DValue *dval);
   llvm::Value *putParam(const IrFuncTyArg &arg, DValue *dval);
-  void getParam(Type *dty, size_t idx, llvm::Value *val, llvm::Value *address);
+  llvm::Value *getParamLVal(Type *dty, size_t idx, llvm::Value *val);
 
   AttrSet getParamAttrs(bool passThisBeforeSret);
 };


### PR DESCRIPTION
Allow ABIRewrites to return the D parameter's LL lvalue directly.
Most rewrites store to memory anyway, so let the D parameter point directly to that memory instead of a dedicated alloca bitcopy.