### PR TITLE
Only enable cross-module inlining when explicitly set on the commandline.

### DIFF
--- a/gen/function-inlining.cpp
+++ b/gen/function-inlining.cpp
@@ -94,6 +94,15 @@ bool defineAsExternallyAvailable(FuncDeclaration &fdecl) {
   return false;
 #endif
 
+  // FIXME: For now, disable all cross-module inlining (also of pragma(inline, true)
+  // functions). This check should be removed when cross-module inlining has
+  // become more stable.
+  // There are related `FIXME`s in a few lit-based `codegen/inlining_*.d` tests.
+  if (!willCrossModuleInline()) {
+    IF_LOG Logger::println("Cross-module inlining fully disabled.");
+    return false;
+  }
+
   // Implementation note: try to do cheap checks first.
 
   if (fdecl.neverInline || fdecl.inlining == PINLINEnever) {

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -92,11 +92,11 @@ static cl::opt<cl::boolOrDefault, false, opts::FlagParser<cl::boolOrDefault>>
 
 static llvm::cl::opt<llvm::cl::boolOrDefault, false,
                      opts::FlagParser<llvm::cl::boolOrDefault>>
-enableCrossModuleInlining(
-    "cross-module-inlining",
-    llvm::cl::desc("Enable cross-module function inlining (default enabled "
-                   "with inlining) (LLVM >= 3.7)"),
-    llvm::cl::ZeroOrMore, llvm::cl::Hidden);
+    enableCrossModuleInlining(
+        "cross-module-inlining",
+        llvm::cl::desc("Enable cross-module function inlining (default "
+                       "disabled) (LLVM >= 3.7)"),
+        llvm::cl::ZeroOrMore, llvm::cl::Hidden);
 
 static cl::opt<bool> unitAtATime("unit-at-a-time", cl::desc("Enable basic IPO"),
                                  cl::init(true));
@@ -141,8 +141,7 @@ bool willInline() {
 
 bool willCrossModuleInline() {
 #if LDC_LLVM_VER >= 307
-  return enableCrossModuleInlining == llvm::cl::BOU_TRUE ||
-         (enableCrossModuleInlining == llvm::cl::BOU_UNSET && willInline());
+  return enableCrossModuleInlining == llvm::cl::BOU_TRUE;
 #else
 // Cross-module inlining is disabled for <3.7 because we don't emit symbols in
 // COMDAT any groups pre-LLVM3.7. With cross-module inlining enabled, without

--- a/tests/codegen/inlining_imports.d
+++ b/tests/codegen/inlining_imports.d
@@ -2,7 +2,7 @@
 
 // REQUIRES: atleast_llvm307
 
-// RUN: %ldc %s -I%S -c -output-ll -release -O3 -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
+// RUN: %ldc %s -I%S -c -output-ll -release -O3 -enable-cross-module-inlining -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
 
 import inputs.inlinables;
 

--- a/tests/codegen/inlining_imports_pragma.d
+++ b/tests/codegen/inlining_imports_pragma.d
@@ -2,10 +2,13 @@
 
 // O0 and O3 should behave the same for these tests with explicit inlining directives by the user.
 
+// FIXME: Currently cross-module inlining is completely disabled per default, also for pragma(inline,true) functions.
+//        The `-enable-cross-module-inlining` flag is therefore necessary for now, but should be removed in the future.
+
 // REQUIRES: atleast_llvm307
 
-// RUN: %ldc %s -I%S -c -output-ll -O0 -of=%t.O0.ll && FileCheck %s --check-prefix OPTNONE < %t.O0.ll
-// RUN: %ldc %s -I%S -c -output-ll -O3 -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
+// RUN: %ldc %s -I%S -c -output-ll -O0 -enable-cross-module-inlining -of=%t.O0.ll && FileCheck %s --check-prefix OPTNONE < %t.O0.ll
+// RUN: %ldc %s -I%S -c -output-ll -O3 -enable-cross-module-inlining -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
 
 import inputs.inlinables;
 

--- a/tests/codegen/inlining_leakdefinitions.d
+++ b/tests/codegen/inlining_leakdefinitions.d
@@ -3,10 +3,10 @@
 
 // REQUIRES: atleast_llvm307
 
-// RUN: %ldc %s -I%S -c -output-ll -release                  -O3 -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
-// RUN: %ldc %s -I%S -c -output-ll -release -enable-inlining -O0 -of=%t.O0.ll && FileCheck %s --check-prefix OPT0 < %t.O0.ll
-// RUN: %ldc -I%S -enable-inlining %S/inputs/inlinables.d -run %s
-// RUN: %ldc -I%S -O3 %S/inputs/inlinables.d -run %s
+// RUN: %ldc %s -I%S -c -output-ll -release                  -O3 -enable-cross-module-inlining -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
+// RUN: %ldc %s -I%S -c -output-ll -release -enable-inlining -O0 -enable-cross-module-inlining -of=%t.O0.ll && FileCheck %s --check-prefix OPT0 < %t.O0.ll
+// RUN: %ldc -I%S -enable-inlining -enable-cross-module-inlining %S/inputs/inlinables.d -run %s
+// RUN: %ldc -I%S -O3 -enable-cross-module-inlining %S/inputs/inlinables.d -run %s
 
 import inputs.inlinables;
 

--- a/tests/codegen/inlining_stdlib.d
+++ b/tests/codegen/inlining_stdlib.d
@@ -3,7 +3,7 @@
 // REQUIRES: atleast_llvm307
 
 // RUN: %ldc %s -c -output-ll -release -O0 -of=%t.O0.ll && FileCheck %s --check-prefix OPT0 < %t.O0.ll
-// RUN: %ldc %s -c -output-ll -release -O3 -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
+// RUN: %ldc %s -c -output-ll -release -O3 -enable-cross-module-inlining -of=%t.O3.ll && FileCheck %s --check-prefix OPT3 < %t.O3.ll
 
 extern (C): // simplify mangling for easier matching
 
@@ -13,7 +13,8 @@ int foo(size_t i)
 {
     // core.bitop.bsf() is force-inlined
     import core.bitop;
-    // OPT0: call {{.*}} @llvm.cttz
+    // FIXME: The OPT0 check is disabled for now, because cross-module inlining is disabled fully (also for `pragma(inline, true)` functions).
+    // O PT0: call {{.*}} @llvm.cttz
     // OPT3: call {{.*}} @llvm.cttz
     return bsf(i);
     // OPT0: ret

--- a/tests/codegen/inlining_templates.d
+++ b/tests/codegen/inlining_templates.d
@@ -3,16 +3,16 @@
 
 // REQUIRES: atleast_llvm307
 
-// RUN: %ldc %s -I%S -c -output-ll -release -enable-inlining -O0 -of=%t.O0.ll && FileCheck %s < %t.O0.ll
+// RUN: %ldc %s -I%S -c -output-ll -release -enable-inlining -enable-cross-module-inlining -O0 -of=%t.O0.ll && FileCheck %s < %t.O0.ll
 
-// RUN: %ldc -singleobj %S/inputs/inlinables.d %s -I%S -c -output-ll -release -enable-inlining -O0 -of=%t.singleobj.O0.ll && FileCheck %s < %t.singleobj.O0.ll
+// RUN: %ldc -singleobj %S/inputs/inlinables.d %s -I%S -c -output-ll -release -enable-inlining -enable-cross-module-inlining -O0 -of=%t.singleobj.O0.ll && FileCheck %s < %t.singleobj.O0.ll
 
 // Test linking too.
 // Separate compilation
-//   RUN: %ldc -c -enable-inlining %S/inputs/inlinables.d -of=%t.inlinables%obj \
-//   RUN: && %ldc -I%S -enable-inlining %t.inlinables%obj %s -of=%t%exe
+//   RUN: %ldc -c -enable-inlining -enable-cross-module-inlining %S/inputs/inlinables.d -of=%t.inlinables%obj \
+//   RUN: && %ldc -I%S -enable-inlining -enable-cross-module-inlining %t.inlinables%obj %s -of=%t%exe
 // Singleobj compilation
-//   RUN: %ldc -I%S -enable-inlining -singleobj %S/inputs/inlinables.d %s -of=%t2%exe
+//   RUN: %ldc -I%S -enable-inlining -enable-cross-module-inlining -singleobj %S/inputs/inlinables.d %s -of=%t2%exe
 
 import inputs.inlinables;
 import std.stdio;


### PR DESCRIPTION
A few subtle cross-module inlining bugs have been discovered, so let's disable it for now per default. See #1718.

This PR completely disables cross-module inlining unless explicitly enabled through the cmdline flag `-enable-cross-module-inlining`.
In particular, this disables cross-module inlining of `pragma(inline, true)` functions.

