### PR TITLE
Fix codegen/asm_output test for RPi 1 (armv6)

### DIFF
--- a/tests/codegen/asm_output.d
+++ b/tests/codegen/asm_output.d
@@ -5,5 +5,5 @@ int foo() {
     return 42;
 // Try to keep these very simple checks independent of architecture:
 // LLVM:  ret i32 42
-// ASM:  {{(\$|#)}}42
+// ASM:  {{(\$|#|.long )}}42
 }


### PR DESCRIPTION
armv6 instruction set used byRaspberry Pi 1 is a little different than armv7.