### PR TITLE
fix issue 1876: MS file tracker fails to run for executables built with debug info

### DIFF
--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -688,15 +688,9 @@ static int linkObjToBinaryMSVC(bool sharedLib) {
   args.push_back("/NOLOGO");
 
   // specify that the image will contain a table of safe exception handlers
-  // (32bit only)
+  // and can handle addresses >2GB (32bit only)
   if (!global.params.is64bit) {
     args.push_back("/SAFESEH");
-  }
-
-  // because of a LLVM bug, see LDC issue 442
-  if (global.params.symdebug) {
-    args.push_back("/LARGEADDRESSAWARE:NO");
-  } else {
     args.push_back("/LARGEADDRESSAWARE");
   }
 


### PR DESCRIPTION
passing /LARGEADDRESSAWARE:NO is a workaround for DWARF debug info, it causes trouble with CodeView debug info.

See https://github.com/ldc-developers/ldc/issues/1876