### PR TITLE
object.classinfo: Return a TypeInfo_Class instead of a TypeInfo_Interface

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1143,7 +1143,7 @@ public:
         // member, so we have to add an extra layer of indirection.
         resultType = Type::typeinfointerface->type->pointerTo();
       } else {
-        resultType = Type::typeinfointerface->type;
+        resultType = Type::typeinfoclass->type;
       }
 
       V = DtoBitCast(V, DtoType(resultType->pointerTo()->pointerTo()));


### PR DESCRIPTION
This may be enough to fix https://github.com/ldc-developers/ldc/issues/1471 (at least there's no crash anymore for @rainers' minimal testcase).