### PR TITLE
Put debuginfo on GEP instead of on the alloca with an offset.

### DIFF
--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -56,20 +56,12 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     return makeVarDValue(astype, vd);
   }
 
-  LLValue *dwarfValue = nullptr;
-#if LDC_LLVM_VER >= 306
-  std::vector<int64_t> dwarfAddr;
-#else
-  std::vector<LLValue *> dwarfAddr;
-#endif
-
   // get the nested context
   LLValue *ctx = nullptr;
   auto currentCtx = gIR->funcGen().nestedVar;
   if (currentCtx) {
     Logger::println("Using own nested context of current function");
     ctx = currentCtx;
-    dwarfValue = currentCtx;
   } else if (irfunc->decl->isMember2()) {
     Logger::println(
         "Current function is member of nested class, loading vthis");
@@ -84,10 +76,6 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     Logger::println("Regular nested function, loading context arg");
 
     ctx = DtoLoad(irfunc->nestArg);
-    dwarfValue = irfunc->nestArg;
-    if (global.params.symdebug) {
-      gIR->DBuilder.OpDeref(dwarfAddr);
-    }
   }
 
   assert(ctx);
@@ -120,10 +108,6 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     IF_LOG Logger::println("Same depth");
   } else {
     // Load frame pointer and index that...
-    if (dwarfValue && global.params.symdebug) {
-      gIR->DBuilder.OpOffset(dwarfAddr, val, vardepth);
-      gIR->DBuilder.OpDeref(dwarfAddr);
-    }
     IF_LOG Logger::println("Lower depth");
     val = DtoGEPi(val, 0, vardepth);
     IF_LOG Logger::cout() << "Frame index: " << *val << '\n';
@@ -135,27 +119,32 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   const auto idx = irLocal->nestedIndex;
   assert(idx != -1 && "Nested context not yet resolved for variable.");
 
-  if (dwarfValue && global.params.symdebug) {
-    gIR->DBuilder.OpOffset(dwarfAddr, val, idx);
-  }
+#if LDC_LLVM_VER >= 306
+    LLSmallVector<int64_t, 2> dwarfAddrOps;
+#else
+    LLSmallVector<LLValue *, 2> dwarfAddrOps;
+#endif
 
-  val = DtoGEPi(val, 0, idx, vd->toChars());
+  LLValue *gep = DtoGEPi(val, 0, idx, vd->toChars());
+  val = gep;
   IF_LOG {
     Logger::cout() << "Addr: " << *val << '\n';
     Logger::cout() << "of type: " << *val->getType() << '\n';
   }
   if (!isSpecialRefVar(vd) && (byref || vd->isRef() || vd->isOut())) {
     val = DtoAlignedLoad(val);
-    // dwarfOpDeref(dwarfAddr);
     IF_LOG {
       Logger::cout() << "Was byref, now: " << *irLocal->value << '\n';
       Logger::cout() << "of type: " << *irLocal->value->getType() << '\n';
     }
   }
 
-  if (dwarfValue && global.params.symdebug) {
-    gIR->DBuilder.EmitLocalVariable(dwarfValue, vd, nullptr, false, true,
-                                    dwarfAddr);
+  if (global.params.symdebug) {
+    // Because we are passing a GEP instead of an alloca to
+    // llvm.dbg.declare, we have to make the address dereference explicit.
+    gIR->DBuilder.OpDeref(dwarfAddrOps);
+    gIR->DBuilder.EmitLocalVariable(gep, vd, nullptr, false, true,
+                                    dwarfAddrOps);
   }
 
   return makeVarDValue(astype, vd, val);

--- a/tests/compilable/gh1933.d
+++ b/tests/compilable/gh1933.d
@@ -1,0 +1,66 @@
+// See Github issue 1933.
+
+// RUN: %ldc -c -release -g -O0 %s
+// RUN: %ldc -c -release -g -O3 %s
+
+ptrdiff_t countUntil(T, N)(T haystack, N needle)
+{
+    ptrdiff_t result;
+    foreach (elem; haystack) {
+        if (elem == needle)
+            return result;
+        result++;
+    }
+    return -1;
+}
+
+bool foo(alias pred, N)(N haystack)
+{
+    foreach (elem; haystack) {
+        if (pred(elem))
+            return true;
+    }
+    return false;
+}
+
+struct MatchTree
+{
+    struct Tag
+    {
+    }
+
+    struct Terminal
+    {
+        string[] varNames;
+    }
+
+    Tag[] m_terminalTags;
+    Terminal term;
+
+    void rebuildGraph()
+    {
+
+        MatchGraphBuilder builder;
+        uint process()
+        {
+            auto aaa = m_terminalTags.length;
+            foreach (t; builder.m_nodes)
+            {
+                auto bbb = term.varNames.countUntil(t.var);
+                assert(m_terminalTags.foo!(u => t.index));
+            }
+            return 0;
+        }
+    }
+}
+
+struct MatchGraphBuilder
+{
+    struct TerminalTag
+    {
+        size_t index;
+        string var;
+    }
+
+    TerminalTag[] m_nodes;
+}

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -12,7 +12,12 @@ void encloser(int arg0, int arg1)
     // CHECK-LABEL: define {{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        // CHECK: %arg0 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg0
+        // CHECK: %arg1 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg1
+        // CHECK: %enc_n = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%enc_n
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
 
         // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as

--- a/tests/debuginfo/nested_llvm306.d
+++ b/tests/debuginfo/nested_llvm306.d
@@ -11,7 +11,12 @@ void encloser(int arg0, int arg1)
     // CHECK-LABEL: define {{.*}} @_D{{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        // CHECK: %arg0 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg0
+        // CHECK: %arg1 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg1
+        // CHECK: %enc_n = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%enc_n
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
     }
 }

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -11,7 +11,12 @@ void encloser(int arg0, int arg1)
     // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: @llvm.dbg.declare{{.*}}%nestedFrame{{.*}}arg1
+        // CHECK: %arg0 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg0
+        // CHECK: %arg1 = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%arg1
+        // CHECK: %enc_n = getelementptr inbounds %nest.encloser
+        // CHECK: @llvm.dbg.declare{{.*}}%enc_n
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
     }
 }


### PR DESCRIPTION
Resolves issue #1933 .

It's the same workaround for an LLVM bug (I think it's a bug) as #1646 .

~~Working on reducing the original testcase further so it doesn't rely on Phobos; will add later.~~ Original testcase added.