### PR TITLE
Add new extern(C++, class) and extern(C++, struct) declarations.

### DIFF
--- a/ddmd/attrib.h
+++ b/ddmd/attrib.h
@@ -94,6 +94,17 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class CPPMangleDeclaration : public AttribDeclaration
+{
+public:
+    CPPMANGLE cppmangle;
+
+    Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
+    const char *toChars() const;
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ProtDeclaration : public AttribDeclaration
 {
 public:

--- a/ddmd/cppmangle.d
+++ b/ddmd/cppmangle.d
@@ -1281,7 +1281,7 @@ static if (IN_LLVM || TARGET_WINDOS)
                 if (type.sym.isUnionDeclaration())
                     buf.writeByte('T');
                 else
-                    buf.writeByte('U');
+                    buf.writeByte(type.cppmangle == CPPMANGLE.asClass ? 'V' : 'U');
                 mangleIdent(type.sym);
             }
             flags &= ~IS_NOT_TOP_TYPE;
@@ -1348,7 +1348,7 @@ static if (IN_LLVM || TARGET_WINDOS)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleModifier(type);
-            buf.writeByte('V');
+            buf.writeByte(type.cppmangle == CPPMANGLE.asStruct ? 'U' : 'V');
             mangleIdent(type.sym);
             flags &= ~IS_NOT_TOP_TYPE;
             flags &= ~IGNORE_CONST;
@@ -1663,7 +1663,12 @@ static if (IN_LLVM || TARGET_WINDOS)
                 name = sym.ident.toChars();
             }
             assert(name);
-            if (!is_dmc_template)
+            if (is_dmc_template)
+            {
+                if (checkAndSaveIdent(name))
+                    return;
+            }
+            else
             {
                 if (dont_use_back_reference)
                 {

--- a/ddmd/dscope.d
+++ b/ddmd/dscope.d
@@ -152,6 +152,9 @@ struct Scope
     // linkage for external functions
     LINK linkage = LINKd;
 
+    // mangle type
+    CPPMANGLE cppmangle = CPPMANGLE.def;
+
     // inlining strategy for functions
     PINLINE inlining = PINLINEdefault;
 
@@ -742,6 +745,7 @@ else
         this.func = sc.func;
         this.slabel = sc.slabel;
         this.linkage = sc.linkage;
+        this.cppmangle = sc.cppmangle;
         this.inlining = sc.inlining;
         this.protection = sc.protection;
         this.explicitProtection = sc.explicitProtection;

--- a/ddmd/globals.d
+++ b/ddmd/globals.d
@@ -485,6 +485,13 @@ alias LINKwindows = LINK.windows;
 alias LINKpascal = LINK.pascal;
 alias LINKobjc = LINK.objc;
 
+enum CPPMANGLE : int
+{
+    def,
+    asStruct,
+    asClass,
+}
+
 enum DYNCAST : int
 {
     object,

--- a/ddmd/globals.h
+++ b/ddmd/globals.h
@@ -373,6 +373,13 @@ enum LINK
     LINKobjc,
 };
 
+enum CPPMANGLE
+{
+    def,
+    asStruct,
+    asClass,
+};
+
 enum DYNCAST
 {
     DYNCAST_OBJECT,

--- a/ddmd/hdrgen.d
+++ b/ddmd/hdrgen.d
@@ -1193,6 +1193,26 @@ public:
         visit(cast(AttribDeclaration)d);
     }
 
+    override void visit(CPPMangleDeclaration d)
+    {
+        const(char)* p;
+        switch (d.cppmangle)
+        {
+        case CPPMANGLE.asClass:
+            p = "class";
+            break;
+        case CPPMANGLE.asStruct:
+            p = "struct";
+            break;
+        default:
+            assert(0);
+        }
+        buf.writestring("extern (C++, ");
+        buf.writestring(p);
+        buf.writestring(") ");
+        visit(cast(AttribDeclaration)d);
+    }
+
     override void visit(ProtDeclaration d)
     {
         protectionToBuffer(buf, d.protection);

--- a/ddmd/mtype.d
+++ b/ddmd/mtype.d
@@ -7819,6 +7819,7 @@ extern (C++) final class TypeStruct : Type
 public:
     StructDeclaration sym;
     AliasThisRec att = RECfwdref;
+    CPPMANGLE cppmangle = CPPMANGLE.def;
 
     version(IN_LLVM)
     {
@@ -7856,7 +7857,10 @@ public:
 
     override Type semantic(Loc loc, Scope* sc)
     {
-        //printf("TypeStruct::semantic('%s')\n", sym->toChars());
+        //printf("TypeStruct::semantic('%s')\n", sym.toChars());
+        if (deco)
+            return this;
+
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
          */
@@ -7864,6 +7868,7 @@ public:
         assert(sym.parent);
         if (sym.type.ty == Terror)
             return Type.terror;
+        this.cppmangle = sc.cppmangle;
         return merge();
     }
 
@@ -8623,6 +8628,7 @@ extern (C++) final class TypeClass : Type
 public:
     ClassDeclaration sym;
     AliasThisRec att = RECfwdref;
+    CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(ClassDeclaration sym)
     {
@@ -8647,7 +8653,10 @@ public:
 
     override Type semantic(Loc loc, Scope* sc)
     {
-        //printf("TypeClass::semantic(%s)\n", sym->toChars());
+        //printf("TypeClass::semantic(%s)\n", sym.toChars());
+        if (deco)
+            return this;
+
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
          */
@@ -8655,6 +8664,7 @@ public:
         assert(sym.parent);
         if (sym.type.ty == Terror)
             return Type.terror;
+        this.cppmangle = sc.cppmangle;
         return merge();
     }
 

--- a/ddmd/visitor.d
+++ b/ddmd/visitor.d
@@ -423,6 +423,11 @@ public:
         visit(cast(AttribDeclaration)s);
     }
 
+    void visit(CPPMangleDeclaration s)
+    {
+        visit(cast(AttribDeclaration)s);
+    }
+
     void visit(ProtDeclaration s)
     {
         visit(cast(AttribDeclaration)s);

--- a/ddmd/visitor.h
+++ b/ddmd/visitor.h
@@ -95,6 +95,7 @@ class AttribDeclaration;
 class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
+class CPPMangleDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -381,6 +382,7 @@ public:
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(DeprecatedDeclaration *s) { visit((StorageClassDeclaration *)s); }
     virtual void visit(LinkDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }


### PR DESCRIPTION
VS has different name manglings for classes and structs. With the
new extern(C++, class) and extern(C++, struct) declarations, the
name mangling algorithm is changed to use a mangling different
from the used D entity.

A common use case is to map a value type modeled as class in C++ to
a struct in D.

This is backport of https://github.com/dlang/dmd/pull/5875.