### PR TITLE
Fix #1924

### DIFF
--- a/gen/arrays.h
+++ b/gen/arrays.h
@@ -42,7 +42,10 @@ LLConstant *DtoConstSlice(LLConstant *dim, LLConstant *ptr,
 Expression *indexArrayLiteral(ArrayLiteralExp *ale, unsigned idx);
 
 /// Returns whether the array literal can be evaluated to a (LLVM) constant.
-bool isConstLiteral(Expression *e);
+/// immutableType indicates whether the literal is used to initialize an
+/// immutable type, in which case allocated dynamic arrays are considered
+/// constant too.
+bool isConstLiteral(Expression *e, bool immutableType = false);
 
 /// Returns the constant for the given array literal expression.
 llvm::Constant *arrayLiteralToConst(IRState *p, ArrayLiteralExp *ale);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2253,7 +2253,7 @@ public:
       result = new DSliceValue(e->type, DtoConstSize_t(0),
                                getNullPtr(getPtrToType(llElemType)));
     } else if (dyn) {
-      if (arrayType->isImmutable() && isConstLiteral(e)) {
+      if (arrayType->isImmutable() && isConstLiteral(e, true)) {
         llvm::Constant *init = arrayLiteralToConst(p, e);
         auto global = new llvm::GlobalVariable(
             gIR->module, init->getType(), true,

--- a/tests/codegen/array_literal_gh1924.d
+++ b/tests/codegen/array_literal_gh1924.d
@@ -1,0 +1,83 @@
+// RUN: %ldc -c -O3 -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -d-version=RUN -run %s
+
+// CHECK-LABEL: define{{.*}} @{{.*}}simple2d
+auto simple2d()
+{
+    // CHECK: _d_newarrayU
+    // CHECK: _d_newarrayU
+    // CHECK-NOT: _d_newarrayU
+    // CHECK: ret {
+    return [[1.0]];
+}
+
+// CHECK-LABEL: define{{.*}} @{{.*}}make3d
+auto make3d()
+{
+    // CHECK: _d_newarrayU
+    // CHECK: _d_newarrayU
+    // CHECK-NOT: _d_newarrayU
+    int[][1][] a = [[[1]]];
+    // CHECK: ret {
+    return a;
+}
+
+struct S
+{
+    auto arr = [[321]];
+}
+
+// CHECK-LABEL: define{{.*}} @{{.*}}makeS
+auto makeS()
+{
+    // CHECK: _d_newarrayU
+    // CHECK: _d_newarrayU
+    // CHECK-NOT: _d_newarrayU
+    // CHECK: ret
+    return S();
+}
+
+mixin template A()
+{
+    auto a = [1, 2, 3];
+    auto b = [[1, 2, 3]];
+}
+
+version (RUN)
+{
+    void main()
+    {
+        {
+            auto a = simple2d();
+            auto b = simple2d();
+            assert(a.ptr !is b.ptr);
+            assert(a[0].ptr !is b[0].ptr);
+        }
+        {
+            auto a = make3d();
+            auto b = make3d();
+            assert(a.ptr !is b.ptr);
+            assert(a[0].ptr !is b[0].ptr);
+        }
+        {
+            enum e = [[1.0]];
+            auto a = e;
+            auto b = e;
+            assert(a.ptr !is b.ptr);
+            assert(a[0].ptr !is b[0].ptr);
+        }
+        {
+            auto a = makeS();
+            auto b = makeS();
+            assert(a.arr.ptr !is b.arr.ptr);
+            assert(a.arr[0].ptr !is b.arr[0].ptr);
+        }
+        {
+            mixin A!() a0;
+            mixin A!() a1;
+            assert(a0.a.ptr !is a1.a.ptr);
+            assert(a0.b.ptr !is a1.b.ptr);
+            assert(a0.b[0].ptr !is a1.b[0].ptr);
+        }
+    }
+}


### PR DESCRIPTION
Back off on what we consider as "constant literals": (some) dynamic array literals are not-const because they are expected to be newly allocated.

~~There is room for optimization, but it's non-trivial.~~ Fixed (needed for our testsuite!).

Resolves #1924