### PR TITLE
Remove the 16MB limit on static array sizes.

### DIFF
--- a/ddmd/mtype.d
+++ b/ddmd/mtype.d
@@ -4633,7 +4633,7 @@ version(IN_LLVM)
                 /+ The size limit that DMD imposes here is only there to work around an optlink bug, which doesn't apply to LDC.
                  + https://issues.dlang.org/show_bug.cgi?id=14859
                  +/
-                mulu(tbn.size(loc), d2, overflow);
+                auto _ = mulu(tbn.size(loc), d2, overflow);
                 if (overflow)
                     goto Loverflow;
 }

--- a/ddmd/mtype.d
+++ b/ddmd/mtype.d
@@ -4612,7 +4612,7 @@ public:
             if (d1 != d2)
             {
             Loverflow:
-                error(loc, "%s size %llu * %llu exceeds 16MiB size limit for static array", toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1);
+                error(loc, "%s size %llu * %llu exceeds the size limit for static arrays (overflow)", toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1);
                 goto Lerror;
             }
             Type tbx = tbn.baseElemOf();
@@ -4628,8 +4628,20 @@ public:
                  * run on them for the size, since they may be forward referenced.
                  */
                 bool overflow = false;
+version(IN_LLVM)
+{
+                /+ The size limit that DMD imposes here is only there to work around an optlink bug, which doesn't apply to LDC.
+                 + https://issues.dlang.org/show_bug.cgi?id=14859
+                 +/
+                mulu(tbn.size(loc), d2, overflow);
+                if (overflow)
+                    goto Loverflow;
+}
+else
+{
                 if (mulu(tbn.size(loc), d2, overflow) >= 0x1000000 || overflow) // put a 'reasonable' limit on it
                     goto Loverflow;
+}
             }
         }
         switch (tbn.ty)

--- a/tests/codegen/static_array_huge.d
+++ b/tests/codegen/static_array_huge.d
@@ -1,0 +1,12 @@
+// Tests that static arrays can be large (> 16MB)
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK: Stuff = type { [209715200 x i8] }
+struct Stuff
+{
+    byte[1024*1024*200] a;
+}
+
+// CHECK: hugeArrayG209715200g ={{.*}} [209715200 x i8]
+byte[1024*1024*200] hugeArray;


### PR DESCRIPTION
The limit is a workaround for an optlink bug, thus unimportant for LDC, see
https://issues.dlang.org/show_bug.cgi?id=14859
https://forum.dlang.org/post/lxzyzcatydfkxkoxfccw@forum.dlang.org
