### PR TITLE
Set `+soft-float` feature instead of `use-soft-float` attribute.

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -598,6 +598,8 @@ createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
   case FloatABI::Soft:
 #if LDC_LLVM_VER < 307
     targetOptions.UseSoftFloat = true;
+#else
+    features.AddFeature("+soft-float");
 #endif
     targetOptions.FloatABIType = llvm::FloatABI::Soft;
     break;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -451,17 +451,6 @@ void applyTargetMachineAttributes(llvm::Function &func,
   func.addFnAttr("no-nans-fp-math", TO.NoNaNsFPMath ? "true" : "false");
 #if LDC_LLVM_VER < 307
   func.addFnAttr("use-soft-float", TO.UseSoftFloat ? "true" : "false");
-#else
-  switch (TO.FloatABIType) {
-  case llvm::FloatABI::Default:
-    break;
-  case llvm::FloatABI::Soft:
-    func.addFnAttr("use-soft-float", "true");
-    break;
-  case llvm::FloatABI::Hard:
-    func.addFnAttr("use-soft-float", "false");
-    break;
-  }
 #endif
 
   // Frame pointer elimination

--- a/tests/codegen/attr_targetoptions.d
+++ b/tests/codegen/attr_targetoptions.d
@@ -13,7 +13,6 @@ void foo()
 
 // DEFAULT: attributes #[[KEYVALUE]]
 // DEFAULT-DAG: "target-cpu"=
-// DEFAULT-DAG: "use-soft-float"="{{(true|false)}}"
 // DEFAULT-DAG: "no-frame-pointer-elim"="false"
 // DEFAULT-DAG: "unsafe-fp-math"="false"
 // DEFAULT-DAG: "less-precise-fpmad"="false"

--- a/tests/codegen/attr_targetoptions_fp.d
+++ b/tests/codegen/attr_targetoptions_fp.d
@@ -1,0 +1,17 @@
+// See Github issue #1860
+
+// REQUIRES: atleast_llvm307
+
+// RUN: %ldc -c -output-ll -of=%t.ll -float-abi=soft   %s && FileCheck --check-prefix=SOFT %s < %t.ll
+// RUN: %ldc -c -output-ll -of=%t.ll -float-abi=softfp %s && FileCheck --check-prefix=HARD %s < %t.ll
+
+// SOFT: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+// HARD: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+void foo()
+{
+}
+
+// SOFT: attributes #[[KEYVALUE]]
+// SOFT-DAG: "target-features"="{{.*}}+soft-float{{.*}}"
+// HARD: attributes #[[KEYVALUE]]
+// HARD-NOT: "target-features"="{{.*}}+soft-float{{.*}}"


### PR DESCRIPTION
Fix issue #1860

UseSoftFloat was removed from the TargetOptions in LLVM3.7. It's replacement (I believe) is the "+soft-float" target feature (in the target feature string). Inside LLVM, the "use-soft-float" attribute is upgraded to the "+soft-float" feature, so we can do that ourselves when creating the target machine.

(note that at the point where we add the attributes to the function, we have no information whether our TargetMachine was created with FloatABI:SoftFP or not)