### PR TITLE
[wip] Add ir2obj cache pruning support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ set(DRV_SRC
     driver/configfile.cpp
     driver/exe_path.cpp
     driver/ir2obj_cache.cpp
+    driver/ir2obj_cache_pruning.cpp
     driver/targetmachine.cpp
     driver/toobj.cpp
     driver/tool.cpp
@@ -346,6 +347,7 @@ set(DRV_HDR
     driver/configfile.h
     driver/exe_path.h
     driver/ir2obj_cache.h
+    driver/ir2obj_cache_pruning.h
     driver/ldc-version.h
     driver/targetmachine.h
     driver/toobj.h

--- a/driver/ir2obj_cache.h
+++ b/driver/ir2obj_cache.h
@@ -22,8 +22,15 @@ namespace ir2obj {
 
 void calculateModuleHash(llvm::Module *m, llvm::SmallString<32> &str);
 std::string cacheLookup(llvm::StringRef cacheObjectHash);
-void cacheObjectFile(llvm::StringRef objectFile, llvm::StringRef cacheObjectHash);
-void recoverObjectFile(llvm::StringRef cacheObjectHash, llvm::StringRef objectFile);
+void cacheObjectFile(llvm::StringRef objectFile,
+                     llvm::StringRef cacheObjectHash);
+void recoverObjectFile(llvm::StringRef cacheObjectHash,
+                       llvm::StringRef objectFile);
+
+/// Prune the cache to avoid filling up disk space.
+///
+/// Note: Does nothing for LLVM < 3.7.
+void pruneCache();
 }
 
 #endif

--- a/driver/ir2obj_cache_pruning.cpp
+++ b/driver/ir2obj_cache_pruning.cpp
@@ -1,0 +1,203 @@
+//===-- driver/ir2obj_cache_pruning.cpp -------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is adapted from LLVM's lib/Support/CachePruning.cpp. Therefore,
+// this file is distributed under the LLVM license.
+// See the LICENSE file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// LLVM IR to object code cache directory pruning, to prevent filling up disk
+// space.
+//
+// LLVM's pruning scheme (LLVM 3.9) is modified to support a maximum absolute
+// size, and to support LLVM < 3.9 (by disabling the percentage-based size
+// limit).
+// Important: it also fixes a bug, the LLVM 3.9 code incorrectly deletes files
+// without looking at access time when pruning for cache size.
+//
+//===----------------------------------------------------------------------===//
+
+#if LDC_LLVM_VER >= 307
+
+#include "driver/ir2obj_cache_pruning.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "cache-pruning"
+
+#include <queue>
+
+using namespace llvm;
+
+namespace llvmldc {
+
+/// Write a new timestamp file with the given path. This is used for the pruning
+/// interval option.
+static void writeTimestampFile(StringRef TimestampFile) {
+  std::error_code EC;
+  raw_fd_ostream Out(TimestampFile.str(), EC, sys::fs::F_None);
+}
+
+/// Prune the cache of files that haven't been accessed in a long time.
+bool CachePruning::prune() {
+  if (Path.empty())
+    return false;
+
+  bool isPathDir;
+  if (sys::fs::is_directory(Path, isPathDir))
+    return false;
+
+  if (!isPathDir)
+    return false;
+
+  if (Expiration == 0 && PercentageOfAvailableSpace == 0) {
+    DEBUG(dbgs() << "No pruning settings set, exit early\n");
+    // Nothing will be pruned, early exit
+    return false;
+  }
+
+  // Try to stat() the timestamp file.
+  SmallString<128> TimestampFile(Path);
+  sys::path::append(TimestampFile, "ldccache.timestamp");
+  sys::fs::file_status FileStatus;
+  sys::TimeValue CurrentTime = sys::TimeValue::now();
+  if (auto EC = sys::fs::status(TimestampFile, FileStatus)) {
+    if (EC == errc::no_such_file_or_directory) {
+      // If the timestamp file wasn't there, create one now.
+      writeTimestampFile(TimestampFile);
+    } else {
+      // Unknown error?
+      return false;
+    }
+  } else {
+    if (Interval) {
+      // Check whether the time stamp is older than our pruning interval.
+      // If not, do nothing.
+      sys::TimeValue TimeStampModTime = FileStatus.getLastModificationTime();
+      auto TimeInterval = sys::TimeValue(sys::TimeValue::SecondsType(Interval));
+      auto TimeStampAge = CurrentTime - TimeStampModTime;
+      if (TimeStampAge <= TimeInterval) {
+        DEBUG(dbgs() << "Timestamp file too recent (" << TimeStampAge.seconds()
+                     << "s old), do not prune.\n");
+        return false;
+      }
+    }
+    // Write a new timestamp file so that nobody else attempts to prune.
+    // There is a benign race condition here, if two processes happen to
+    // notice at the same time that the timestamp is out-of-date.
+    writeTimestampFile(TimestampFile);
+  }
+
+  bool ShouldComputeSize =
+      (MaxSizeInBytes > 0) || (PercentageOfAvailableSpace > 0);
+
+  // Keep track of space
+  struct FileSizeAndAge {
+    std::string File;
+    uint64_t Size;
+    sys::TimeValue Age;
+
+    // Comparison function for priority_queue (return "false" if f1 is ordered
+    // first).
+    struct OldAgesFirst {
+      bool operator()(FileSizeAndAge const &f1, FileSizeAndAge const &f2) {
+        return f1.Age < f2.Age;
+      }
+    };
+  };
+  std::priority_queue<FileSizeAndAge, std::vector<FileSizeAndAge>,
+                      FileSizeAndAge::OldAgesFirst>
+      FileSizes;
+  uint64_t TotalSize = 0;
+
+  // Helper to add a path to the set of files to consider for size-based
+  // pruning, sorted by size.
+  auto AddToFileListForSizePruning = [&](StringRef Path, sys::TimeValue Age) {
+    if (!ShouldComputeSize)
+      return;
+    TotalSize += FileStatus.getSize();
+    FileSizes.push({Path, FileStatus.getSize(), Age});
+  };
+
+  // Walk the entire directory cache, looking for unused files.
+  std::error_code EC;
+  SmallString<128> CachePathNative;
+  sys::path::native(Path, CachePathNative);
+  auto TimeExpiration = sys::TimeValue(sys::TimeValue::SecondsType(Expiration));
+  // Walk all of the files within this directory.
+  for (sys::fs::directory_iterator File(CachePathNative, EC), FileEnd;
+       File != FileEnd && !EC; File.increment(EC)) {
+    // Do not touch the timestamp.
+    if (File->path() == TimestampFile)
+      continue;
+
+    // Look at this file. If we can't stat it, there's nothing interesting
+    // there.
+    if (sys::fs::status(File->path(), FileStatus)) {
+      DEBUG(dbgs() << "Ignore " << File->path() << " (can't stat)\n");
+      continue;
+    }
+
+// If the file hasn't been used recently enough, delete it
+#if LDC_LLVM_VER >= 309
+    sys::TimeValue FileAccessTime = FileStatus.getLastAccessedTime();
+#else
+    // getLastAccessedTime is not available in LLVM < 3.9.
+    // Resort to last modification time (this is updated everytime LDC does a
+    // cache file recovery)
+    sys::TimeValue FileAccessTime = FileStatus.getLastModificationTime();
+#endif
+    auto FileAge = CurrentTime - FileAccessTime;
+    if (FileAge > TimeExpiration) {
+      DEBUG(dbgs() << "Remove " << File->path() << " (" << FileAge.seconds()
+                   << "s old)\n");
+      sys::fs::remove(File->path());
+      continue;
+    }
+
+    // Leave it here for now, but add it to the list of size-based pruning.
+    AddToFileListForSizePruning(File->path(), FileAge);
+  }
+
+  // Prune for size now if needed
+  if (ShouldComputeSize) {
+#if LDC_LLVM_VER >= 309
+    auto ErrOrSpaceInfo = sys::fs::disk_space(Path);
+    if (!ErrOrSpaceInfo) {
+      report_fatal_error("Can't get available size");
+    }
+    sys::fs::space_info SpaceInfo = ErrOrSpaceInfo.get();
+    auto AvailableSpace = TotalSize + SpaceInfo.free;
+#else
+    // The AvailableSpace will be ignored for LLVM < 3.9. This is just to get
+    // its type right.
+    auto AvailableSpace = TotalSize;
+#endif
+    DEBUG(dbgs() << "Occupancy: " << ((100 * TotalSize) / AvailableSpace)
+                 << "% target is: " << PercentageOfAvailableSpace << "\n");
+    // Remove the oldest accessed files first, till we get below the threshold
+    while (IsSizeAboveMaximum(TotalSize, AvailableSpace) &&
+           !FileSizes.empty()) {
+      auto const &FileAndSize = FileSizes.top();
+      // Remove the file.
+      sys::fs::remove(FileAndSize.File);
+      // Update size
+      TotalSize -= FileAndSize.Size;
+      DEBUG(dbgs() << " - Remove " << FileAndSize.File << " (size "
+                   << FileAndSize.Size << "), new occupancy is " << TotalSize
+                   << "%\n");
+      FileSizes.pop();
+    }
+  }
+  return true;
+}
+
+} // namespace llvmldc
+
+#endif

--- a/driver/ir2obj_cache_pruning.h
+++ b/driver/ir2obj_cache_pruning.h
@@ -1,0 +1,93 @@
+//===-- driver/ir2obj_cache_pruning.h ---------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is adapted from LLVM's lib/Support/CachePruning.h. Therefore,
+// this file is distributed under the LLVM license.
+// See the LICENSE file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if LDC_LLVM_VER >= 307
+
+#ifndef LLVMLDC_SUPPORT_CACHE_PRUNING_H
+#define LLVMLDC_SUPPORT_CACHE_PRUNING_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace llvmldc {
+
+/// Handle pruning a directory provided a path and some options to control what
+/// to prune.
+class CachePruning {
+public:
+  /// Prepare to prune \p Path.
+  CachePruning(llvm::StringRef Path) : Path(Path) {}
+
+  /// Define the pruning interval. This is intended to be used to avoid scanning
+  /// the directory too often. It does not impact the decision of which file to
+  /// prune. A value of 0 forces the scan to occurs.
+  CachePruning &setPruningInterval(int PruningInterval) {
+    Interval = PruningInterval;
+    return *this;
+  }
+
+  /// Define the expiration for a file. When a file hasn't been accessed for
+  /// \p ExpireAfter seconds, it is removed from the cache. A value of 0 disable
+  /// the expiration-based pruning.
+  CachePruning &setEntryExpiration(unsigned ExpireAfter) {
+    Expiration = ExpireAfter;
+    return *this;
+  }
+
+  /// Define the maximum size for the cache directory, in terms of bytes.
+  /// Set to 0 (default) to limit the cache size to the percentage of
+  /// the available space on the the disk set by setMaxSize.
+  CachePruning &setMaxSizeBytes(uint64_t SizeInBytes) {
+    MaxSizeInBytes = SizeInBytes;
+    return *this;
+  }
+
+  /// Define the maximum size for the cache directory, in terms of percentage of
+  /// the available space on the the disk. Set to 100 to indicate no limit, 50
+  /// to indicate that the cache size will not be left over half the
+  /// available disk space. A value over 100 will be reduced to 100. A value of
+  /// 0 disable the size-based pruning.
+  /// For LLVM < 3.9 this setting is ignored (the available disk space is not
+  /// available).
+  CachePruning &setMaxSize(unsigned Percentage) {
+    PercentageOfAvailableSpace = std::min(100u, Percentage);
+    return *this;
+  }
+
+  /// Peform pruning using the supplied options, returns true if pruning
+  /// occured, i.e. if PruningInterval was expired.
+  bool prune();
+
+private:
+  // Options that matches the setters above.
+  std::string Path;
+  unsigned Expiration = 0;
+  unsigned Interval = 0;
+  unsigned PercentageOfAvailableSpace = 0;
+  uint64_t MaxSizeInBytes = 0;
+
+  bool IsSizeAboveMaximum(uint64_t Size, uint64_t AvailableSpace) {
+    bool TooLarge = false;
+    if (MaxSizeInBytes > 0)
+      TooLarge = Size > MaxSizeInBytes;
+
+#if LDC_LLVM_VER >= 309
+    TooLarge = TooLarge ||
+               ((100 * Size) / AvailableSpace) > PercentageOfAvailableSpace;
+#endif
+
+    return TooLarge;
+  }
+};
+
+} // namespace llvmldc
+
+#endif
+
+#endif

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -23,6 +23,7 @@
 #include "driver/codegenerator.h"
 #include "driver/configfile.h"
 #include "driver/exe_path.h"
+#include "driver/ir2obj_cache.h"
 #include "driver/ldc-version.h"
 #include "driver/linker.h"
 #include "driver/targetmachine.h"
@@ -1169,6 +1170,11 @@ void codegenModules(Modules &modules) {
       if (global.errors)
         fatal();
     }
+  }
+
+  // Prune the ir2obj cache if needed.
+  if (!opts::ir2objCacheDir.empty()) {
+    ir2obj::pruneCache();
   }
 
   freeRuntime();

