### PR TITLE
Don't necessarily enforce file extension of .bc, .ll, .s files

### DIFF
--- a/driver/toobj.h
+++ b/driver/toobj.h
@@ -14,12 +14,10 @@
 #ifndef LDC_DRIVER_TOOBJ_H
 #define LDC_DRIVER_TOOBJ_H
 
-#include <string>
-
 namespace llvm {
 class Module;
 }
 
-void writeModule(llvm::Module *m, std::string filename);
+void writeModule(llvm::Module *m, const char *filename);
 
 #endif

--- a/tests/codegen/gh1843.d
+++ b/tests/codegen/gh1843.d
@@ -1,0 +1,5 @@
+// Just make sure LDC doesn't necessarily enforce the .ll extension (issue #1843).
+// RUN: %ldc -output-ll -of=%t.myIR %s && FileCheck %s < %t.myIR
+
+// CHECK: define{{.*}} void @{{.*}}_D6gh18433fooFZv
+void foo() {}


### PR DESCRIPTION
Use the output filename (-of or inferred) directly if a single file is emitted per compiled module.

Fixes issue #1843.