### PR TITLE
Adapt emission of debuginfos for parameters

### DIFF
--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -136,15 +136,15 @@ public:
 
   /// \brief Emits all things necessary for making debug info for a local
   /// variable vd.
-  /// \param ll       LLVM Value of the variable.
+  /// \param ll       LL lvalue of the variable.
   /// \param vd       Variable declaration to emit debug info for.
-  /// \param type     Type of parameter if different from vd->type
-  /// \param isThisPtr Parameter is hidden this pointer
-  /// \param bool rewrittenToLocal Parameter is copied to local stack frame/closure
+  /// \param type     Type of variable if different from vd->type
+  /// \param isThisPtr Variable is hidden this pointer
+  /// \param forceAsLocal Emit as local even if the variable is a parameter
   /// \param addr     An array of complex address operations.
   void
   EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd, Type *type = nullptr,
-                    bool isThisPtr = false, bool rewrittenToLocal = false,
+                    bool isThisPtr = false, bool forceAsLocal = false,
 #if LDC_LLVM_VER >= 306
                     llvm::ArrayRef<int64_t> addr = llvm::ArrayRef<int64_t>()
 #else

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -79,6 +79,8 @@ class DIBuilder {
   const llvm::MDNode *CUNode;
 #endif
 
+  const bool isTargetMSVCx64;
+
   DICompileUnit GetCU() {
 #if LDC_LLVM_VER >= 307
     return CUNode;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -705,7 +705,6 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
     // E.g., for a lazy parameter of type T, vd->type is T (with lazy storage
     // class) while irparam->arg->type is the delegate type.
     Type *const paramType = (irparam ? irparam->arg->type : vd->type);
-    bool rewrittenToLocal = false;
 
     if (!irparam) {
       // This is a parameter that is not passed on the LLVM level.
@@ -722,10 +721,8 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
         assert(irparam->value->getType() == DtoPtrToType(paramType));
       } else {
         // Let the ABI transform the parameter back to an lvalue.
-        auto Lvalue =
+        irparam->value =
             irFty.getParamLVal(paramType, llArgIdx, irparam->value);
-        rewrittenToLocal = Lvalue != irparam->value;
-        irparam->value = Lvalue;
       }
 
       irparam->value->setName(vd->ident->toChars());
@@ -734,7 +731,7 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
     }
 
     if (global.params.symdebug)
-      gIR->DBuilder.EmitLocalVariable(irparam->value, vd, paramType, false, rewrittenToLocal);
+      gIR->DBuilder.EmitLocalVariable(irparam->value, vd, paramType);
   }
 }
 

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -155,7 +155,8 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   }
 
   if (dwarfValue && global.params.symdebug) {
-    gIR->DBuilder.EmitLocalVariable(dwarfValue, vd, nullptr, false, /*fromNested=*/ true, dwarfAddr);
+    gIR->DBuilder.EmitLocalVariable(dwarfValue, vd, nullptr, false, true,
+                                    dwarfAddr);
   }
 
   return makeVarDValue(astype, vd, val);

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -28,16 +28,6 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: !args_cdb.byValue
 // CDB: dv /t
 
-// arguments not converted to locals come first:
-// x64: cdouble * c
-// x64: int delegate() * dg
-// "Internal implementation error for fa" with cdb on x64, ok in VS
-// x64: Interface * ifc
-
-// x86: unsigned char [16] fa
-// x86: Interface ifc
-
-// locals:
 // CHECK: unsigned char ub = 0x01
 // CHECK: unsigned short us = 2
 // CHECK: unsigned int ui = 3
@@ -45,15 +35,22 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: float f = 5
 // CHECK: double d = 6
 // CHECK: double r = 7
+// x64: cdouble * c =
 // x86: cdouble c =
+// x64: int delegate() * dg =
 // x86: int delegate() dg =
 // CHECK: <function> * fun = {{0x[0-9a-f`]*}}
