### PR TITLE
[dcompute] backend

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/IR/Module.h"
 #include "mars.h"
 #include "gen/logger.h"
 
@@ -631,4 +632,14 @@ createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
   return target->createTargetMachine(triple.str(), cpu, features.getString(),
                                      targetOptions, relocModel, codeModel,
                                      codeGenOptLevel);
+}
+
+ComputeBackend::Type getComputeTargetType(llvm::Module* m) {
+  llvm::Triple::ArchType a = llvm::Triple(m->getTargetTriple()).getArch();
+  if (a == llvm::Triple::spir || a == llvm::Triple::spir64)
+    return ComputeBackend::SPIRV;
+  else if (a == llvm::Triple::nvptx || a == llvm::Triple::nvptx64)
+    return ComputeBackend::NVPTX;
+  else
+    return ComputeBackend::None;
 }

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -38,7 +38,14 @@ namespace llvm {
 class Triple;
 class Target;
 class TargetMachine;
+class Module;
 }
+
+namespace ComputeBackend {
+enum Type { None, SPIRV, NVPTX };
+}
+
+ComputeBackend::Type getComputeTargetType(llvm::Module*);
 
 /**
  * Creates an LLVM TargetMachine suitable for the given (usually command-line)

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -80,6 +80,7 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
 #else
     error(Loc(), "Trying to target SPIRV, but LDC is not built to do so!");
 #endif
+
     return;
   }
 #if LDC_LLVM_VER >= 307

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -83,6 +83,7 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
 
     return;
   }
+
 #if LDC_LLVM_VER >= 307
 // The DataLayout is already set at the module (in module.cpp,
 // method Module::genLLVMModule())

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -116,7 +116,7 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
           fout,
 #endif
           // Always generate assembly for ptx as it is an assembly format
-          // The PTX backend fails if we pass anything esle.
+          // The PTX backend fails if we pass anything else.
           (cb == ComputeBackend::NVPTX) ? llvm::TargetMachine::CGFT_AssemblyFile
                                         : fileType,
           codeGenOptLevel())) {

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -344,6 +344,12 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 // This function runs optimization passes based on command line arguments.
 // Returns true if any optimization passes were invoked.
 bool ldc_optimize_module(llvm::Module *M) {
+  // Dont optimise spirv modules as turning GEPs into extracts triggers asserts
+  // in the IR -> SPIR-V translation pass
+  llvm::Triple::ArchType a = llvm::Triple(M->getTargetTriple()).getArch();
+  if (a == Triple::spir || a == Triple::spir64)
+    return false;
+
 // Create a PassManager to hold and optimize the collection of
 // per-module passes we are about to build.
 #if LDC_LLVM_VER >= 307

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -345,10 +345,11 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 // This function runs optimization passes based on command line arguments.
 // Returns true if any optimization passes were invoked.
 bool ldc_optimize_module(llvm::Module *M) {
-  
-  // Dont optimise spirv modules because turning GEPs into extracts triggers asserts
-  // in the IR -> SPIR-V translation pass. SPIRV doesn't have a target machine,
-  // so any optimisation passes that rely on it to provide analysis, like DCE.
+
+  // Dont optimise spirv modules because turning GEPs into extracts triggers
+  // asserts in the IR -> SPIR-V translation pass. SPIRV doesn't have a target
+  // machine, so any optimisation passes that rely on it to provide analysis,
+  // like DCE can't be run.
   // The optimisation is supposed to happen between the SPIRV -> native machine
   // code pass of the consumer of the binary.
   // TODO: run rudimentary optimisations to improve IR debuggability.

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -346,12 +346,12 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 // Returns true if any optimization passes were invoked.
 bool ldc_optimize_module(llvm::Module *M) {
   
-  // Dont optimise spirv modules as turning GEPs into extracts triggers asserts
+  // Dont optimise spirv modules because turning GEPs into extracts triggers asserts
   // in the IR -> SPIR-V translation pass. SPIRV doesn't have a target machine,
   // so any optimisation passes that rely on it to provide analysis, like DCE.
-  // The optimisation is supposed to bappen between the SPIRV -> native machine
+  // The optimisation is supposed to happen between the SPIRV -> native machine
   // code pass of the consumer of the binary.
-  // TODO: run rudimentary to improve IR debuggability.
+  // TODO: run rudimentary optimisations to improve IR debuggability.
   if (getComputeTargetType(M) == ComputeBackend::SPIRV)
     return false;
 

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -12,6 +12,7 @@
 #include "gen/cl_helpers.h"
 #include "gen/logger.h"
 #include "gen/passes/Passes.h"
+#include "driver/targetmachine.h"
 #include "llvm/LinkAllPasses.h"
 #if LDC_LLVM_VER >= 307
 #include "llvm/IR/LegacyPassManager.h"
@@ -344,10 +345,14 @@ static void addOptimizationPasses(PassManagerBase &mpm,
 // This function runs optimization passes based on command line arguments.
 // Returns true if any optimization passes were invoked.
 bool ldc_optimize_module(llvm::Module *M) {
+  
   // Dont optimise spirv modules as turning GEPs into extracts triggers asserts
-  // in the IR -> SPIR-V translation pass
-  llvm::Triple::ArchType a = llvm::Triple(M->getTargetTriple()).getArch();
-  if (a == Triple::spir || a == Triple::spir64)
+  // in the IR -> SPIR-V translation pass. SPIRV doesn't have a target machine,
+  // so any optimisation passes that rely on it to provide analysis, like DCE.
+  // The optimisation is supposed to bappen between the SPIRV -> native machine
+  // code pass of the consumer of the binary.
+  // TODO: run rudimentary to improve IR debuggability.
+  if (getComputeTargetType(M) == ComputeBackend::SPIRV)
     return false;
 
 // Create a PassManager to hold and optimize the collection of


### PR DESCRIPTION
* dont optimise SPIR-V as turning GEPs into extracts causes the back end to assert.
* Always use llvm::TargetMachine::CGFT_AssemblyFile for ptx, if we don't
create target machine will return null
* llvm::createSPIRVWriterPass(out)->runOnModule(m) is the way to make
output happen for SPIR-V as there is no target machine for SPIR-V.