### PR TITLE
Add predefined version identifier D_Coverage.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -902,6 +902,10 @@ static void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("D_Ddoc");
   }
 
+  if (global.params.cov) {
+    VersionCondition::addPredefinedGlobalIdent("D_Coverage");
+  }
+
   if (global.params.useUnitTests) {
     VersionCondition::addPredefinedGlobalIdent("unittest");
   }


### PR DESCRIPTION
(tests ~~well~~ will be upstreamed)