### PR TITLE
[dcompute] toobj and optimiser

### DIFF
--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -144,8 +144,14 @@ void insertBitcodeFiles(llvm::Module &M, llvm::LLVMContext &Ctx,
 //////////////////////////////////////////////////////////////////////////////
 
 static void appendObjectFiles(std::vector<std::string> &args) {
-  for (unsigned i = 0; i < global.params.objfiles->dim; i++)
-    args.push_back((*global.params.objfiles)[i]);
+  for (unsigned i = 0; i < global.params.objfiles->dim; i++) {
+    const char *p = static_cast<const char *>(global.params.objfiles->data[i]);
+    llvm::SmallString<24> s(p);
+    if (s.endswith(".spv") || s.endswith(".ptx")) {
+      continue;
+    }
+    args.push_back(p);
+  }
 
   if (global.params.targetTriple->isWindowsMSVCEnvironment()) {
     if (global.params.resfile)

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -144,14 +144,8 @@ void insertBitcodeFiles(llvm::Module &M, llvm::LLVMContext &Ctx,
 //////////////////////////////////////////////////////////////////////////////
 
 static void appendObjectFiles(std::vector<std::string> &args) {
-  for (unsigned i = 0; i < global.params.objfiles->dim; i++) {
-    const char *p = static_cast<const char *>(global.params.objfiles->data[i]);
-    llvm::SmallString<24> s(p);
-    if (s.endswith(".spv") || s.endswith(".ptx")) {
-      continue;
-    }
-    args.push_back(p);
-  }
+  for (unsigned i = 0; i < global.params.objfiles->dim; i++)
+    args.push_back((*global.params.objfiles)[i]);
 
   if (global.params.targetTriple->isWindowsMSVCEnvironment()) {
     if (global.params.resfile)

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -598,6 +598,8 @@ createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
   case FloatABI::Soft:
 #if LDC_LLVM_VER < 307
     targetOptions.UseSoftFloat = true;
+#else
+    features.AddFeature("+soft-float");
 #endif
     targetOptions.FloatABIType = llvm::FloatABI::Soft;
     break;

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -74,10 +74,6 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   const bool isSpirv = a == Triple::spir || a == Triple::spir64;
   const bool isNvptx = a == Triple::nvptx || a == Triple::nvptx64;
 
-#if LDC_LLVM_VER < 307
-  llvm::formatted_raw_ostream fout(out);
-#endif
-
   if (isSpirv) {
 #ifdef LDC_WITH_DCOMPUTE_SPIRV
     IF_LOG Logger::println("running createSPIRVWriterPass()");
@@ -110,6 +106,9 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   Target.addAnalysisPasses(Passes);
 #endif
 
+#if LDC_LLVM_VER < 307
+  llvm::formatted_raw_ostream fout(out);
+#endif
   if (Target.addPassesToEmitFile(Passes,
 #if LDC_LLVM_VER >= 307
                                  out,

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -32,6 +32,9 @@
 #if LDC_LLVM_VER >= 307
 #include "llvm/Support/Path.h"
 #endif
+#if LDC_WITH_COMPUTE_SPIRV
+#include "llvm/Support/SPIRV.h"
+#endif
 #include "llvm/Target/TargetMachine.h"
 #if LDC_LLVM_VER >= 307
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -67,7 +70,23 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   legacy::
 #endif
       PassManager Passes;
+  llvm::Triple::ArchType a = llvm::Triple(m.getTargetTriple()).getArch();
+  const bool isSpirv = a == Triple::spir || a == Triple::spir64;
+  const bool isNvptx = a == Triple::nvptx || a == Triple::nvptx64;
 
+#if LDC_LLVM_VER < 307
+  llvm::formatted_raw_ostream fout(out);
+#endif
+
+  if (isSpirv) {
+#ifdef LDC_WITH_DCOMPUTE_SPIRV
+    IF_LOG Logger::println("adding createSPIRVWriterPass()");
+    llvm::createSPIRVWriterPass(fout)->runOnModule(m);
+#else
+    IF_LOG Logger::println("Trying to target SPIRV, but LDC is not built to do so!");
+#endif
+    return;
+  }
 #if LDC_LLVM_VER >= 307
 // The DataLayout is already set at the module (in module.cpp,
 // method Module::genLLVMModule())
@@ -90,16 +109,16 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   Target.addAnalysisPasses(Passes);
 #endif
 
-#if LDC_LLVM_VER < 307
-  llvm::formatted_raw_ostream fout(out);
-#endif
   if (Target.addPassesToEmitFile(Passes,
 #if LDC_LLVM_VER >= 307
                                  out,
 #else
                                  fout,
 #endif
-                                 fileType, codeGenOptLevel())) {
+      // Always generate assembly for ptx as it is as assembly format
+      // The PTX backend fails if we pass anything esle.
+      isNvptx ? llvm::TargetMachine::CGFT_AssemblyFile : fileType,
+      codeGenOptLevel())) {
     llvm_unreachable("no support for asm output");
   }
 

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -80,8 +80,9 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
 
   if (isSpirv) {
 #ifdef LDC_WITH_DCOMPUTE_SPIRV
-    IF_LOG Logger::println("adding createSPIRVWriterPass()");
-    llvm::createSPIRVWriterPass(fout)->runOnModule(m);
+    IF_LOG Logger::println("running createSPIRVWriterPass()");
+    llvm::createSPIRVWriterPass(out)->runOnModule(m);
+    IF_LOG Logger::println("Success.");
 #else
     IF_LOG Logger::println("Trying to target SPIRV, but LDC is not built to do so!");
 #endif

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -451,17 +451,6 @@ void applyTargetMachineAttributes(llvm::Function &func,
   func.addFnAttr("no-nans-fp-math", TO.NoNaNsFPMath ? "true" : "false");
 #if LDC_LLVM_VER < 307
   func.addFnAttr("use-soft-float", TO.UseSoftFloat ? "true" : "false");
-#else
-  switch (TO.FloatABIType) {
-  case llvm::FloatABI::Default:
-    break;
-  case llvm::FloatABI::Soft:
-    func.addFnAttr("use-soft-float", "true");
-    break;
-  case llvm::FloatABI::Hard:
-    func.addFnAttr("use-soft-float", "false");
-    break;
-  }
 #endif
 
   // Frame pointer elimination

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -344,6 +344,12 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 // This function runs optimization passes based on command line arguments.
 // Returns true if any optimization passes were invoked.
 bool ldc_optimize_module(llvm::Module *M) {
+  // Dont optimise spirv modules as turning GEPs into extracts triggers asserts
+  // in the IR -> SPIR-V translation pass
+  const llvm::Triple::ArchType a = M->getTargetTriple().getArch();
+  if(a == Triple::spir || a == Triple::spir64)
+    return false;
+
 // Create a PassManager to hold and optimize the collection of
 // per-module passes we are about to build.
 #if LDC_LLVM_VER >= 307

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -346,10 +346,10 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 bool ldc_optimize_module(llvm::Module *M) {
   // Dont optimise spirv modules as turning GEPs into extracts triggers asserts
   // in the IR -> SPIR-V translation pass
-  const llvm::Triple::ArchType a = M->getTargetTriple().getArch();
+  llvm::Triple::ArchType a = llvm::Triple(M->getTargetTriple()).getArch();
   if(a == Triple::spir || a == Triple::spir64)
     return false;
-
+    
 // Create a PassManager to hold and optimize the collection of
 // per-module passes we are about to build.
 #if LDC_LLVM_VER >= 307

--- a/tests/codegen/attr_targetoptions.d
+++ b/tests/codegen/attr_targetoptions.d
@@ -13,7 +13,6 @@ void foo()
 
 // DEFAULT: attributes #[[KEYVALUE]]
 // DEFAULT-DAG: "target-cpu"=
-// DEFAULT-DAG: "use-soft-float"="{{(true|false)}}"
 // DEFAULT-DAG: "no-frame-pointer-elim"="false"
 // DEFAULT-DAG: "unsafe-fp-math"="false"
 // DEFAULT-DAG: "less-precise-fpmad"="false"

--- a/tests/codegen/attr_targetoptions_fp.d
+++ b/tests/codegen/attr_targetoptions_fp.d
@@ -1,0 +1,17 @@
+// See Github issue #1860
+
+// REQUIRES: atleast_llvm307
+
+// RUN: %ldc -c -output-ll -of=%t.ll -float-abi=soft   %s && FileCheck --check-prefix=SOFT %s < %t.ll
+// RUN: %ldc -c -output-ll -of=%t.ll -float-abi=softfp %s && FileCheck --check-prefix=HARD %s < %t.ll
+
+// SOFT: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+// HARD: define{{.*}} @{{.*}}3fooFZv{{.*}} #[[KEYVALUE:[0-9]+]]
+void foo()
+{
+}
+
+// SOFT: attributes #[[KEYVALUE]]
+// SOFT-DAG: "target-features"="{{.*}}+soft-float{{.*}}"
+// HARD: attributes #[[KEYVALUE]]
+// HARD-NOT: "target-features"="{{.*}}+soft-float{{.*}}"


### PR DESCRIPTION
* dont optimise SPIR-V as turning GEPs into extracts causes the back end to assert.
* Always use `llvm::TargetMachine::CGFT_AssemblyFile` for ptx, if we don't create target machine will return null
* `llvm::createSPIRVWriterPass(out)->runOnModule(m)` is the way to make output happen for SPIR-V as there is no target machine for SPIR-V.