### PR TITLE
enable gdb tests in the dmd-testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   - eval "${DC} --version"
   - pip install --user lit
   - python -c "import lit; lit.main();" --version | head -n 1
-  - gdb --version
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then gdb --version; fi
 
 script:
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ install:
   - eval "${DC} --version"
   - pip install --user lit
   - python -c "import lit; lit.main();" --version | head -n 1
+  - gdb --version
 
 script:
   - cmake --version

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ dependencies:
     - ldc2 -version
     - cmake --version
     - python -c "import lit; lit.main();" --version | head -n 1
+    - gdb --version
 
 checkout:
   post:

--- a/ddmd/globals.d
+++ b/ddmd/globals.d
@@ -217,6 +217,7 @@ struct Param
 
         // Codegen cl options
         bool disableRedZone;
+        uint dwarfVersion;
 
         uint hashThreshold; // MD5 hash symbols larger than this threshold (0 = no hashing)
     }

--- a/ddmd/globals.h
+++ b/ddmd/globals.h
@@ -215,6 +215,7 @@ struct Param
 
     // Codegen cl options
     bool disableRedZone;
+    uint32_t dwarfVersion;
 
     uint32_t hashThreshold; // MD5 hash symbols larger than this threshold (0 = no hashing)
 #endif

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -119,6 +119,11 @@ static cl::opt<ubyte, true>
                          clEnumValEnd),
               cl::location(global.params.symdebug), cl::init(0));
 
