### PR TITLE
Implement the betterC switch like DMD does.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -437,6 +437,11 @@ cl::opt<bool, true>
              cl::desc("implement http://wiki.dlang.org/DIP25 (experimental)"),
              cl::location(global.params.useDIP25));
 
+cl::opt<bool, true> betterC(
+    "betterC",
+    cl::desc("omit generating some runtime information and helper functions"),
+    cl::location(global.params.betterC));
+
 cl::opt<unsigned char, true, CoverageParser> coverageAnalysis(
     "cov", cl::desc("Compile-in code coverage analysis\n(use -cov=n for n% "
                     "minimum required coverage)"),

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -722,8 +722,8 @@ void codegenModule(IRState *irs, Module *m) {
   }
 
   // Skip emission of all the additional module metadata if requested by the
-  // user.
-  if (!m->noModuleInfo) {
+  // user or the betterC switch is on.
+  if (!global.params.betterC && !m->noModuleInfo) {
     // generate ModuleInfo
     registerModuleInfo(m);
   }

--- a/tests/linking/betterc.d
+++ b/tests/linking/betterc.d
@@ -1,0 +1,15 @@
+// RUN: %ldc -betterC -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -betterC -defaultlib= -run %s
+
+// CHECK-NOT: ModuleInfoZ
+// CHECK-NOT: ModuleRefZ
+// CHECK-NOT: call void @ldc.register_dso
+version (CRuntime_Microsoft) {
+    extern(C) int mainCRTStartup() {
+        return 0;
+    }
+}
+
+extern (C) int main() {
+    return 0;
+}


### PR DESCRIPTION
Namely, don't emit the ModuleInfo.
Additionally, for the following code we emit less symbols than dmd (`28` vs `38`) and the resulting executable actually runs as we don't emit any `dso` section (which explains the former) and no code that fondles with `_d_dso_registry` (which explains the latter).

```D                     
module main;

extern(C) __gshared int __dmd_personality_v0;
extern(C) __gshared void* _d_dso_registry;

extern (C) int printf(in char*, ...);

extern (C) int main()
{
    printf("asd\n");
    return 0;
}
```
