### PR TITLE
[wip] Add initial ThinLTO support (LLVM >= 3.9)

### DIFF
--- a/tests/linking/thinlto_1.d
+++ b/tests/linking/thinlto_1.d
@@ -1,0 +1,12 @@
+// Test ThinLTO commandline flag
+
+// REQUIRES: atleast_llvm309
+
+// RUN: %ldc %s -of=%t%obj -c -thinlto -vv | FileCheck %s
+
+// CHECK: Writing LLVM bitcode
+// CHECK: Creating module summary for ThinLTO
+
+void main()
+{
+}


### PR DESCRIPTION
For information about ThinLTO, read: http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html

All that is needed inside LDC when ThinLTO is enabled:
- output bitcode instead of object code (but keep the `.o` extension)
- add a module summary index to the bitcode file

**What commandline flag name shall we give this?** 


ThinLTO needs linker support, and testing it on our CI systems is nigh impossible at the moment. :/
Tested with XCode 8:
```d
// file b.d
extern(C) void doesNothing() {}
```

```d
// file a.d
extern(C) void doesNothing(); // declaration only

void main() {
    for (ulong i = 0; i < 100_000_000; ++i) {
        doesNothing();
    }
}
```

Separate compilation (the usual):
```
> ../bin/ldc2 -c b.d -O3 -of=b.o
> ../bin/ldc2 a.d b.o -of=a -O3
> time ./a
./a  1.77s user 0.01s system 98% cpu 1.802 total
```

Separate compilation with ThinLTO:
```
> ../bin/ldc2 -c b.d -O3 -of=bthin.o -thinlto
> ../bin/ldc2 a.d bthin.o -of=athin -O3 -thinlto
> time ./athin
./athin  0.00s user 0.00s system 61% cpu 0.006 total
```

BAM!