### PR TITLE
Revert "Check existing runtime function declarations for matching type"

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -127,24 +127,22 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
                                    const char *name) {
   checkForImplicitGCCall(loc, name);
 
-  if (!M)
+  if (!M) {
     initRuntime();
+  }
 
-  LLFunction *fn = M->getFunction(name);
+  LLFunction *fn = target.getFunction(name);
+  if (fn) {
+    return fn;
+  }
+
+  fn = M->getFunction(name);
   if (!fn) {
     error(loc, "Runtime function '%s' was not found", name);
     fatal();
   }
+
   LLFunctionType *fnty = fn->getFunctionType();
-
-  if (LLFunction *existing = target.getFunction(name)) {
-    if (existing->getFunctionType() != fnty) {
-      error(Loc(), "Incompatible declaration of runtime function '%s'", name);
-      fatal();
-    }
-    return existing;
-  }
-
   LLFunction *resfn =
       llvm::cast<llvm::Function>(target.getOrInsertFunction(name, fnty));
   resfn->setAttributes(fn->getAttributes());


### PR DESCRIPTION
Reverts ldc-developers/ldc#1570.

This broke the build due to mismatch with the _d_dso_registry definition in druntime. We should probably just change the latter to take a void* instead of CompilerDSOData*.