+static cl::opt<unsigned, true>
+    dwarfVersion("dwarf-version", cl::desc("Dwarf version"),
+                 cl::location(global.params.dwarfVersion), cl::init(0),
+                 cl::Hidden);
+
 cl::opt<bool> noAsm("noasm", cl::desc("Disallow use of inline assembler"));
 
 // Output file options

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -700,6 +700,9 @@ void ldc::DIBuilder::EmitCompileUnit(Module *m) {
 #if LDC_LLVM_VER >= 308
   if (global.params.targetTriple->isWindowsMSVCEnvironment())
     IR->module.addModuleFlag(llvm::Module::Warning, "CodeView", 1);
+  else if (global.params.dwarfVersion > 0)
+    IR->module.addModuleFlag(llvm::Module::Warning, "Dwarf Version",
+                             global.params.dwarfVersion);
 #endif
   // Metadata without a correct version will be stripped by UpgradeDebugInfo.
   IR->module.addModuleFlag(llvm::Module::Warning, "Debug Info Version",

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -17,11 +17,28 @@ function(add_testsuite config_name dflags model)
     # testsuite build system provides no way to run the test cases with a
     # given set of flags without trying all combinations of them.
     add_test(NAME ${name}
-        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${dflags} MODEL=${model} quick
+        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${dflags} MODEL=${model} GDB_FLAGS=${gdb_flags} quick
     )
     set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
 endfunction()
 
+if((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${LDC_LLVM_VER} GREATER 307))
+    execute_process(COMMAND gdb --version
+                    COMMAND head -n 1
+                    OUTPUT_VARIABLE GDB_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION}")
+    message(STATUS "GDB ${GDB_VERSION} detected")
+    if(GDB_VERSION VERSION_LESS "7.6.1")
+        set(gdb_flags "ON_NOTLS")
+    else()
+        set(gdb_flags "ON")
+    endif()
+else()
+    set(gdb_flags "OFF")
+endif()
+
+string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION}")
 # Would like to specify the "-release" flag for release builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -33,7 +33,7 @@ function(add_testsuite config_name dflags model)
     add_test(NAME clean-${name}
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
 
-    set(all_dflags ${dflags} ${gdb_dflags})
+    string(CONCAT all_dflags ${dflags} ${gdb_dflags})
 
     # The DFLAGS environment variable read by LDMD is used because the DMD
     # testsuite build system provides no way to run the test cases with a

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -6,22 +6,7 @@ elseif(${ptr_size} MATCHES "^8$")
     set(host_model 64)
 endif()
 
-function(add_testsuite config_name dflags model)
-    set(name dmd-testsuite${config_name})
-    set(outdir ${CMAKE_BINARY_DIR}/${name})
-
-    add_test(NAME clean-${name}
-        COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
-
-    # The DFLAGS environment variable read by LDMD is used because the DMD
-    # testsuite build system provides no way to run the test cases with a
-    # given set of flags without trying all combinations of them.
-    add_test(NAME ${name}
-        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${dflags} MODEL=${model} GDB_FLAGS=${gdb_flags} quick
-    )
-    set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
-endfunction()
-
+set(gdb_dflags "")
 if((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${LDC_LLVM_VER} GREATER 307))
     execute_process(COMMAND gdb --version
                     COMMAND head -n 1
@@ -34,19 +19,40 @@ if((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${LDC_LLVM_VER} GREATER 307))
     else()
         set(gdb_flags "ON")
     endif()
+    if(GDB_VERSION VERSION_LESS "7.8")
+        set(gdb_dflags "-dwarf-version=2")
+    endif()
 else()
     set(gdb_flags "OFF")
 endif()
+
+function(add_testsuite config_name dflags model)
+    set(name dmd-testsuite${config_name})
+    set(outdir ${CMAKE_BINARY_DIR}/${name})
+
+    add_test(NAME clean-${name}
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
+
+    set(all_dflags ${dflags} ${gdb_dflags})
+
+    # The DFLAGS environment variable read by LDMD is used because the DMD
+    # testsuite build system provides no way to run the test cases with a
+    # given set of flags without trying all combinations of them.
+    add_test(NAME ${name}
+        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${all_dflags} MODEL=${model} GDB_FLAGS=${gdb_flags} quick
+    )
+    set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
+endfunction()
 
 string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION}")
 # Would like to specify the "-release" flag for release builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
-add_testsuite("-debug" "-g -dwarf-version=2 -link-debuglib" ${host_model})
+add_testsuite("-debug" "-g -link-debuglib" ${host_model})
 add_testsuite("" -O3 ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)
     # Also test in 32 bit mode on x86_64 multilib builds.
-    add_testsuite("-debug-32" "-gc -link-debuglib" 32)
+    add_testsuite("-debug-32" "-g -link-debuglib" 32)
     add_testsuite("-32" -O3 32)
 endif()

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -25,7 +25,7 @@ endfunction()
 # Would like to specify the "-release" flag for relase builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
-add_testsuite("-debug" "-gc -link-debuglib" ${host_model})
+add_testsuite("-debug" "-g -link-debuglib" ${host_model})
 add_testsuite("" -O3 ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -22,10 +22,10 @@ function(add_testsuite config_name dflags model)
     set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
 endfunction()
 
-# Would like to specify the "-release" flag for relase builds, but some of the
+# Would like to specify the "-release" flag for release builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
-add_testsuite("-debug" "-g -link-debuglib" ${host_model})
+add_testsuite("-debug" "-g -dwarf-version=2 -link-debuglib" ${host_model})
 add_testsuite("" -O3 ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -15,7 +15,7 @@ if((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${LDC_LLVM_VER} GREATER 307))
     string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION}")
     message(STATUS "GDB ${GDB_VERSION} detected")
     if(GDB_VERSION VERSION_LESS "7.6.1")
-        set(gdb_flags "ON_NOTLS")
+        set(gdb_flags "NOTLS")
     else()
         set(gdb_flags "ON")
     endif()
@@ -33,7 +33,7 @@ function(add_testsuite config_name dflags model)
     add_test(NAME clean-${name}
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
 
-    string(CONCAT all_dflags ${dflags} ${gdb_dflags})
+    set(all_dflags "${dflags} ${gdb_dflags}")
 
     # The DFLAGS environment variable read by LDMD is used because the DMD
     # testsuite build system provides no way to run the test cases with a

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     set(gdb_flags "OFF")
 endif()
 
-function(add_testsuite config_name dflags model)
+function(add_testsuite config_name dflags gdbflags model)
     set(name dmd-testsuite${config_name})
     set(outdir ${CMAKE_BINARY_DIR}/${name})
 
@@ -39,7 +39,7 @@ function(add_testsuite config_name dflags model)
     # testsuite build system provides no way to run the test cases with a
     # given set of flags without trying all combinations of them.
     add_test(NAME ${name}
-        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${all_dflags} MODEL=${model} GDB_FLAGS=${gdb_flags} quick
+        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${all_dflags} MODEL=${model} GDB_FLAGS=${gdbflags} quick
     )
     set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
 endfunction()
@@ -48,11 +48,11 @@ string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION
 # Would like to specify the "-release" flag for release builds, but some of the
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
-add_testsuite("-debug" "-g -link-debuglib" ${host_model})
-add_testsuite("" -O3 ${host_model})
+add_testsuite("-debug" "-g -link-debuglib" "${gdb_flags}" ${host_model})
+add_testsuite("" -O3 "OFF" ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)
     # Also test in 32 bit mode on x86_64 multilib builds.
-    add_testsuite("-debug-32" "-g -link-debuglib" 32)
-    add_testsuite("-32" -O3 32)
+    add_testsuite("-debug-32" "-g -link-debuglib" "${gdb_flags}" 32)
+    add_testsuite("-32" -O3 "OFF" 32)
 endif()


### PR DESCRIPTION
Another attempt at getting these running. gdb works much better if `-g` is used instead of `-gc` when compiling, as gdb then uses the correct initial source file and interprets global `uint` variables correctly.

@kinke I hope it's ok that I abuse the gdb branch by merging current dmd-testsuite's ldc.

One known issue is "optimized-out" variable in gdb10311.d.

see also https://github.com/ldc-developers/ldc/pull/1658