### PR TITLE
Fixes for building Phobos as shared library on FreeBSD

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -206,7 +206,7 @@ endif()
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of
 # fat binaries. Other Posixen might need to be added here.
-if(MULTILIB AND ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux")))
+if(MULTILIB AND ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")))
     set(MULTILIB_ADDITIONAL_PATH         "\n        \"-L-L${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
     set(MULTILIB_ADDITIONAL_INSTALL_PATH "\n        \"-L-L${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
 endif()
@@ -418,15 +418,18 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
     # When building a shared library, we need to link in all the default
     # libraries otherwise implicitly added by LDC to make it loadable from
     # C executables.
+
+    if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+        set(SharedLinkLibraries "m" "pthread")
+    else()
+        set(SharedLinkLibraries "m" "pthread" "rt" "dl")
+    endif()
+
     if(BUILD_SHARED_LIBS)
         # TOOD: Once BUILD_SHARED_LIBS is supported on operating systems other
         # than Linux, the library selection will need to be adapted based on
         # the target.
-	if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
-            target_link_libraries(druntime-ldc${target_suffix} "m" "pthread")
-	else()
-            target_link_libraries(druntime-ldc${target_suffix} "m" "pthread" "rt" "dl")
-	endif()
+        target_link_libraries(druntime-ldc${target_suffix} ${SharedLinkLibraries})
     endif()
 
     list(APPEND ${outlist_targets} druntime-ldc${target_suffix})
@@ -453,14 +456,9 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
         if(BUILD_SHARED_LIBS)
             # TODO: As for druntime, adapt once shared libraries are supported
             # on more operating systems.
-	    if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
-	        target_link_libraries(phobos2-ldc${target_suffix}
-                   druntime-ldc${target_suffix} "m" "pthread")
-	    else()
-               target_link_libraries(phobos2-ldc${target_suffix}
-                   druntime-ldc${target_suffix} "m" "pthread" "dl")
-            endif()
-	endif()
+            target_link_libraries(phobos2-ldc${target_suffix}
+                druntime-ldc${target_suffix} ${SharedLinkLibraries})
+        endif()
 
         list(APPEND ${outlist_targets} "phobos2-ldc${target_suffix}")
     endif()
@@ -790,22 +788,22 @@ endif()
 if(BUILD_SHARED_LIBS)
     get_property(druntime_path TARGET druntime-ldc PROPERTY LOCATION)
     set(outdir ${PROJECT_BINARY_DIR}/druntime-test-shared)
+    set(CFLAGS "-Wall -Wl,-rpath,${CMAKE_BINARY_DIR}/lib")
 
     add_test(NAME clean-druntime-test-shared
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
 
-    if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
-       add_test(NAME druntime-test-shared
-          COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
-             ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${druntime_path}
-             CFLAGS=-Wall\ -Wl,-rpath,${CMAKE_BINARY_DIR}/lib 
-       )
+    if(FreeBSD)
+        set(LINKFLAGS "")
     else()
-       add_test(NAME druntime-test-shared
-          COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
-             ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${drunt
-             CFLAGS=-Wall\ -Wl,-rpath,${CMAKE_BINARY_DIR}/lib LINKDL=-L-ldl
-       )
+        set(LINKFLAGS "LINKDL=-L-ldl")
     endif()
+
+    add_test(NAME druntime-test-shared
+      COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
+         ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${druntime_path}
+         CFLAGS=${CFLAGS} ${LINKFLAGS}
+    )
+
     set_tests_properties(druntime-test-shared PROPERTIES DEPENDS clean-druntime-test-shared)
 endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -37,8 +37,8 @@ else()
 endif()
 
 if(BUILD_SHARED_LIBS)
-    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        message(FATAL_ERROR "Shared libraries (BUILD_SHARED_LIBS) are only supported on Linux for the time being.")
+    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+        message(FATAL_ERROR "Shared libraries (BUILD_SHARED_LIBS) are only supported on Linux and FreeBSD for the time being.")
     endif()
 
     list(APPEND D_FLAGS -relocation-model=pic)
@@ -151,6 +151,8 @@ if(PHOBOS2_DIR)
     file(GLOB PHOBOS2_ETC ${PHOBOS2_DIR}/etc/c/*.d)
     if(APPLE)
         file(GLOB PHOBOS2_D_C_SYS ${PHOBOS2_DIR}/std/c/osx/*.d)
+    elseif(FreeBSD)
+        file(GLOB PHOBOS2_D_C_SYS ${PHOBOS2_DIR}/std/c/freebsd/*.d)
     elseif(UNIX)
         # Install Linux headers on all non-Apple *nixes - not correct, but
         # shouldn't cause any harm either.
@@ -204,12 +206,12 @@ endif()
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of
 # fat binaries. Other Posixen might need to be added here.
-if(MULTILIB AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+if(MULTILIB AND ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux")))
     set(MULTILIB_ADDITIONAL_PATH         "\n        \"-L-L${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
     set(MULTILIB_ADDITIONAL_INSTALL_PATH "\n        \"-L-L${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
 endif()
 
-if(BUILD_SHARED_LIBS AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+if(BUILD_SHARED_LIBS AND ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")))
     set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib\",")
 endif()
 
@@ -420,7 +422,11 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
         # TOOD: Once BUILD_SHARED_LIBS is supported on operating systems other
         # than Linux, the library selection will need to be adapted based on
         # the target.
-        target_link_libraries(druntime-ldc${target_suffix} "m" "pthread" "rt" "dl")
+	if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+            target_link_libraries(druntime-ldc${target_suffix} "m" "pthread")
+	else()
+            target_link_libraries(druntime-ldc${target_suffix} "m" "pthread" "rt" "dl")
+	endif()
     endif()
 
     list(APPEND ${outlist_targets} druntime-ldc${target_suffix})
@@ -447,9 +453,14 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
         if(BUILD_SHARED_LIBS)
             # TODO: As for druntime, adapt once shared libraries are supported
             # on more operating systems.
-            target_link_libraries(phobos2-ldc${target_suffix}
-                druntime-ldc${target_suffix} "m" "pthread" "dl")
-        endif()
+	    if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+	        target_link_libraries(phobos2-ldc${target_suffix}
+                   druntime-ldc${target_suffix} "m" "pthread")
+	    else()
+               target_link_libraries(phobos2-ldc${target_suffix}
+                   druntime-ldc${target_suffix} "m" "pthread" "dl")
+            endif()
+	endif()
 
         list(APPEND ${outlist_targets} "phobos2-ldc${target_suffix}")
     endif()
@@ -782,10 +793,19 @@ if(BUILD_SHARED_LIBS)
 
     add_test(NAME clean-druntime-test-shared
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
-    add_test(NAME druntime-test-shared
-        COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
-            ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${druntime_path}
-            CFLAGS=-Wall\ -Wl,-rpath,${CMAKE_BINARY_DIR}/lib LINKDL=-L-ldl
-    )
+
+    if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+       add_test(NAME druntime-test-shared
+          COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
+             ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${druntime_path}
+             CFLAGS=-Wall\ -Wl,-rpath,${CMAKE_BINARY_DIR}/lib 
+       )
+    else()
+       add_test(NAME druntime-test-shared
+          COMMAND make -C ${PROJECT_SOURCE_DIR}/druntime/test/shared
+             ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default DRUNTIMESO=${drunt
+             CFLAGS=-Wall\ -Wl,-rpath,${CMAKE_BINARY_DIR}/lib LINKDL=-L-ldl
+       )
+    endif()
     set_tests_properties(druntime-test-shared PROPERTIES DEPENDS clean-druntime-test-shared)
 endif()


### PR DESCRIPTION
The hello program has been tested. See here:

zxp@freebsd:~/demos/ldc % ldd hello
hello:
        libphobos2-ldc.so.71 => /usr/local/lib/libphobos2-ldc.so.71 (0x28400000)
        libdruntime-ldc.so.71 => /usr/local/lib/libdruntime-ldc.so.71 (0x28091000)
        libthr.so.3 => /lib/libthr.so.3 (0x28175000)
        libm.so.5 => /lib/libm.so.5 (0x28199000)
        libc.so.7 => /lib/libc.so.7 (0x281c1000)
        libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x28337000)