### PR TITLE
[CircleCI] Use official LLVM APT again

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,13 +8,17 @@ dependencies:
     - ldc2-1.0.0-linux-x86_64
     #- clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04
   pre:
-    # LLVM's APT repositories are shut down until further notice. Use temporary solution:
-    - sudo add-apt-repository -y 'deb http://llvm-apt.ecranbleu.org/apt/trusty/ llvm-toolchain-trusty main'
-    - wget -O - http://llvm-apt.ecranbleu.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+    # LLVM's official APT repo:
+    - sudo add-apt-repository -y 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main'
+    - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
     - sudo apt-get update
+
+    # Download and cache a prebuilt LLVM package:
     #- if [[ ! -e clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04 ]]; then wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz && xzcat clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | tar -xvf - ; fi
 
+    # Download and cache a prebuilt LDC package:
     - if [[ ! -e ldc2-1.0.0-linux-x86_64/bin/ldc2 ]]; then wget https://github.com/ldc-developers/ldc/releases/download/v1.0.0/ldc2-1.0.0-linux-x86_64.tar.xz && xzcat ldc2-1.0.0-linux-x86_64.tar.xz | tar -xvf - ; fi
+
   override:
     - sudo apt-get remove clang
     - sudo apt-get install libconfig++8-dev libedit-dev


### PR DESCRIPTION
Still an old LLVM revision, but should be up-to-date soon.

http://lists.llvm.org/pipermail/llvm-dev/2016-June/101500.html