### PR TITLE
Refactor the call to `llvm::sys::fs::getMainExecutable`.

### DIFF
--- a/driver/exe_path.cpp
+++ b/driver/exe_path.cpp
@@ -19,9 +19,15 @@ namespace {
 string exePath;
 }
 
-void exe_path::initialize(const char *arg0, void *mainAddress) {
+void exe_path::initialize(const char *arg0) {
   assert(exePath.empty());
-  exePath = llvm::sys::fs::getMainExecutable(arg0, mainAddress);
+
+  // Some platforms can't implement LLVM's getMainExecutable
+  // without being given the address of a function in the main executable.
+  // Thus getMainExecutable needs the address of a function;
+  // any function address in the main executable will do.
+  exePath = llvm::sys::fs::getMainExecutable(
+      arg0, reinterpret_cast<void *>(&exe_path::initialize));
 }
 
 const string &exe_path::getExePath() {

--- a/driver/exe_path.h
+++ b/driver/exe_path.h
@@ -18,7 +18,8 @@
 #include <string>
 
 namespace exe_path {
-void initialize(const char *arg0, void *mainAddress);
+
+void initialize(const char *arg0);
 
 const std::string &getExePath();               // <baseDir>/bin/ldc2
 std::string getBinDir();                       // <baseDir>/bin

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -1046,7 +1046,7 @@ static size_t addStrlen(size_t acc, const char *str) {
 int main(int argc, char **argv);
 
 int cppmain(int argc, char **argv) {
-  exe_path::initialize(argv[0], reinterpret_cast<void *>(main));
+  exe_path::initialize(argv[0]);
 
   std::string ldcExeName = LDC_EXE_NAME;
 #ifdef _WIN32

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1052,7 +1052,7 @@ int cppmain(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal();
 #endif
 
-  exe_path::initialize(argv[0], reinterpret_cast<void *>(main));
+  exe_path::initialize(argv[0]);
 
   global._init();
   global.version = ldc::dmd_version;


### PR DESCRIPTION
Taking the address of `main` is UB in C++. Reading LLVM's source, any function address can be used (that's what clang does too).

See Clang's examples/clang-interpreter/main.cpp - Clang C Interpreter Example.