### PR TITLE
Win64: Get rid of 2 obsolete fields in TypeInfo_Struct

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -309,12 +309,13 @@ public:
     const auto structTypeInfoType = getStructTypeInfoType();
     const auto structTypeInfoDecl = Type::typeinfostruct;
 
-    // On x86_64, class TypeInfo_Struct contains 2 additional fields
-    // (m_arg1/m_arg2) which are used for the X86_64 System V ABI varargs
-    // implementation. They are not present on any other cpu/os.
-    const bool isX86_64 =
-        global.params.targetTriple->getArch() == llvm::Triple::x86_64;
-    const unsigned expectedFields = 11 + (isX86_64 ? 2 : 0);
+    // For non-Windows x86_64, class TypeInfo_Struct contains 2 additional
+    // fields (m_arg1/m_arg2) which are used for the x86_64 System V ABI varargs
+    // implementation.
+    const bool isSystemVx64 =
+        global.params.targetTriple->getArch() == llvm::Triple::x86_64 &&
+        !global.params.targetTriple->isOSWindows();
+    const unsigned expectedFields = 11 + (isSystemVx64 ? 2 : 0);
     const unsigned actualFields =
         structTypeInfoDecl->fields.dim -
         1; // union of xdtor/xdtorti counts as 2 overlapping fields
@@ -340,7 +341,7 @@ public:
       b.push_null_vp();         // xdtor/xdtorti
       b.push_null_vp();         // xpostblit
       b.push_uint(0);           // m_align
-      if (isX86_64) {
+      if (isSystemVx64) {
         b.push_null_vp();       // m_arg1
         b.push_null_vp();       // m_arg2
       }
@@ -439,7 +440,7 @@ public:
     // uint m_align
     b.push_uint(DtoAlignment(tc));
 
-    if (isX86_64) {
+    if (isSystemVx64) {
       // TypeInfo m_arg1
       // TypeInfo m_arg2
       Type *t = sd->arg1type;


### PR DESCRIPTION
The required changes to druntime turned out a bit more extensive than I had hoped for at the beginning, but since the job is already done, I thought I'd just open a PR.