### PR TITLE
Allow alignment below sizeof(void*).

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -846,10 +846,10 @@ void DtoResolveVariable(VarDeclaration *vd) {
                           linkage, nullptr, llName, vd->isThreadlocal());
     getIrGlobal(vd)->value = gvar;
 
-    // Set the alignment and use the target pointer size as lower bound.
-    unsigned alignment =
-        std::max(DtoAlignment(vd), gDataLayout->getPointerSize());
-    gvar->setAlignment(alignment);
+    // Set the alignment (it is important not to use type->alignsize because
+    // VarDeclarations can have an align() attribute independent of the type
+    // as well).
+    gvar->setAlignment(DtoAlignment(vd));
 
     applyVarDeclUDAs(vd, gvar);
 

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -6,10 +6,14 @@
 align(32) struct Outer { int a; }
 struct Inner { align(32) int a; }
 
+align(1) ubyte globalByte1;
+// CHECK-DAG: align11globalByte1h = {{.*}} align 1
 static Outer globalOuter;
-// CHECK: constant %align.Outer_init zeroinitializer{{(, comdat)?}}, align 32
+// CHECK-DAG: constant %align.Outer_init zeroinitializer{{(, comdat)?}}, align 32
+// CHECK-DAG: align11globalOuterS5align5Outer = {{.*}} align 32
 static Inner globalInner;
-// CHECK: constant %align.Inner_init zeroinitializer{{(, comdat)?}}, align 32
+// CHECK-DAG: constant %align.Inner_init zeroinitializer{{(, comdat)?}}, align 32
+// CHECK-DAG: align11globalInnerS5align5Inner = {{.*}} align 32
 
 Outer passAndReturnOuterByVal(Outer arg) { return arg; }
 // CHECK: define{{.*}} void @{{.*}}_D5align23passAndReturnOuterByValFS5align5OuterZS5align5Outer
@@ -29,6 +33,8 @@ void main() {
   Inner inner;
   // CHECK: %inner = alloca %align.Inner, align 32
 
+  align(1) byte byte1;
+  // CHECK: %byte1 = alloca i8, align 1
   align(16) byte byte16;
   // CHECK: %byte16 = alloca i8, align 16
   align(64) Outer outer64;


### PR DESCRIPTION
Currently, alignment below the pointer size is ignored:
```d
align(1) ushort counter; // gets "align 8" in LLVM IR
```
So you cannot closely pack variables.

The minimum alignment is intended according to a39997d326f0d3da353d8b9f27ffd559e6fcc5d7.
Reverting a39997d326f0d3da353d8b9f27ffd559e6fcc5d7 to see which std.conv test fails.