### PR TITLE
LLVMContext::setDiscardValueNames(true) when not compiling to textual IR

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -84,6 +84,13 @@ CodeGenerator::CodeGenerator(llvm::LLVMContext &context, bool singleObj)
                  "configured properly");
     fatal();
   }
+
+#if LDC_LLVM_VER >= 309
+  // Set the context to discard value names when not generating textual IR.
+  if (!global.params.output_ll) {
+    context_.setDiscardValueNames(true);
+  }
+#endif
 }
 
 CodeGenerator::~CodeGenerator() {

--- a/tests/codegen/discard_value_names_gh1749.d
+++ b/tests/codegen/discard_value_names_gh1749.d
@@ -1,0 +1,24 @@
+// Test value name discarding when creating non-textual IR.
+
+// REQUIRES: atleast_llvm309
+
+// RUN: %ldc %S/inputs/input_discard_valuename.d -c -output-ll -of=%t.bar.ll && FileCheck %S/inputs/input_discard_valuename.d < %t.bar.ll
+
+// Output a bitcode file (i.e. with discarded names) and input it into a second LDC command that outputs textual IR.
+// RUN: %ldc %S/inputs/input_discard_valuename.d -g -c -output-bc -of=%t.bar.bc \
+// RUN: && %ldc %s %t.bar.bc -g -c -output-ll -of=%t.ll && FileCheck %s < %t.ll
+
+// IR imported from the bitcode file should not have local value names:
+// CHECK-LABEL: define{{.*}} @foo
+// CHECK: %localfoovar
+// CHECK-LABEL: define{{.*}} @bar
+// CHECK-NOT: %localbarvar
+
+// But the imported IR should still have debug names:
+// CHECK: DILocalVariable{{.*}}"localfoovar"
+// CHECK: DILocalVariable{{.*}}"localbarvar"
+
+extern(C) void foo()
+{
+    int localfoovar;
+}

--- a/tests/codegen/inputs/input_discard_valuename.d
+++ b/tests/codegen/inputs/input_discard_valuename.d
@@ -1,0 +1,14 @@
+// CHECK-LABEL: define{{.*}} @bar(
+extern(C) void bar()
+{
+    // CHECK: localbarvar
+    int localbarvar;
+}
+
+// Make sure we can use inline IR in non-textual IR compiles:
+pragma(LDC_inline_ir) R __ir(string s, R, P...)(P);
+double inlineIR(double a)
+{
+    auto s = __ir!(`ret double %0`, double)(a);
+    return s;
+}


### PR DESCRIPTION
Resolves #1749