### PR TITLE
Remove explicit `noinline` call attribute inside SEH catch/cleanup pads.

### DIFF
--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -91,7 +91,6 @@ void remapBlocksValue(std::vector<llvm::BasicBlock *> &blocks,
 // - redirect srcTarget to continueWith
 // - set "funclet" attribute inside catch/cleanup pads
 // - inside funclets, replace "unreachable" with "branch cleanupret"
-// - disable inlining inside a funclet
 void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
                  std::vector<llvm::BasicBlock *> &blocks,
                  llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
@@ -116,12 +115,10 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
         if (auto IInst = llvm::dyn_cast<llvm::InvokeInst> (Inst)) {
           auto invoke = llvm::InvokeInst::Create(
             IInst, llvm::OperandBundleDef("funclet", funclet));
-          invoke->setIsNoInline();
           newInst = invoke;
         } else if (auto CInst = llvm::dyn_cast<llvm::CallInst> (Inst)) {
           auto call = llvm::CallInst::Create(
               CInst, llvm::OperandBundleDef("funclet", funclet));
-          call->setIsNoInline();
           newInst = call;
         } else if (funclet && llvm::isa<llvm::UnreachableInst>(Inst)) {
           newInst = llvm::BranchInst::Create(continueWith); // to cleanupret


### PR DESCRIPTION
See https://llvm.org/bugs/show_bug.cgi?id=25162
However the LLVM inliner now knows not to inline functions inside cleanup pads and so this is no longer needed. I have tested with clang (trunk) and clang also no longer marks function calls explicitly with noinline: the inliner no longer tries to inline `alwaysinline` functions.
http://llvm.org/viewvc/llvm-project/cfe/trunk/test/CodeGenCXX/microsoft-abi-eh-cleanups.cpp?r1=251576&r2=255423&diff_format=h

The change is necessary because setting `noinline` conflicts with functions that have `alwaysinline` attribute added (due to `pragma(inline, true)`).

@rainers Can you confirm this is correct? Thanks.

(this PR is needed for https://github.com/ldc-developers/ldc/pull/1577)