### PR TITLE
Add PS4 version identifier

### DIFF
--- a/ddmd/cond.d
+++ b/ddmd/cond.d
@@ -202,6 +202,8 @@ public:
             "SysV4",
             "Hurd",
             "Android",
+            "PlayStation",
+            "PlayStation4",
             "Cygwin",
             "MinGW",
             "FreeStanding",


### PR DESCRIPTION
Add the identifiers that just got added to upstream DMD.