### PR TITLE
Apply TargetMachine options as function attributes in IR.

### DIFF
--- a/tests/codegen/attr_targetoptions.d
+++ b/tests/codegen/attr_targetoptions.d
@@ -1,0 +1,27 @@
+// Tests that our TargetMachine options are added as function attributes
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix=DEFAULT < %t.ll
+// RUN: %ldc -c -output-ll -of=%t.ll %s -disable-fp-elim && FileCheck %s --check-prefix=FRAMEPTR < %t.ll
+// RUN: %ldc -c -output-ll -of=%t.ll %s -mattr=test && FileCheck %s --check-prefix=ATTR < %t.ll
+
+// DEFAULT: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+// FRAMEPTR: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+// ATTR: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+void foo()
+{
+}
+
+// DEFAULT: attributes #[[KEYVALUE]]
+// DEFAULT-DAG: "target-cpu"=
+// DEFAULT-DAG: "use-soft-float"="{{(true|false)}}"
+// DEFAULT-DAG: "no-frame-pointer-elim"="false"
+// DEFAULT-DAG: "unsafe-fp-math"="false"
+// DEFAULT-DAG: "less-precise-fpmad"="false"
+// DEFAULT-DAG: "no-infs-fp-math"="false"
+// DEFAULT-DAG: "no-nans-fp-math"="false"
+
+// FRAMEPTR: attributes #[[KEYVALUE]]
+// FRAMEPTR-DAG: "no-frame-pointer-elim"="true"
+
+// ATTR: attributes #[[KEYVALUE]]
+// ATTR-DAG: "target-features"="{{.*}}+test{{.*}}"

--- a/tests/codegen/inlineIR_math.d
+++ b/tests/codegen/inlineIR_math.d
@@ -113,4 +113,4 @@ double neverInlinedEnclosingFunction()
 // LLVM-DAG: attributes #[[UNSAFEFPMATH]] ={{.*}} "unsafe-fp-math"="true"
 // LLVM-DAG: attributes #[[UNSAFEFPMATH2]] ={{.*}} "unsafe-fp-math"="true"
 // LLVM-DAG: attributes #[[UNSAFEFPMATH3]] ={{.*}} "unsafe-fp-math"="false"
-// LLVM-DAG: attributes #[[FEAT]] ={{.*}} "target-features"="+fma"
+// LLVM-DAG: attributes #[[FEAT]] ={{.*}} "target-features"="{{.*}}+fma{{.*}}"


### PR DESCRIPTION
This change is needed for LTO, as the linker/LTO-codegen otherwise would use the default TargetOptions.

~~Work-in-progress: will add tests when green.~~

Note: Clang does exactly the same.