### PR TITLE
Issue 1716: Improve CodeView debug info

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - if [[ ! -e ldc2-1.0.0-linux-x86_64/bin/ldc2 ]]; then wget https://github.com/ldc-developers/ldc/releases/download/v1.0.0/ldc2-1.0.0-linux-x86_64.tar.xz && xzcat ldc2-1.0.0-linux-x86_64.tar.xz | tar -xvf - ; fi
 
   override:
-    - sudo apt-get remove clang
+    - sudo apt-get remove clang llvm
     - sudo apt-get install libconfig++8-dev libedit-dev
     - sudo apt-get install llvm-3.9 llvm-3.9-dev clang-3.9
     - pip install --user lit

--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -1,10 +1,10 @@
 // REQUIRES: atleast_llvm308
-// REQUIRES: Windows_x64
+// REQUIRES: Windows
 // REQUIRES: cdb
-// RUN: %ldc -g -of=%t.exe %s \
-// RUN:   && sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
-// RUN:    | %cdb -lines %t.exe >%t.out \
-// RUN:   && FileCheck %s < %t.out
+// RUN: %ldc -g -of=%t.exe %s
+// RUN: sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
+// RUN:    | %cdb -lines %t.exe >%t.out
+// RUN: FileCheck %s -check-prefix=CHECK -check-prefix=%arch < %t.out
 
 int main(string[] args)
 {
@@ -21,20 +21,23 @@ int main(string[] args)
 
 // CDB: dt string
 // CHECK: !string
-// CHECK: +0x000 length {{ *}}: Uint8B
-// CHECK: +0x008 ptr {{ *}}: Ptr64 UChar
+// capture size_t and pointer representation
+// x64: +0x000 length {{ *}}: [[SIZE_T:Uint8B]]
+// x64: +[[OFF:0x008]] ptr {{ *}}: [[PTR:Ptr64]] UChar
+// x86: +0x000 length {{ *}}: [[SIZE_T:Uint4B]]
+// x86: +[[OFF:0x004]] ptr {{ *}}: [[PTR:Ptr32]] UChar
 
 // wchar unsupported by cdb
 // CDB: dt wstring
 // CHECK: !wstring
-// CHECK: +0x000 length {{ *}}: Uint8B
-// CHECK: +0x008 ptr {{ *}}: Ptr64
+// CHECK: +0x000 length {{ *}}: [[SIZE_T]]
+// CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // dchar unsupported by cdb
 // CDB: dt dstring
 // CHECK: !dstring
-// CHECK: +0x000 length {{ *}}: Uint8B
-// CHECK: +0x008 ptr {{ *}}: Ptr64
+// CHECK: +0x000 length {{ *}}: [[SIZE_T]]
+// CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // CDB: dv /t
 // struct arguments passed by reference
@@ -43,6 +46,10 @@ int main(string[] args)
 // CHECK: string ns
 // CHECK: string ws
 // CHECK: string ds
+
+// CDB: ?? ns
+// CHECK: +0x000 length {{ *}}: 1
+// CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *}} "a"
 }
 
 // CDB: q

--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -1,0 +1,49 @@
+// REQUIRES: atleast_llvm308
+// REQUIRES: Windows_x64
+// REQUIRES: cdb
+// RUN: %ldc -g -of=%t.exe %s \
+// RUN:   && sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
+// RUN:    | %cdb -lines %t.exe >%t.out \
+// RUN:   && FileCheck %s < %t.out
+
+int main(string[] args)
+{
+    string[] nargs = args;
+    string ns = "a";
+    wstring ws = "b";
+    dstring ds = "c";
+
+// CDB: ld codeview
+// CDB: bp `codeview.d:19`
+// CDB: g
+    return 0;
+// CHECK: !D main
+
+// CDB: dt string
+// CHECK: !string
+// CHECK: +0x000 length {{ *}}: Uint8B
+// CHECK: +0x008 ptr {{ *}}: Ptr64 UChar
+
+// wchar unsupported by cdb
+// CDB: dt wstring
+// CHECK: !wstring
+// CHECK: +0x000 length {{ *}}: Uint8B
+// CHECK: +0x008 ptr {{ *}}: Ptr64
+
+// dchar unsupported by cdb
+// CDB: dt dstring
+// CHECK: !dstring
+// CHECK: +0x000 length {{ *}}: Uint8B
+// CHECK: +0x008 ptr {{ *}}: Ptr64
+
+// CDB: dv /t
+// struct arguments passed by reference
+// CHECK: string[] * args
+// CHECK: string[] nargs
+// CHECK: string ns
+// CHECK: string ws
+// CHECK: string ds
+}
+
+// CDB: q
+// CHECK: quit:

--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -40,8 +40,9 @@ int main(string[] args)
 // CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // CDB: dv /t
-// struct arguments passed by reference
-// CHECK: string[] * args
+// struct arguments passed by reference on x64
+// x64: string[] * args
+// x86: string[] args
 // CHECK: string[] nargs
 // CHECK: string ns
 // CHECK: string ws

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -2,6 +2,7 @@ import lit.formats
 import os
 import sys
 import platform
+import string
 
 ## Auto-initialized variables by cmake:
 config.ldc2_bin         = "@LDC2_BIN@"
@@ -58,9 +59,11 @@ config.available_features.add(platform.system())
 for t in config.llvm_targetsstr.split(';'):
     config.available_features.add('target_' + t)
 
-# Add a specific feature for Windows x86 testing
+# Add specific features for Windows x86/x64 testing
 if (platform.system() == 'Windows') and (config.default_target_bits == 32):
     config.available_features.add('Windows_x86')
+if (platform.system() == 'Windows') and (config.default_target_bits == 64):
+    config.available_features.add('Windows_x64')
 
 config.target_triple = '(unused)'
 
@@ -91,3 +94,13 @@ if (platform.system() == 'Windows'):
 else:
     config.substitutions.append( ('%obj', '.o') )
     config.substitutions.append( ('%exe', '') )
+
+# Add cdb substitution
+if (platform.system() == 'Windows') and (config.default_target_bits == 32):
+    cdb = os.environ['WindowsSDKDir'] + 'Debuggers\\x86\\cdb.exe'
+if (platform.system() == 'Windows') and (config.default_target_bits == 64):
+    cdb = os.environ['WindowsSDKDir'] + 'Debuggers\\x64\\cdb.exe'
+
+if (platform.system() == 'Windows') and os.path.isfile( cdb ):
+    config.available_features.add('cdb')
+    config.substitutions.append( ('%cdb', '"' + string.replace( cdb, '\\', '\\\\') + '"') )

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -98,8 +98,10 @@ else:
 # Add cdb substitution
 if (platform.system() == 'Windows') and (config.default_target_bits == 32):
     cdb = os.environ['WindowsSDKDir'] + 'Debuggers\\x86\\cdb.exe'
+    config.substitutions.append( ('%arch', 'x86') )
 if (platform.system() == 'Windows') and (config.default_target_bits == 64):
     cdb = os.environ['WindowsSDKDir'] + 'Debuggers\\x64\\cdb.exe'
+    config.substitutions.append( ('%arch', 'x64') )
 
 if (platform.system() == 'Windows') and os.path.isfile( cdb ):
     config.available_features.add('cdb')


### PR DESCRIPTION
Changes:
- byte,ubyte should be encoded as DW_ATE_signed_char/DW_ATE_unsigned_char, not DW_ATE_signed/DW_ATE_unsigned
- encode wchar,dchar as UTF
- do not declare struct/class definitions as FlagFwdDecl
- pass deco as unique identifier to UDTs
- dynamic arrays: use type name, don't leave it empty
- use proper type name for delegates
- add support for type "void" and "typeof(null)"

Not sure how much of this can negatively affect other platforms. Should I put it under some Windows/codeView specific conditional?
