### PR TITLE
Do not generate DI for non-integral enum types.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -695,7 +695,9 @@ ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type, bool derefclass) {
                                       8, 8, "typeof(null)");
   if (t->ty == Tvector)
     return CreateVectorType(type);
-  if (t->isintegral() || t->isfloating()) {
+  if (t->isfloating())
+    return CreateBasicType(type);
+  if (t->isintegral()) {
     if (type->ty == Tenum)
       return CreateEnumType(type);
     return CreateBasicType(type);

--- a/tests/debuginfo/enum.d
+++ b/tests/debuginfo/enum.d
@@ -1,0 +1,18 @@
+// RUN: %ldc -g -output-ll -of=%t.ll %s
+// RUN: FileCheck %s < %t.ll
+
+enum Foo : float
+{
+  Bar = 3.15,
+  Bar2,
+  Bar3
+}
+
+void openBar (Foo f) { asm { int 3; } }
+
+void main()
+{
+  openBar(Foo.Bar3);
+}
+
+// CHECK-NOT: DW_TAG_enumeration_type


### PR DESCRIPTION
Found while working on DMD's DWARF output, I have no idea if the test works but you get the point :)