### PR TITLE
Fix unused private field warning (`SwitchCaseTargets::llFunc`) and remove use of global gIR.

### DIFF
--- a/gen/funcgenstate.cpp
+++ b/gen/funcgenstate.cpp
@@ -20,8 +20,7 @@ JumpTarget::JumpTarget(llvm::BasicBlock *targetBlock,
     : targetBlock(targetBlock), cleanupScope(cleanupScope),
       targetStatement(targetStatement) {}
 
-JumpTargets::JumpTargets(IRState &irs, TryCatchFinallyScopes &scopes)
-    : irs(irs), scopes(scopes) {}
+JumpTargets::JumpTargets(TryCatchFinallyScopes &scopes) : scopes(scopes) {}
 
 void JumpTargets::pushLoopTarget(Statement *loopStatement,
                                  llvm::BasicBlock *continueTarget,
@@ -100,5 +99,5 @@ llvm::BasicBlock *SwitchCaseTargets::getOrCreate(Statement *stmt,
 }
 
 FuncGenState::FuncGenState(IrFunction &irFunc, IRState &irs)
-    : irFunc(irFunc), scopes(irs), jumpTargets(irs, scopes),
-      switchTargets(), irs(irs) {}
+    : irFunc(irFunc), scopes(irs), jumpTargets(scopes), switchTargets(),
+      irs(irs) {}

--- a/gen/funcgenstate.cpp
+++ b/gen/funcgenstate.cpp
@@ -91,13 +91,14 @@ llvm::BasicBlock *SwitchCaseTargets::get(Statement *stmt) {
 }
 
 llvm::BasicBlock *SwitchCaseTargets::getOrCreate(Statement *stmt,
-                                                 const llvm::Twine &name) {
+                                                 const llvm::Twine &name,
+                                                 IRState &irs) {
   auto &bb = targetBBs[stmt];
   if (!bb)
-    bb = gIR->insertBB(name);
+    bb = irs.insertBB(name);
   return bb;
 }
 
 FuncGenState::FuncGenState(IrFunction &irFunc, IRState &irs)
     : irFunc(irFunc), scopes(irs), jumpTargets(irs, scopes),
-      switchTargets(irFunc.func), irs(irs) {}
+      switchTargets(), irs(irs) {}

--- a/gen/funcgenstate.h
+++ b/gen/funcgenstate.h
@@ -62,7 +62,7 @@ struct JumpTarget {
 /// Keeps track of labels and implicit loop targets for goto/break/continue.
 class JumpTargets {
 public:
-  JumpTargets(IRState &irs, TryCatchFinallyScopes &scopes);
+  explicit JumpTargets(TryCatchFinallyScopes &scopes);
 
   /// Registers a loop statement to be used as a target for break/continue
   /// statements in the current scope.
@@ -126,7 +126,6 @@ private:
   /// Unified implementation for unlabeled break/continue.
   void jumpToClosest(std::vector<JumpTarget> &targets);
 
-  IRState &irs;
   TryCatchFinallyScopes &scopes;
 
   using LabelTargetMap = llvm::DenseMap<Identifier *, JumpTarget>;

--- a/gen/funcgenstate.h
+++ b/gen/funcgenstate.h
@@ -149,18 +149,16 @@ private:
 /// e.g. when goto-ing forward), we lazily create them as needed.
 class SwitchCaseTargets {
 public:
-  explicit SwitchCaseTargets(llvm::Function *llFunc) : llFunc(llFunc) {}
-
   /// Returns the basic block associated with the given case/default statement,
   /// asserting that it has already been created.
   llvm::BasicBlock *get(Statement *stmt);
 
   /// Returns the basic block associated with the given case/default statement
   /// or creates one with the given name if it does not already exist
-  llvm::BasicBlock *getOrCreate(Statement *stmt, const llvm::Twine &name);
+  llvm::BasicBlock *getOrCreate(Statement *stmt, const llvm::Twine &name,
+                                IRState &irs);
 
 private:
-  llvm::Function *const llFunc;
   llvm::DenseMap<Statement *, llvm::BasicBlock *> targetBBs;
 };
 

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -927,7 +927,7 @@ public:
     if (stmt->sdefault) {
       Logger::println("has default");
       defaultTargetBB =
-          funcGen.switchTargets.getOrCreate(stmt->sdefault, "default");
+          funcGen.switchTargets.getOrCreate(stmt->sdefault, "default", *irs);
     }
 
     // do switch body
@@ -1082,7 +1082,7 @@ public:
     auto &PGO = funcGen.pgo;
     PGO.setCurrentStmt(stmt);
 
-    const auto body = funcGen.switchTargets.getOrCreate(stmt, "case");
+    const auto body = funcGen.switchTargets.getOrCreate(stmt, "case", *irs);
     // The BB may have already been created by a `goto case` statement.
     // Move it after the current scope BB for lexical order.
     body->moveAfter(irs->scopebb());
@@ -1113,7 +1113,7 @@ public:
     auto &PGO = irs->funcGen().pgo;
     PGO.setCurrentStmt(stmt);
 
-    const auto body = funcGen.switchTargets.getOrCreate(stmt, "default");
+    const auto body = funcGen.switchTargets.getOrCreate(stmt, "default", *irs);
     // The BB may have already been created.
     // Move it after the current scope BB for lexical order.
     body->moveAfter(irs->scopebb());
@@ -1556,7 +1556,7 @@ public:
     assert(!irs->scopereturned());
 
     const auto caseBB =
-        funcGen.switchTargets.getOrCreate(stmt->cs, "goto_case");
+        funcGen.switchTargets.getOrCreate(stmt->cs, "goto_case", *irs);
     llvm::BranchInst::Create(caseBB, irs->scopebb());
 
     // TODO: Should not be needed.


### PR DESCRIPTION
We got two new warnings:
```
In file included from ../gen/funcgenstate.cpp:10:
.././gen/funcgenstate.h:129:12: warning: private field 'irs' is not used [-Wunused-private-field]
  IRState &irs;
           ^
.././gen/funcgenstate.h:163:25: warning: private field 'llFunc' is not used [-Wunused-private-field]
  llvm::Function *const llFunc;
                        ^
```

The first warning appears to be a clang bug :(, the second one is fixed by this PR.
Also removed use of `gIR` (originally `llFunc` was used instead of `gIR` for creating BBs).
