### PR TITLE
Validate the __asm constraints.

### DIFF
--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -435,6 +435,12 @@ DValue *DtoInlineAsmExpr(Loc &loc, FuncDeclaration *fd,
   LLType *ret_type = DtoType(type);
   llvm::FunctionType *FT = llvm::FunctionType::get(ret_type, argtypes, false);
 
+  // make sure the constraints are valid
+  if (!llvm::InlineAsm::Verify(FT, constraints)) {
+    e->error("__asm constraint argument is invalid");
+    fatal();
+  }
+
   // build asm call
   bool sideeffect = true;
   llvm::InlineAsm *ia = llvm::InlineAsm::get(FT, code, constraints, sideeffect);

--- a/tests/codegen/asm_constraints.d
+++ b/tests/codegen/asm_constraints.d
@@ -1,0 +1,7 @@
+// RUN: not %ldc -c -w %s 2>&1 | FileCheck %s
+
+void main () {
+    import ldc.llvmasm : __asm;
+    // CHECK: Error: __asm constraint argument is invalid
+    __asm("", "][");
+}


### PR DESCRIPTION
Way better than a llvm assertion, no? :)
On my system (running `llvm 3.8.1`) an invalid constraint causes the codegen phase to hang indefinitely :\
Fixes #802.