### PR TITLE
Default to PIC code on Linux

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -528,7 +528,10 @@ llvm::TargetMachine *createTargetMachine(
       // Darwin defaults to PIC (and as of 10.7.5/LLVM 3.1-3.3, TLS use leads
       // to crashes for non-PIC code). LLVM doesn't handle this.
       relocModel = llvm::Reloc::PIC_;
-    } else if (triple.getEnvironment() == llvm::Triple::Android) {
+    } else if (triple.isOSLinux()) {
+      // Modern Linux distributions have their toolchain generate PIC code for additional security
+      // features (like ASLR). We default to PIC code to avoid linking issues on these OSes.
+      // On Android, PIC is default as well.
       relocModel = llvm::Reloc::PIC_;
     } else {
       // ARM for other than Darwin or Android defaults to static


### PR DESCRIPTION
Modern Linux distributions have their toolchain generate PIC code for
additional security features (like ASLR).
Since there is no (sane) way to detect whether the toolchain defaults to
PIC code, we simply default to PIC code on all Linux
distributions to avoid linking issues on these OSes.

The relocation model can be switched back to non-PIC code manually at
any time.

This change resolves issue #1618