### PR TITLE
fix build against LLVM master: clEnumValEnd removed

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -60,10 +60,10 @@ cl::list<std::string> runargs(
 
 static cl::opt<ubyte, true> useDeprecated(
     cl::desc("Allow deprecated code/language features:"), cl::ZeroOrMore,
-    cl::values(clEnumValN(0, "de", "Do not allow deprecated features"),
-               clEnumValN(1, "d", "Silently allow deprecated features"),
-               clEnumValN(2, "dw", "Warn about the use of deprecated features"),
-               clEnumValEnd),
+    clEnumValues(clEnumValN(0, "de", "Do not allow deprecated features"),
+                 clEnumValN(1, "d", "Silently allow deprecated features"),
+                 clEnumValN(2, "dw",
+                            "Warn about the use of deprecated features")),
     cl::location(global.params.useDeprecated), cl::init(2));
 
 cl::opt<bool, true>
@@ -106,21 +106,19 @@ static cl::opt<unsigned, true> errorLimit(
 
 static cl::opt<ubyte, true>
     warnings(cl::desc("Warnings:"), cl::ZeroOrMore,
-             cl::values(clEnumValN(1, "w", "Enable warnings"),
-                        clEnumValN(2, "wi", "Enable informational warnings"),
-                        clEnumValEnd),
+             clEnumValues(clEnumValN(1, "w", "Enable warnings"),
+                          clEnumValN(2, "wi", "Enable informational warnings")),
              cl::location(global.params.warnings), cl::init(0));
 
 static cl::opt<bool, true> ignoreUnsupportedPragmas(
     "ignore", cl::desc("Ignore unsupported pragmas"), cl::ZeroOrMore,
     cl::location(global.params.ignoreUnsupportedPragmas));
 
-static cl::opt<ubyte, true>
-    debugInfo(cl::desc("Generating debug information:"), cl::ZeroOrMore,
-              cl::values(clEnumValN(1, "g", "Generate debug information"),
-                         clEnumValN(2, "gc", "Same as -g, but pretend to be C"),
-                         clEnumValEnd),
-              cl::location(global.params.symdebug), cl::init(0));
+static cl::opt<ubyte, true> debugInfo(
+    cl::desc("Generating debug information:"), cl::ZeroOrMore,
+    clEnumValues(clEnumValN(1, "g", "Generate debug information"),
+                 clEnumValN(2, "gc", "Same as -g, but pretend to be C")),
+    cl::location(global.params.symdebug), cl::init(0));
 
 static cl::opt<unsigned, true>
     dwarfVersion("dwarf-version", cl::desc("Dwarf version"),
@@ -299,7 +297,7 @@ cl::opt<llvm::Reloc::Model> mRelocModel(
 #if LDC_LLVM_VER < 309
     cl::init(llvm::Reloc::Default),
 #endif
-    cl::values(
+    clEnumValues(
 #if LDC_LLVM_VER < 309
         clEnumValN(llvm::Reloc::Default, "default",
                    "Target default relocation model"),
@@ -308,24 +306,22 @@ cl::opt<llvm::Reloc::Model> mRelocModel(
         clEnumValN(llvm::Reloc::PIC_, "pic",
                    "Fully relocatable, position independent code"),
         clEnumValN(llvm::Reloc::DynamicNoPIC, "dynamic-no-pic",
-                   "Relocatable external references, non-relocatable code"),
-        clEnumValEnd));
+                   "Relocatable external references, non-relocatable code")));
 
 cl::opt<llvm::CodeModel::Model> mCodeModel(
     "code-model", cl::desc("Code model"), cl::init(llvm::CodeModel::Default),
-    cl::values(
+    clEnumValues(
         clEnumValN(llvm::CodeModel::Default, "default",
                    "Target default code model"),
         clEnumValN(llvm::CodeModel::Small, "small", "Small code model"),
         clEnumValN(llvm::CodeModel::Kernel, "kernel", "Kernel code model"),
         clEnumValN(llvm::CodeModel::Medium, "medium", "Medium code model"),
-        clEnumValN(llvm::CodeModel::Large, "large", "Large code model"),
-        clEnumValEnd));
+        clEnumValN(llvm::CodeModel::Large, "large", "Large code model")));
 
 cl::opt<FloatABI::Type> mFloatABI(
     "float-abi", cl::desc("ABI/operations to use for floating-point types:"),
     cl::init(FloatABI::Default),
-    cl::values(
+    clEnumValues(
         clEnumValN(FloatABI::Default, "default",
                    "Target default floating-point ABI"),
         clEnumValN(FloatABI::Soft, "soft",
@@ -333,8 +329,7 @@ cl::opt<FloatABI::Type> mFloatABI(
         clEnumValN(FloatABI::SoftFP, "softfp",
                    "Soft-float ABI, but hardware floating-point instructions"),
         clEnumValN(FloatABI::Hard, "hard",
-                   "Hardware floating-point ABI and instructions"),
-        clEnumValEnd));
+                   "Hardware floating-point ABI and instructions")));
 
 cl::opt<bool>
     disableFpElim("disable-fp-elim",
@@ -348,12 +343,11 @@ static cl::opt<bool, true, FlagParser<bool>>
 
 cl::opt<BOUNDSCHECK> boundsCheck(
     "boundscheck", cl::desc("Enable array bounds check"),
-    cl::values(clEnumValN(BOUNDSCHECKoff, "off", "no array bounds checks"),
-               clEnumValN(BOUNDSCHECKsafeonly, "safeonly",
-                          "array bounds checks for safe functions only"),
-               clEnumValN(BOUNDSCHECKon, "on",
-                          "array bounds checks for all functions"),
-               clEnumValEnd),
+    clEnumValues(clEnumValN(BOUNDSCHECKoff, "off", "no array bounds checks"),
+                 clEnumValN(BOUNDSCHECKsafeonly, "safeonly",
+                            "array bounds checks for safe functions only"),
+                 clEnumValN(BOUNDSCHECKon, "on",
+                            "array bounds checks for all functions")),
     cl::init(BOUNDSCHECKdefault));
 
 static cl::opt<bool, true, FlagParser<bool>>

--- a/gen/cl_helpers.h
+++ b/gen/cl_helpers.h
@@ -206,4 +206,16 @@ public:
 };
 }
 
