### PR TITLE
[profile-rt] Add check for defining COMPILER_RT_HAS_FCNTL_LCK in CMake script.

### DIFF
--- a/runtime/profile-rt/DefineBuildProfileRT.cmake
+++ b/runtime/profile-rt/DefineBuildProfileRT.cmake
@@ -44,6 +44,24 @@ if (LDC_WITH_PGO)
      set(PROFRT_EXTRA_FLAGS "${PROFRT_EXTRA_FLAGS} -DCOMPILER_RT_HAS_ATOMICS=1")
     endif()
 
+    CHECK_CXX_SOURCE_COMPILES("
+    #if defined(__linux__)
+    #include <unistd.h>
+    #endif
+    #include <fcntl.h>
+    int fd;
+    int main() {
+     struct flock s_flock;
+
+     s_flock.l_type = F_WRLCK;
+     fcntl(fd, F_SETLKW, &s_flock);
+     return 0;
+    }
+    " COMPILER_RT_TARGET_HAS_FCNTL_LCK)
+    if(COMPILER_RT_TARGET_HAS_FCNTL_LCK)
+     set(PROFRT_EXTRA_FLAGS "${PROFRT_EXTRA_FLAGS} -DCOMPILER_RT_HAS_FCNTL_LCK=1")
+    endif()
+
     # Sets up the targets for building the D-source profile-rt object files,
     # appending the names of the (bitcode) files to link into the library to
     # outlist_o (outlist_bc).


### PR DESCRIPTION
I just discovered that PGO in LLVM3.9 has yet again become more awesome: automatic merging of profile data across multiple runs of the same executable.

The define checked for in this PR is for file-locking during the awesome on-the-fly profile merging feature using `%m` in `-fprofile-instr-generate=abc_%m_xyz` (for example).