### PR TITLE
Fix LLVM 4.0 build.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -686,7 +686,9 @@ static void initializePasses() {
 #if LDC_LLVM_VER < 308
   initializeIPA(Registry);
 #endif
-#if LDC_LLVM_VER >= 306
+#if LDC_LLVM_VER >= 400
+  initializeRewriteSymbolsLegacyPassPass(Registry);
+#elif LDC_LLVM_VER >= 306
   initializeRewriteSymbolsPass(Registry);
 #endif
 #if LDC_LLVM_VER >= 307


### PR DESCRIPTION
(note: AppVeyor is temporary on LLVM 4.0)