### PR TITLE
Use direct sret construction for return statements too

### DIFF
--- a/tests/codegen/in_place_construct.d
+++ b/tests/codegen/in_place_construct.d
@@ -6,24 +6,38 @@
 struct S
 {
     long a, b, c, d;
-    /*
-    this(this) {}
-    ~this() {}
-    */
 }
 
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct13returnLiteralFZS18in_place_construct1S
 S returnLiteral()
 {
+    // make sure the literal is emitted directly into the sret pointee
+    // CHECK: %1 = getelementptr inbounds {{.*}}%in_place_construct.S* %.sret_arg, i32 0, i32 0
+    // CHECK: store i64 1, i64* %1
+    // CHECK: %2 = getelementptr inbounds {{.*}}%in_place_construct.S* %.sret_arg, i32 0, i32 1
+    // CHECK: store i64 2, i64* %2
+    // CHECK: %3 = getelementptr inbounds {{.*}}%in_place_construct.S* %.sret_arg, i32 0, i32 2
+    // CHECK: store i64 3, i64* %3
+    // CHECK: %4 = getelementptr inbounds {{.*}}%in_place_construct.S* %.sret_arg, i32 0, i32 3
+    // CHECK: store i64 4, i64* %4
     return S(1, 2, 3, 4);
 }
 
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct12returnRValueFZS18in_place_construct1S
 S returnRValue()
 {
+    // make sure the sret pointer is forwarded
+    // CHECK: call {{.*}}_D18in_place_construct13returnLiteralFZS18in_place_construct1S
+    // CHECK-SAME: %in_place_construct.S* {{.*}} %.sret_arg
     return returnLiteral();
 }
 
+// CHECK-LABEL: define{{.*}} @{{.*}}_D18in_place_construct10returnNRVOFZS18in_place_construct1S
 S returnNRVO()
 {
+    // make sure NRVO zero-initializes the sret pointee directly
+    // CHECK: %1 = bitcast %in_place_construct.S* %.sret_arg to i8*
+    // CHECK: call void @llvm.memset.{{.*}}(i8* %1, i8 0,
     const S r;
     return r;
 }


### PR DESCRIPTION
Okay so this sadly isn't working.
Some Phobos unittests crash (and so does dmd-testsuite's `d_do_test` tool), apparently due to a lifetime issue exposed by regex stuff. Specifically, the `std.regex.internal.parser` tests crash in a `std.uni.CowArray` dtor (the single field, a `uint[]` slice, seems corrupt when setting the `refCount` property). This is triggered by `std.regex.internal.ir.wordCharacter()` which uses lazy caching via `memoizeExpr()`.
So it seems like there's a missing postblit call. But iirc, the IR for `std.regex.internal.ir` was pretty similar (except for a lot of omitted `.sret_tmp` allocas + memcopies), I didn't immediately spot the missing postblit call. Various experiments with `doPostblit` all failed (e.g., using the current logic for in-place construction too), and so did my attempts at generating a reduced test case.

So any hints are welcome. This isn't crucial, but the IR would be much nicer. ;)

PS: It has nothing to do with directly constructing struct/array literals. It works if I disable the forwarding of the sret pointer to a function producing the return value (`S foo() { return bar(); }`).