### PR TITLE
[PGO] For LLVM >= 3.9, let profile-rt set the default filename. 

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -483,7 +483,12 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
   if (genfileInstrProf.getNumOccurrences() > 0) {
     global.params.genInstrProf = true;
     if (genfileInstrProf.empty()) {
+#if LDC_LLVM_VER >= 309
+      // profile-rt provides a default filename by itself
+      global.params.datafileInstrProf = nullptr;
+#else
       global.params.datafileInstrProf = "default.profraw";
+#endif
     } else {
       initFromString(global.params.datafileInstrProf, genfileInstrProf);
     }

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -228,7 +228,8 @@ static void addInstrProfilingPass(legacy::PassManagerBase &mpm) {
   if (global.params.genInstrProf) {
     InstrProfOptions options;
     options.NoRedZone = global.params.disableRedZone;
-    options.InstrProfileOutput = global.params.datafileInstrProf;
+    if (global.params.datafileInstrProf)
+      options.InstrProfileOutput = global.params.datafileInstrProf;
 #if LDC_LLVM_VER >= 309
     mpm.add(createInstrProfilingLegacyPass(options));
 #else


### PR DESCRIPTION
For LLVM >= 3.9, let profile-rt set the default filename. 
This prevents extra stderr messages when overriding the filename using the "LLVM_PROFILE_FILE" environment variable.