### PR TITLE
Accept LLVM bitcode files (*.bc) on the commandline

### DIFF
--- a/ddmd/globals.d
+++ b/ddmd/globals.d
@@ -189,6 +189,8 @@ struct Param
 
     version(IN_LLVM)
     {
+        Array!(const(char)*)* bitcodeFiles; // LLVM bitcode files passed on cmdline
+
         uint nestedTmpl; // maximum nested template instantiations
 
         // Whether to keep all function bodies in .di file generation or to strip

--- a/ddmd/globals.h
+++ b/ddmd/globals.h
@@ -188,6 +188,8 @@ struct Param
     const char *mapfile;
 
 #if IN_LLVM
+    Array<const char *> *bitcodeFiles; // LLVM bitcode files passed on cmdline
+
     uint32_t nestedTmpl; // maximum nested template instantiations
 
     // Whether to keep all function bodies in .di file generation or to strip

--- a/driver/linker.h
+++ b/driver/linker.h
@@ -15,6 +15,19 @@
 #ifndef LDC_DRIVER_LINKER_H
 #define LDC_DRIVER_LINKER_H
 
+namespace llvm {
+class Module;
+class LLVMContext;
+}
+
+template <typename TYPE> struct Array;
+
+/**
+ * Inserts bitcode files passed on the commandline into a module.
+ */
+void insertBitcodeFiles(llvm::Module &M, llvm::LLVMContext &Ctx,
+                        Array<const char *> &bitcodeFiles);
+
 /**
  * Link an executable only from object files.
  * @return 0 on success.

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -389,6 +389,7 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
   global.params.libfiles = new Strings();
   global.params.objfiles = new Strings();
   global.params.ddocfiles = new Strings();
+  global.params.bitcodeFiles = new Strings();
 
   global.params.moduleDeps = nullptr;
   global.params.moduleDepsFile = nullptr;
@@ -1157,14 +1158,24 @@ int cppmain(int argc, char **argv) {
     ext = FileName::ext(p);
     if (ext) {
 #if LDC_POSIX
-      if (strcmp(ext, global.obj_ext) == 0 || strcmp(ext, global.bc_ext) == 0)
+      if (strcmp(ext, global.obj_ext) == 0)
 #else
       if (Port::stricmp(ext, global.obj_ext) == 0 ||
-          Port::stricmp(ext, global.obj_ext_alt) == 0 ||
-          Port::stricmp(ext, global.bc_ext) == 0)
+          Port::stricmp(ext, global.obj_ext_alt) == 0)
 #endif
       {
         global.params.objfiles->push(static_cast<const char *>(files.data[i]));
+        continue;
+      }
+
+      // Detect LLVM bitcode files on commandline
+#if LDC_POSIX
+      if (strcmp(ext, global.bc_ext) == 0)
+#else
+      if (Port::stricmp(ext, global.bc_ext) == 0)
+#endif
+      {
+        global.params.bitcodeFiles->push(static_cast<const char *>(files.data[i]));
         continue;
       }
 

--- a/tests/linking/inputs/link_bitcode_import.d
+++ b/tests/linking/inputs/link_bitcode_import.d
@@ -1,0 +1,8 @@
+module inputs.link_bitcode_import;
+
+extern(C)
+struct SomeStrukt {
+    int i;
+}
+
+extern(C) void takeStrukt(SomeStrukt*) {};

--- a/tests/linking/inputs/link_bitcode_input.d
+++ b/tests/linking/inputs/link_bitcode_input.d
@@ -1,0 +1,12 @@
+module inputs.link_bitcode_input;
+
+extern(C) int return_seven() {
+  return 7;
+}
+
+import inputs.link_bitcode_import;
+void bar()
+{
+    SomeStrukt r = {1};
+    takeStrukt(&r);
+}

--- a/tests/linking/inputs/link_bitcode_input3.d
+++ b/tests/linking/inputs/link_bitcode_input3.d
@@ -1,0 +1,9 @@
+module inputs.link_bitcode_input3;
+
+import inputs.link_bitcode_import;
+
+void foo()
+{
+    SomeStrukt r = {0};
+    takeStrukt(&r);
+}

--- a/tests/linking/inputs/link_bitcode_libs_input.d
+++ b/tests/linking/inputs/link_bitcode_libs_input.d
@@ -1,0 +1,4 @@
+module inputs.link_bitcode_libs_input;
+
+pragma(lib, "imported_one");
+pragma(lib, "imported_two");

--- a/tests/linking/link_bitcode.d
+++ b/tests/linking/link_bitcode.d
@@ -1,0 +1,19 @@
+// Test linking with an LLVM bitcode file
+
+// RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_input.d -of=%t.bc
+// RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_import.d -of=%t2.bc
+// RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_input3.d -of=%t3.bc
+// RUN: %ldc -c -singleobj -output-bc %t.bc %t3.bc %s
+// RUN: %ldc -c -singleobj -I%S %t.bc %s %S/inputs/link_bitcode_input3.d
+// RUN: %ldc -c -singleobj -I%S %t.bc %S/inputs/link_bitcode_input3.d %s
+// RUN: %ldc -c -I%S %t.bc %S/inputs/link_bitcode_input3.d %s
+
+// RUN: %ldc %t.bc %t2.bc %t3.bc -run %s
+// RUN: %ldc %t.bc %S/inputs/link_bitcode_import.d %t3.bc -run %s
+
+// Defined in input/link_bitcode_input.d
+extern(C) int return_seven();
+
+void main() {
+  assert( return_seven() == 7 );
+}

--- a/tests/linking/link_bitcode_libs.d
+++ b/tests/linking/link_bitcode_libs.d
@@ -1,0 +1,18 @@
+// Test passing of LLVM bitcode file with Linker Options set
+
+// Linker Options are currently only set on Windows platform, so we must (cross-)compile to Windows
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-windows -c -output-bc %S/inputs/link_bitcode_libs_input.d -of=%t.bc \
+// RUN:    && %ldc -mtriple=x86_64-windows -c -singleobj -output-ll %t.bc %s -of=%t.ll \
+// RUN:    && FileCheck %s < %t.ll
+
+pragma(lib, "library_one");
+pragma(lib, "library_two");
+
+// CHECK: !"Linker Options", ![[ATTR_TUPLE:[0-9]+]]
+// CHECK: ![[ATTR_TUPLE]] = !{![[ATTR_LIB1:[0-9]+]], ![[ATTR_LIB2:[0-9]+]], ![[ATTR_LIB3:[0-9]+]], ![[ATTR_LIB4:[0-9]+]]}
+// CHECK: ![[ATTR_LIB1]]{{.*}}library_one
+// CHECK: ![[ATTR_LIB2]]{{.*}}library_two
+// CHECK: ![[ATTR_LIB3]]{{.*}}imported_one
+// CHECK: ![[ATTR_LIB4]]{{.*}}imported_two


### PR DESCRIPTION
Accept LLVM bitcode files (*.bc) on the commandline and add the code to the first source file on the cmdline (the first emitted module).

(succesfully tested on Weka's codebase)