### PR TITLE
Fix issue #1608

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -365,7 +365,7 @@ void DtoAssign(Loc &loc, DValue *lhs, DValue *rhs, int op,
       }
 #if 1
       if (r->getType() !=
-          lit) { // It's wierd but it happens. TODO: try to remove this hack
+          lit) { // It's weird but it happens. TODO: try to remove this hack
         r = DtoBitCast(r, lit);
       }
 #else
@@ -1334,7 +1334,7 @@ LLValue *makeLValue(Loc &loc, DValue *value) {
 
   LLValue *mem = DtoAlloca(value->type, ".makelvaluetmp");
   DLValue var(value->type, mem);
-  DtoAssign(loc, &var, value);
+  DtoAssign(loc, &var, value, TOKblit);
   return mem;
 }
 
@@ -1812,7 +1812,8 @@ DValue *makeVarDValue(Type *type, VarDeclaration *vd, llvm::Value *storage) {
     // The type of globals is determined by their initializer, and the front-end
     // may inject implicit casts for class references and static arrays.
     assert(vd->isDataseg() || (vd->storage_class & STCextern) ||
-           type->toBasetype()->ty == Tclass || type->toBasetype()->ty == Tsarray);
+           type->toBasetype()->ty == Tclass ||
+           type->toBasetype()->ty == Tsarray);
     llvm::Type *pointeeType = val->getType()->getPointerElementType();
     if (isSpecialRef)
       pointeeType = pointeeType->getPointerElementType();

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -83,7 +83,7 @@ void DtoEnterMonitor(Loc &loc, LLValue *v);
 void DtoLeaveMonitor(Loc &loc, LLValue *v);
 
 // basic operations
-void DtoAssign(Loc &loc, DValue *lhs, DValue *rhs, int op = -1,
+void DtoAssign(Loc &loc, DValue *lhs, DValue *rhs, int op,
                bool canSkipPostblit = false);
 
 DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl);

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -171,8 +171,6 @@ public:
 
           // store the return value unless NRVO already used the sret pointer
           if (!e->isLVal() || DtoLVal(e) != sretPointer) {
-            DtoAssign(stmt->loc, &returnValue, e, TOKblit);
-
             // call postblit if the expression is a D lvalue
             // exceptions: NRVO and special __result variable (out contracts)
             bool doPostblit = !(fd->nrvo_can && fd->nrvo_var);
@@ -181,6 +179,8 @@ public:
               if (ve->var->isResult())
                 doPostblit = false;
             }
+
+            DtoAssign(stmt->loc, &returnValue, e, TOKblit);
             if (doPostblit)
               callPostblit(stmt->loc, stmt->exp, sretPointer);
           }
@@ -1619,7 +1619,7 @@ public:
       // Copy value to local variable, and use it as the value variable.
       DLValue dst(stmt->value->type, valvar);
       DLValue src(stmt->value->type, gep);
-      DtoAssign(stmt->loc, &dst, &src);
+      DtoAssign(stmt->loc, &dst, &src, TOKassign);
       getIrLocal(stmt->value)->value = valvar;
     } else {
       // Use the GEP as the address of the value variable.


### PR DESCRIPTION
Not happy at all with this change, that whole `canSkipPostblit` logic seems quite fragile. It's determined in `visit(AssignExp*)`, passed to `DtoAssign()`, and exclusively used in `DtoArrayAssign()` (i.e., when assigning to a static/dynamic array).