### PR TITLE
Some more direct in-place construction

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -547,7 +547,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
 
   if (irFty.arg_sret && !passThisBeforeSret) {
     iarg->setName(".sret_arg");
-    irFunc->retArg = &(*iarg);
+    irFunc->sretArg = &(*iarg);
     ++iarg;
   }
 
@@ -585,7 +585,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
 
   if (passThisBeforeSret) {
     iarg->setName(".sret_arg");
-    irFunc->retArg = &(*iarg);
+    irFunc->sretArg = &(*iarg);
     ++iarg;
   }
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -884,7 +884,7 @@ void DtoVarDeclaration(VarDeclaration *vd) {
 
   if (isIrLocalCreated(vd)) {
     // Nothing to do if it has already been allocated.
-  } else if (gIR->func()->retArg && gIR->func()->decl->nrvo_can &&
+  } else if (gIR->func()->sretArg && gIR->func()->decl->nrvo_can &&
              gIR->func()->decl->nrvo_var == vd) {
     // Named Return Value Optimization (NRVO):
     // T f() {
@@ -893,7 +893,7 @@ void DtoVarDeclaration(VarDeclaration *vd) {
     //   return ret;    // NRVO.
     // }
     assert(!isSpecialRefVar(vd) && "Can this happen?");
-    getIrLocal(vd, true)->value = gIR->func()->retArg;
+    getIrLocal(vd, true)->value = gIR->func()->sretArg;
   } else {
     // normal stack variable, allocate storage on the stack if it has not
     // already been done

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -884,8 +884,9 @@ void DtoVarDeclaration(VarDeclaration *vd) {
 
   if (isIrLocalCreated(vd)) {
     // Nothing to do if it has already been allocated.
-  } else if (gIR->func()->sretArg && gIR->func()->decl->nrvo_can &&
-             gIR->func()->decl->nrvo_var == vd) {
+  } else if (gIR->func()->sretArg && ((gIR->func()->decl->nrvo_can &&
+                                       gIR->func()->decl->nrvo_var == vd) ||
+                                      vd->isResult())) {
     // Named Return Value Optimization (NRVO):
     // T f() {
     //   T ret;        // &ret == hidden pointer

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -291,9 +291,8 @@ DValue *makeVarDValue(Type *type, VarDeclaration *vd,
                       llvm::Value *storage = nullptr);
 
 /// Checks whether the rhs expression is able to construct the lhs lvalue
-/// directly via sret ('struct return').
-/// If so, it performs the according codegen and returns true; otherwise it just
-/// returns false.
-bool toDirectSretConstruction(DLValue *lhs, Expression *rhs);
+/// directly in-place. If so, it performs the according codegen and returns
+/// true; otherwise it just returns false.
+bool toInPlaceConstruction(DLValue *lhs, Expression *rhs);
 
 #endif

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -290,4 +290,10 @@ inline llvm::Value *DtoLVal(Expression *e) { return DtoLVal(toElem(e)); }
 DValue *makeVarDValue(Type *type, VarDeclaration *vd,
                       llvm::Value *storage = nullptr);
 
+/// Checks whether the rhs expression is able to construct the lhs lvalue
+/// directly via sret ('struct return').
+/// If so, it performs the according codegen and returns true; otherwise it just
+/// returns false.
+bool toDirectSretConstruction(DLValue *lhs, Expression *rhs);
+
 #endif

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -225,7 +225,7 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
 
 ///
 DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
-                        Expressions *arguments, LLValue *retvar = nullptr);
+                        Expressions *arguments, LLValue *sretPointer = nullptr);
 
 Type *stripModifiers(Type *type, bool transitive = false);
 

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -145,12 +145,12 @@ public:
           LLType::getVoidTy(irs->context())) {
         // sanity check
         IrFunction *f = irs->func();
-        assert(getIrFunc(f->decl)->retArg);
+        assert(getIrFunc(f->decl)->sretArg);
 
         // FIXME: is there ever a case where a sret return needs to be rewritten
         // for the ABI?
 
-        LLValue *sretPointer = getIrFunc(f->decl)->retArg;
+        LLValue *sretPointer = getIrFunc(f->decl)->sretArg;
         DValue *e = toElemDtor(stmt->exp);
         // store return value
         if (!e->isLVal() || DtoLVal(e) != sretPointer) {

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -150,17 +150,18 @@ public:
         // FIXME: is there ever a case where a sret return needs to be rewritten
         // for the ABI?
 
-        // get return pointer
-        DValue *rvar = new DLValue(f->type->next, getIrFunc(f->decl)->retArg);
+        LLValue *sretPointer = getIrFunc(f->decl)->retArg;
         DValue *e = toElemDtor(stmt->exp);
         // store return value
-        if (!e->isLVal() || DtoLVal(e) != DtoLVal(rvar))
-          DtoAssign(stmt->loc, rvar, e, TOKblit);
+        if (!e->isLVal() || DtoLVal(e) != sretPointer) {
+          DLValue rvar(f->type->next, sretPointer);
+          DtoAssign(stmt->loc, &rvar, e, TOKblit);
+        }
 
         // call postblit if necessary
         if (!irs->func()->type->isref &&
             !(f->decl->nrvo_can && f->decl->nrvo_var)) {
-          callPostblit(stmt->loc, stmt->exp, DtoLVal(rvar));
+          callPostblit(stmt->loc, stmt->exp, sretPointer);
         }
       }
       // the return type is not void, so this is a normal "register" return

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -156,12 +156,17 @@ public:
         if (!e->isLVal() || DtoLVal(e) != sretPointer) {
           DLValue rvar(f->type->next, sretPointer);
           DtoAssign(stmt->loc, &rvar, e, TOKblit);
-        }
 
-        // call postblit if necessary
-        if (!irs->func()->type->isref &&
-            !(f->decl->nrvo_can && f->decl->nrvo_var)) {
-          callPostblit(stmt->loc, stmt->exp, sretPointer);
+          // call postblit if the expression is a D lvalue
+          // exceptions: NRVO and special __result variable (for out contracts)
+          bool doPostblit = !(f->decl->nrvo_can && f->decl->nrvo_var);
+          if (doPostblit && stmt->exp->op == TOKvar) {
+            auto ve = static_cast<VarExp *>(stmt->exp);
+            if (ve->var->isResult())
+              doPostblit = false;
+          }
+          if (doPostblit)
+            callPostblit(stmt->loc, stmt->exp, sretPointer);
         }
       }
       // the return type is not void, so this is a normal "register" return

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -920,7 +920,7 @@ public:
 
   //////////////////////////////////////////////////////////////////////////////
 
-  static DValue *call(IRState *p, CallExp *e, LLValue *retvar = nullptr) {
+  static DValue *call(IRState *p, CallExp *e, LLValue *sretPointer = nullptr) {
     IF_LOG Logger::print("CallExp::toElem: %s @ %s\n", e->toChars(),
                          e->type->toChars());
     LOG_SCOPE;
@@ -1012,7 +1012,7 @@ public:
     }
 
     DValue *result =
-        DtoCallFunction(e->loc, e->type, fnval, e->arguments, retvar);
+        DtoCallFunction(e->loc, e->type, fnval, e->arguments, sretPointer);
 
     if (delayedDtorVar) {
       delayedDtorVar->edtor = delayedDtorExp;

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -3095,6 +3095,14 @@ bool toInPlaceConstruction(DLValue *lhs, Expression *rhs) {
     return true;
   }
 
+  // static array literals too
+  Type *lhsBasetype = lhs->type->toBasetype();
+  if (rhs->op == TOKarrayliteral && lhsBasetype->ty == Tsarray) {
+    auto al = static_cast<ArrayLiteralExp *>(rhs);
+    initializeArrayLiteral(gIR, al, DtoLVal(lhs));
+    return true;
+  }
+
   return false;
 }
 

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -484,7 +484,7 @@ struct IrFunction {
   /// Points to the associated scope stack while emitting code for the function.
   ScopeStack *scopes = nullptr;
 
-  llvm::Value *retArg = nullptr;  // return in ptr arg
+  llvm::Value *sretArg = nullptr; // sret pointer arg
   llvm::Value *thisArg = nullptr; // class/struct 'this' arg
   llvm::Value *nestArg = nullptr; // nested function 'this' arg
 

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -47,16 +47,16 @@ void main() {
   // C HECK: %outeroverride = alloca %align.Outer, align 16
   // C HECK: %outeroverride = alloca %align.Outer, align 32
 
-  // CHECK: %.rettmp{{.*}} = alloca %align.Outer, align 32
-  // CHECK: %.rettmp{{.*}} = alloca %align.Inner, align 32
+  // CHECK: %.sret_tmp{{.*}} = alloca %align.Outer, align 32
+  // CHECK: %.sret_tmp{{.*}} = alloca %align.Inner, align 32
 
   outer = passAndReturnOuterByVal(outer);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
-  // CHECK-SAME: %align.Outer* {{noalias sret|inreg noalias}} align 32 %.rettmp
+  // CHECK-SAME: %align.Outer* {{noalias sret|inreg noalias}} align 32 %.sret_tmp
   // CHECK-SAME: align 32 %
 
   inner = passAndReturnInnerByVal(inner);
   // CHECK: call{{.*}} void @{{.*}}_D5align23passAndReturnInnerByValFS5align5InnerZS5align5Inner
-  // CHECK-SAME: %align.Inner* {{noalias sret|inreg noalias}} align 32 %.rettmp1
+  // CHECK-SAME: %align.Inner* {{noalias sret|inreg noalias}} align 32 %.sret_tmp
   // CHECK-SAME: align 32 %
 }

--- a/tests/codegen/in_place_construct.d
+++ b/tests/codegen/in_place_construct.d
@@ -28,6 +28,23 @@ S returnNRVO()
     return r;
 }
 
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct15withOutContractFZS18in_place_construct1S
+S withOutContract()
+out { assert(__result.a == 0); }
+body
+{
+    // make sure NRVO zero-initializes the sret pointee directly
+    // CHECK: %1 = bitcast %in_place_construct.S* %.sret_arg to i8*
+    // CHECK: call void @llvm.memset.{{.*}}(i8* %1, i8 0,
+    const S r;
+    return r;
+
+    // make sure `__result` inside the out contract is just an alias to the sret pointee
+    // CHECK: %2 = getelementptr inbounds {{.*}}%in_place_construct.S* %.sret_arg, i32 0, i32 0
+    // CHECK: %3 = load {{.*}}i64* %2
+    // CHECK: %4 = icmp eq i64 %3, 0
+}
+
 // CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct7structsFZv
 void structs()
 {
@@ -57,6 +74,8 @@ void structs()
     // CHECK: call {{.*}}_D18in_place_construct10returnNRVOFZS18in_place_construct1S
     // CHECK-SAME: %in_place_construct.S* {{.*}} %c
     const c = returnNRVO();
+
+    withOutContract();
 }
 
 // CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct12staticArraysFZv

--- a/tests/codegen/in_place_construct.d
+++ b/tests/codegen/in_place_construct.d
@@ -28,8 +28,8 @@ S returnNRVO()
     return r;
 }
 
-// CHECK-LABEL: define{{.*}} @{{.*}}_Dmain
-void main()
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct7structsFZv
+void structs()
 {
     // CHECK: %literal = alloca %in_place_construct.S
     // CHECK: %a = alloca %in_place_construct.S
@@ -57,4 +57,21 @@ void main()
     // CHECK: call {{.*}}_D18in_place_construct10returnNRVOFZS18in_place_construct1S
     // CHECK-SAME: %in_place_construct.S* {{.*}} %c
     const c = returnNRVO();
+}
+
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct12staticArraysFZv
+void staticArrays()
+{
+    // CHECK: %sa = alloca [2 x i32]
+
+    // make sure static array literals are in-place constructed too
+    // CHECK: store [2 x i32] [i32 1, i32 2], [2 x i32]* %sa
+    const(int[2]) sa = [ 1, 2 ];
+}
+
+// CHECK-LABEL: define{{.*}} @{{.*}}_Dmain
+void main()
+{
+    structs();
+    staticArrays();
 }

--- a/tests/codegen/in_place_construct.d
+++ b/tests/codegen/in_place_construct.d
@@ -1,0 +1,60 @@
+// Tests in-place construction of variables.
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// 256 bits, returned via sret:
+struct S
+{
+    long a, b, c, d;
+    /*
+    this(this) {}
+    ~this() {}
+    */
+}
+
+S returnLiteral()
+{
+    return S(1, 2, 3, 4);
+}
+
+S returnRValue()
+{
+    return returnLiteral();
+}
+
+S returnNRVO()
+{
+    const S r;
+    return r;
+}
+
+// CHECK-LABEL: define{{.*}} @{{.*}}_Dmain
+void main()
+{
+    // CHECK: %literal = alloca %in_place_construct.S
+    // CHECK: %a = alloca %in_place_construct.S
+    // CHECK: %b = alloca %in_place_construct.S
+    // CHECK: %c = alloca %in_place_construct.S
+
+    // make sure the literal is emitted directly into the lvalue
+    // CHECK: %1 = getelementptr inbounds {{.*}}%in_place_construct.S* %literal, i32 0, i32 0
+    // CHECK: store i64 5, i64* %1
+    // CHECK: %2 = getelementptr inbounds {{.*}}%in_place_construct.S* %literal, i32 0, i32 1
+    // CHECK: store i64 6, i64* %2
+    // CHECK: %3 = getelementptr inbounds {{.*}}%in_place_construct.S* %literal, i32 0, i32 2
+    // CHECK: store i64 7, i64* %3
+    // CHECK: %4 = getelementptr inbounds {{.*}}%in_place_construct.S* %literal, i32 0, i32 3
+    // CHECK: store i64 8, i64* %4
+    const literal = S(5, 6, 7, 8);
+
+    // make sure the variables are in-place constructed via sret
+    // CHECK: call {{.*}}_D18in_place_construct13returnLiteralFZS18in_place_construct1S
+    // CHECK-SAME: %in_place_construct.S* {{.*}} %a
+    const a = returnLiteral();
+    // CHECK: call {{.*}}_D18in_place_construct12returnRValueFZS18in_place_construct1S
+    // CHECK-SAME: %in_place_construct.S* {{.*}} %b
+    const b = returnRValue();
+    // CHECK: call {{.*}}_D18in_place_construct10returnNRVOFZS18in_place_construct1S
+    // CHECK-SAME: %in_place_construct.S* {{.*}} %c
+    const c = returnNRVO();
+}


### PR DESCRIPTION
The plan is to in-place construct return expressions too if the function uses sret.
And I'd also like to get rid of all the temporary struct literals (possibly array literals too) which get memcopied too instead of being directly constructed into the variable. This should make life easier for the LLVM optimizer and speed-up debug builds as well as render the IR more compact and easier to read.