### PR TITLE
Fix -finstrument-functions. The wrong return address was used.

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -760,7 +760,7 @@ static void emitInstrumentationFn(const char *name) {
 
   // Grab the address of the calling function
   auto *caller =
-      gIR->ir->CreateCall(GET_INTRINSIC_DECL(returnaddress), DtoConstInt(1));
+      gIR->ir->CreateCall(GET_INTRINSIC_DECL(returnaddress), DtoConstInt(0));
   auto callee = DtoBitCast(gIR->topfunc(), getVoidPtrType());
 
 #if LDC_LLVM_VER >= 307

--- a/tests/codegen/instrumentation.d
+++ b/tests/codegen/instrumentation.d
@@ -2,8 +2,10 @@
 
 void fun0 () {
   // CHECK-LABEL: define{{.*}} @{{.*}}4fun0FZv
-  // CHECK: call void @__cyg_profile_func_enter
-  // CHECK: call void @__cyg_profile_func_exit
+  // CHECK: [[RET1:%[0-9]]] = call i8* @llvm.returnaddress(i32 0)
+  // CHECK: call void @__cyg_profile_func_enter{{.*}}4fun0FZv{{.*}}[[RET1]]
+  // CHECK: [[RET2:%[0-9]]] = call i8* @llvm.returnaddress(i32 0)
+  // CHECK: call void @__cyg_profile_func_exit{{.*}}4fun0FZv{{.*}}[[RET2]]
   // CHECK-NEXT: ret
   return;
 }
@@ -11,8 +13,8 @@ void fun0 () {
 pragma(LDC_profile_instr, false)
 int fun1 (int x) {
   // CHECK-LABEL: define{{.*}} @{{.*}}4fun1FiZi
-  // CHECK-NOT: call void @__cyg_profile_func_enter
-  // CHECK-NOT: call void @__cyg_profile_func_exit
+  // CHECK-NOT: __cyg_profile_func_enter
+  // CHECK-NOT: __cyg_profile_func_exit
   return 42;
 }
 


### PR DESCRIPTION
Don't know whether this has ever worked, but... according to LLVM spec passing a non-zero argument to `llvm.returnaddress` is likely to be incorrect. More importantly: we need the return address of the current function (level 0), not of the calling function (level 1).

@LemonBoy did you ever test whether `uftrace` gives sane output for LDC programs?