### PR TITLE
Fix debuginfo generation for the local variable frame for a function with nested functions

### DIFF
--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -507,8 +507,10 @@ void DtoCreateNestedContext(FuncDeclaration *fd) {
 #else
         LLSmallVector<LLValue *, 2> addr;
 #endif
-        gIR->DBuilder.OpOffset(addr, frameType, irLocal->nestedIndex);
-        gIR->DBuilder.EmitLocalVariable(frame, vd, nullptr, false, false, addr);
+        // Because we are passing a GEP instead of an alloca to
+        // llvm.dbg.declare, we have to make the address dereference explicit.
+        gIR->DBuilder.OpDeref(addr);
+        gIR->DBuilder.EmitLocalVariable(gep, vd, nullptr, false, false, addr);
       }
     }
   }

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -6,7 +6,7 @@
 // CHECK-SAME: !dbg
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    // CHECK: @llvm.dbg.declare{{.*}}%enc_n{{.*}}enc_n
     int enc_n;
 
     // CHECK-LABEL: define {{.*}}encloser{{.*}}nested

--- a/tests/debuginfo/nested_llvm306.d
+++ b/tests/debuginfo/nested_llvm306.d
@@ -5,7 +5,7 @@
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloserFiiZv
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    // CHECK: @llvm.dbg.declare{{.*}}%enc_n{{.*}}enc_n
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}encloser{{.*}}nested

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -5,7 +5,7 @@
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%.frame{{.*}}enc_n
+    // CHECK: @llvm.dbg.declare{{.*}}%enc_n{{.*}}enc_n
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested


### PR DESCRIPTION
__See #1598 for context.__

Declare debuginfo directly on the GEP instead of on the frame alloca+offset, . An explicit DW_OP_deref is necessary (tested in LLDB).

Resolves an ICE introduced by PR #1598. 