### PR TITLE
added Homebrew osx/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ installing it might not be necessary. For several platforms, there
 are also stand-alone binary builds available at the
 [GitHub release page](https://github.com/ldc-developers/ldc/releases).
 
-| Distribution | Command               |
-| ------------ | --------------------- |
-| Arch Linux   | `pacman -S ldc`       |
-| Debian       | `apt-get install ldc` |
-| Fedora       | `yum install ldc`     |
-| Gentoo       | `layman -a ldc`       |
-| HomeBrew     | `brew install ldc`    |
-| Ubuntu       | `apt-get install ldc` |
+| Distribution       | Command               |
+| ------------------ | --------------------- |
+| Homebrew osx/linux | `brew install ldc`    |
+| Arch Linux         | `pacman -S ldc`       |
+| Debian             | `apt-get install ldc` |
+| Fedora             | `yum install ldc`     |
+| Gentoo             | `layman -a ldc`       |
+| Ubuntu             | `apt-get install ldc` |
 
 ##### Windows
 


### PR DESCRIPTION
now that ldc is fixed on linux (https://github.com/Linuxbrew/homebrew-core/issues/852). Moved to top since since should be the preferred way to install since it's cross-platform, doesn't require sudo and adds more flexibility (more recent versions) w all of brew's advantages