### PR TITLE
dmd-testsuite: Enable GDB tests to see which ones still fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ script:
       make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest;
     fi
   # Run dmd-testsuite.
+  - gdb --version
   -
     if [ "${TEST_CONFIG}" = "Debug" ]; then
       CC="" MAKEOPTS=-j4 ctest --verbose -R "dmd-testsuite-debug";


### PR DESCRIPTION
See https://github.com/ldc-developers/ldc/issues/1190.