### PR TITLE
cmake: Directly use (g)cc for linking on Unix-like systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,38 +521,76 @@ set(LDC_EXE_FULL ${PROJECT_BINARY_DIR}/bin/${LDC_EXE_NAME}${CMAKE_EXECUTABLE_SUF
 set(LDMD_EXE_FULL ${PROJECT_BINARY_DIR}/bin/${LDMD_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX})
 add_custom_target(${LDC_EXE} ALL DEPENDS ${LDC_EXE_FULL})
 add_custom_target(${LDMD_EXE} ALL DEPENDS ${LDMD_EXE_FULL})
+
+# Figure out how to link the main LDC executable, for which we need to take the
+# libconfig/LLVM flags into account.
 set(LDC_LINKERFLAG_LIST "${SANITIZE_LDFLAGS};${LIBCONFIG_LIBRARY};${LLVM_LIBRARIES};${LLVM_LDFLAGS}")
-set(tempVar "")
-foreach(f ${LDC_LINKERFLAG_LIST})
-    string (REPLACE "-Wl," "" f ${f})
-    string (REPLACE "-LIBPATH:" "/LIBPATH:" f ${f})
-    append("-L\"${f}\"" tempVar)
-endforeach(f)
-if(MSVC)
-    # Issue 1297
-    # The default system-allocated stack size is 8MB on Linux and Mac, but only 1MB on Windows
-    # Set LDC's stack to 8MB also on Windows:
-    append("-L/STACK:8388608" tempVar)
+
+set(LDC_LINK_MANUALLY OFF)
+if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")))
+    # On Unix-like systems, DMD and LDC will use the C compiler for linking, but
+    # will pass on -L options prefixed by -Xlinker to directly forward them to
+    # the underlying ld. Since there are some flags the GCC driver handles itself
+    # rather than passing them to ld, we cannot just directly translate
+    # LDC_LINKERFLAG_LIST to -L options. To be able to handle general linker flags,
+    # we manually invoke the linker instead of using the D compiler to do so.
+    set(LDC_LINK_MANUALLY ON)
+
+    include(ExtractDMDSystemLinker)
+    list(APPEND LDC_LINKERFLAG_LIST ${D_LINKER_ARGS})
+
+    if(NOT "${CMAKE_EXE_LINKER_FLAGS}" STREQUAL "")
+        separate_arguments(flags UNIX_COMMAND "${CMAKE_EXE_LINKER_FLAGS}")
+        list(APPEND LDC_LINKERFLAG_LIST ${flags})
+    endif()
 else()
-    if(${D_COMPILER_ID} STREQUAL "LDC" OR ${D_COMPILER_ID} STREQUAL "LDMD")
-        # Translate flags from CMAKE_EXE_LINKER_FLAGS
-        if(NOT "${CMAKE_EXE_LINKER_FLAGS}" STREQUAL "")
-            separate_arguments(flags UNIX_COMMAND "${CMAKE_EXE_LINKER_FLAGS}")
-            foreach(f ${flags})
-                append("-L${f}" tempVar)
-            endforeach()
-        endif()
-        # Use the C++ compiler for linking - only for ldc or ldmd.
-        append("-gcc=${CMAKE_CXX_COMPILER}" tempVar)
-    else()
-        # Link against libstdc++
-        append("-L-lstdc++" tempVar)
+    # Use D compiler for linking, trying to translate a few common linker flags.
+    set(LDC_TRANSLATED_LINKER_FLAGS "")
+    foreach(f ${LDC_LINKERFLAG_LIST})
+        string(REPLACE "-Wl," "" f ${f})
+        string(REPLACE "-LIBPATH:" "/LIBPATH:" f ${f})
+        append("-L\"${f}\"" LDC_TRANSLATED_LINKER_FLAGS)
+    endforeach()
+
+    if(MSVC)
+        # Issue 1297 – set LDC's stack to 8 MiB like on Linux and Mac (default: 1 MiB).
+        append("-L/STACK:8388608" LDC_TRANSLATED_LINKER_FLAGS)
     endif()
 endif()
 
+function(build_d_executable output_exe compiler_args linker_args dependencies)
+    if(LDC_LINK_MANUALLY)
+        set(object_file ${output_exe}${CMAKE_CXX_OUTPUT_EXTENSION})
+        separate_arguments(dmd_flags UNIX_COMMAND "${D_COMPILER_FLAGS} ${DDMD_DFLAGS}")
+        add_custom_command(
+            OUTPUT ${object_file}
+            COMMAND ${D_COMPILER} -c ${dmd_flags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${object_file} ${compiler_args}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            DEPENDS ${dependencies}
+        )
+        add_custom_command(
+            OUTPUT ${output_exe}
+            COMMAND ${CMAKE_CXX_COMPILER} -o ${output_exe} ${object_file} ${linker_args} ${LDC_LINKERFLAG_LIST}
+            DEPENDS ${object_file}
+        )
+    else()
+        set(lflags ${LDC_TRANSLATED_LINKER_FLAGS})
+        separate_arguments(lflags)
+        foreach(f ${linker_args})
+            append("-L\"${f}\"" lflags)
+        endforeach()
+        add_custom_command(
+            OUTPUT ${output_exe}
+            COMMAND ${D_COMPILER} ${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS} ${lflags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_exe} ${compiler_args} ${linker_args}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            DEPENDS ${dependencies}
+        )
+    endif()
+endfunction()
+
 # CONFIG generator expressions need to be repeated due to https://cmake.org/Bug/view.php?id=14353
-separate_arguments(LDC_FLAG_LIST WINDOWS_COMMAND "${tempVar} ${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS}")
 if(MSVC_IDE)
+    separate_arguments(LDC_FLAG_LIST WINDOWS_COMMAND "${LDC_TRANSLATED_LINKER_FLAGS} ${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS}")
     add_custom_command(
         OUTPUT ${LDC_EXE_FULL}
         COMMAND ${D_COMPILER} -L$<TARGET_LINKER_FILE:${LDC_LIB}> ${LDC_FLAG_LIST} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${LDC_EXE_FULL} ${LDC_D_SOURCE_FILES} $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-g> $<$<NOT:$<CONFIG:Debug>>:-O> $<$<NOT:$<CONFIG:Debug>>:-inline> $<$<NOT:$<CONFIG:Debug>>:-release>
@@ -560,11 +598,11 @@ if(MSVC_IDE)
         DEPENDS ${LDC_D_SOURCE_FILES} ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.d ${LDC_LIB}
     )
 else()
-    add_custom_command(
-        OUTPUT ${LDC_EXE_FULL}
-        COMMAND ${D_COMPILER} -L$<TARGET_LINKER_FILE:${LDC_LIB}> ${LDC_FLAG_LIST} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${LDC_EXE_FULL} ${LDC_D_SOURCE_FILES}
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        DEPENDS ${LDC_D_SOURCE_FILES} ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.d ${LDC_LIB}
+    build_d_executable(
+        "${LDC_EXE_FULL}"
+        "${LDC_D_SOURCE_FILES}"
+        "$<TARGET_LINKER_FILE:${LDC_LIB}>"
+        "${LDC_D_SOURCE_FILES};${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.d;${LDC_LIB}"
     )
 endif()
 
@@ -598,12 +636,13 @@ set_target_properties(
     ARCHIVE_OUTPUT_NAME ldmd
     LIBRARY_OUTPUT_NAME ldmd
 )
-add_custom_command(
-    OUTPUT ${LDMD_EXE_FULL}
-    COMMAND ${D_COMPILER} -L$<TARGET_LINKER_FILE:LDMD_CXX_LIB> ${LDC_FLAG_LIST} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${LDMD_EXE_FULL} ${DDMDFE_PATH}/root/man.d driver/ldmd.d
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    DEPENDS LDMD_CXX_LIB ${LDC_LIB}
+build_d_executable(
+    "${LDMD_EXE_FULL}"
+    "${DDMDFE_PATH}/root/man.d;driver/ldmd.d"
+    "$<TARGET_LINKER_FILE:LDMD_CXX_LIB>"
+    "LDMD_CXX_LIB;${LDC_LIB}"
 )
+
 
 #
 # Auxiliary tools.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,77 +578,6 @@ endif()
 
 
 #
-# Intrinsics module generation tools.
-#
-
-# The LLVM_INCLUDE_DIR definition is not always set, e.g. on Windows.
-# strip off anything but the first path
-string(REGEX REPLACE ";.*$" "" LLVM_INC_DIR "${LLVM_INCLUDE_DIRS}")
-find_path(LLVM_INTRINSIC_TD_PATH "Intrinsics.td" PATHS ${LLVM_INC_DIR}/llvm ${LLVM_INC_DIR}/llvm/IR NO_DEFAULT_PATH)
-if (${LLVM_INTRINSIC_TD_PATH} STREQUAL "LLVM_INTRINSIC_TD_PATH-NOTFOUND")
-    message(SEND_ERROR "File Intrinsics.td not found")
-else()
-    string(REGEX REPLACE "/llvm(/IR)?$" "" LLVM_INTRINSIC_TD_PATH ${LLVM_INTRINSIC_TD_PATH})
-    message(STATUS "Using path for Intrinsics.td: ${LLVM_INTRINSIC_TD_PATH}")
-endif()
-append("-DLLVM_INTRINSIC_TD_PATH=\"${LLVM_INTRINSIC_TD_PATH}\"" CMAKE_CXX_FLAGS )
-
-add_executable(gen_gccbuiltins utils/gen_gccbuiltins.cpp)
-
-set_target_properties(
-    gen_gccbuiltins PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
-    LINK_FLAGS "${SANITIZE_LDFLAGS}"
-)
-target_link_libraries(gen_gccbuiltins ${LLVM_TABLEGEN_LIBRARY} ${LLVM_LIBRARIES} ${PTHREAD_LIBS} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries(gen_gccbuiltins dl)
-endif()
-
-
-# Build FileCheck for testing (build source version depending on LLVM version)
-set(FILECHECK_SRC utils/FileCheck-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.cpp)
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${FILECHECK_SRC})
-    add_executable(FileCheck ${FILECHECK_SRC})
-    set_target_properties(
-        FileCheck PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
-        LINK_FLAGS "${SANITIZE_LDFLAGS}"
-    )
-    target_link_libraries(FileCheck  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
-else()
-    message(STATUS "Skip building FileCheck, assuming it can be found in LLVM bin directory")
-endif()
-
-# Build `not` for testing
-add_executable(not utils/not.cpp)
-set_target_properties(
-    not PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
-    LINK_FLAGS "${SANITIZE_LDFLAGS}"
-)
-target_link_libraries(not  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
-
-# Build ldc-profdata for converting profile data formats (source version depends on LLVM version)
-set(LDCPROFDATA_SRC utils/llvm-profdata-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.cpp)
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LDCPROFDATA_SRC})
-    add_executable(ldc-profdata ${LDCPROFDATA_SRC})
-    set_target_properties(
-        ldc-profdata PROPERTIES
-        OUTPUT_NAME "${LDCPROFDATA_EXE_NAME}"
-        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
-        LINK_FLAGS "${SANITIZE_LDFLAGS}"
-    )
-    target_link_libraries(ldc-profdata  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
-    install(TARGETS ${LDCPROFDATA_EXE} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-endif()
-
-
-#
 # LDMD
 #
 include(CheckSymbolExists)
@@ -677,6 +606,10 @@ add_custom_command(
     DEPENDS LDMD_CXX_LIB ${LDC_LIB}
 )
 
+#
+# Auxiliary tools.
+#
+add_subdirectory(utils)
 
 #
 # Test and runtime targets. Note that enable_testing() is order-sensitive!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,60 +259,6 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 endif()
 
 
-# Compiles the given D module into an object file.
-macro(Dcompile  input_d  output_dir  extra_d_flags  outlist_o extra_deps)
-    if (IS_ABSOLUTE ${input_d})
-        file(RELATIVE_PATH output ${output_dir} ${input_d})
-    else()
-        set(output ${input_d})
-    endif()
-
-    get_filename_component(name ${output} NAME)
-    get_filename_component(path ${output} PATH)
-    if("${path}" STREQUAL "")
-        set(output_root ${name})
-    else()
-        set(output_root ${path}/${name})
-    endif()
-
-    set(output_o  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output_root}${CMAKE_C_OUTPUT_EXTENSION})
-    list(APPEND ${outlist_o} ${output_o})
-
-    separate_arguments(FLAG_LIST WINDOWS_COMMAND "${D_COMPILER_FLAGS} ${extra_d_flags}")
-    add_custom_command(
-        OUTPUT ${output_o}
-        COMMAND ${D_COMPILER} ${FLAG_LIST} -c -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_o} ${input_d}
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        DEPENDS ${input_d} ${extra_deps}
-    )
-endmacro()
-macro(Dcompilelib  input_d  output_dir  extra_d_flags  outlist_o)
-    if (IS_ABSOLUTE ${input_d})
-        file(RELATIVE_PATH output ${output_dir} ${input_d})
-    else()
-        set(output ${input_d})
-    endif()
-
-    get_filename_component(name ${output} NAME_WE)
-    get_filename_component(path ${output} PATH)
-    if("${path}" STREQUAL "")
-        set(output_root ${name})
-    else()
-        set(output_root ${path}/${name})
-    endif()
-
-    set(output_lib  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output_root}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    list(APPEND ${outlist_o} ${output_lib})
-
-    separate_arguments(FLAG_LIST WINDOWS_COMMAND "${D_COMPILER_FLAGS} ${extra_d_flags}")
-    add_custom_command(
-        OUTPUT ${output_lib}
-        COMMAND ${D_COMPILER} ${FLAG_LIST} -lib -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_lib} ${input_d}
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        DEPENDS ${input_d}
-    )
-endmacro()
-
 # Build (generate executable) of D source
 macro(build_idgen  input_d  output_exec  extra_d_flags  link_flags  extra_deps)
     separate_arguments(FLAG_LIST WINDOWS_COMMAND "${D_COMPILER_FLAGS} ${extra_d_flags} ${link_flags}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,13 @@ if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Cla
     # we manually invoke the linker instead of using the D compiler to do so.
     set(LDC_LINK_MANUALLY ON)
 
+    # gdmd's -of option is incompatible with DMD/LDMD when -c is given. We could
+    # detect this and modify the command line accordingly, but for now, just
+    # disallow gdmd.
+    if(D_COMPILER_ID STREQUAL "GDMD")
+        message(FATAL_ERROR "GDMD currently not supported due to http://bugzilla.gdcproject.org/show_bug.cgi?id=232.")
+    endif()
+
     include(ExtractDMDSystemLinker)
     list(APPEND LDC_LINKERFLAG_LIST ${D_LINKER_ARGS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,14 +581,21 @@ function(build_d_executable output_exe compiler_args linker_args dependencies)
             DEPENDS ${object_file}
         )
     else()
+        set(dflags "${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS}")
         set(lflags ${LDC_TRANSLATED_LINKER_FLAGS})
-        separate_arguments(lflags)
+        if(UNIX)
+          separate_arguments(dflags UNIX_COMMAND "${dflags}")
+          separate_arguments(lflags UNIX_COMMAND "${lflags}")
+        else()
+          separate_arguments(dflags WINDOWS_COMMAND "${dflags}")
+          separate_arguments(lflags WINDOWS_COMMAND "${lflags}")
+        endif()
         foreach(f ${linker_args})
             append("-L\"${f}\"" lflags)
         endforeach()
         add_custom_command(
             OUTPUT ${output_exe}
-            COMMAND ${D_COMPILER} ${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS} ${lflags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_exe} ${compiler_args} ${linker_args}
+            COMMAND ${D_COMPILER} ${dflags} ${lflags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_exe} ${compiler_args} ${linker_args}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             DEPENDS ${dependencies}
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,7 @@ elseif(MSVC)
     ENABLE_LANGUAGE(ASM_MASM)
 endif()
 
-# Setup D compiler flags and linker flags for phobos (system linker) etc. We use
-# DMD syntax for all the flags so we can work with both DMD and LDMD.
+# Setup D compiler flags (DMD syntax, which also works with LDMD).
 set(DDMD_DFLAGS "-wi")
 set(DDMD_LFLAGS "")
 if(NOT MSVC_IDE)
@@ -522,7 +521,7 @@ set(LDC_EXE_FULL ${PROJECT_BINARY_DIR}/bin/${LDC_EXE_NAME}${CMAKE_EXECUTABLE_SUF
 set(LDMD_EXE_FULL ${PROJECT_BINARY_DIR}/bin/${LDMD_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX})
 add_custom_target(${LDC_EXE} ALL DEPENDS ${LDC_EXE_FULL})
 add_custom_target(${LDMD_EXE} ALL DEPENDS ${LDMD_EXE_FULL})
-set(LDC_LINKERFLAG_LIST "${SANITIZE_LDFLAGS};${WINDOWS_STACK_SIZE};${LIBCONFIG_LIBRARY};${LLVM_LIBRARIES};${LLVM_LDFLAGS}")
+set(LDC_LINKERFLAG_LIST "${SANITIZE_LDFLAGS};${LIBCONFIG_LIBRARY};${LLVM_LIBRARIES};${LLVM_LDFLAGS}")
 set(tempVar "")
 foreach(f ${LDC_LINKERFLAG_LIST})
     string (REPLACE "-Wl," "" f ${f})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,8 @@ if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Cla
     endif()
 
     include(ExtractDMDSystemLinker)
+    message(STATUS "Host D compiler linker program: ${D_LINKER_COMMAND}")
+    message(STATUS "Host D compiler linker flags: ${D_LINKER_ARGS}")
     list(APPEND LDC_LINKERFLAG_LIST ${D_LINKER_ARGS})
 
     if(NOT "${CMAKE_EXE_LINKER_FLAGS}" STREQUAL "")

--- a/cmake/Modules/ExtractDMDSystemLinker.cmake
+++ b/cmake/Modules/ExtractDMDSystemLinker.cmake
@@ -1,0 +1,52 @@
+# Determines the system linker program and default command line arguments
+# used by a DMD-compatible D compiler to link executables.
+#
+# The following variables are read:
+#  - D_COMPILER: The D compiler command (i.e., executable) to use.
+#  - D_COMPILER_DMD_COMPAT: Must be TRUE, only compilers with a DMD-compatible
+#    command line interface are supported.
+#
+# The following variables are set:
+#  - D_LINKER_COMMAND: The system linker command used (gcc, clang, …)
+#    internally by ${D_COMPILER}.
+#  - D_LINKER_ARGS: The additional command line arguments the ${D_COMPILER}
+#    passes to the linker (apart from those specifying the input object file and
+#    the output file).
+#
+
+# Create a temporary file with an empty main. We do not use the `-main` compiler
+# switch as it might behave differently (e.g. some versions of LDC emit the dummy
+# module into a separate __main.o file).
+set(source_name cmakeExtractDMDSystemLinker)
+set(source_file ${CMAKE_BINARY_DIR}/${source_name}.d)
+file(WRITE ${source_file} "void main() {}")
+
+# Compile the file in verbose mode and capture the compiler's stdout.
+set(result_code)
+set(stdout)
+execute_process(
+    COMMAND ${D_COMPILER} -v ${source_file}
+    RESULT_VARIABLE result_code
+    OUTPUT_VARIABLE stdout
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(result_code)
+	message(FATAL_ERROR "Failed to compile empty program using D compiler '${D_COMPILER}'")
+endif()
+
+# Extract last line, which (due to -v) contains the linker command line.
+string(REGEX REPLACE "\n" ";" stdout_lines "${stdout}")
+list(GET stdout_lines -1 linker_line)
+
+# Remove object file/output file arguments. This of course makes assumptions on
+# the object file names used by the compilers. Another option would be to swallow
+# all .o/-o arguments.
+string(REPLACE "${source_name}.o" "" linker_line "${linker_line}")
+string(REPLACE "-o ${source_name}" "" linker_line "${linker_line}")
+
+# Split up remaining part into executable and arguments.
+separate_arguments(linker_line)
+list(GET linker_line 0 D_LINKER_COMMAND)
+list(REMOVE_AT linker_line 0)
+set(D_LINKER_ARGS ${linker_line})

--- a/cmake/Modules/ExtractDMDSystemLinker.cmake
+++ b/cmake/Modules/ExtractDMDSystemLinker.cmake
@@ -25,7 +25,7 @@ file(WRITE ${source_file} "void main() {}")
 set(result_code)
 set(stdout)
 execute_process(
-    COMMAND ${D_COMPILER} -v ${source_file}
+    COMMAND ${D_COMPILER} ${D_COMPILER_FLAGS} -v ${source_file}
     RESULT_VARIABLE result_code
     OUTPUT_VARIABLE stdout
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/Modules/FindDCompiler.cmake
+++ b/cmake/Modules/FindDCompiler.cmake
@@ -70,8 +70,8 @@ endif()
 
 
 if (D_COMPILER_FOUND)
-    message(STATUS "Found D compiler ${D_COMPILER}, with default flags '${D_COMPILER_FLAGS}'")
-    message(STATUS "D compiler version: ${D_COMPILER_VERSION_STRING}")
+    message(STATUS "Found host D compiler ${D_COMPILER}, with default flags '${D_COMPILER_FLAGS}'")
+    message(STATUS "Host D compiler version: ${D_COMPILER_VERSION_STRING}")
 else()
-    message(FATAL_ERROR "Did not find D compiler! Try setting the 'D_COMPILER' variable or 'DMD' environment variable.")
+    message(FATAL_ERROR "No D compiler found! Try setting the 'D_COMPILER' variable or 'DMD' environment variable.")
 endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Build gen_gccbuiltins tools to generate D module from LLVM's list of
+# GCC-style intrinsics.
+
+# The LLVM_INCLUDE_DIR definition is not always set, e.g. on Windows.
+# strip off anything but the first path
+string(REGEX REPLACE ";.*$" "" LLVM_INC_DIR "${LLVM_INCLUDE_DIRS}")
+find_path(LLVM_INTRINSIC_TD_PATH "Intrinsics.td" PATHS ${LLVM_INC_DIR}/llvm ${LLVM_INC_DIR}/llvm/IR NO_DEFAULT_PATH)
+if (${LLVM_INTRINSIC_TD_PATH} STREQUAL "LLVM_INTRINSIC_TD_PATH-NOTFOUND")
+    message(SEND_ERROR "File Intrinsics.td not found")
+else()
+    string(REGEX REPLACE "/llvm(/IR)?$" "" LLVM_INTRINSIC_TD_PATH ${LLVM_INTRINSIC_TD_PATH})
+    message(STATUS "Using path for Intrinsics.td: ${LLVM_INTRINSIC_TD_PATH}")
+endif()
+append("-DLLVM_INTRINSIC_TD_PATH=\"${LLVM_INTRINSIC_TD_PATH}\"" CMAKE_CXX_FLAGS )
+
+add_executable(gen_gccbuiltins gen_gccbuiltins.cpp)
+
+set_target_properties(
+    gen_gccbuiltins PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+    LINK_FLAGS "${SANITIZE_LDFLAGS}"
+)
+target_link_libraries(gen_gccbuiltins ${LLVM_TABLEGEN_LIBRARY} ${LLVM_LIBRARIES} ${PTHREAD_LIBS} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    target_link_libraries(gen_gccbuiltins dl)
+endif()
+
+
+# Build FileCheck for testing (build source version depending on LLVM version)
+set(FILECHECK_SRC FileCheck-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.cpp)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${FILECHECK_SRC})
+    add_executable(FileCheck ${FILECHECK_SRC})
+    set_target_properties(
+        FileCheck PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+        LINK_FLAGS "${SANITIZE_LDFLAGS}"
+    )
+    target_link_libraries(FileCheck  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
+else()
+    message(STATUS "Skip building FileCheck, assuming it can be found in LLVM bin directory")
+endif()
+
+# Build `not` for testing
+add_executable(not not.cpp)
+set_target_properties(
+    not PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+    LINK_FLAGS "${SANITIZE_LDFLAGS}"
+)
+target_link_libraries(not  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
+
+# Build ldc-profdata for converting profile data formats (source version depends on LLVM version)
+set(LDCPROFDATA_SRC llvm-profdata-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.cpp)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LDCPROFDATA_SRC})
+    add_executable(ldc-profdata ${LDCPROFDATA_SRC})
+    set_target_properties(
+        ldc-profdata PROPERTIES
+        OUTPUT_NAME "${LDCPROFDATA_EXE_NAME}"
+        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+        LINK_FLAGS "${SANITIZE_LDFLAGS}"
+    )
+    target_link_libraries(ldc-profdata  ${LLVM_LIBRARIES} ${TERMINFO_LIBS} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
+    install(TARGETS ${LDCPROFDATA_EXE} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+endif()


### PR DESCRIPTION
Currently, we are translating the linker flags for LLVM/libconfig and from `CMAKE_EXE_LINKER_FLAGS` into `-L` options. Since DMD/LDC prefix `-L` options by `-Xlinker` before passing them to the GCC driver (causing the latter to forward it directly to the underlying `ld`), this does not work in the general case, causing issues such as #1494.

In https://github.com/ldc-developers/ldc/pull/1468, a few driver-only flags were special-cased in LDC so that `-Xlinker` is not applied to them. However, I don't think this is a viable strategy in the long run. First of all, there are quite a few more options which are supposed to be passed to the linker driver instead of the linker. But rather more importantly, this only works with an LDC version that contains this fix, and not DMD.

Thus, we need a solution that works on the build-system level. One possibility would be to white-list flags we know how to handle in the CMake scripts (e.g. all of them starting with `-Xlinker` or `-Wl,…`, where we can just strip off the prefix and pass them to the D compiler using `-L`), and just ignore all the others. However, for some common use cases, we do want to pass flags to the linker driver, such as to link against a static C++ standard library when building binary releases.

Since there is no DMD flag for passing flags to the linker driver (we could of course add one in the next LDC version, but this wouldn't help with DMD or older versions), this PR changes the build system to again use the system linker directly from CMake instead of going through the D compiler for linking. Compared to @JohanEngelen's earlier version (sorry!), this now parses the `-v` output to determine the default linker flags used internally by the D compiler instead of trying to guess them.

Fixes #1494, #1544.


