### PR TITLE
dcompute: addrspace awareness

### DIFF
--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -62,7 +62,7 @@ DRValue::DRValue(Type *t, LLValue *v) : DValue(t, v) {
 
 DImValue::DImValue(Type *t, llvm::Value *v) : DRValue(t, v) {
   // TODO: get rid of Tfunction exception
-  assert(t->toBasetype()->ty == Tfunction || StripAddrSpaces(v->getType()) == DtoType(t));
+  assert(t->toBasetype()->ty == Tfunction || stripAddrSpaces(v->getType()) == DtoType(t));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ DConstValue::DConstValue(Type *t, LLConstant *con) : DRValue(t, con) {
 
 DSliceValue::DSliceValue(Type *t, LLValue *pair) : DRValue(t, pair) {
   assert(t->toBasetype()->ty == Tarray);
-  assert(StripAddrSpaces(pair->getType()) == DtoType(t));
+  assert(stripAddrSpaces(pair->getType()) == DtoType(t));
 }
 
 DSliceValue::DSliceValue(Type *t, LLValue *length, LLValue *ptr)
@@ -101,7 +101,7 @@ bool DFuncValue::definedInFuncEntryBB() {
 ////////////////////////////////////////////////////////////////////////////////
 
 DLValue::DLValue(Type *t, LLValue *v) : DValue(t, v) {
-  assert(t->toBasetype()->ty == Ttuple || StripAddrSpaces(v->getType()) == DtoPtrToType(t));
+  assert(t->toBasetype()->ty == Ttuple || stripAddrSpaces(v->getType()) == DtoPtrToType(t));
 }
 
 DRValue *DLValue::getRVal() {

--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -62,6 +62,8 @@ DRValue::DRValue(Type *t, LLValue *v) : DValue(t, v) {
 
 DImValue::DImValue(Type *t, llvm::Value *v) : DRValue(t, v) {
   // TODO: get rid of Tfunction exception
+  // v may be an addrspace qualified pointer so strip it before doing a pointer
+  // equality check.
   assert(t->toBasetype()->ty == Tfunction || stripAddrSpaces(v->getType()) == DtoType(t));
 }
 
@@ -75,6 +77,8 @@ DConstValue::DConstValue(Type *t, LLConstant *con) : DRValue(t, con) {
 
 DSliceValue::DSliceValue(Type *t, LLValue *pair) : DRValue(t, pair) {
   assert(t->toBasetype()->ty == Tarray);
+  // v may have an addrspace qualified pointer so strip it before doing a pointer
+  // equality check.
   assert(stripAddrSpaces(pair->getType()) == DtoType(t));
 }
 
@@ -101,6 +105,8 @@ bool DFuncValue::definedInFuncEntryBB() {
 ////////////////////////////////////////////////////////////////////////////////
 
 DLValue::DLValue(Type *t, LLValue *v) : DValue(t, v) {
+  // v may be an addrspace qualified pointer so strip it before doing a pointer
+  // equality check.
   assert(t->toBasetype()->ty == Ttuple || stripAddrSpaces(v->getType()) == DtoPtrToType(t));
 }
 

--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -62,7 +62,7 @@ DRValue::DRValue(Type *t, LLValue *v) : DValue(t, v) {
 
 DImValue::DImValue(Type *t, llvm::Value *v) : DRValue(t, v) {
   // TODO: get rid of Tfunction exception
-  assert(t->toBasetype()->ty == Tfunction || v->getType() == DtoType(t));
+  assert(t->toBasetype()->ty == Tfunction || StripAddrSpaces(v->getType()) == DtoType(t));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ DConstValue::DConstValue(Type *t, LLConstant *con) : DRValue(t, con) {
 
 DSliceValue::DSliceValue(Type *t, LLValue *pair) : DRValue(t, pair) {
   assert(t->toBasetype()->ty == Tarray);
-  assert(pair->getType() == DtoType(t));
+  assert(StripAddrSpaces(pair->getType()) == DtoType(t));
 }
 
 DSliceValue::DSliceValue(Type *t, LLValue *length, LLValue *ptr)
@@ -101,7 +101,7 @@ bool DFuncValue::definedInFuncEntryBB() {
 ////////////////////////////////////////////////////////////////////////////////
 
 DLValue::DLValue(Type *t, LLValue *v) : DValue(t, v) {
-  assert(t->toBasetype()->ty == Ttuple || v->getType() == DtoPtrToType(t));
+  assert(t->toBasetype()->ty == Ttuple || StripAddrSpaces(v->getType()) == DtoPtrToType(t));
 }
 
 DRValue *DLValue::getRVal() {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -531,7 +531,7 @@ void DtoAlignedStore(LLValue *src, LLValue *dst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-LLType *StripAddrSpaces(LLType *t)
+LLType *stripAddrSpaces(LLType *t)
 {
   // Fastpath for normal compilation.
   if(gIR->dcomputetarget == nullptr)
@@ -549,7 +549,7 @@ LLType *StripAddrSpaces(LLType *t)
 }
 
 LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
-  if (StripAddrSpaces(v->getType()) == t) {
+  if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }
   assert(!isaStruct(t));

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -549,6 +549,12 @@ LLType *stripAddrSpaces(LLType *t)
 }
 
 LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
+  // Strip addrspace qualifications from v before comparing types by pointer
+  // equality. This avoids the case where the pointer in { T addrspace(n)* }
+  // is dereferenced and generates a GEP -> (invalid) bitcast -> load sequence.
+  // Bitcasting of pointers between addrspaces is invalid in LLVM IR. Even if
+  // te were, it wouldn't be the desired outcome as we would always load from
+  // addrspace(0), not the addrspace of the pointer.
   if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }
@@ -557,6 +563,7 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
 }
 
 LLConstant *DtoBitCast(LLConstant *v, LLType *t) {
+  // Same as above.
   if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -557,7 +557,7 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
 }
 
 LLConstant *DtoBitCast(LLConstant *v, LLType *t) {
-  if (StripAddrSpaces(v->getType()) == t) {
+  if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }
   return llvm::ConstantExpr::getBitCast(v, t);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -553,8 +553,8 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
   // equality. This avoids the case where the pointer in { T addrspace(n)* }
   // is dereferenced and generates a GEP -> (invalid) bitcast -> load sequence.
   // Bitcasting of pointers between addrspaces is invalid in LLVM IR. Even if
-  // te were, it wouldn't be the desired outcome as we would always load from
-  // addrspace(0), not the addrspace of the pointer.
+  // it were valid, it wouldn't be the desired outcome as we would always load
+  // from addrspace(0), instead of the addrspace of the pointer.
   if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }
@@ -563,7 +563,7 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
 }
 
 LLConstant *DtoBitCast(LLConstant *v, LLType *t) {
-  // Same as above.
+  // Refer to the explanation in the other DtoBitCast overloaded function.
   if (stripAddrSpaces(v->getType()) == t) {
     return v;
   }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -533,14 +533,17 @@ void DtoAlignedStore(LLValue *src, LLValue *dst) {
 
 LLType *StripAddrSpaces(LLType *t)
 {
-  //if(!gDcomputeTarget) return t;
+  // Fastpath for normal compilation.
+  if(gIR->dcomputetarget == nullptr)
+    return t;
+
   int indirections = 0;
   while (t->isPointerTy()) {
     indirections++;
     t = t->getPointerElementType();
   }
   while (indirections-- != 0) {
-        t = t->getPointerTo(0);
+    t = t->getPointerTo(0);
   }
   return t;
 }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -531,8 +531,22 @@ void DtoAlignedStore(LLValue *src, LLValue *dst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+LLType *StripAddrSpaces(LLType *t)
+{
+    int indirections = 0;
+    while (t->isPointerTy()) {
+        indirections++;
+        t = t->getPointerElementType();
+    }
+    while (indirections-- != 0) {
+        t = t->getPointerTo(0);
+    }
+    return t;
+}
+
 LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
-  if (v->getType() == t) {
+  // Dont generate an invalid bitcast from say float addrspace(1)** to float**
+  if (StripAddrSpaces(v->getType()) == t) {
     return v;
   }
   assert(!isaStruct(t));

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -533,15 +533,16 @@ void DtoAlignedStore(LLValue *src, LLValue *dst) {
 
 LLType *StripAddrSpaces(LLType *t)
 {
-    int indirections = 0;
-    while (t->isPointerTy()) {
-        indirections++;
-        t = t->getPointerElementType();
-    }
-    while (indirections-- != 0) {
+  //if(!gDcomputeTarget) return t;
+  int indirections = 0;
+  while (t->isPointerTy()) {
+    indirections++;
+    t = t->getPointerElementType();
+  }
+  while (indirections-- != 0) {
         t = t->getPointerTo(0);
-    }
-    return t;
+  }
+  return t;
 }
 
 LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -546,7 +546,6 @@ LLType *StripAddrSpaces(LLType *t)
 }
 
 LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
-  // Dont generate an invalid bitcast from say float addrspace(1)** to float**
   if (StripAddrSpaces(v->getType()) == t) {
     return v;
   }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -554,7 +554,7 @@ LLValue *DtoBitCast(LLValue *v, LLType *t, const llvm::Twine &name) {
 }
 
 LLConstant *DtoBitCast(LLConstant *v, LLType *t) {
-  if (v->getType() == t) {
+  if (StripAddrSpaces(v->getType()) == t) {
     return v;
   }
   return llvm::ConstantExpr::getBitCast(v, t);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -42,15 +42,8 @@ LLType *voidToI8(LLType *t);
 LLType *i1ToI8(LLType *t);
 
 // Removes all addrspace qualifications. float addrspace(1)** -> float**
-// Used to avoid invalid bitcasts between addrspaces when comparing pointer
-// types for equality when GEP'ing a struct containing a pointer with an
-// addrspace qualifier. Needed because we turn
-//      struct Pointer!(uint n ,T) {T* ptr; alias ptr this;}
-// into { T addrspace(n)* } instead of { T* }, so when dereferencing this type
-// we would GEP the pointer, see that the types are not equal, bitcast and then
-// load. The generated bitcast crosses addrspace boundries and is thus invalid.
-// By considering pointer types equal by ignoring the addrspace we avert
-// this problem (see DtoBitCast).
+// Use when compare pointers LLType* for equality with `== ` when one side
+// may be addrspace qualified.
 LLType *stripAddrSpaces(LLType *v);
 
 // Returns true if the type is a value type which LDC keeps exclusively in

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -40,8 +40,19 @@ LLPointerType *DtoPtrToType(Type *t);
 
 LLType *voidToI8(LLType *t);
 LLType *i1ToI8(LLType *t);
+
 // Removes all addrspace qualifications. float addrspace(1)** -> float**
+// Used to avoid invalid bitcasts between addrspaces when comparing pointer
+// types for equality when GEP'ing a struct containing a pointer with an
+// addrspace qualifier. Needed because we turn
+//      struct Pointer!(uint n ,T) {T* ptr; alias ptr this;}
+// into { T addrspace(n)* } instead of { T* }, so when dereferencing this type
+// we would GEP the pointer, see that the types are not equal, bitcast and then
+// load. The generated bitcast crosses addrspace boundries and is thus invalid.
+// By considering pointer types equal by ignoring the addrspace we avert
+// this problem (see DtoBitCast).
 LLType *stripAddrSpaces(LLType *v);
+
 // Returns true if the type is a value type which LDC keeps exclusively in
 // memory, referencing all values via LL pointers (structs and static arrays).
 bool DtoIsInMemoryOnly(Type *type);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -42,7 +42,7 @@ LLType *voidToI8(LLType *t);
 LLType *i1ToI8(LLType *t);
 
 // Removes all addrspace qualifications. float addrspace(1)** -> float**
-// Use when compare pointers LLType* for equality with `== ` when one side
+// Use when comparing pointers LLType* for equality with `== ` when one side
 // may be addrspace qualified.
 LLType *stripAddrSpaces(LLType *v);
 

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -41,7 +41,7 @@ LLPointerType *DtoPtrToType(Type *t);
 LLType *voidToI8(LLType *t);
 LLType *i1ToI8(LLType *t);
 // Removes all addrspace qualifications. float addrspace(1)** -> float**
-LLType *StripAddrSpaces(LLType *v);
+LLType *stripAddrSpaces(LLType *v);
 // Returns true if the type is a value type which LDC keeps exclusively in
 // memory, referencing all values via LL pointers (structs and static arrays).
 bool DtoIsInMemoryOnly(Type *type);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -40,7 +40,8 @@ LLPointerType *DtoPtrToType(Type *t);
 
 LLType *voidToI8(LLType *t);
 LLType *i1ToI8(LLType *t);
-
+// Removes all addrspace qualifications. float addrspace(1)** -> float**
+LLType *StripAddrSpaces(LLType *v);
 // Returns true if the type is a value type which LDC keeps exclusively in
 // memory, referencing all values via LL pointers (structs and static arrays).
 bool DtoIsInMemoryOnly(Type *type);


### PR DESCRIPTION
LDC currently assumes that there is only one addrspace, zero.
dcompute requires the use of multiple AS to deal with global/shared
generic pointer. This PR addresses this issue.

There are only two root uses (bar asserts) that I have identified, (there may
be more, but libmir/dcompute build fine with #1786 HEAD~3) which is
generating an invalid  bitcast, because the types are not equal, but
for the purposes of copying do not require, and cannot be done with, a
bitcast.

Most suspicious type comparisons seem to resort to using DtoBitCast. 
Further testing will be required to see if any resulting from 
`gIR->ir->CreateBitCast(...)` are valid in dcompute 
(i.e. not classes,aa,typeinfo etc.) 
