### PR TITLE
Infer return type of functions for vtbl initializer

### DIFF
--- a/tests/compilable/gh1906.d
+++ b/tests/compilable/gh1906.d
@@ -1,0 +1,5 @@
+// RUN: %ldc -c -I%S/inputs %s
+
+import gh1906b;
+
+class C : Base {}

--- a/tests/compilable/inputs/gh1906b.d
+++ b/tests/compilable/inputs/gh1906b.d
@@ -1,0 +1,5 @@
+class Base
+{
+    auto foo() { return this; }
+    abstract int bar();
+}


### PR DESCRIPTION
Fixes regression #1906 introduced by #1891.

Also get rid of another bug wrt. potentially failing `DtoFunctionType()` for abstract functions.