### PR TITLE
Be more forgiving when pre-parsing target triple for config file lookup

### DIFF
--- a/tests/driver/gh1945.d
+++ b/tests/driver/gh1945.d
@@ -1,0 +1,5 @@
+// REQUIRES: target_X86
+// RUN: %ldc -c %s -v -march=x86 | FileCheck %s
+// RUN: %ldc -c %s -v -march x86 | FileCheck %s
+
+// CHECK: config {{.*}}.conf (i686-


### PR DESCRIPTION
Fixes issue #1945 by allowing `-march x86` besides `-march=x86`.