### PR TITLE
Only emit llvm.used _once_ in an LLVM module

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -382,7 +382,7 @@ public:
       // artificial "use" for it, or it could be removed by the optimizer if
       // the only reference to it is in inline asm.
       if (irGlobal->nakedUse) {
-        irs->usedArray.push_back(DtoBitCast(gvar, getVoidPtrType()));
+        irs->usedArray.push_back(gvar);
       }
 
       IF_LOG Logger::cout() << *gvar << '\n';

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -484,26 +484,6 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
   llvm::appendToGlobalDtors(gIR->module, dsoDtor, 65535);
 }
 
-void build_llvm_used_array(IRState *p) {
-  if (p->usedArray.empty()) {
-    return;
-  }
-
-  std::vector<llvm::Constant *> usedVoidPtrs;
-  usedVoidPtrs.reserve(p->usedArray.size());
-
-  for (auto constant : p->usedArray) {
-    usedVoidPtrs.push_back(DtoBitCast(constant, getVoidPtrType()));
-  }
-
-  llvm::ArrayType *arrayType =
-      llvm::ArrayType::get(getVoidPtrType(), usedVoidPtrs.size());
-  auto llvmUsed = new llvm::GlobalVariable(
-      p->module, arrayType, false, llvm::GlobalValue::AppendingLinkage,
-      llvm::ConstantArray::get(arrayType, usedVoidPtrs), "llvm.used");
-  llvmUsed->setSection("llvm.metadata");
-}
-
 // Add module-private variables and functions for coverage analysis.
 void addCoverageAnalysis(Module *m) {
   IF_LOG {
@@ -746,8 +726,6 @@ void codegenModule(IRState *irs, Module *m) {
   if (!m->noModuleInfo) {
     // generate ModuleInfo
     registerModuleInfo(m);
-
-    build_llvm_used_array(irs);
   }
 
   if (m->d_cover_valid) {

--- a/tests/codegen/inputs/module_ctor.d
+++ b/tests/codegen/inputs/module_ctor.d
@@ -1,0 +1,6 @@
+import core.stdc.stdio;
+
+static this()
+{
+    puts("ctor\n");
+}

--- a/tests/codegen/llvm_used_1.d
+++ b/tests/codegen/llvm_used_1.d
@@ -1,0 +1,26 @@
+// Test that llvm.used is emitted correctly when multiple D modules are compiled into one LLVM module.
+
+// Explicitly use OS X triple, so that llvm.used is used for moduleinfo globals.
+// RUN: %ldc -c -output-ll -O3 %S/inputs/module_ctor.d %s -of=%t.ll -mtriple=x86_64-apple-macosx && FileCheck --check-prefix=LLVM %s < %t.ll
+
+// RUN: %ldc -O3 %S/inputs/module_ctor.d -run %s | FileCheck --check-prefix=EXECUTE %s
+
+// There was a bug where llvm.used was emitted more than once, whose symptom was that suffixed versions would appear: e.g. `@llvm.used.3`.
+// LLVM-NOT: @llvm.used.
+// LLVM: @llvm.used = appending global [2 x i8*]
+// LLVM-NOT: @llvm.used.
+
+// EXECUTE: ctor
+// EXECUTE: main
+// EXECUTE: dtor
+
+import core.stdc.stdio;
+
+static ~this()
+{
+    puts("dtor\n");
+}
+
+void main() {
+    puts("main\n");
+}


### PR DESCRIPTION
Before, when compiling multiple D modules into one LLVM module, we would emit llvm.used multiple times. All except the first would actually be recognized as llvm.used (the others would be renamed to llvm.used.* which is not recognized by LLVM).
This fixes that.

(For testing, I used the testcase that would start bugging for ThinLTO. I used the OS X triple and moduleinfo stuff, because I tried but did not find another way to get things to be added to llvm.used. Symbols referenced in inline asm are not added to llvm.used, surprisingly, but LLVM parses the assembly to find such references I think, so not a bug?)