### PR TITLE
Does DMD 2.072.0 miscompile LDC?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       d: ldc-0.17.2
       env: LLVM_VERSION=3.6.2 OPTS="-DBUILD_SHARED_LIBS=ON"
     - os: linux
-      d: dmd
+      d: dmd-2.071.2
       env: LLVM_VERSION=3.5.2 OPTS="-DTEST_COVERAGE=ON"
     - os: osx
       d: ldc


### PR DESCRIPTION
Master now has funny build errors when LDC is built with dmd 2.072.0:
```
[  9%] Generating bin/ldc2
[  9%] Built target ldc2
...
[ 13%] Generating src/core/atomic-debug.o
object.Error@src/rt/minfo.d(356): Cyclic dependency between module ddmd.traits and ddmd.cond
ddmd.traits* ->
ddmd.attrib ->
ddmd.cond* ->
ddmd.expression ->
ddmd.traits*
make[2]: *** [runtime/src/core/atomic-debug.o] Error 1
make[1]: *** [runtime/CMakeFiles/druntime-ldc-debug.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 13%] [ 13%] Generating std/array.o
Generating std/ascii.o
[ 13%] object.Error@src/rt/minfo.d(356): Cyclic dependency between module ddmd.traits and ddmd.cond
ddmd.traits* ->
ddmd.attrib ->
ddmd.cond* ->
ddmd.expression ->
ddmd.traits*
```