### PR TITLE
Map `export` visibility to LLVM DLL storage classes

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -356,6 +356,7 @@ public:
           setLinkage(lwc, newGvar);
 
           newGvar->setAlignment(gvar->getAlignment());
+          newGvar->setDLLStorageClass(gvar->getDLLStorageClass());
           applyVarDeclUDAs(decl, newGvar);
           newGvar->takeName(gvar);
 
@@ -367,6 +368,8 @@ public:
           gvar = newGvar;
           irGlobal->value = newGvar;
         }
+
+        assert(!gvar->hasDLLImportStorageClass());
 
         // Now, set the initializer.
         assert(!irGlobal->constInit);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -930,8 +930,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
 
   // On x86_64, always set 'uwtable' for System V ABI compatibility.
   // TODO: Find a better place for this.
-  // TODO: Is this required for Win64 as well?
-  if (global.params.targetTriple->getArch() == llvm::Triple::x86_64) {
+  if (global.params.targetTriple->getArch() == llvm::Triple::x86_64 &&
+      !global.params.isWindows) {
     func->addFnAttr(LLAttribute::UWTable);
   }
   if (opts::sanitize != opts::None) {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -851,6 +851,14 @@ void DtoResolveVariable(VarDeclaration *vd) {
     // as well).
     gvar->setAlignment(DtoAlignment(vd));
 
+    /* TODO: set DLL storage class when `export` is fixed (an attribute)
+    if (global.params.isWindows && vd->isExport()) {
+      auto c = vd->isImportedSymbol() ? LLGlobalValue::DLLImportStorageClass
+                                      : LLGlobalValue::DLLExportStorageClass;
+      gvar->setDLLStorageClass(c);
+    }
+    */
+
     applyVarDeclUDAs(vd, gvar);
 
     IF_LOG Logger::cout() << *gvar << '\n';

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -1,0 +1,19 @@
+// RUN: %ldc -output-ll -of=%t.ll %s
+// RUN: FileCheck %s < %t.ll
+
+// REQUIRES: Windows
+
+export
+{
+    // CHECK-DAG: define dllexport {{.*}}_D6export11exportedFooFZv
+    void exportedFoo() {}
+
+    // CHECK-DAG: declare dllimport {{.*}}_D6export11importedFooFZv
+    void importedFoo();
+}
+
+void bar()
+{
+    exportedFoo();
+    importedFoo();
+}

--- a/tests/codegen/export_crossModuleInlining.d
+++ b/tests/codegen/export_crossModuleInlining.d
@@ -1,0 +1,19 @@
+// Make sure exported functions can be cross-module inlined without exporting the local function copy.
+
+// REQUIRES: atleast_llvm307
+
+// RUN: %ldc -O -release -enable-cross-module-inlining -output-ll -of=%t.ll -I%S/inputs %s
+// RUN: FileCheck %s < %t.ll
+
+import export2;
+
+// CHECK-NOT: _D7export23fooFZi
+
+// CHECK: define {{.*}}_D26export_crossModuleInlining3barFZi
+int bar()
+{
+    // CHECK-NEXT: ret i32 666
+    return foo();
+}
+
+// CHECK-NOT: _D7export23fooFZi

--- a/tests/codegen/inputs/export2.d
+++ b/tests/codegen/inputs/export2.d
@@ -1,0 +1,1 @@
+export int foo() { return 666; }


### PR DESCRIPTION
Trying to fix #1745.
