### PR TITLE
[PGO] Add Indirect Call instrumentation and promotion.

### DIFF
--- a/gen/pgo.h
+++ b/gen/pgo.h
@@ -82,8 +82,10 @@ public:
     return I;
   }
 
+  void emitIndirectCallPGO(llvm::Instruction *callSite, llvm::Value *funcPtr) {}
+
   void valueProfile(uint32_t valueKind, llvm::Instruction *valueSite,
-                    llvm::Value *valuePtr) {}
+                    llvm::Value *value, bool ptrCastNeeded) {}
 };
 
 #else
@@ -170,11 +172,21 @@ public:
     return I;
   }
 
+  /// Adds profiling instrumentation/annotation of indirect calls to `funcPtr`
+  /// for callsite `callSite`.
+  /// Does nothing for LLVM < 3.9.
+  void emitIndirectCallPGO(llvm::Instruction *callSite, llvm::Value *funcPtr);
+
+  /// Adds profiling instrumentation/annotation of a certain value.
   /// This method either inserts a call to the profile run-time during
   /// instrumentation or puts profile data into metadata for PGO use.
+  /// The profiled value is of kind `valueKind`, will be added right before IR
+  /// code site `valueSite`, and the to be profiled value is given by
+  /// `value`. `value` should be of LLVM i64 type, unless `ptrCastNeeded` is
+  /// true, in which case a ptrtoint cast to i64 is added.
   /// Does nothing for LLVM < 3.9.
   void valueProfile(uint32_t valueKind, llvm::Instruction *valueSite,
-                    llvm::Value *valuePtr);
+                    llvm::Value *value, bool ptrCastNeeded);
 
 private:
   std::string FuncName;

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -892,8 +892,7 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
   // sites.
   if (!call.getCalledFunction()) {
     auto &PGO = gIR->func()->pgo;
-    PGO.valueProfile(llvm::IPVK_IndirectCallTarget, call.getInstruction(),
-                     callable);
+    PGO.emitIndirectCallPGO(call.getInstruction(), callable);
   }
 #endif
 

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -887,6 +887,16 @@ DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
   // call the function
   LLCallSite call = gIR->func()->scopes->callOrInvoke(callable, args);
 
+#if LDC_LLVM_VER >= 309
+  // PGO: Insert instrumentation or attach profile metadata at indirect call
+  // sites.
+  if (!call.getCalledFunction()) {
+    auto &PGO = gIR->func()->pgo;
+    PGO.valueProfile(llvm::IPVK_IndirectCallTarget, call.getInstruction(),
+                     callable);
+  }
+#endif
+
   // get return value
   const int sretArgIndex =
       (irFty.arg_sret && irFty.arg_this && gABI->passThisBeforeSret(tf) ? 1

--- a/tests/PGO/indirect_calls.d
+++ b/tests/PGO/indirect_calls.d
@@ -1,0 +1,67 @@
+// Test instrumentation of indirect calls
+
+// REQUIRES: atleast_llvm309
+
+// RUN: %ldc -c -output-ll -fprofile-instr-generate -of=%t.ll %s && FileCheck %s --check-prefix=PROFGEN < %t.ll
+
+// RUN: %ldc -fprofile-instr-generate=%t.profraw -run %s  \
+// RUN:   &&  %profdata merge %t.profraw -o %t.profdata \
+// RUN:   &&  %ldc -O3 -c -output-ll -of=%t2.ll -fprofile-instr-use=%t.profdata %s \
+// RUN:   &&  FileCheck %s -check-prefix=PROFUSE < %t2.ll
+
+import ldc.attributes : weak;
+
+extern (C)
+{ // simplify name mangling for simpler string matching
+
+    @weak // disable reasoning about this function
+    void hot()
+    {
+    }
+
+    void luke()
+    {
+    }
+
+    void cold()
+    {
+    }
+
+    void function() foo;
+
+    @weak // disable reasoning about this function
+    void select_func(int i)
+    {
+        if (i < 1700)
+            foo = &hot;
+        else if (i < 1990)
+            foo = &luke;
+        else
+            foo = &cold;
+    }
+
+} // extern C
+
+// PROFGEN-LABEL: @_Dmain(
+// PROFUSE-LABEL: @_Dmain(
+int main()
+{
+    for (int i; i < 2000; ++i)
+    {
+        select_func(i);
+
+        // PROFGEN:  [[REG1:%[0-9]+]] = load void ()*, void ()** @foo
+        // PROFGEN-NEXT:  [[REG2:%[0-9]+]] = ptrtoint void ()* [[REG1]] to i64
+        // PROFGEN-NEXT:  call void @__llvm_profile_instrument_target(i64 [[REG2]], i8* bitcast ({{.*}}_Dmain to i8*), i32 0)
+        // PROFGEN-NEXT:  call void [[REG1]]()
+
+        // PROFUSE:  [[REG1:%[0-9]+]] = load void ()*, void ()** @foo
+        // PROFUSE:  [[REG2:%[0-9]+]] = icmp eq void ()* [[REG1]], @hot
+        // PROFUSE:  call void @hot()
+        // PROFUSE:  call void [[REG1]]()
+
+        foo();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Now that LLVM 3.9 is being prepared for release, I am adding my indirect call PGO work.

_Only applies to LLVM >= 3.9. No functional changes intended for LLVM < 3.9._

This PR adds instrumentation code and metadata tagging code for PGO of indirect calls (a call through a function pointer that is unknown at compile-time).
The new PGO functionality is enabled by default but can be disabled with `-disable-pgo-indirect-calls`.
AFAIK this puts us on par with all front-end PGO capabilities of LLVM/Clang 3.9.

Because it is a relatively simple addition to the code (and for the unreleased LLVM 3.9 only), I hope this can still make it into the 1.1.0 release.

Blog article: https://johanengelen.github.io/ldc/2016/04/13/PGO-in-LDC-virtual-calls.html