-// CHECK: struct int[] slice =
+// x64: struct int[] * slice =
+// x86: struct int[] slice =
 // CHECK: unsigned char * aa = {{0x[0-9a-f`]*}}
+// "Internal implementation error for fa" with cdb on x64, ok in VS
+// x86: unsigned char [16] fa
 // CHECK: float [4] f4 = float [4]
 // CHECK: double [4] d4 = double [4]
+// x64: Interface * ifc
+// x86: Interface ifc
 // CHECK: struct TypeInfo_Class * ti = {{0x[0-9a-f`]*}}
-// noCHECK: <CLR type> np = <unknown base type 80000013> 
+// CHECK: void * np = {{0x[0`]*}}
 
 // check arguments with indirections
 // CDB: ?? c
@@ -68,7 +65,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK-SAME: args_cdb.main.__lambda
 
 // CDB: ?? fa[1]
-// "Internal implementation error for fa" on x64
+// "Internal implementation error for fa" with cdb on x64, ok in VS
 // no-x86: unsigned char 0x0e (displays 0xf6)
 
 // CDB: ?? ifc
@@ -90,7 +87,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
           float4* f4, double4* d4,
           Interface* ifc, TypeInfo_Class* ti, typeof(null)* np)
 {
-// CDB: bp `args_cdb.d:94`
+// CDB: bp `args_cdb.d:91`
 // CDB: g
     return 3;
 // CHECK: !args_cdb.byPtr
@@ -141,7 +138,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CHECK-NEXT: m_init : byte[]
 // shows bad member values
 // CDB: ?? *np
-// noCHECK: <CLR type> np = <unknown base type 80000013> 
+// CHECK: void * {{0x[0`]*}}
 }
 
 int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
@@ -151,7 +148,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
           ref float4 f4, ref double4 d4,
           ref Interface ifc, ref TypeInfo_Class ti, ref typeof(null) np)
 {
-// CDB: bp `args_cdb.d:206`
+// CDB: bp `args_cdb.d:203`
 // CDB: g
 // CHECK: !args_cdb.byRef
 
@@ -201,7 +198,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 // CHECK: struct TypeInfo_Class * {{0x[0-9a-f`]*}}
 // CHECK-NEXT: m_init : byte[]
 // CDB: ?? *np
-// noCHECK: <CLR type> <unknown base type 80000013> 
+// CHECK: void * {{0x[0`]*}}
 
 // needs access to references to actually generate debug info
     ub++;
@@ -254,4 +251,3 @@ int main()
 }
 // CDB: q
 // CHECK: quit
-

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -40,17 +40,21 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // x64: int delegate() * dg =
 // x86: int delegate() dg =
 // CHECK: <function> * fun = {{0x[0-9a-f`]*}}
-// x64: struct int[] * slice =
 // x86: struct int[] slice =
 // CHECK: unsigned char * aa = {{0x[0-9a-f`]*}}
 // "Internal implementation error for fa" with cdb on x64, ok in VS
 // x86: unsigned char [16] fa
-// CHECK: float [4] f4 = float [4]
-// CHECK: double [4] d4 = double [4]
+// x86: float [4] f4 = float [4]
+// x86: double [4] d4 = double [4]
 // x64: Interface * ifc
 // x86: Interface ifc
 // CHECK: struct TypeInfo_Class * ti = {{0x[0-9a-f`]*}}
 // CHECK: void * np = {{0x[0`]*}}
+
+// params emitted as locals (listed after params) for Win64:
+// x64: struct int[] slice
+// x64: float [4] f4 = float [4]
+// x64: double [4] d4 = double [4]
 
 // check arguments with indirections
 // CDB: ?? c
@@ -64,9 +68,20 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK-NEXT: funcptr
 // CHECK-SAME: args_cdb.main.__lambda
 
+// CDB: ?? slice
+// CHECK: struct int[]
+// CHECK-NEXT: length : 2
+// CHECK-NEXT: ptr
+
 // CDB: ?? fa[1]
 // "Internal implementation error for fa" with cdb on x64, ok in VS
 // no-x86: unsigned char 0x0e (displays 0xf6)
