### PR TITLE
CI: Parallelize dmd-testsuite execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,22 +92,22 @@ script:
   # Run dmd-testsuite.
   -
     if [ "${TEST_CONFIG}" = "Debug" ]; then
-      CC="" MAKEOPTS=-j4 ctest --verbose -R "dmd-testsuite-debug";
+      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite-debug";
     elif [ "${TEST_CONFIG}" = "Release" ]; then
-      CC="" MAKEOPTS=-j4 ctest --verbose -R "dmd-testsuite" -E "-debug";
+      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite" -E "-debug";
     else
-      CC="" MAKEOPTS=-j4 ctest --verbose -R "dmd-testsuite";
+      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite";
     fi
   # Run LLVM IR testsuite.
   - ctest --output-on-failure -V -R "lit-tests"
   # Link and run Phobos & druntime unittest runners.
   -
     if [ "${TEST_CONFIG}" = "Debug" ]; then
-      ctest -j4 --output-on-failure -R "-debug" -E "dmd-testsuite|lit-tests";
+      ctest -j3 --output-on-failure -R "-debug" -E "dmd-testsuite|lit-tests";
     elif [ "${TEST_CONFIG}" = "Release" ]; then
-      ctest -j4 --output-on-failure -E "-debug|dmd-testsuite|lit-tests";
+      ctest -j3 --output-on-failure -E "-debug|dmd-testsuite|lit-tests";
     else
-      ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests";
+      ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests";
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
       env: LLVM_VERSION=3.5.2 OPTS="-DTEST_COVERAGE=ON"
     - os: osx
       d: ldc
-      env: LLVM_CONFIG="llvm-config-3.8" TEST_CONFIG="Debug"
-    - os: osx
-      d: dmd
-      env: LLVM_CONFIG="llvm-config-3.8" TEST_CONFIG="Release"
+      env: LLVM_CONFIG="llvm-config-3.8"
   allow_failures:
     #- env: LLVM_VERSION=3.9
 
@@ -76,13 +73,7 @@ script:
   - bin/ldc2 -version || exit 1
   # Build Phobos & druntime unittest modules.
   -
-    if [ "${TEST_CONFIG}" = "Debug" ]; then
-      make -j2 phobos2-ldc-unittest-debug;
-      make -j3 druntime-ldc-unittest-debug;
-    elif [ "${TEST_CONFIG}" = "Release" ]; then
-      make -j2 phobos2-ldc-unittest;
-      make -j3 druntime-ldc-unittest;
-    elif [ "${OPTS}" = "-DMULTILIB=ON" ]; then
+    if [ "${OPTS}" = "-DMULTILIB=ON" ]; then
       make -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest phobos2-ldc-unittest-debug-32 phobos2-ldc-unittest-32;
       make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest druntime-ldc-unittest-debug-32 druntime-ldc-unittest-32;
     else
@@ -90,25 +81,11 @@ script:
       make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest;
     fi
   # Run dmd-testsuite.
-  -
-    if [ "${TEST_CONFIG}" = "Debug" ]; then
-      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite-debug";
-    elif [ "${TEST_CONFIG}" = "Release" ]; then
-      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite" -E "-debug";
-    else
-      CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite";
-    fi
+  - CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite"
   # Run LLVM IR testsuite.
   - ctest --output-on-failure -V -R "lit-tests"
   # Link and run Phobos & druntime unittest runners.
-  -
-    if [ "${TEST_CONFIG}" = "Debug" ]; then
-      ctest -j3 --output-on-failure -R "-debug" -E "dmd-testsuite|lit-tests";
-    elif [ "${TEST_CONFIG}" = "Release" ]; then
-      ctest -j3 --output-on-failure -E "-debug|dmd-testsuite|lit-tests";
-    else
-      ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests";
-    fi
+  - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
 
 after_success:
   -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -194,13 +194,14 @@ test_script:
   - hello.exe
   # Compile the druntime & phobos unit tests
   - ninja -j2 druntime-ldc-unittest-debug phobos2-ldc-unittest-debug druntime-ldc-unittest phobos2-ldc-unittest
-  # Execute the unit tests
-  - ctest --output-on-failure -E "dmd-testsuite|lit-tests"
-  # Execute the LLVM IR tests
-  - ctest --output-on-failure -V -R lit-tests
   # Execute dmd-testsuite
   - if "%APPVEYOR_JOB_ARCH%"=="x64" ( set OS=Win_64) else ( set OS=Win_32)
+  - set DMD_TESTSUITE_MAKE_ARGS=-j2
   - ctest --verbose -R dmd-testsuite
+  # Execute the LLVM IR tests
+  - ctest --output-on-failure -V -R lit-tests
+  # Execute the unit tests
+  - ctest -j2 --output-on-failure -E "dmd-testsuite|lit-tests"
 
 #---------------------------------#
 #     deployment configuration    #

--- a/circle.yml
+++ b/circle.yml
@@ -45,14 +45,14 @@ test:
   pre:
     - CC=clang CXX=clang++ cmake .
     #- CC=clang CXX=clang++ cmake -DLLVM_ROOT_DIR="~/$CIRCLE_PROJECT_REPONAME/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04" -DD_COMPILER="~/$CIRCLE_PROJECT_REPONAME/ldc2-1.0.0-linux-x86_64/bin/ldmd2" .
-    - make -j4
+    - make -j3
     - bin/ldc2 -version || exit 1
   override:
-    - MAKEOPTS=-j2 ctest -j 2 --verbose -R "build-"
-    - CC="" MAKEOPTS=-j4 ctest --verbose -R "dmd-testsuite"
+    - make -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest
+    - make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest
+    - CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest --verbose -R "dmd-testsuite"
     - ctest --output-on-failure -V -R "lit-tests"
-    - MAKEOPTS=-j3 ctest --verbose -R "-test-runner"
-    - ctest -j4 --output-on-failure -E "testsuite"
+    - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
 
 # To add more value the test results could be collected, see https://circleci.com/docs/test-metadata
 # A way how to convert the ctest output is described here:


### PR DESCRIPTION
Result on my quad-core for dmd-testsuite-debug, using `DMD_TESTSUITE_MAKE_ARGS=-j4`: 490 secs => 175 secs

I've also used the opportunity to streamline the Travis/CircleCI/AppVeyor scripts.
The tests order has changed for AppVeyor (dmd-testsuite => Lit tests => unit tests) and the unit tests execution has been parallelized.
For CircleCI, the unittest compilation should now be properly parallelized, which should give another nice speed-up.