### PR TITLE
Fix issue #1698 (missing semantic3() for special member functions)

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -429,21 +429,27 @@ public:
 
         // We won't emit ti, so emit the special member functions in here.
         if (sd->xeq && sd->xeq != StructDeclaration::xerreq) {
+          sd->xeq->semantic3(sd->xeq->_scope);
           Declaration_codegen(sd->xeq);
         }
         if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp) {
+          sd->xcmp->semantic3(sd->xcmp->_scope);
           Declaration_codegen(sd->xcmp);
         }
         if (FuncDeclaration *ftostr = search_toString(sd)) {
+          ftostr->semantic3(ftostr->_scope);
           Declaration_codegen(ftostr);
         }
         if (sd->xhash) {
+          sd->xhash->semantic3(sd->xhash->_scope);
           Declaration_codegen(sd->xhash);
         }
         if (sd->postblit) {
+          sd->postblit->semantic3(sd->postblit->_scope);
           Declaration_codegen(sd->postblit);
         }
         if (sd->dtor) {
+          sd->dtor->semantic3(sd->dtor->_scope);
           Declaration_codegen(sd->dtor);
         }
       }

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -428,28 +428,25 @@ public:
         assert(ti->minst || sd->requestTypeInfo);
 
         // We won't emit ti, so emit the special member functions in here.
-        if (sd->xeq && sd->xeq != StructDeclaration::xerreq) {
-          sd->xeq->semantic3(sd->xeq->_scope);
+        if (sd->xeq && sd->xeq != StructDeclaration::xerreq &&
+            sd->xeq->semanticRun >= PASSsemantic3) {
           Declaration_codegen(sd->xeq);
         }
-        if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp) {
-          sd->xcmp->semantic3(sd->xcmp->_scope);
+        if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp &&
+            sd->xcmp->semanticRun >= PASSsemantic3) {
           Declaration_codegen(sd->xcmp);
         }
         if (FuncDeclaration *ftostr = search_toString(sd)) {
-          ftostr->semantic3(ftostr->_scope);
-          Declaration_codegen(ftostr);
+          if (ftostr->semanticRun >= PASSsemantic3)
+            Declaration_codegen(ftostr);
         }
-        if (sd->xhash) {
-          sd->xhash->semantic3(sd->xhash->_scope);
+        if (sd->xhash && sd->xhash->semanticRun >= PASSsemantic3) {
           Declaration_codegen(sd->xhash);
         }
-        if (sd->postblit) {
-          sd->postblit->semantic3(sd->postblit->_scope);
+        if (sd->postblit && sd->postblit->semanticRun >= PASSsemantic3) {
           Declaration_codegen(sd->postblit);
         }
-        if (sd->dtor) {
-          sd->dtor->semantic3(sd->dtor->_scope);
+        if (sd->dtor && sd->dtor->semanticRun >= PASSsemantic3) {
           Declaration_codegen(sd->dtor);
         }
       }

--- a/ir/irtypeclass.cpp
+++ b/ir/irtypeclass.cpp
@@ -166,10 +166,10 @@ IrTypeClass::buildVtblType(Type *first, FuncDeclarations *vtbl_array) {
     // This pops up in some other places in the frontend as well, however
     // it is probably a bug that it still occurs that late.
     if (!fd->type->nextOf() && fd->inferRetType) {
-      Logger::println("Running late semantic3 to infer return type.");
+      Logger::println("Running late functionSemantic to infer return type.");
       TemplateInstance *spec = fd->isSpeculative();
       unsigned int olderrs = global.errors;
-      fd->semantic3(fd->_scope);
+      fd->functionSemantic();
       if (spec && global.errors != olderrs) {
         spec->errors = global.errors - olderrs;
       }


### PR DESCRIPTION
I have no idea about all the implications of this, but it seems to fix issue #1698.