### PR TITLE
Fix ARM soft-float ABI when passing structs with floating-point numbers

### DIFF
--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -16,6 +16,7 @@
 #include "gen/abi.h"
 #include "gen/abi-generic.h"
 #include "gen/abi-arm.h"
+#include "llvm/Target/TargetMachine.h"
 
 struct ArmTargetABI : TargetABI {
   HFAToArray hfaToArray;
@@ -38,7 +39,9 @@ struct ArmTargetABI : TargetABI {
       return rt->ty == Tsarray || rt->ty == Tstruct;
 
     return rt->ty == Tsarray ||
-           (rt->ty == Tstruct && rt->size() > 4 && !isHFA((TypeStruct *)rt));
+           (rt->ty == Tstruct && rt->size() > 4 &&
+             (gTargetMachine->Options.FloatABIType == llvm::FloatABI::Soft ||
+             !isHFA((TypeStruct *)rt)));
   }
 
   bool passByVal(Type *t) override {


### PR DESCRIPTION
Some tests from the dmd testsuite fail because of this, specifically `ctest10` from `cabi1` and a handful from `ldc_cabi1`.  Once I put this fix in, the entire dmd testsuite passes natively on Android/ARM.  Presumably Dan put this in for `armhf` but iOS is `armel` also, isn't it?  Once @smolt and I hash out how to make this work across all tested ARM systems, I'll modify this patch and remove the WIP tag, then someone can merge.