### PR TITLE
Implement single-thread fences via the LDC_fence pragma.

### DIFF
--- a/tests/codegen/fence_pragma.d
+++ b/tests/codegen/fence_pragma.d
@@ -1,0 +1,10 @@
+// RUN: %ldc %s -c -output-ll -of=%t.ll && FileCheck %s < %t.ll
+
+import ldc.intrinsics;
+
+void fun0 () {
+  llvm_memory_fence(DefaultOrdering, SynchronizationScope.CrossThread);
+  // CHECK: fence seq_cst
+  llvm_memory_fence(DefaultOrdering, SynchronizationScope.SingleThread);
+  // CHECK: fence singlethread seq_cst
+}


### PR DESCRIPTION
Think `std::atomic_signal_fence` [1], but for D.
I tried implementing this as an extra and optional argument for `LDC_fence` but then discovered the hard way that it would break the bootstrap cycle.

[1] http://en.cppreference.com/w/cpp/atomic/atomic_signal_fence