### PR TITLE
Fix build for LLVM < 3.8

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -38,6 +38,11 @@ void emitLinkerOptions(IRState &irs, llvm::Module &M, llvm::LLVMContext &ctx) {
     // Merge the Linker Options with the pre-existing one
     // (this can happen when passing a .bc file on the commandline)
 
+#if LDC_LLVM_VER < 306
+    // Passing a bitcode file on the commandline is not supported for LLVM 3.5.
+    llvm_unreachable(
+        "Merging of Linker Options is not implemented for LLVM 3.5");
+#else
     auto *moduleFlags = M.getModuleFlagsMetadata();
     for (unsigned i = 0, e = moduleFlags->getNumOperands(); i < e; ++i) {
       auto *flag = moduleFlags->getOperand(i);
@@ -66,6 +71,7 @@ void emitLinkerOptions(IRState &irs, llvm::Module &M, llvm::LLVMContext &ctx) {
 
       break;
     }
+#endif
   }
 }
 }
@@ -212,14 +218,14 @@ void CodeGenerator::emit(Module *m) {
       auto startSymbol = new llvm::GlobalVariable(
           ir_->module, llvm::Type::getInt32Ty(ir_->module.getContext()), false,
           llvm::GlobalValue::ExternalLinkage,
-          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32,0)),
+          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32, 0)),
           "_tlsstart", &*(ir_->module.global_begin()));
       startSymbol->setSection(".tdata");
 
       auto endSymbol = new llvm::GlobalVariable(
           ir_->module, llvm::Type::getInt32Ty(ir_->module.getContext()), false,
           llvm::GlobalValue::ExternalLinkage,
-          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32,0)),
+          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32, 0)),
           "_tlsend");
       endSymbol->setSection(".tcommon");
     }

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -119,7 +119,7 @@ void insertBitcodeIntoModule(const char *bcFile, llvm::Module &M,
       getLazyIRFileModule(bcFile, Err, Context));
   if (!loadedModule) {
     error(Loc(), "Error when loading LLVM bitcode file: %s", bcFile);
-    return;
+    fatal();
   }
 #if LDC_LLVM_VER >= 308
   llvm::Linker(M).linkInModule(std::move(loadedModule));
@@ -141,6 +141,7 @@ void insertBitcodeFiles(llvm::Module &M, llvm::LLVMContext &Ctx,
   if (!bitcodeFiles.empty()) {
     error(Loc(),
           "Passing LLVM bitcode files to LDC is not supported for LLVM < 3.6");
+    fatal();
   }
 #endif
 }

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -108,29 +108,41 @@ static std::string getOutputName(bool const sharedLib) {
 
 namespace {
 
+#if LDC_LLVM_VER >= 306
 /// Insert an LLVM bitcode file into the module
 void insertBitcodeIntoModule(const char *bcFile, llvm::Module &M,
                              llvm::LLVMContext &Context) {
   Logger::println("*** Linking-in bitcode file %s ***", bcFile);
 
   llvm::SMDiagnostic Err;
-  std::unique_ptr<llvm::Module> loadedModule =
-      getLazyIRFileModule(bcFile, Err, Context);
+  std::unique_ptr<llvm::Module> loadedModule(
+      getLazyIRFileModule(bcFile, Err, Context));
   if (!loadedModule) {
     error(Loc(), "Error when loading LLVM bitcode file: %s", bcFile);
     return;
   }
-
+#if LDC_LLVM_VER >= 308
   llvm::Linker(M).linkInModule(std::move(loadedModule));
+#else
+  llvm::Linker(&M).linkInModule(loadedModule.release());
+#endif
 }
+#endif
 }
 
 /// Insert LLVM bitcode files into the module
 void insertBitcodeFiles(llvm::Module &M, llvm::LLVMContext &Ctx,
                         Array<const char *> &bitcodeFiles) {
+#if LDC_LLVM_VER >= 306
   for (const char *fname : bitcodeFiles) {
     insertBitcodeIntoModule(fname, M, Ctx);
   }
+#else
+  if (!bitcodeFiles.empty()) {
+    error(Loc(),
+          "Passing LLVM bitcode files to LDC is not supported for LLVM < 3.6");
+  }
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -218,9 +230,9 @@ static int linkObjToBinaryGcc(bool sharedLib, bool fullyStatic) {
       args.push_back("-Wl,--gc-sections");
     }
     if (global.params.targetTriple->getEnvironment() == llvm::Triple::Android) {
-        args.push_back("-ldl");
-        args.push_back("-lm");
-        break;
+      args.push_back("-ldl");
+      args.push_back("-lm");
+      break;
     }
     args.push_back("-lrt");
   // fallthrough
@@ -298,8 +310,7 @@ static int linkObjToBinaryGcc(bool sharedLib, bool fullyStatic) {
       default:
         if (global.params.is64bit) {
           args.push_back("-m64");
-        }
-        else {
+        } else {
           args.push_back("-m32");
         }
       }
@@ -431,7 +442,8 @@ int executeMsvcToolAndWait(const std::string &tool,
 
     auto comspecEnv = getenv("ComSpec");
     if (!comspecEnv) {
-      warning(Loc(), "'ComSpec' environment variable is not set, assuming 'cmd.exe'.");
+      warning(Loc(),
+              "'ComSpec' environment variable is not set, assuming 'cmd.exe'.");
       comspecEnv = "cmd.exe";
     }
     std::string cmdExecutable = comspecEnv;

--- a/tests/linking/link_bitcode.d
+++ b/tests/linking/link_bitcode.d
@@ -1,5 +1,7 @@
 // Test linking with an LLVM bitcode file
 
+// REQUIRES: atleast_llvm306
+
 // RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_input.d -of=%t.bc
 // RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_import.d -of=%t2.bc
 // RUN: %ldc -c -output-bc -I%S %S/inputs/link_bitcode_input3.d -of=%t3.bc

--- a/tests/linking/link_bitcode_libs.d
+++ b/tests/linking/link_bitcode_libs.d
@@ -1,5 +1,7 @@
 // Test passing of LLVM bitcode file with Linker Options set
 
+// REQUIRES: atleast_llvm306
+
 // Linker Options are currently only set on Windows platform, so we must (cross-)compile to Windows
 // REQUIRES: target_X86
 

--- a/tests/semantic/target_traits_diag.d
+++ b/tests/semantic/target_traits_diag.d
@@ -16,7 +16,10 @@ void main()
 // CHECK: Error: string expected as argument of __traits targetHasFeature instead of 1
     enum e = __traits(targetHasFeature, 1);
 
-// CHECK: '-夜畔' is not a recognized feature for this target (ignoring feature)
+// Diagnostics of an unrecognized feature depends on the LLVM version (LLVM < 3.7 does not warn at all)
+// Newer LLVM versions do warn.
+// TODO: Re-enable test when LLVM < 3.7 is no longer supported.
+// CHE CK: 夜畔' is not a recognized feature for this target (ignoring feature)
     enum f = __traits(targetHasFeature, "夜畔");
 }
 


### PR DESCRIPTION
I had too much trouble supporting bitcode file arguments for LLVM 3.5, so I disabled it (gives an error).

Also had to disable a __traits(target..) test because of LLVM-dependent error messaging.