--- a/tests/linking/ir2obj_cache_pruning.d
+++ b/tests/linking/ir2obj_cache_pruning.d
@@ -1,0 +1,15 @@
+// Test recognition of -ir2obj-cache-prune-* commandline flags
+
+// REQUIRES: atleast_llvm309
+
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=10 -ir2obj-cache-prune-maxbytes=10000
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-maxbytes=10000
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-expiration=10000
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-maxpercentage=50
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-maxpercentage=150
+
+void main()
+{
+}

--- a/tests/linking/ir2obj_cache_pruning2.d
+++ b/tests/linking/ir2obj_cache_pruning2.d
@@ -1,0 +1,36 @@
+// Test ir2obj-cache pruning for size
+
+// REQUIRES: atleast_llvm309
+
+// This test assumes that the `void main(){}` object file size is below and somewhat close to 2000 bytes,
+// such that rebuilding with version(NEW_OBJ_FILE) will clear the cache of all but the latest object file.
+
+// RUN: %ldc %s -ir2obj-cache=%T/cachedirectory \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -d-version=SLEEP \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -vv -d-version=NEW_OBJ_FILE | FileCheck --check-prefix=NO_HIT %s \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc -d-version=SLEEP -run %s \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -ir2obj-cache-prune-maxbytes=2000 -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -d-version=SLEEP -vv | FileCheck --check-prefix=NO_HIT %s \
+// RUN: && %ldc -d-version=SLEEP -run %s \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -ir2obj-cache-prune-maxbytes=2000 -d-version=NEW_OBJ_FILE \
+// RUN: && %ldc %s -ir2obj-cache=%T/cachedirectory -ir2obj-cache-prune -ir2obj-cache-prune-interval=0 -vv | FileCheck --check-prefix=NO_HIT %s
+
+// MUST_HIT: Cache object found!
+// NO_HIT-NOT: Cache object found!
+
+void main()
+{
+    version(NEW_OBJ_FILE)
+    {
+        auto a = __TIME__;
+    }
+
+    version(SLEEP)
+    {
+        // Sleep for 2 seconds, so we are sure that the cache object file timestamps are "aging".
+        import core.thread;
+        Thread.sleep( dur!("seconds")( 2 ) );
+    }
+}


### PR DESCRIPTION
< summary of changes to be written >
testing the CI systems with this.

Because of lacking LLVM cross-platform filesystem functions, pruning is only available from LLVM 3.7.
