### PR TITLE
(release-1.0.1) Debug info generation fixes for LLVM >= 3.8

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -900,7 +900,7 @@ void ldc::DIBuilder::EmitValue(llvm::Value *val, VarDeclaration *vd) {
 }
 
 void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
-                                       Type *type, bool isThisPtr,
+                                       Type *type, bool isThisPtr, bool fromNested,
 #if LDC_LLVM_VER >= 306
                                        llvm::ArrayRef<int64_t> addr
 #else
@@ -935,7 +935,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
 
 #if LDC_LLVM_VER < 308
   unsigned tag;
-  if (vd->isParameter()) {
+  if (!fromNested && vd->isParameter()) {
     tag = llvm::dwarf::DW_TAG_arg_variable;
   } else {
     tag = llvm::dwarf::DW_TAG_auto_variable;
@@ -979,7 +979,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
                                                Flags                // flags
                                                );
 #else
-  if (vd->isParameter()) {
+  if (!fromNested && vd->isParameter()) {
     FuncDeclaration *fd = vd->parent->isFuncDeclaration();
     assert(fd);
     size_t argNo = 0;

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -650,7 +650,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
     CreateFunctionType(static_cast<TypeFunction *>(fd->type));
 
   // FIXME: duplicates?
-  return DBuilder.createFunction(
+  auto SP = DBuilder.createFunction(
       CU,                                 // context
       fd->toPrettyChars(),                // name
       getIrFunc(fd)->func->getName(),     // linkage name
@@ -667,6 +667,12 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
       getIrFunc(fd)->func
 #endif
       );
+#if LDC_LLVM_VER >= 308
+  if (fd->fbody) {
+    getIrFunc(fd)->func->setSubprogram(SP);
+  }
+#endif
+  return SP;
 }
 
 ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
@@ -695,7 +701,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
   name.append(".__thunk");
 
   // FIXME: duplicates?
-  return DBuilder.createFunction(
+  auto SP = DBuilder.createFunction(
       CU,                                 // context
       name,                               // name
       Thunk->getName(),                   // linkage name
@@ -712,6 +718,12 @@ ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
       getIrFunc(fd)->func
 #endif
       );
+#if LDC_LLVM_VER >= 308
+  if (fd->fbody) {
+    getIrFunc(fd)->func->setSubprogram(SP);
+  }
+#endif
+  return SP;
 }
 
 ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
@@ -756,7 +768,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
 #endif
 
   // FIXME: duplicates?
-  return DBuilder.createFunction(
+  auto SP = DBuilder.createFunction(
       CU,            // context
       prettyname,    // name
       Fn->getName(), // linkage name
@@ -773,6 +785,10 @@ ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
       Fn
 #endif
       );
+#if LDC_LLVM_VER >= 308
+  Fn->setSubprogram(SP);
+#endif
+  return SP;
 }
 
 void ldc::DIBuilder::EmitFuncStart(FuncDeclaration *fd) {

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -137,10 +137,11 @@ public:
   /// \param vd       Variable declaration to emit debug info for.
   /// \param type     Type of parameter if diferent from vd->type
   /// \param isThisPtr Parameter is hidden this pointer
+  /// \param fromNested Is a closure variable accessed through nest_arg
   /// \param addr     An array of complex address operations.
   void
   EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd, Type *type = nullptr,
-                    bool isThisPtr = false,
+                    bool isThisPtr = false, bool fromNested = false,
 #if LDC_LLVM_VER >= 306
                     llvm::ArrayRef<int64_t> addr = llvm::ArrayRef<int64_t>()
 #else

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -170,7 +170,7 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   }
 
   if (dwarfValue && global.params.symdebug) {
-    gIR->DBuilder.EmitLocalVariable(dwarfValue, vd, nullptr, false, dwarfAddr);
+    gIR->DBuilder.EmitLocalVariable(dwarfValue, vd, nullptr, false, /*fromNested=*/ true, dwarfAddr);
   }
 
   return makeVarDValue(astype, vd, val);
@@ -540,7 +540,7 @@ void DtoCreateNestedContext(FuncDeclaration *fd) {
         LLSmallVector<LLValue *, 2> addr;
 #endif
         gIR->DBuilder.OpOffset(addr, frameType, irLocal->nestedIndex);
-        gIR->DBuilder.EmitLocalVariable(gep, vd, nullptr, false, addr);
+        gIR->DBuilder.EmitLocalVariable(frame, vd, nullptr, false, false, addr);
       }
     }
   }

--- a/tests/debuginfo/debug_nested.d
+++ b/tests/debuginfo/debug_nested.d
@@ -1,0 +1,28 @@
+// Tests debug info generation for nested functions
+// REQUIRES: atleast_llvm308
+// RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK: define void @{{.*}}encloser
+// CHECK-SAME: !dbg
+void encloser(int arg0, int arg1)
+{
+    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    int enc_n;
+
+    // CHECK-LABEL: define {{.*}}encloser{{.*}}nested
+    void nested(int nes_i)
+    {
+        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
+
+        // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as
+        // function parameters this triggers off an assert in LLVM >=3.8 (see Github PR #1597)
+    }
+}
+
+// CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}encloser.nested"
+// CHECK: !DILocalVariable{{.*}}nes_i
+// CHECK-SAME: arg: 2
+// CHECK: !DILocalVariable{{.*}}arg1
+// CHECK-NOT: arg:
+// CHECK-SAME: ){{$}}

--- a/tests/debuginfo/debug_nested_llvm306.d
+++ b/tests/debuginfo/debug_nested_llvm306.d
@@ -1,0 +1,25 @@
+// Tests debug info generation for nested functions
+// REQUIRES: atmost_llvm306
+// RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK-LABEL: define {{.*}} @_D{{.*}}8encloserFiiZv
+void encloser(int arg0, int arg1)
+{
+    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    int enc_n;
+
+    // CHECK-LABEL: define {{.*}} @_D{{.*}}encloser{{.*}}nested
+    void nested(int nes_i)
+    {
+        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
+
+        // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as
+        // function parameters this triggers off an assert in LLVM >=3.8 (see Github PR #1597)
+    }
+}
+
+// CHECK: @_D{{.*}}8encloserFiiZv{{.*}}DW_TAG_subprogram
+// CHECK: @_D{{.*}}8encloserFiiZ6nestedMFiZv{{.*}}DW_TAG_subprogram
+// CHECK: nes_i{{.*}}DW_TAG_arg_variable
+// CHECK: arg1{{.*}}DW_TAG_auto_variable

--- a/tests/debuginfo/debug_nested_llvm307.d
+++ b/tests/debuginfo/debug_nested_llvm307.d
@@ -1,0 +1,26 @@
+// Tests debug info generation for nested functions
+// REQUIRES: llvm307
+// RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser
+void encloser(int arg0, int arg1)
+{
+    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    int enc_n;
+
+    // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested
+    void nested(int nes_i)
+    {
+        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
+
+        // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as
+        // function parameters this triggers off an assert in LLVM >=3.8 (see Github PR #1597)
+    }
+}
+
+// CHECK: !DISubprogram(name:{{.*}}"{{.*}}.encloser"
+// CHECK-SAME: function: void {{.*}} @_D{{.*}}8encloserFiiZv
+// CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}.encloser.nested"
+// CHECK: !DILocalVariable{{.*}}DW_TAG_arg_variable{{.*}}nes_i
+// CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}arg1

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -34,6 +34,8 @@ config.excludes = [
 config.available_features.add("llvm%d" % config.llvm_version)
 for version in range(305, config.llvm_version+1):
     config.available_features.add("atleast_llvm%d" % version)
+for version in reversed(range(config.llvm_version, 310)):
+    config.available_features.add("atmost_llvm%d" % version)
 
 # Define OS as available feature (Windows, Darwin, Linux)
 config.available_features.add(platform.system())


### PR DESCRIPTION
Debug info generation is broken when LDC is built against LLVM 3.8:

```
(gdb) break test.d:20  <= works
(gdb) run
(gdb) bt  <= no location info
#0  0x0000000000402f49 in D main ()
(gdb) info locals
No symbol table info available.
```

A `llvm::Function::setSubprogram()` call to assign the descriptor to the function was missing. Restoring it resulted in new compilation errors while building druntime and phobos, which were due to function parameters accessed from a nested function being declared as function parameters (they're not, they're fields of `nest_arg`) instead of "auto variables", and setting two variables for the same parameter index was triggering an assert:

```
ldc2: DwarfDebug.h:125: void llvm::DbgVariable::addMMIEntry(const llvm::DbgVariable&): Assertion `V.Var == Var && "conflicting variable"' failed.
```

There's also a fix not specific to LLVM 3.8 for closure variables not getting declared correctly in the parent function. 