### PR TITLE
Implement the @allocSize magic UDA.

### DIFF
--- a/tests/codegen/attr_allocsize.d
+++ b/tests/codegen/attr_allocsize.d
@@ -1,0 +1,45 @@
+// Test ldc.attributes.allocSize
+
+// REQUIRES: atleast_llvm309
+
+// RUN: %ldc -O3 -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import ldc.attributes;
+
+// CHECK-LABEL: define{{.*}}@{{.*}}my_calloc
+// CHECK-SAME: #[[ATTR0:[0-9]+]]
+extern (C) void* my_calloc(size_t num, size_t size) @allocSize(1, 0)
+{
+    return null;
+}
+
+// CHECK-LABEL: define{{.*}}@{{.*}}my_malloc
+// CHECK-SAME: #[[ATTR1:[0-9]+]]
+extern (C) void* my_malloc(int a, int b, size_t size, int c) @allocSize(2)
+{
+    return null;
+}
+
+// Test the reversed parameter order of D calling convention
+// CHECK-LABEL: define{{.*}}@{{.*}}Dlinkage_calloc
+// CHECK-SAME: #[[ATTR2:[0-9]+]]
+extern (D) void* Dlinkage_calloc(int size, int b, size_t num, int c) @allocSize(0, 2)
+{
+    return null;
+}
+
+// Test function type with hidden `this` argument
+class A
+{
+    // CHECK-LABEL: define{{.*}}@{{.*}}this_calloc
+    // CHECK-SAME: #[[ATTR3:[0-9]+]]
+    void* this_calloc(int size, int b, size_t num, int c) @allocSize(0, 2)
+    {
+        return null;
+    }
+}
+
+// CHECK-DAG: attributes #[[ATTR0]] ={{.*}} allocsize(1,0)
+// CHECK-DAG: attributes #[[ATTR1]] ={{.*}} allocsize(2)
+// CHECK-DAG: attributes #[[ATTR2]] ={{.*}} allocsize(3,1)
+// CHECK-DAG: attributes #[[ATTR3]] ={{.*}} allocsize(4,2)

--- a/tests/codegen/attr_allocsize_diag.d
+++ b/tests/codegen/attr_allocsize_diag.d
@@ -1,0 +1,32 @@
+// Test ldc.attributes.allocSize diagnostics
+
+// Although @allocSize is only effective for LLVM>=3.9, diagnostics should work for all LLVM versions
+
+// RUN: not %ldc -d-version=NORMAL %s 2>&1 | FileCheck %s --check-prefix=NORMAL
+// RUN: not %ldc -d-version=THIS   %s 2>&1 | FileCheck %s --check-prefix=THIS
+
+import ldc.attributes;
+
+version(NORMAL)
+{
+// NORMAL: attr_allocsize_diag.d([[@LINE+2]]): Error: @ldc.attributes.allocSize.sizeArgIdx=2 too large for function `my_calloc` with 2 arguments.
+// NORMAL: attr_allocsize_diag.d([[@LINE+1]]): Error: @ldc.attributes.allocSize.numArgIdx=2 too large for function `my_calloc` with 2 arguments.
+extern (C) void* my_calloc(size_t num, size_t size) @allocSize(2, 2)
+{
+    return null;
+}
+}
+
+version(THIS)
+{
+// Test function type with hidden `this` argument
+class A
+{
+    // THIS: attr_allocsize_diag.d([[@LINE+2]]): Error: @ldc.attributes.allocSize.sizeArgIdx=4 too large for function `this_calloc` with 4 arguments.
+    // THIS: attr_allocsize_diag.d([[@LINE+1]]): Error: @ldc.attributes.allocSize.numArgIdx=4 too large for function `this_calloc` with 4 arguments.
+    void* this_calloc(int size, int b, size_t num, int c) @allocSize(4, 4)
+    {
+        return null;
+    }
+}
+}


### PR DESCRIPTION
Resolves https://github.com/ldc-developers/ldc/issues/1452

I implemented it "because I can". I think this leads to optimization potential for LLVM (InstCombine?) but I have not tested what kind of code becomes better.

In subsequent work, the attribute should be applied to druntime functions. In the end, I am not sure how much this brings. When we can inline e.g. `_d_allocmemory`, it will be inlined to a `malloc` call (if I'm correct) for which LLVM automatically assumes the `allocsize` attribute...