+
+#if LDC_LLVM_VER >= 400
+#define clEnumValues llvm::cl::values
+#else
+template <typename DataType, typename... OptsTy>
+llvm::cl::ValuesClass<DataType> clEnumValues(const char *Arg, DataType Val,
+                                             const char *Desc,
+                                             OptsTy... Options) {
+  return llvm::cl::values(Arg, Val, Desc, Options..., clEnumValEnd);
+}
+#endif
+
 #endif

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/llvmhelpers.h"
+#include "gen/cl_helpers.h"
 #include "declaration.h"
 #include "expression.h"
 #include "gen/abi.h"
@@ -44,19 +45,23 @@
 
 #include "llvm/Support/CommandLine.h"
 
+#if LDC_LLVM_VER >= 400
+// trick clEnumValN() into prepending the llvm namesspace 
+namespace cl { using OptionEnumValue = llvm::cl::OptionEnumValue; }
+#endif
+
 llvm::cl::opt<llvm::GlobalVariable::ThreadLocalMode> clThreadModel(
     "fthread-model", llvm::cl::desc("Thread model"),
     llvm::cl::init(llvm::GlobalVariable::GeneralDynamicTLSModel),
-    llvm::cl::values(clEnumValN(llvm::GlobalVariable::GeneralDynamicTLSModel,
-                                "global-dynamic",
-                                "Global dynamic TLS model (default)"),
-                     clEnumValN(llvm::GlobalVariable::LocalDynamicTLSModel,
-                                "local-dynamic", "Local dynamic TLS model"),
-                     clEnumValN(llvm::GlobalVariable::InitialExecTLSModel,
-                                "initial-exec", "Initial exec TLS model"),
-                     clEnumValN(llvm::GlobalVariable::LocalExecTLSModel,
-                                "local-exec", "Local exec TLS model"),
-                     clEnumValEnd));
+    clEnumValues(clEnumValN(llvm::GlobalVariable::GeneralDynamicTLSModel,
+                            "global-dynamic",
+                            "Global dynamic TLS model (default)"),
+                 clEnumValN(llvm::GlobalVariable::LocalDynamicTLSModel,
+                            "local-dynamic", "Local dynamic TLS model"),
+                 clEnumValN(llvm::GlobalVariable::InitialExecTLSModel,
+                            "initial-exec", "Initial exec TLS model"),
+                 clEnumValN(llvm::GlobalVariable::LocalExecTLSModel,
+                            "local-exec", "Local exec TLS model")));
 
 /******************************************************************************
  * Simple Triple helpers for DFE

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -42,17 +42,16 @@ using namespace llvm;
 
 static cl::opt<signed char> optimizeLevel(
     cl::desc("Setting the optimization level:"), cl::ZeroOrMore,
-    cl::values(clEnumValN(3, "O", "Equivalent to -O3"),
-               clEnumValN(0, "O0", "No optimizations (default)"),
-               clEnumValN(1, "O1", "Simple optimizations"),
-               clEnumValN(2, "O2", "Good optimizations"),
-               clEnumValN(3, "O3", "Aggressive optimizations"),
-               clEnumValN(4, "O4", "Equivalent to -O3"), // Not implemented yet.
-               clEnumValN(5, "O5", "Equivalent to -O3"), // Not implemented yet.
-               clEnumValN(-1, "Os",
-                          "Like -O2 with extra optimizations for size"),
-               clEnumValN(-2, "Oz", "Like -Os but reduces code size further"),
-               clEnumValEnd),
+    clEnumValues(
+        clEnumValN(3, "O", "Equivalent to -O3"),
+        clEnumValN(0, "O0", "No optimizations (default)"),
+        clEnumValN(1, "O1", "Simple optimizations"),
+        clEnumValN(2, "O2", "Good optimizations"),
+        clEnumValN(3, "O3", "Aggressive optimizations"),
+        clEnumValN(4, "O4", "Equivalent to -O3"), // Not implemented yet.
+        clEnumValN(5, "O5", "Equivalent to -O3"), // Not implemented yet.
+        clEnumValN(-1, "Os", "Like -O2 with extra optimizations for size"),
+        clEnumValN(-2, "Oz", "Like -Os but reduces code size further")),
     cl::init(0));
 
 static cl::opt<bool> noVerify("disable-verify",
@@ -108,10 +107,10 @@ static cl::opt<bool> stripDebug(
 cl::opt<opts::SanitizerCheck> opts::sanitize(
     "sanitize", cl::desc("Enable runtime instrumentation for bug detection"),
     cl::init(opts::None),
-    cl::values(clEnumValN(opts::AddressSanitizer, "address", "memory errors"),
-               clEnumValN(opts::MemorySanitizer, "memory", "memory errors"),
-               clEnumValN(opts::ThreadSanitizer, "thread", "race detection"),
-               clEnumValEnd));
+    clEnumValues(clEnumValN(opts::AddressSanitizer, "address", "memory errors"),
+                 clEnumValN(opts::MemorySanitizer, "memory", "memory errors"),
+                 clEnumValN(opts::ThreadSanitizer, "thread",
+                            "race detection")));
 
 static cl::opt<bool> disableLoopUnrolling(
     "disable-loop-unrolling",

--- a/tools/ldc-profdata/llvm-profdata-4.0.cpp
+++ b/tools/ldc-profdata/llvm-profdata-4.0.cpp
@@ -393,14 +393,13 @@ static int merge_main(int argc, const char *argv[]) {
   cl::opt<ProfileKinds> ProfileKind(
       cl::desc("Profile kind:"), cl::init(instr),
       cl::values(clEnumVal(instr, "Instrumentation profile (default)"),
-                 clEnumVal(sample, "Sample profile"), clEnumValEnd));
+                 clEnumVal(sample, "Sample profile")));
   cl::opt<ProfileFormat> OutputFormat(
       cl::desc("Format of output profile"), cl::init(PF_Binary),
       cl::values(clEnumValN(PF_Binary, "binary", "Binary encoding (default)"),
                  clEnumValN(PF_Text, "text", "Text encoding"),
                  clEnumValN(PF_GCC, "gcc",
-                            "GCC encoding (only meaningful for -sample)"),
-                 clEnumValEnd));
+                            "GCC encoding (only meaningful for -sample)")));
   cl::opt<bool> OutputSparse("sparse", cl::init(false),
       cl::desc("Generate a sparse profile (only meaningful for -instr)"));
   cl::opt<unsigned> NumThreads(
@@ -612,7 +611,7 @@ static int show_main(int argc, const char *argv[]) {
   cl::opt<ProfileKinds> ProfileKind(
       cl::desc("Profile kind:"), cl::init(instr),
       cl::values(clEnumVal(instr, "Instrumentation profile (default)"),
-                 clEnumVal(sample, "Sample profile"), clEnumValEnd));
+                 clEnumVal(sample, "Sample profile")));
 
   cl::ParseCommandLineOptions(argc, argv, "LLVM profile data summary\n");
 


### PR DESCRIPTION
Not sure if has landed in circleCI already, but probably will soon.