### PR TITLE
Disable cross-module inlining of functions that call __invariant*.

### DIFF
--- a/gen/function-inlining.cpp
+++ b/gen/function-inlining.cpp
@@ -123,6 +123,17 @@ bool defineAsExternallyAvailable(FuncDeclaration &fdecl) {
     return false;
   }
 
+  // Because the frontend names `__invariant*` functions differently depending
+  // on the compilation order, we cannot emit the `__invariant` wrapper that
+  // calls the `__invariant*` functions.
+  // This is a workaround, the frontend needs to be changed such that the
+  // __invariant* names no longer depend on semantic analysis order.
+  // See https://github.com/ldc-developers/ldc/issues/1678
+  if (fdecl.isInvariantDeclaration()) {
+    IF_LOG Logger::println("__invariant cannot be emitted.");
+    return false;
+  }
+
   // TODO: Fix inlining functions from object.d. Currently errors because of
   // TypeInfo type-mismatch issue (TypeInfo classes get special treatment by the
   // compiler). To start working on it: comment-out this check and druntime will

--- a/tests/codegen/inlining_invariants_gh1678.d
+++ b/tests/codegen/inlining_invariants_gh1678.d
@@ -1,0 +1,21 @@
+// RUN: %ldc --enable-inlining -of=%t%exe %s
+
+// https://github.com/ldc-developers/ldc/issues/1678
+
+import std.datetime;
+
+// Extra test that fail when a simple frontend change is tried that names __invariant using the line and column number.
+class A {
+    mixin(genInv("666")); mixin(genInv("777"));
+}
+
+string genInv(string a) {
+    return "invariant() { }";
+}
+
+void main()
+{
+    auto currentTime = Clock.currTime();
+    auto timeString = currentTime.toISOExtString();
+    auto restoredTime = SysTime.fromISOExtString(timeString);
+}


### PR DESCRIPTION
Resolves #1678.

If this fixes things, I'll try to make the testcase independent of phobos. That should also make it compile much faster.