### PR TITLE
Fix long running codeview tests

### DIFF
--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -3,7 +3,7 @@
 // REQUIRES: cdb
 // RUN: %ldc -g -of=%t.exe %s
 // RUN: sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
-// RUN:    | %cdb -snul -lines %t.exe >%t.out
+// RUN:    | %cdb -snul -lines -y . %t.exe >%t.out
 // RUN: FileCheck %s -check-prefix=CHECK -check-prefix=%arch < %t.out
 
 int main(string[] args)

--- a/tests/debuginfo/cvbasictypes.d
+++ b/tests/debuginfo/cvbasictypes.d
@@ -3,7 +3,7 @@
 // REQUIRES: cdb
 // RUN: %ldc -g -of=%t.exe %s
 // RUN: sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
-// RUN:    | %cdb -snul -lines %t.exe >%t.out
+// RUN:    | %cdb -snul -lines -y . %t.exe >%t.out
 // RUN: FileCheck %s -check-prefix=CHECK -check-prefix=%arch < %t.out
 
 void main()


### PR DESCRIPTION
this disables the default symbol search path that might access the MS symbol servers