### PR TITLE
Non-Windows x86_64: Pass more structs in registers

### DIFF
--- a/tests/codegen/abi_emptystructs.d
+++ b/tests/codegen/abi_emptystructs.d
@@ -1,0 +1,19 @@
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+struct Empty {}
+struct OnlyZeroSizedFields { int[0] dummy; }
+struct Container { Empty empty; OnlyZeroSizedFields onlyZeroSizedFields; }
+
+// Make sure all of these structs are returned in registers (no sret).
+// CHECK-NOT: %.sret_arg
+
+Empty makeEmpty() { return Empty(); }
+OnlyZeroSizedFields makeOnlyZeroSizedFields() { return OnlyZeroSizedFields(); }
+Container makeContainer() { return Container(); }
+
+void main()
+{
+    makeEmpty();
+    makeOnlyZeroSizedFields();
+    makeContainer();
+}


### PR DESCRIPTION
* Treat empty structs as single byte instead of forcing them to be passed
  on the stack and returned via sret.
  This also enables other structs containing empty struct fields to be
  passed/returned in registers.
* Ignore zero-sized fields of a struct, such as zero-length static arrays.
  These fields previously forced the struct to be passed/returned on the
  stack.

I'll try to get that into upstream.