### PR TITLE
Fix issue #1723

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - if [[ ! -e ldc2-1.0.0-linux-x86_64/bin/ldc2 ]]; then wget https://github.com/ldc-developers/ldc/releases/download/v1.0.0/ldc2-1.0.0-linux-x86_64.tar.xz && xzcat ldc2-1.0.0-linux-x86_64.tar.xz | tar -xvf - ; fi
 
   override:
-    - sudo apt-get remove clang
+    - sudo apt-get remove clang llvm
     - sudo apt-get install libconfig++8-dev libedit-dev
     - sudo apt-get install llvm-3.9 llvm-3.9-dev clang-3.9
     - pip install --user lit

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -311,11 +311,9 @@ public:
 #endif
       }
       result = DtoBitCast(value, DtoType(tb));
-    } else if (tb->ty == Tclass && e->e1->type->ty == Tclass) {
-      assert(e->e1->op == TOKclassreference);
-      ClassDeclaration *cd =
-          static_cast<ClassReferenceExp *>(e->e1)->originalClass();
-
+    } else if (tb->ty == Tclass && e->e1->type->ty == Tclass &&
+               e->e1->op == TOKclassreference) {
+      auto cd = static_cast<ClassReferenceExp *>(e->e1)->originalClass();
       llvm::Constant *instance = toConstElem(e->e1);
       if (InterfaceDeclaration *it =
               static_cast<TypeClass *>(tb)->sym->isInterfaceDeclaration()) {


### PR DESCRIPTION
Errors are gagged while trying to create a constant initializer for an associative array literal. So don't die with an assertion if the cast source is a NewExp (or something else than a supported ClassReferenceExp),
emit a gaggable error instead.

A dmd-testsuite test will follow once merged, as usual.