### PR TITLE
dcompute: [NFC] Refactor emission of debug info.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -74,6 +74,8 @@ llvm::StringRef uniqueIdent(Type* t) {
 
 } // namespace
 
+bool mustEmitDebugInfo() { return global.params.symdebug; }
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // get the module the symbol is in, or - for template instances - the current
@@ -684,7 +686,7 @@ ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type, bool derefclass) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void ldc::DIBuilder::EmitCompileUnit(Module *m) {
-  if (!global.params.symdebug) {
+  if (!mustEmitDebugInfo()) {
     return;
   }
 
@@ -720,7 +722,7 @@ void ldc::DIBuilder::EmitCompileUnit(Module *m) {
 }
 
 ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
-  if (!global.params.symdebug) {
+  if (!mustEmitDebugInfo()) {
 #if LDC_LLVM_VER >= 307
     return nullptr;
 #else
@@ -768,7 +770,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
 
 ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
                                             FuncDeclaration *fd) {
-  if (!global.params.symdebug) {
+  if (!mustEmitDebugInfo()) {
 #if LDC_LLVM_VER >= 307
     return nullptr;
 #else
@@ -817,7 +819,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitThunk(llvm::Function *Thunk,
 
 ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
                                                  llvm::StringRef prettyname) {
-  if (!global.params.symdebug) {
+  if (!mustEmitDebugInfo()) {
 #if LDC_LLVM_VER >= 307
     return nullptr;
 #else
@@ -872,7 +874,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
 }
 
 void ldc::DIBuilder::EmitFuncStart(FuncDeclaration *fd) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf funcstart");
@@ -883,7 +885,7 @@ void ldc::DIBuilder::EmitFuncStart(FuncDeclaration *fd) {
 }
 
 void ldc::DIBuilder::EmitFuncEnd(FuncDeclaration *fd) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf funcend");
@@ -894,7 +896,7 @@ void ldc::DIBuilder::EmitFuncEnd(FuncDeclaration *fd) {
 }
 
 void ldc::DIBuilder::EmitBlockStart(Loc &loc) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf block start");
@@ -915,7 +917,7 @@ void ldc::DIBuilder::EmitBlockStart(Loc &loc) {
 }
 
 void ldc::DIBuilder::EmitBlockEnd() {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf block end");
@@ -927,7 +929,7 @@ void ldc::DIBuilder::EmitBlockEnd() {
 }
 
 void ldc::DIBuilder::EmitStopPoint(Loc &loc) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
 // If we already have a location set and the current loc is invalid
@@ -958,7 +960,7 @@ void ldc::DIBuilder::EmitValue(llvm::Value *val, VarDeclaration *vd) {
     return;
 
   ldc::DILocalVariable debugVariable = sub->second;
-  if (!global.params.symdebug || !debugVariable)
+  if (!global.params.symdebug || !debugVariable || gDComputeTarget)
     return;
 
   llvm::Instruction *instr =
@@ -982,7 +984,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
                                        llvm::ArrayRef<llvm::Value *> addr
 #endif
                                        ) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf local variable");
@@ -1100,7 +1102,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
 
 void ldc::DIBuilder::EmitGlobalVariable(llvm::GlobalVariable *llVar,
                                         VarDeclaration *vd) {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   Logger::println("D to dwarf global_variable");
@@ -1135,7 +1137,7 @@ void ldc::DIBuilder::EmitGlobalVariable(llvm::GlobalVariable *llVar,
 }
 
 void ldc::DIBuilder::Finalize() {
-  if (!global.params.symdebug)
+  if (!mustEmitDebugInfo())
     return;
 
   DBuilder.finalize();

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -74,7 +74,7 @@ llvm::StringRef uniqueIdent(Type* t) {
 
 } // namespace
 
-bool mustEmitDebugInfo() { return global.params.symdebug; }
+bool ldc::DIBuilder::mustEmitDebugInfo() { return global.params.symdebug; }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -960,7 +960,7 @@ void ldc::DIBuilder::EmitValue(llvm::Value *val, VarDeclaration *vd) {
     return;
 
   ldc::DILocalVariable debugVariable = sub->second;
-  if (!global.params.symdebug || !debugVariable || gDComputeTarget)
+  if (!mustEmitDebugInfo() || !debugVariable)
     return;
 
   llvm::Instruction *instr =

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -196,6 +196,8 @@ private:
   DIType CreateDelegateType(Type *type);
   DIType CreateTypeDescription(Type *type, bool derefclass = false);
 
+  bool mustEmitDebugInfo();
+
 public:
   template <typename T>
   void OpOffset(T &addr, llvm::StructType *type, int index) {


### PR DESCRIPTION
Better annotate reasons for not emitting debug info. Also make it
easier to change conditions under which DI should be emitted.

This will make it easier when more dcompute related code is added, as
there cannot be any DI emission for dcompute (SPIRV does allow some
extra debug info but that is not in the current scope of dcompute yet, and done
a very different way, ~~not sure about CUDA~~ CUDA appears to support dwarf, with some extensions).