### PR TITLE
Implement different cache recovery mechanisms.

### DIFF
--- a/tests/linking/ir2obj_caching.d
+++ b/tests/linking/ir2obj_caching.d
@@ -9,7 +9,6 @@
 
 // SECOND: Use IR-to-Object cache in {{.*}}cachedirectory
 // SECOND: Cache object found!
-// SECOND: SymLink output to cached object file
 
 void main()
 {

--- a/tests/linking/ir2obj_caching_retrieval.d
+++ b/tests/linking/ir2obj_caching_retrieval.d
@@ -1,0 +1,19 @@
+// Test recognition of -cache-retrieval commandline flag
+
+// RUN: %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -vv | FileCheck --check-prefix=FIRST %s \
+// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=copy -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc %t%obj \
+// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=link -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc %t%obj \
+// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=hardlink -vv | FileCheck --check-prefix=MUST_HIT %s \
+// RUN: && %ldc %t%obj
+
+// FIRST: Use IR-to-Object cache in {{.*}}cachedirectory
+// Don't check whether the object is in the cache on the first run, because if this test is ran twice the cache will already be there.
+
+// MUST_HIT: Use IR-to-Object cache in {{.*}}cachedirectory
+// MUST_HIT: Cache object found!
+
+void main()
+{
+}


### PR DESCRIPTION
The current retrieval mechanism (retrieve file from cache upon cache hit) is LLVM `create_link`, which creates a symbolic link on Unix/OSX and creates a hard link on Windows.  When symlinked cache files keep being used without the compiler knowing about it (e.g. they are only used by the linker), the cache pruning algorithm will delete the cached file when it becomes old.

`-cache-retrieval={copy|hardlink|link|symlink}`

This PR implements 4 different cache retrieval methods: copy, symlink, hardlink, "link" (previous behavior). "copy" is the safest, as it will work for all kinds of setups, so I've set that as the default. 
The downside is more disk space usage and longer cache retrieval time, especially for large files. The recommendation is to use "hardlink" when it works for the user's setup (doesn't work across filesystems, for example).

