### PR TITLE
fix build with LLVM 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 #
 
 find_package(LLVM 3.5 REQUIRED
-    all-targets analysis asmparser asmprinter bitreader bitwriter codegen core debuginfocodeview debuginfodwarf debuginfopdb globalisel instcombine ipa ipo instrumentation irreader linker lto mc mcdisassembler mcparser objcarcopts object option profiledata scalaropts selectiondag support tablegen target transformutils vectorize ${EXTRA_LLVM_MODULES})
+    all-targets analysis asmparser asmprinter bitreader bitwriter codegen core debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel instcombine ipa ipo instrumentation irreader linker lto mc mcdisassembler mcparser objcarcopts object option profiledata scalaropts selectiondag support tablegen target transformutils vectorize ${EXTRA_LLVM_MODULES})
 math(EXPR LDC_LLVM_VER ${LLVM_VERSION_MAJOR}*100+${LLVM_VERSION_MINOR})
 # Remove LLVMTableGen library from list of libraries
 string(REGEX MATCH "^-.*LLVMTableGen[^;]*;|;-.*LLVMTableGen[^;]*" LLVM_TABLEGEN_LIBRARY "${LLVM_LIBRARIES}")

--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -104,6 +104,10 @@ if ((WIN32 AND NOT(MINGW OR CYGWIN)) OR NOT LLVM_CONFIG)
             # Versions beginning with 3.8 do not support component ipa
             list(REMOVE_ITEM LLVM_FIND_COMPONENTS "ipa" index)
         endif()
+        if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-9][\\.0-9A-Za-z]*")
+            # Versions below 4.0 do not support component debuginfomsf
+            list(REMOVE_ITEM LLVM_FIND_COMPONENTS "debuginfomsf" index)
+        endif()
         if(${LLVM_VERSION_STRING} MATCHES "^4\\.[\\.0-9A-Za-z]*")
             # Versions beginning with 4. do not support component ipa
             list(REMOVE_ITEM LLVM_FIND_COMPONENTS "ipa" index)
@@ -200,6 +204,10 @@ else()
     if(${LLVM_VERSION_STRING} MATCHES "^3\\.[8-9][\\.0-9A-Za-z]*")
         # Versions beginning with 3.8 do not support component ipa
         list(REMOVE_ITEM LLVM_FIND_COMPONENTS "ipa" index)
+    endif()
+    if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-9][\\.0-9A-Za-z]*")
+        # Versions below 4.0 do not support component debuginfomsf
+        list(REMOVE_ITEM LLVM_FIND_COMPONENTS "debuginfomsf" index)
     endif()
     if(${LLVM_VERSION_STRING} MATCHES "^4\\.[\\.0-9A-Za-z]*")
         # Versions beginning with 4. do not support component ipa


### PR DESCRIPTION
At least on Windows, library debuginfomsf is needed by debuginfocodeview.