### PR TITLE
Fix ICE upon second codegen pass of the same SwitchStatement.

### DIFF
--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -1125,6 +1125,16 @@ public:
 
     llvm::BasicBlock *oldbb = irs->scopebb();
 
+    // Codegen state variables stored in the AST must be reset (see end of
+    // function)
+    for (CaseStatement *cs : *stmt->cases) {
+      assert(cs->bodyBB == nullptr);
+      assert(cs->llvmIdx == nullptr);
+    }
+    if (stmt->sdefault) {
+      assert(stmt->sdefault->bodyBB == nullptr);
+    }
+
     // If one of the case expressions is non-constant, we can't use
     // 'switch' instruction (that can happen because D2 allows to
     // initialize a global variable in a static constructor).
@@ -1357,6 +1367,17 @@ public:
     }
 
     irs->scope() = IRScope(endbb);
+
+    // Reset backend variables to original state (to allow multiple codegen
+    // passes of same ast nodes)
+    // TODO: move the codegen state variables out of the AST.
+    for (CaseStatement *cs : *stmt->cases) {
+      cs->bodyBB = nullptr;
+      cs->llvmIdx = nullptr;
+    }
+    if (stmt->sdefault) {
+      stmt->sdefault->bodyBB = nullptr;
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/tests/codegen/inputs/switch_ICE_gh1638_bar.d
+++ b/tests/codegen/inputs/switch_ICE_gh1638_bar.d
@@ -1,17 +1,26 @@
-// Don't make any changes to this file without consulting Github issue 1638 first.
+// Don't make any changes/additions to this file without consulting Github issue 1638 first.
 
 module switch_ICE_gh1638_bar;
 
-import switch_ICE_gh1638;
-import std.conv;
-
-static class F
+struct S(T)
 {
-    static Q[] X;
+    auto fun = (T a) {
+        T r;
+        switch (a)
+        {
+        case 1:
+            r = 1;
+            break;
+        default:
+            return 0;
+        }
+        return r * 2;
+    };
+}
 
-    public static void A(int x)
-    {
-        emplace(X[x].Y);
-        return;
-    }
+alias T = S!int;
+
+void f(int a)
+{
+    int r = T().fun(a);
 }

--- a/tests/codegen/inputs/switch_ICE_gh1638_bar.d
+++ b/tests/codegen/inputs/switch_ICE_gh1638_bar.d
@@ -1,0 +1,17 @@
+// Don't make any changes to this file without consulting Github issue 1638 first.
+
+module switch_ICE_gh1638_bar;
+
+import switch_ICE_gh1638;
+import std.conv;
+
+static class F
+{
+    static Q[] X;
+
+    public static void A(int x)
+    {
+        emplace(X[x].Y);
+        return;
+    }
+}

--- a/tests/codegen/switch_ICE_gh1638.d
+++ b/tests/codegen/switch_ICE_gh1638.d
@@ -1,0 +1,37 @@
+// Test for ICE bug Github issue 1638
+
+// Don't make any changes to this file without consulting GH #1638 first.
+
+// RUN: %ldc -I%S %s %S/inputs/switch_ICE_gh1638_bar.d -c
+// RUN: %ldc -I%S %S/inputs/switch_ICE_gh1638_bar.d %s -c
+
+module switch_ICE_gh1638;
+public struct Q
+{
+    C* Y;
+}
+
+enum E
+{
+    A,
+    C,
+    B
+}
+
+struct C
+{
+    int function(int s, int v) foo = (int s, int v) {
+
+        with (E) switch (s)
+        {
+            // Crash goes away case A is removed.
+        case A:
+            if (v == B || v == C)
+                return 1;
+            break;
+        default:
+            return 0;
+        }
+        return 0;
+    };
+}

--- a/tests/codegen/switch_ICE_gh1638.d
+++ b/tests/codegen/switch_ICE_gh1638.d
@@ -1,37 +1,13 @@
 // Test for ICE bug Github issue 1638
 
-// Don't make any changes to this file without consulting GH #1638 first.
+// Don't make any changes/additions to this file without consulting GH #1638 first.
 
-// RUN: %ldc -I%S %s %S/inputs/switch_ICE_gh1638_bar.d -c
 // RUN: %ldc -I%S %S/inputs/switch_ICE_gh1638_bar.d %s -c
+// RUN: %ldc -I%S %s %S/inputs/switch_ICE_gh1638_bar.d -c
 
-module switch_ICE_gh1638;
-public struct Q
+import switch_ICE_gh1638_bar;
+
+int main()
 {
-    C* Y;
-}
-
-enum E
-{
-    A,
-    C,
-    B
-}
-
-struct C
-{
-    int function(int s, int v) foo = (int s, int v) {
-
-        with (E) switch (s)
-        {
-            // Crash goes away case A is removed.
-        case A:
-            if (v == B || v == C)
-                return 1;
-            break;
-        default:
-            return 0;
-        }
-        return 0;
-    };
+    return T().fun(123);
 }


### PR DESCRIPTION
Note: this fixes the bug but leaves proper refactoring for later.
We should not store codegen state into the AST and the variables touched in this commit should be moved out of the AST. Added a TODO item for it.

(I have tested several times that the testcase fails without the fix.)