### PR TITLE
Fix check if nested function can access outer function frame

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -852,7 +852,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   // data from the template function itself, but it would still mess up our
   // nested context creation code.
   FuncDeclaration *parent = fd;
-  while ((parent = getParentFunc(parent, true))) {
+  while ((parent = getParentFunc(parent))) {
     if (parent->semanticRun != PASSsemantic3done || parent->semantic3Errors) {
       IF_LOG Logger::println(
           "Ignoring nested function with unanalyzed parent.");

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1733,29 +1733,26 @@ llvm::GlobalVariable *getOrCreateGlobal(const Loc &loc, llvm::Module &module,
                                   nullptr, tlsModel);
 }
 
-FuncDeclaration *getParentFunc(Dsymbol *sym, bool stopOnStatic) {
+FuncDeclaration *getParentFunc(Dsymbol *sym) {
   if (!sym) {
     return nullptr;
   }
 
-  // check if symbol is itself a static function/aggregate
-  if (stopOnStatic) {
-    // Static functions and function (not delegate) literals don't allow
-    // access to a parent context, even if they are nested.
-    if (FuncDeclaration *fd = sym->isFuncDeclaration()) {
-      bool certainlyNewRoot =
-          fd->isStatic() ||
-          (fd->isFuncLiteralDeclaration() &&
-           static_cast<FuncLiteralDeclaration *>(fd)->tok == TOKfunction);
-      if (certainlyNewRoot) {
-        return nullptr;
-      }
+  // Static functions and function (not delegate) literals don't allow
+  // access to a parent context, even if they are nested.
+  if (FuncDeclaration *fd = sym->isFuncDeclaration()) {
+    bool certainlyNewRoot =
+        fd->isStatic() ||
+        (fd->isFuncLiteralDeclaration() &&
+         static_cast<FuncLiteralDeclaration *>(fd)->tok == TOKfunction);
+    if (certainlyNewRoot) {
+      return nullptr;
     }
-    // Fun fact: AggregateDeclarations are not Declarations.
-    else if (AggregateDeclaration *ad = sym->isAggregateDeclaration()) {
-      if (!ad->isNested()) {
-        return nullptr;
-      }
+  }
+  // Fun fact: AggregateDeclarations are not Declarations.
+  else if (AggregateDeclaration *ad = sym->isAggregateDeclaration()) {
+    if (!ad->isNested()) {
+      return nullptr;
     }
   }
 
@@ -1764,11 +1761,9 @@ FuncDeclaration *getParentFunc(Dsymbol *sym, bool stopOnStatic) {
       return fd;
     }
 
-    if (stopOnStatic) {
-      if (AggregateDeclaration *ad = parent->isAggregateDeclaration()) {
-        if (!ad->isNested()) {
-          return nullptr;
-        }
+    if (AggregateDeclaration *ad = parent->isAggregateDeclaration()) {
+      if (!ad->isNested()) {
+        return nullptr;
       }
     }
   }

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -260,7 +260,7 @@ llvm::GlobalVariable *getOrCreateGlobal(const Loc &loc, llvm::Module &module,
                                         llvm::StringRef name,
                                         bool isThreadLocal = false);
 
-FuncDeclaration *getParentFunc(Dsymbol *sym, bool stopOnStatic);
+FuncDeclaration *getParentFunc(Dsymbol *sym);
 
 void Declaration_codegen(Dsymbol *decl);
 void Declaration_codegen(Dsymbol *decl, IRState *irs);


### PR DESCRIPTION
The previous check wouldn't check intermediate aggregates for static-ness, that was one problem. The other was the assertion that the outer function can be reached as long as there are no static functions inbetween, which isn't always the case, as issue #1864 clearly shows, which is resolved by this.