### PR TITLE
Produce linking errors when calling abstract functions

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -700,7 +700,7 @@ public:
       DotVarExp *dve = static_cast<DotVarExp *>(e->e1);
       FuncDeclaration *fdecl = dve->var->isFuncDeclaration();
       assert(fdecl);
-      DtoResolveFunction(fdecl);
+      DtoDeclareFunction(fdecl);
       fnval = new DFuncValue(fdecl, getIrFunc(fdecl)->func, DtoRVal(dve->e1));
     } else {
       fnval = toElem(e->e1);


### PR DESCRIPTION
Fixes issue #1822.

`DtoResolveFunction()` explicitly excludes body-less abstract functions from being automatically declared. If we want to emit linking errors like DMD, we need a LL function for the call (we previously hadn't for abstract functions, so it was null and LDC crashed). Thus make sure the function is resolved and declared by invoking `DtoDeclareFunction()`.