### PR TITLE
Create static libs in -od directory for LDMD only

### DIFF
--- a/ddmd/globals.d
+++ b/ddmd/globals.d
@@ -207,6 +207,7 @@ struct Param
         bool verbose_cg;
         bool hasObjectiveC;
         bool fullyQualifiedObjectFiles;
+        bool cleanupObjectFiles;
 
         // Profile-guided optimization:
         bool genInstrProf;             // Whether to generate PGO instrumented code

--- a/ddmd/globals.h
+++ b/ddmd/globals.h
@@ -206,6 +206,7 @@ struct Param
     bool verbose_cg;
     bool hasObjectiveC;
     bool fullyQualifiedObjectFiles;
+    bool cleanupObjectFiles;
 
     // Profile-guided optimization:
     bool genInstrProf;             // Whether to generate PGO instrumented code

--- a/ddmd/mars.d
+++ b/ddmd/mars.d
@@ -1754,6 +1754,17 @@ extern (C++) int mars_mainBody(ref Strings files, ref Strings libmodules)
             status = linkObjToBinary();
         else if (global.params.lib)
             status = createStaticLibrary();
+
+        if (status == EXIT_SUCCESS &&
+            (global.params.cleanupObjectFiles || global.params.run))
+        {
+            for (size_t i = 0; i < modules.dim; i++)
+            {
+                modules[i].deleteObjFile();
+                if (global.params.oneobj)
+                    break;
+            }
+        }
       }
       else
       {
@@ -1767,12 +1778,15 @@ extern (C++) int mars_mainBody(ref Strings files, ref Strings libmodules)
                 status = runProgram();
                 /* Delete .obj files and .exe file
                  */
+              version (IN_LLVM) {} else
+              {
                 for (size_t i = 0; i < modules.dim; i++)
                 {
                     modules[i].deleteObjFile();
                     if (global.params.oneobj)
                         break;
                 }
+              }
                 deleteExeFile();
             }
         }

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -151,6 +151,12 @@ cl::opt<bool> output_s("output-s", cl::desc("Write native assembly"));
 cl::opt<cl::boolOrDefault> output_o("output-o",
                                     cl::desc("Write native object"));
 
+static cl::opt<bool, true>
+    cleanupObjectFiles("cleanup-obj",
+                       cl::desc("Remove generated object files on success"),
+                       cl::ZeroOrMore, cl::ReallyHidden,
+                       cl::location(global.params.cleanupObjectFiles));
+
 // Disabling Red Zone
 cl::opt<bool, true>
     disableRedZone("disable-red-zone",

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -888,6 +888,14 @@ void buildCommandLine(std::vector<const char *> &r, const Params &p) {
   }
   if (p.emitStaticLib) {
     r.push_back("-lib");
+
+    // DMD seems to emit objects directly into the static lib being generated.
+    // No object files are created and therefore they never collide due to
+    // duplicate .d filenames (in different dirs).
+    // Approximate that behavior by naming the object files uniquely via -oq and
+    // instructing LDC to remove the object files on success.
+    r.push_back("-oq");
+    r.push_back("-cleanup-obj");
   }
   // -quiet is the default in (newer?) frontend versions, just ignore it.
   if (p.release) {

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -839,6 +839,11 @@ void buildCommandLine(std::vector<const char *> &r, const Params &p) {
   }
   if (p.objDir) {
     r.push_back(concat("-od=", p.objDir));
+
+    // DMD creates static libraries in the objects directory (unless using an
+    // absolute output path via `-of`).
+    if (p.emitStaticLib)
+      r.push_back("-create-static-lib-in-objdir");
   }
   if (p.objName) {
     r.push_back(concat("-of=", p.objName));

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -40,6 +40,12 @@ static llvm::cl::opt<bool> staticFlag(
         "Create a statically linked binary, including all system dependencies"),
     llvm::cl::ZeroOrMore);
 
+// used by LDMD
+static llvm::cl::opt<bool> createStaticLibInObjdir(
+    "create-static-lib-in-objdir",
+    llvm::cl::desc("Create static library in -od directory (DMD-compliant)"),
+    llvm::cl::ZeroOrMore, llvm::cl::ReallyHidden);
+
 //////////////////////////////////////////////////////////////////////////////
 
 static void CreateDirectoryOnDisk(llvm::StringRef fileName) {
@@ -717,8 +723,10 @@ int createStaticLibrary() {
     libName.push_back('.');
     libName.append(global.lib_ext);
   }
-  if (global.params.objdir && !FileName::absolute(libName.c_str()))
+  if (createStaticLibInObjdir && global.params.objdir &&
+      !FileName::absolute(libName.c_str())) {
     libName = FileName::combine(global.params.objdir, libName.c_str());
+  }
 
   if (isTargetMSVC) {
     args.push_back("/OUT:" + libName);


### PR DESCRIPTION
Let LDC treat relative output paths as relative to the current working directory again (as it always used to until a few weeks ago). It's more intuitive and avoids breaking build systems/scripts using LDC directly.

Only LDMD continues to prepend the -od directory to the relative output path, for DMD compatibility.

Fixes issue #1819.