### PR TITLE
Check existing runtime function declarations for matching type

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -126,22 +126,24 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
                                    const char *name) {
   checkForImplicitGCCall(loc, name);
 
-  if (!M) {
+  if (!M)
     initRuntime();
-  }
 
-  LLFunction *fn = target.getFunction(name);
-  if (fn) {
-    return fn;
-  }
-
-  fn = M->getFunction(name);
+  LLFunction *fn = M->getFunction(name);
   if (!fn) {
     error(loc, "Runtime function '%s' was not found", name);
     fatal();
   }
-
   LLFunctionType *fnty = fn->getFunctionType();
+
+  if (LLFunction *existing = target.getFunction(name)) {
+    if (existing->getFunctionType() != fnty) {
+      error(Loc(), "Incompatible declaration of runtime function '%s'", name);
+      fatal();
+    }
+    return existing;
+  }
+
   LLFunction *resfn =
       llvm::cast<llvm::Function>(target.getOrInsertFunction(name, fnty));
   resfn->setAttributes(fn->getAttributes());


### PR DESCRIPTION
This fixes issue #958 by checking the function type of an existing function declaration with the same runtime function name inside the codegen'd module.
This should normally be an existing forward declaration from a previous runtime call, but the user is free to declare (and even implement) it too.

The LOC for the error is empty as the provided `loc` may likely be from a template instantiation from another module.