### PR TITLE
[don't pull] Fix debuginfo generation for the local variable frame for a function with nested functions.

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -160,6 +160,8 @@ public:
   DIGlobalVariable EmitGlobalVariable(llvm::GlobalVariable *ll,
                                       VarDeclaration *vd); // FIXME
 
+  void EmitNestedContextDebugInfo(llvm::Value *frame, FuncDeclaration *fd);
+
   void Finalize();
 
 private:

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -431,6 +431,10 @@ void DtoCreateNestedContext(FuncDeclaration *fd) {
       frame = DtoRawAlloca(frameType, alignment, ".frame");
     }
 
+    if (global.params.symdebug) {
+      gIR->DBuilder.EmitNestedContextDebugInfo(frame, fd);
+    }
+
     // copy parent frames into beginning
     if (depth != 0) {
       LLValue *src = irfunction->nestArg;
@@ -499,16 +503,6 @@ void DtoCreateNestedContext(FuncDeclaration *fd) {
         IF_LOG Logger::println("nested var:   %s", vd->toChars());
         assert(!irLocal->value);
         irLocal->value = gep;
-      }
-
-      if (global.params.symdebug) {
-#if LDC_LLVM_VER >= 306
-        LLSmallVector<int64_t, 2> addr;
-#else
-        LLSmallVector<LLValue *, 2> addr;
-#endif
-        gIR->DBuilder.OpOffset(addr, frameType, irLocal->nestedIndex);
-        gIR->DBuilder.EmitLocalVariable(frame, vd, nullptr, false, false, addr);
       }
     }
   }

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -1,28 +1,55 @@
 // Tests debug info generation for nested functions
+
 // REQUIRES: atleast_llvm308
+
 // RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// Also test compilation with optimization on, because it uncovers debuginfo errors (see e.g. PR 1598)
+// RUN: %ldc -g -c -O3 -of=%t %s
+
+module mod;
 
 // CHECK: define {{.*}} @{{.*}}encloser
 // CHECK-SAME: !dbg
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
     int enc_n;
+    // Check allocation of the frame with alignment that is checked later in the debuginfo
+    // CHECK: %.frame = alloca %{{.*}} align 4
+    // CHECK: call void @llvm.dbg.declare(metadata %{{.*}} %.frame, metadata ![[FRAME:[0-9]+]], metadata ![[EXPR:[0-9]+]]), !dbg ![[ENCL_LOC:[0-9]+]]
 
     // CHECK-LABEL: define {{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
 
-        // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as
-        // function parameters this triggers off an assert in LLVM >=3.8 (see Github PR #1598)
+        // TODO: Debuginfo generation in the nested function is incorrect at the moment. The first argument (nested frame) should have struct debuginfo attached to it. Perhaps the exact same as in the enclosing function.
     }
 }
 
-// CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}encloser.nested"
+void pr1598(string fmt)
+{
+    size_t fmtIdx;
+    void nested()
+    {
+        auto a = fmt[fmtIdx .. $];
+    }
+}
+
+
+// CHECK: ![[ENCL_SCOPE:[0-9]+]] ={{.*}} !DISubprogram(name: "mod.encloser"
+// CHECK: ![[INTTYPE:[0-9]+]] = !DIBasicType(name: "int"
+// CHECK: ![[FRAME]] = !DILocalVariable(name: ".frame", scope: ![[ENCL_SCOPE]],{{.*}} type: ![[FRAME2:[0-9]+]],{{.*}} flags: DIFlagArtificial
+// CHECK: ![[FRAME2]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} line: 14, size: 96, align: 32, flags: DIFlagArtificial, elements: ![[FRAME3:[0-9]+]]
+// CHECK: ![[FRAME3]] = !{![[FRAME_ARG0:[0-9]+]], ![[FRAME_ARG1:[0-9]+]], ![[FRAME_ENCN:[0-9]+]]}
+// CHECK: ![[FRAME_ARG0]] = !DIDerivedType(tag: DW_TAG_member, name: "arg0",{{.*}} line: 14, baseType: ![[INTTYPE]], size: 32, align: 32
+// CHECK: ![[FRAME_ARG1]] = !DIDerivedType(tag: DW_TAG_member, name: "arg1",{{.*}} line: 14, baseType: ![[INTTYPE]], size: 32, align: 32, offset: 32
+// CHECK: ![[FRAME_ENCN]] = !DIDerivedType(tag: DW_TAG_member, name: "enc_n",{{.*}} line: 16, baseType: ![[INTTYPE]], size: 32, align: 32, offset: 64
+
+// CHECK: ![[ENCL_LOC]] = !DILocation(line: 14, column: 6, scope: ![[ENCL_SCOPE]])
+// CHECK: ![[EXPR]] = !DIExpression()
+
+// CHECK: ![[NEST_SCOPE:[0-9]+]] ={{.*}} !DISubprogram(name: "{{.*}}encloser.nested"
 // CHECK: !DILocalVariable{{.*}}nes_i
 // CHECK-SAME: arg: 2
-// CHECK: !DILocalVariable{{.*}}arg1
-// CHECK-NOT: arg:
-// CHECK-SAME: ){{$}}
+

--- a/tests/debuginfo/nested_llvm306.d
+++ b/tests/debuginfo/nested_llvm306.d
@@ -1,22 +1,32 @@
 // Tests debug info generation for nested functions
 // REQUIRES: atmost_llvm306
 // RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -g -c -O3 -of=%t %s
+
+// See test "nested.d".
 
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloserFiiZv
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
+    }
+}
+
+void pr1598(string fmt)
+{
+    size_t fmtIdx;
+    void nested()
+    {
+        auto a = fmt[fmtIdx .. $];
     }
 }
 
 // CHECK: @_D{{.*}}8encloserFiiZv{{.*}}DW_TAG_subprogram
 // CHECK: @_D{{.*}}8encloserFiiZ6nestedMFiZv{{.*}}DW_TAG_subprogram
 // CHECK: nes_i{{.*}}DW_TAG_arg_variable
-// CHECK: arg1{{.*}}DW_TAG_auto_variable

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -1,17 +1,19 @@
 // Tests debug info generation for nested functions
 // REQUIRES: llvm307
 // RUN: %ldc -g -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -g -c -O3 -of=%t %s
+
+// See test "nested.d".
 
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
     }
 }
@@ -20,4 +22,3 @@ void encloser(int arg0, int arg1)
 // CHECK-SAME: function: void {{.*}} @_D{{.*}}8encloserFiiZv
 // CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}.encloser.nested"
 // CHECK: !DILocalVariable{{.*}}DW_TAG_arg_variable{{.*}}nes_i
-// CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}arg1


### PR DESCRIPTION
Instead of defining debug information for each variable separately, the frame that contains them should get debug info (it is a struct with named variables inside).

Resolves an ICE introduced by PR #1598. See #1598 for more context.

Debug information is still "broken" inside the _nested_ function. That will require more work:
- the frame argument type is `i8*` instead of the proper struct type e.g. `%nest.encloser = type { i32, i32, i32 }`.
- similarly to this PR, debug information should be emitted about the frame _struct_  (perhaps exactly the same info as in the enclosing function), instead of for each variable individually.