### PR TITLE
Shared library support for OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - os: osx
       d: ldc
       env: LLVM_CONFIG="llvm-config-3.8"
+    - os: osx
+      d: ldc
+      env: LLVM_CONFIG="llvm-config-3.8" OPTS="-DBUILD_SHARED_LIBS=ON"
   allow_failures:
     #- env: LLVM_VERSION=3.9
 

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -677,29 +677,14 @@ static void buildRuntimeModule() {
   //////////////////////////////////////////////////////////////////////////////
 
   // void invariant._d_invariant(Object o)
-  createFwdDecl(
-      LINKd, voidTy,
-      {gABI->mangleFunctionForLLVM("_D9invariant12_d_invariantFC6ObjectZv", LINKd)},
-      {objectTy});
+  createFwdDecl(LINKd, voidTy,
+                {gABI->mangleFunctionForLLVM(
+                    "_D9invariant12_d_invariantFC6ObjectZv", LINKd)},
+                {objectTy});
 
-  // void _d_dso_registry(CompilerDSOData* data)
-  llvm::StringRef fname("_d_dso_registry");
-
-  LLType *LLvoidTy = LLType::getVoidTy(gIR->context());
-  LLType *LLvoidPtrPtrTy = getPtrToType(getPtrToType(LLvoidTy));
-  LLType *moduleInfoPtrPtrTy =
-      getPtrToType(getPtrToType(DtoType(Module::moduleinfo->type)));
-
-  llvm::StructType *dsoDataTy =
-      llvm::StructType::get(DtoSize_t(),        // version
-                            LLvoidPtrPtrTy,     // slot
-                            moduleInfoPtrPtrTy, // _minfo_beg
-                            moduleInfoPtrPtrTy, // _minfo_end
-                            NULL);
-
-  llvm::Type *types[] = {getPtrToType(dsoDataTy)};
-  llvm::FunctionType *fty = llvm::FunctionType::get(LLvoidTy, types, false);
-  llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
+  // void _d_dso_registry(void* data)
+  // (the argument is really a pointer to rt.sections_elf_shared.CompilerDSOData)
+  createFwdDecl(LINKc, voidTy, {"_d_dso_registry"}, {voidPtrTy});
 
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
@@ -717,9 +702,9 @@ static void buildRuntimeModule() {
 
     // The types of these functions don't really matter because they are always
     // bitcast to correct signature before calling.
-    Type* objectPtrTy = voidPtrTy;
-    Type* selectorPtrTy = voidPtrTy;
-    Type* realTy = Type::tfloat80;
+    Type *objectPtrTy = voidPtrTy;
+    Type *selectorPtrTy = voidPtrTy;
+    Type *realTy = Type::tfloat80;
 
     // id objc_msgSend(id self, SEL op, ...)
     // Function called early and/or often, so lazy binding isn't worthwhile.
@@ -732,13 +717,13 @@ static void buildRuntimeModule() {
       // creal objc_msgSend_fp2ret(id self, SEL op, ...)
       createFwdDecl(LINKc, Type::tcomplex80, {"objc_msgSend_fp2ret"},
                     {objectPtrTy, selectorPtrTy});
-      // fall-thru
+    // fall-thru
     case llvm::Triple::x86:
       // x86_64 real return only,  x86 float, double, real return
       // real objc_msgSend_fpret(id self, SEL op, ...)
       createFwdDecl(LINKc, realTy, {"objc_msgSend_fpret"},
                     {objectPtrTy, selectorPtrTy});
-      // fall-thru
+    // fall-thru
     case llvm::Triple::arm:
     case llvm::Triple::thumb:
       // used when return value is aggregate via a hidden sret arg

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -37,8 +37,10 @@ else()
 endif()
 
 if(BUILD_SHARED_LIBS)
-    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-        message(FATAL_ERROR "Shared libraries (BUILD_SHARED_LIBS) are only supported on Linux and FreeBSD for the time being.")
+    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND
+       NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND
+       NOT APPLE)
+        message(FATAL_ERROR "Shared libraries (BUILD_SHARED_LIBS) are only supported on Linux, macOS and FreeBSD for the time being.")
     endif()
 
     list(APPEND D_FLAGS -relocation-model=pic)
@@ -422,10 +424,10 @@ macro(build_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targ
     # C executables.
 
     if(BUILD_SHARED_LIBS)
-        if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
-            set(dso_system_libs "m" "pthread")
-        else()
+        if(${CMAKE_SYSTEM} MATCHES "Linux")
             set(dso_system_libs "m" "pthread" "rt" "dl")
+        else()
+            set(dso_system_libs "m" "pthread")
         endif()
         target_link_libraries(druntime-ldc${target_suffix} ${dso_system_libs})
     endif()
@@ -638,6 +640,10 @@ macro(build_test_runner name_suffix d_flags c_flags)
             add_test(build-${l} "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${l})
         endforeach()
 
+        if(NOT APPLE)
+            list(APPEND flags -L--no-as-needed)
+        endif()
+
         set(libarg "druntime-ldc-unittest${name_suffix}")
         add_test(NAME build-druntime-test-runner${name_suffix}
             COMMAND ${LDC_EXE_FULL}
@@ -653,7 +659,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
             add_test(NAME build-phobos2-test-runner${name_suffix}
                 COMMAND ${LDC_EXE_FULL}
                     -of${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
-                    -L--no-as-needed -defaultlib=${libarg} -debuglib=${libarg}
+                    -defaultlib=${libarg} -debuglib=${libarg}
                     -singleobj ${flags} ${RUNTIME_DIR}/src/test_runner.d
             )
             set_tests_properties(build-phobos2-test-runner${name_suffix} PROPERTIES


### PR DESCRIPTION
Passes all of the test suite, including the shared library tests, except for module collision checking (which is most easily implemented with a hash table, as symbol resolution works differently on OS X).

Requires/includes #1704.