### PR TITLE
Apply DDMD PR #5885 (f5f9150ea57cce5fabb43c79ff1b187d34d37044).

### DIFF
--- a/ddmd/attrib.h
+++ b/ddmd/attrib.h
@@ -90,7 +90,7 @@ public:
     LinkDeclaration(LINK p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    char *toChars();
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -101,7 +101,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars() const;
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/ddmd/ctfe.h
+++ b/ddmd/ctfe.h
@@ -74,7 +74,7 @@ public:
     VarDeclaration *var;
 
     VoidInitExp(VarDeclaration *var, Type *type);
-    char *toChars();
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -89,7 +89,7 @@ class ThrownExceptionExp : public Expression
 public:
     ClassReferenceExp *thrown; // the thing being tossed
     ThrownExceptionExp(Loc loc, ClassReferenceExp *victim);
-    char *toChars();
+    const char *toChars();
     /// Generate an error message when this exception is not caught
     void generateUncaughtError();
     void accept(Visitor *v) { v->visit(this); }
@@ -104,7 +104,7 @@ class CTFEExp : public Expression
 public:
     CTFEExp(TOK tok);
 
-    char *toChars();
+    const char *toChars();
 
     // Handy instances to share
     static CTFEExp *cantexp;

--- a/ddmd/declaration.h
+++ b/ddmd/declaration.h
@@ -325,7 +325,7 @@ public:
     static TypeInfoDeclaration *create(Type *tinfo, int internal);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
-    char *toChars();
+    const char *toChars();
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -753,7 +753,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();
-    char *toChars();
+    const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();
@@ -785,7 +785,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();
-    char *toChars();
+    const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();

--- a/ddmd/dsymbol.h
+++ b/ddmd/dsymbol.h
@@ -186,7 +186,7 @@ public:
     Dsymbol();
     Dsymbol(Identifier *);
     static Dsymbol *create(Identifier *);
-    char *toChars();
+    const char *toChars();
     virtual char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc& getLoc();
     const char *locToChars();

--- a/ddmd/expression.h
+++ b/ddmd/expression.h
@@ -146,7 +146,7 @@ public:
     int dyncast() { return DYNCAST_EXPRESSION; }
 
     void print();
-    char *toChars();
+    const char *toChars();
     virtual void printAST(int ident = 0);
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;
@@ -672,7 +672,7 @@ public:
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);
     MATCH matchType(Type *to, Scope *sc, FuncExp **pfe, int flag = 0);
-    char *toChars();
+    const char *toChars();
     bool checkType();
     bool checkValue();
 

--- a/ddmd/identifier.h
+++ b/ddmd/identifier.h
@@ -31,7 +31,7 @@ public:
     bool equals(RootObject *o);
     int compare(RootObject *o);
     void print();
-    char *toChars();
+    const char *toChars();
     const char *toHChars2();
     int dyncast();
 

--- a/ddmd/init.h
+++ b/ddmd/init.h
@@ -48,7 +48,7 @@ public:
     // needInterpret is INITinterpret if must be a manifest constant, 0 if not.
     virtual Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret) = 0;
     virtual Expression *toExpression(Type *t = NULL) = 0;
-    char *toChars();
+    const char *toChars();
 
     virtual ErrorInitializer   *isErrorInitializer() { return NULL; }
     virtual VoidInitializer    *isVoidInitializer() { return NULL; }

--- a/ddmd/module.h
+++ b/ddmd/module.h
@@ -221,7 +221,7 @@ struct ModuleDeclaration
 
     ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id);
 
-    char *toChars();
+    const char *toChars();
 };
 
 #endif /* DMD_MODULE_H */

--- a/ddmd/mtype.h
+++ b/ddmd/mtype.h
@@ -243,7 +243,7 @@ public:
     // kludge for template.isType()
     int dyncast() { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL);
-    char *toChars();
+    const char *toChars();
     char *toPrettyChars(bool QualifyTypes = false);
     static char needThisPrefix();
     static void _init();

--- a/ddmd/root/array.h
+++ b/ddmd/root/array.h
@@ -53,7 +53,7 @@ struct Array
 
     char *toChars()
     {
-        char **buf = (char **)mem.xmalloc(dim * sizeof(char *));
+        const char **buf = (const char **)mem.xmalloc(dim * sizeof(const char *));
         d_size_t len = 2;
         for (d_size_t u = 0; u < dim; u++)
         {

--- a/ddmd/root/object.h
+++ b/ddmd/root/object.h
@@ -45,7 +45,7 @@ public:
      */
     virtual void print();
 
-    virtual char *toChars();
+    virtual const char *toChars();
     virtual void toBuffer(OutBuffer *buf);
 
     /**

--- a/ddmd/statement.h
+++ b/ddmd/statement.h
@@ -93,7 +93,7 @@ public:
     virtual Statement *syntaxCopy();
 
     void print();
-    char *toChars();
+    const char *toChars();
 
     void error(const char *format, ...);
     void warning(const char *format, ...);

--- a/ddmd/template.h
+++ b/ddmd/template.h
@@ -49,7 +49,7 @@ public:
     // kludge for template.isType()
     int dyncast() { return DYNCAST_TUPLE; }
 
-    char *toChars() { return objects.toChars(); }
+    const char *toChars() { return objects.toChars(); }
 };
 
 struct TemplatePrevious
@@ -95,7 +95,7 @@ public:
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
     const char *kind();
-    char *toChars();
+    const char *toChars();
 
     Prot prot();
 
@@ -339,7 +339,7 @@ public:
     Dsymbol *toAlias();                 // resolve real symbol
     const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    char *toChars();
+    const char *toChars();
     char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
@@ -382,7 +382,7 @@ public:
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    char *toChars();
+    const char *toChars();
 
     bool findTempDecl(Scope *sc);
 

--- a/ddmd/version.h
+++ b/ddmd/version.h
@@ -27,7 +27,7 @@ public:
     DebugSymbol(Loc loc, unsigned level);
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    char *toChars();
+    const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     const char *kind();
@@ -43,7 +43,7 @@ public:
     VersionSymbol(Loc loc, unsigned level);
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    char *toChars();
+    const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     const char *kind();

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2396,7 +2396,7 @@ struct AsmProcessor {
     asmcode->args.push_back(AsmArg(type, e, mode));
   }
 
-  void addLabel(char *id) {
+  void addLabel(const char *id) {
     // We need to delay emitting the actual function name, see
     // replace_func_name in asmstmt.cpp for details.
     printLabelName(insnTemplate, "<<func>>", id);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -375,7 +375,7 @@ DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *_to) {
 ////////////////////////////////////////////////////////////////////////////////
 
 LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
-                                   char *name) {
+                                   const char *name) {
   // sanity checks
   assert(fdecl->isVirtual());
   assert(!fdecl->isFinalFunc());

--- a/gen/classes.h
+++ b/gen/classes.h
@@ -40,6 +40,6 @@ DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *to);
 DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *to);
 
 llvm::Value *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
-                                       char *name);
+                                       const char *name);
 
 #endif

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1227,7 +1227,7 @@ int isDruntimeArrayOp(FuncDeclaration *fd) {
       "_arraySliceSliceMulass_s",         "_arraySliceSliceMulass_t",
       "_arraySliceSliceMulass_u",         "_arraySliceSliceMulass_w",
   };
-  char *name = fd->ident->toChars();
+  const char *name = fd->ident->toChars();
   int i =
       binary(name, libArrayopFuncs, sizeof(libArrayopFuncs) / sizeof(char *));
   if (i != -1) {


### PR DESCRIPTION
This fixes incorrect overriding of class methods and gets rid of many C++ warnings.