+
+// CDB: ?? f4[1]
+// CHECK: float 16
+
+// CDB: ?? d4[2]
+// CHECK: double 17
 
 // CDB: ?? ifc
 // CHECK: Interface
@@ -87,7 +102,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
           float4* f4, double4* d4,
           Interface* ifc, TypeInfo_Class* ti, typeof(null)* np)
 {
-// CDB: bp `args_cdb.d:91`
+// CDB: bp `args_cdb.d:106`
 // CDB: g
     return 3;
 // CHECK: !args_cdb.byPtr
@@ -148,7 +163,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
           ref float4 f4, ref double4 d4,
           ref Interface ifc, ref TypeInfo_Class ti, ref typeof(null) np)
 {
-// CDB: bp `args_cdb.d:203`
+// CDB: bp `args_cdb.d:218`
 // CDB: g
 // CHECK: !args_cdb.byRef
 

--- a/tests/debuginfo/nested_llvm306.d
+++ b/tests/debuginfo/nested_llvm306.d
@@ -18,5 +18,5 @@ void encloser(int arg0, int arg1)
 
 // CHECK: @_D{{.*}}8encloserFiiZv{{.*}}DW_TAG_subprogram
 // CHECK: @_D{{.*}}8encloserFiiZ6nestedMFiZv{{.*}}DW_TAG_subprogram
-// CHECK: nes_i{{.*}}DW_TAG_auto_variable
+// CHECK: nes_i{{.*}}DW_TAG_arg_variable
 // CHECK: arg1{{.*}}DW_TAG_auto_variable

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -19,5 +19,5 @@ void encloser(int arg0, int arg1)
 // CHECK: !DISubprogram(name:{{.*}}"{{.*}}.encloser"
 // CHECK-SAME: function: void {{.*}} @_D{{.*}}8encloserFiiZv
 // CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}.encloser.nested"
-// CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}nes_i
+// CHECK: !DILocalVariable{{.*}}DW_TAG_arg_variable{{.*}}nes_i
 // CHECK: !DILocalVariable{{.*}}DW_TAG_auto_variable{{.*}}arg1

--- a/tests/debuginfo/strings_cdb.d
+++ b/tests/debuginfo/strings_cdb.d
@@ -43,7 +43,8 @@ int main(string[] args)
 // CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // CDB: dv /t
-// CHECK: string[] args
+// x64: string[] * args
+// x86: string[] args
 // CHECK: string[] nargs
 // CHECK: string ns
 // CHECK: string ws
@@ -52,7 +53,7 @@ int main(string[] args)
 // CDB: ?? ns
 // CHECK: +0x000 length {{ *}}: 1
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *}} "a"
-// CDB: ?? args.ptr[0]
+// CDB: ?? nargs.ptr[0]
 // CHECK: +0x000 length
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe.*"}}
 }

--- a/tests/debuginfo/strings_cdb.d
+++ b/tests/debuginfo/strings_cdb.d
@@ -43,8 +43,7 @@ int main(string[] args)
 // CHECK: +[[OFF]] ptr {{ *}}: [[PTR]]
 
 // CDB: dv /t
-// x64: string[] * args
-// x86: string[] args
+// CHECK: string[] args
 // CHECK: string[] nargs
 // CHECK: string ns
 // CHECK: string ws
@@ -53,7 +52,7 @@ int main(string[] args)
 // CDB: ?? ns
 // CHECK: +0x000 length {{ *}}: 1
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *}} "a"
-// CDB: ?? nargs.ptr[0]
+// CDB: ?? args.ptr[0]
 // CHECK: +0x000 length
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe.*"}}
 }


### PR DESCRIPTION
Non-MSVC targets: emit all parameters (except for captured ones) as DI parameters.

MSVC targets: emit all parameters as DI locals to work around misc. issues discussed in PR #1804.