### PR TITLE
Windows: Detect Visual C++ Build Tools automatically

### DIFF
--- a/vcbuild/msvcEnv.bat
+++ b/vcbuild/msvcEnv.bat
@@ -3,24 +3,31 @@
 :: Environment already set up?
 if not "%VSINSTALLDIR%"=="" goto :eof
 
-:: Clear an existing LDC_VSDIR environment variable if the directory doesn't exist
-if not "%LDC_VSDIR%"=="" if not exist "%LDC_VSDIR%" set LDC_VSDIR=
+if "%LDC_VSDIR%"=="" goto detect
 
-:: Try to detect the latest VS installation directory if LDC_VSDIR is not set
-if not "%LDC_VSDIR%"=="" goto setup
-for /F "tokens=1,2*" %%i in ('reg query HKCU\Software\Microsoft\VisualStudio\12.0_Config /v ShellFolder 2^> nul') do set LDC_VSDIR=%%k
-for /F "tokens=1,2*" %%i in ('reg query HKCU\Software\Microsoft\VisualStudio\14.0_Config /v ShellFolder 2^> nul') do set LDC_VSDIR=%%k
+:: Check if the existing LDC_VSDIR environment variable points to a VS/VC installation folder
+if not "%LDC_VSDIR:~-1%"=="\" set LDC_VSDIR=%LDC_VSDIR%\
+if not "%LDC_VSDIR:~-4%"=="\VC\" set LDC_VSDIR=%LDC_VSDIR%VC\
+if exist "%LDC_VSDIR%vcvarsall.bat" goto setup
+
+:: Try to detect the latest VC installation directory
+:detect
+set LDC_VSDIR=
+for /F "tokens=1,2*" %%i in ('reg query HKLM\SOFTWARE\Microsoft\VisualStudio\12.0\Setup\VC /v ProductDir 2^> nul') do set LDC_VSDIR=%%k
+for /F "tokens=1,2*" %%i in ('reg query HKLM\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\12.0\Setup\VC /v ProductDir 2^> nul') do set LDC_VSDIR=%%k
+for /F "tokens=1,2*" %%i in ('reg query HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC /v ProductDir 2^> nul') do set LDC_VSDIR=%%k
+for /F "tokens=1,2*" %%i in ('reg query HKLM\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\Setup\VC /v ProductDir 2^> nul') do set LDC_VSDIR=%%k
 if "%LDC_VSDIR%"=="" (
-    echo WARNING: no Visual Studio installation detected
+    echo WARNING: no Visual C++ installation detected
     goto :eof
 )
 
 :: Let MSVC set up environment variables
 :setup
-echo Using Visual Studio: %LDC_VSDIR%
-if not exist "%LDC_VSDIR%VC\vcvarsall.bat" (
-    echo WARNING: could not find VC\vcvarsall.bat
+echo Using Visual C++: %LDC_VSDIR:~0,-1%
+if not exist "%LDC_VSDIR%vcvarsall.bat" (
+    echo WARNING: could not find vcvarsall.bat
     goto :eof
 )
 :: Forward the first arg to the MS batch file
-call "%LDC_VSDIR%VC\vcvarsall.bat" %1
+call "%LDC_VSDIR%vcvarsall.bat" %1


### PR DESCRIPTION
Based on http://forum.dlang.org/post/xnjxxqypqycxlhzgzsrt@forum.dlang.org (thanks André!). Visual Studio provides the same keys in HKLM, so detecting them this way should work for both Visual Studio and the stand-alone Build Tools.
The lookup outside `WOW6432Node` is for 32-bit Windows.
A user-provided `LDC_VSDIR` environment variable doesn't have to end with a backslash anymore, and may point to a VS folder (backward-compatible) or a VC folder directly.