### PR TITLE
Fix too restrictive assertion for binassigns

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -605,8 +605,10 @@ public:
     DValue *assignedResult = DtoCast(e->loc, opResult, lhsLVal->type);
     DtoAssign(e->loc, lhsLVal, assignedResult, TOKassign);
 
-    assert(e->type->toBasetype()->equals(lhsLVal->type->toBasetype()));
-    return lhsLVal;
+    if (e->type->equals(lhsLVal->type))
+        return lhsLVal;
+
+    return new DLValue(e->type, DtoLVal(lhsLVal));
   }
 
 #define BIN_ASSIGN(Op, Func, useLValTypeForBinOp)                              \


### PR DESCRIPTION
This was hit when compiling `ddmd/lexer.d:1189`, where a `const(T)*` is implicitly cast to a `const(T*)`.
The `DLValue` ctor makes sure the LL pointer and the D type are compatible.