### PR TITLE
Tighten NRVO detection for VarDeclarations

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -894,9 +894,7 @@ void DtoVarDeclaration(VarDeclaration *vd) {
     // }
     assert(!isSpecialRefVar(vd) && "Can this happen?");
     getIrLocal(vd, true)->value = gIR->func()->retArg;
-  }
-
-  else {
+  } else {
     // normal stack variable, allocate storage on the stack if it has not
     // already been done
     IrLocal *irLocal = getIrLocal(vd, true);
@@ -920,14 +918,13 @@ void DtoVarDeclaration(VarDeclaration *vd) {
     /* NRVO again:
         T t = f();    // t's memory address is taken hidden pointer
     */
-    Type *vdBasetype = vd->type->toBasetype();
     ExpInitializer *ei = nullptr;
-    if ((vdBasetype->ty == Tstruct || vdBasetype->ty == Tsarray) && vd->_init &&
-        (ei = vd->_init->isExpInitializer())) {
-      if (ei->exp->op == TOKconstruct) {
-        auto ae = static_cast<AssignExp *>(ei->exp);
-        Expression *rhs = ae->e2;
-
+    if (vd->_init && (ei = vd->_init->isExpInitializer()) &&
+        ei->exp->op == TOKconstruct) {
+      const auto ae = static_cast<AssignExp *>(ei->exp);
+      Expression *rhs = ae->e2;
+      Type *const vdBasetype = vd->type->toBasetype();
+      if (rhs->type->toBasetype() == vdBasetype) {
         // Allow casts only emitted because of differing static array
         // constness. See runnable.sdtor.test10094.
         if (rhs->op == TOKcast && vdBasetype->ty == Tsarray) {


### PR DESCRIPTION
The D types of the variable and the right-hand-side of the init `AssignExp` must match; this fixes issue #1548.
Don't restrict it to memory-only types anymore though; the sret-check performed by `DtoIsReturnInArg()` should suffice and makes more sense to me.

A test will follow once merged.