### PR TITLE
Lit: add testing with lldb

### DIFF
--- a/tests/debuginfo/lldb.d
+++ b/tests/debuginfo/lldb.d
@@ -1,0 +1,29 @@
+// REQUIRES: atleast_llvm308
+// REQUIRES: lldb, sed
+// RUN: %ldc -g -of=%t%exe %s \
+// RUN: && sed -e "/^\\/\\/ LLDB:/!d" -e "s,// LLDB:,," %s > %t.lldb \
+// RUN: && %lldb %t%exe -s %t.lldb > %t.out.txt 2>&1 \
+// RUN: && FileCheck %s -check-prefix=CHECK < %t.out.txt
+
+int globalvar = 123;
+
+void main()
+{
+    int a = 42;
+    return;
+}
+
+// CHECK: Current executable set to {{.*}}lldb
+// LLDB: break set --file lldb.d --line 13
+// LLDB: run
+// CHECK:      void main()
+// CHECK-NEXT: {
+// CHECK-NEXT: int a = 42;
+// CHECK-NEXT: -> {{[0-9]+}} return;
+// CHECK-NEXT: }
+// LLDB: frame variable
+// check for frame variable name 'a', broken atm
+// LLDB: target variable
+// check for global variable name 'globalvar', broken atm
+// LLDB: continue
+// LLDB: exit

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -108,3 +108,9 @@ if (platform.system() == 'Windows') and (config.default_target_bits == 64):
 if (platform.system() == 'Windows') and os.path.isfile( cdb ):
     config.available_features.add('cdb')
     config.substitutions.append( ('%cdb', '"' + string.replace( cdb, '\\', '\\\\') + '"') )
+
+# Add lldb substitution
+if platform.system() == 'Darwin':
+    config.available_features.add('lldb')
+    config.available_features.add('sed')
+    config.substitutions.append( ('%lldb', 'lldb') )


### PR DESCRIPTION
I don't know what happened, but I can no longer debug much with LLDB. Local variables don't show up anymore, and global variables have a `<could not resolve type>`.
I have debugged with lldb before where these variables did show up correctly, so... I don't know.
I have the same problem with LDC0.17 and LDC1.1.0. Perhaps I dreamed it, or it was on Linux, where things worked better.

So: added testing with LLDB.
Testing works similar as with CDB (great stuff @rainers ): lines prefixed with "// LLDB:" are output to a `%t.lldb` file, which is then inserted into LLDB for execution. LLDB output goes into `%t.out.txt` which is then inserted into FileCheck to do the string matching.