### PR TITLE
[CircleCI] Use LLVM 4.0 from APT

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ dependencies:
     #- clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04
   pre:
     # LLVM's official APT repo:
-    - sudo add-apt-repository -y 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main'
     - sudo add-apt-repository -y 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main'
     - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
     - sudo apt-get update
@@ -23,11 +22,11 @@ dependencies:
   override:
     - sudo apt-get remove clang llvm
     - sudo apt-get install libconfig++8-dev libedit-dev
-    - sudo apt-get install llvm-3.9 llvm-3.9-dev clang-3.9
+    - sudo apt-get install llvm-4.0 llvm-4.0-dev clang-4.0
     - pip install --user lit
   post:
-    - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 99
-    - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 99
+    - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 99
+    - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0 99
     #- sudo update-alternatives --install /usr/bin/clang clang ~/$CIRCLE_PROJECT_REPONAME/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang 99
     #- sudo update-alternatives --install /usr/bin/clang++ clang++ ~/$CIRCLE_PROJECT_REPONAME/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++ 99
     - gcc --version

--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -27,7 +27,9 @@
 # We also want an user-specified LLVM_ROOT_DIR to take precedence over the
 # system default locations such as /usr/local/bin. Executing find_program()
 # multiples times is the approach recommended in the docs.
-set(llvm_config_names llvm-config-3.9 llvm-config39
+set(llvm_config_names llvm-config-4.1 llvm-config41
+                      llvm-config-4.0 llvm-config40
+                      llvm-config-3.9 llvm-config39
                       llvm-config-3.8 llvm-config38
                       llvm-config-3.7 llvm-config37
                       llvm-config-3.6 llvm-config36

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -274,7 +274,11 @@ static void addOptimizationPasses(PassManagerBase &mpm,
     }
     builder.Inliner = createFunctionInliningPass(threshold);
   } else {
+#if LDC_LLVM_VER >= 400
+    builder.Inliner = createAlwaysInlinerLegacyPass();
+#else
     builder.Inliner = createAlwaysInlinerPass();
+#endif
   }
   builder.DisableUnitAtATime = !unitAtATime;
   builder.DisableUnrollLoops = optLevel == 0;


### PR DESCRIPTION
Now that LLVM 3.9 is released, we can use Travis and AppVeyor for all "serious" testing: they must be green. And we can use CircleCI for LLVM 4.0 (trunk) testing that may break e.g. upon LLVM API changes. This way, we get notified early about relevant LLVM trunk changes, and can react with easy small LDC patches.
Makes sense?

Also see https://forum.dlang.org/thread/nwajbeceaokohknjhlqb@forum.dlang.org