### PR TITLE
CodeView: fix display of dynamic array arguments

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -138,13 +138,13 @@ public:
   /// variable vd.
   /// \param ll       LLVM Value of the variable.
   /// \param vd       Variable declaration to emit debug info for.
-  /// \param type     Type of parameter if diferent from vd->type
+  /// \param type     Type of parameter if different from vd->type
   /// \param isThisPtr Parameter is hidden this pointer
-  /// \param fromNested Is a closure variable accessed through nest_arg
+  /// \param bool rewrittenToLocal Parameter is copied to local stack frame/closure
   /// \param addr     An array of complex address operations.
   void
   EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd, Type *type = nullptr,
-                    bool isThisPtr = false, bool fromNested = false,
+                    bool isThisPtr = false, bool rewrittenToLocal = false,
 #if LDC_LLVM_VER >= 306
                     llvm::ArrayRef<int64_t> addr = llvm::ArrayRef<int64_t>()
 #else

--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -42,9 +42,7 @@ int main(string[] args)
 // CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // CDB: dv /t
-// struct arguments passed by reference on x64
-// x64: string[] * args
-// x86: string[] args
+// CHECK: string[] args
 // CHECK: string[] nargs
 // CHECK: string ns
 // CHECK: string ws
@@ -53,6 +51,9 @@ int main(string[] args)
 // CDB: ?? ns
 // CHECK: +0x000 length {{ *}}: 1
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *}} "a"
+// CDB: ?? args.ptr[0]
+// CHECK: +0x000 length
+// CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe"}}
 }
 
 // CDB: q

--- a/tests/debuginfo/codeview.d
+++ b/tests/debuginfo/codeview.d
@@ -53,7 +53,7 @@ int main(string[] args)
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *}} "a"
 // CDB: ?? args.ptr[0]
 // CHECK: +0x000 length
-// CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe"}}
+// CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe.*"}}
 }
 
 // CDB: q

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -22,7 +22,6 @@ void encloser(int arg0, int arg1)
 
 // CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}encloser.nested"
 // CHECK: !DILocalVariable{{.*}}nes_i
-// CHECK-SAME: arg: 2
 // CHECK: !DILocalVariable{{.*}}arg1
 // CHECK-NOT: arg:
 // CHECK-SAME: ){{$}}

--- a/tests/debuginfo/nested_llvm306.d
+++ b/tests/debuginfo/nested_llvm306.d
@@ -18,5 +18,5 @@ void encloser(int arg0, int arg1)
 
 // CHECK: @_D{{.*}}8encloserFiiZv{{.*}}DW_TAG_subprogram
 // CHECK: @_D{{.*}}8encloserFiiZ6nestedMFiZv{{.*}}DW_TAG_subprogram
-// CHECK: nes_i{{.*}}DW_TAG_arg_variable
+// CHECK: nes_i{{.*}}DW_TAG_auto_variable
 // CHECK: arg1{{.*}}DW_TAG_auto_variable

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -19,5 +19,5 @@ void encloser(int arg0, int arg1)
 // CHECK: !DISubprogram(name:{{.*}}"{{.*}}.encloser"
 // CHECK-SAME: function: void {{.*}} @_D{{.*}}8encloserFiiZv
 // CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}.encloser.nested"
-// CHECK: !DILocalVariable{{.*}}DW_TAG_arg_variable{{.*}}nes_i
+// CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}nes_i
 // CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}arg1


### PR DESCRIPTION
see https://github.com/ldc-developers/ldc/issues/1716

Is this relevant for gdb, too?