### PR TITLE
Add code for logging within D code.

### DIFF
--- a/gen/logger.cpp
+++ b/gen/logger.cpp
@@ -42,29 +42,32 @@ void Stream::writeValue(std::ostream &OS, const llvm::Value &V) {
   }
 }
 
+// This variable is pulled out of the Logger namespace to work around D bug 15576.
+// https://issues.dlang.org/show_bug.cgi?id=15576
+bool _Logger_enabled;
+
 namespace Logger {
 static std::string indent_str;
-bool _enabled;
 
 static llvm::cl::opt<bool, true>
     enabledopt("vv", llvm::cl::desc("Print front-end/glue code debug log"),
-               llvm::cl::location(_enabled), llvm::cl::ZeroOrMore);
+               llvm::cl::location(_Logger_enabled), llvm::cl::ZeroOrMore);
 
 void indent() {
-  if (_enabled) {
+  if (_Logger_enabled) {
     indent_str += "* ";
   }
 }
 
 void undent() {
-  if (_enabled) {
+  if (_Logger_enabled) {
     assert(!indent_str.empty());
     indent_str.resize(indent_str.size() - 2);
   }
 }
 
 Stream cout() {
-  if (_enabled) {
+  if (_Logger_enabled) {
     return Stream(std::cout << indent_str);
   }
   return Stream(nullptr);
@@ -89,8 +92,10 @@ static inline void search_and_replace(std::string &str, const std::string &what,
 #define WORKAROUND_C99_SPECIFIERS_BUG(f)
 #endif
 
+void printIndentation() { printf("%s", indent_str.c_str()); }
+
 void println(const char *fmt, ...) {
-  if (_enabled) {
+  if (_Logger_enabled) {
     printf("%s", indent_str.c_str());
     va_list va;
     va_start(va, fmt);
@@ -101,7 +106,7 @@ void println(const char *fmt, ...) {
   }
 }
 void print(const char *fmt, ...) {
-  if (_enabled) {
+  if (_Logger_enabled) {
     printf("%s", indent_str.c_str());
     va_list va;
     va_start(va, fmt);

--- a/gen/logger.d
+++ b/gen/logger.d
@@ -1,0 +1,79 @@
+//===-- gen/logger.d - Codegen debug logging ----------------------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// D implementation of the functionality of logger.{h/cpp}.
+//
+//===----------------------------------------------------------------------===//
+
+module gen.logger;
+
+private extern (C++) extern __gshared bool _Logger_enabled;
+extern (C++, Logger)
+{
+    void indent();
+    void undent();
+    private void printIndentation();
+}
+
+struct Log
+{
+    static bool enabled()
+    {
+        return _Logger_enabled;
+    }
+
+    static void indent()
+    {
+        if (enabled())
+            .indent();
+    }
+
+    static void undent()
+    {
+        if (enabled())
+            .undent();
+    }
+
+    // Usage:  auto _ = Log.newScope();
+    static auto newScope()
+    {
+        struct ScopeExitUndenter
+        {
+            ~this()
+            {
+                Logger.undent();
+            }
+        }
+
+        Logger.indent();
+        return ScopeExitUndenter();
+    }
+
+    static void printfln(T...)(T args)
+    {
+        static import std.stdio;
+
+        if (enabled())
+        {
+            printIndentation();
+            std.stdio.writefln(args);
+        }
+    }
+
+    static void printf(T...)(T args)
+    {
+        static import std.stdio;
+
+        if (enabled())
+        {
+            printIndentation();
+            std.stdio.writef(args);
+        }
+    }
+}

--- a/gen/logger.h
+++ b/gen/logger.h
@@ -92,17 +92,19 @@ private:
   short sfinae_bait(...);
 };
 
+extern bool _Logger_enabled;
+
 namespace Logger {
-extern bool _enabled;
 
 void indent();
 void undent();
 Stream cout();
+void printIndentation();
 void println(const char *fmt, ...) IS_PRINTF(1);
 void print(const char *fmt, ...) IS_PRINTF(1);
-inline void enable() { _enabled = true; }
-inline void disable() { _enabled = false; }
-inline bool enabled() { return _enabled; }
+inline void enable() { _Logger_enabled = true; }
+inline void disable() { _Logger_enabled = false; }
+inline bool enabled() { return _Logger_enabled; }
 
 void attention(Loc loc, const char *fmt, ...) IS_PRINTF(2);
 


### PR DESCRIPTION
This adds the D counterpart of logger.{h,cpp}.

(Not currently used in D source, but I am already using it in my ccaching branch.)