### PR TITLE
Debuginfo: add inheritance information to classes

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -172,13 +172,13 @@ private:
                ldc::DIExpression diexpr
 #endif
                );
-  void AddBaseFields(ClassDeclaration *sd, ldc::DIFile file,
+  void AddFields(AggregateDeclaration *sd, ldc::DIFile file,
 #if LDC_LLVM_VER >= 306
-                     llvm::SmallVector<llvm::Metadata *, 16> &elems
+                 llvm::SmallVector<llvm::Metadata *, 16> &elems
 #else
-                     llvm::SmallVector<llvm::Value *, 16> &elems
+                 llvm::SmallVector<llvm::Value *, 16> &elems
 #endif
-                     );
+                 );
   DIFile CreateFile(Loc &loc);
   DIFile CreateFile();
   DIType CreateBasicType(Type *type);

--- a/tests/debuginfo/cvbaseclass.d
+++ b/tests/debuginfo/cvbaseclass.d
@@ -1,0 +1,39 @@
+// REQUIRES: atleast_llvm308
+// REQUIRES: Windows
+// REQUIRES: cdb
+// RUN: %ldc -g -of=%t.exe %s
+// RUN: sed -e "/^\\/\\/ CDB:/!d" -e "s,// CDB:,," %s \
+// RUN:    | %cdb -snul -lines -y . %t.exe >%t.out
+// RUN: FileCheck %s -check-prefix=CHECK -check-prefix=%arch < %t.out
+
+class BaseClass
+{
+    uint baseMember = 3;
+}
+
+class DerivedClass : BaseClass
+{
+    uint derivedMember = 7;
+}
+
+int main(string[] args)
+{
+    auto dc = new DerivedClass;
+// CDB: ld /f cvbaseclass*
+// enable case sensitive symbol lookup
+// CDB: .symopt-1
+// CDB: bp `cvbaseclass.d:27`
+// CDB: g
+    return 0;
+// CHECK: !D main
+
+// CDB: ?? dc
+// cdb doesn't show base class info, but lists their members
+// CHECK: DerivedClass
+// CHECK: baseMember{{ *: *3}}
+// verify baseMember is not listed twice
+// CHECK-NEXT: derivedMember{{ *: *7}}
+}
+
+// CDB: q
+// CHECK: quit:


### PR DESCRIPTION
uses inheritance information for base classes instead of listing base class members in derived classes