### PR TITLE
Optimize/beautify static array initializations

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -28,6 +28,7 @@
 #include "gen/optimizer.h"
 #include "gen/pragma.h"
 #include "gen/runtime.h"
+#include "gen/scope_exit.h"
 #include "gen/structs.h"
 #include "gen/tollvm.h"
 #include "gen/typinf.h"
@@ -486,31 +487,38 @@ public:
       }
     }
 
+    // The front-end sometimes rewrites a static-array-lhs to a slice, e.g.,
+    // when initializing a static array with an array literal.
+    // Use the static array as lhs in that case.
+    DValue *rewrittenLhsStaticArray = nullptr;
     if (e->e1->op == TOKslice) {
-      // Check if this is an initialization of a static array with an array
-      // literal that the frontend has foolishly rewritten into an
-      // assignment of a dynamic array literal to a slice.
-      Logger::println("performing static array literal assignment");
-      SliceExp *const se = static_cast<SliceExp *>(e->e1);
-      Type *const t2 = e->e2->type->toBasetype();
-      Type *const ta = se->e1->type->toBasetype();
-
-      if (se->lwr == nullptr && ta->ty == Tsarray &&
-          e->e2->op == TOKarrayliteral &&
-          e->op == TOKconstruct && // DMD Bugzilla 11238: avoid aliasing issue
-          t2->nextOf()->mutableOf()->implicitConvTo(ta->nextOf())) {
-        ArrayLiteralExp *const ale = static_cast<ArrayLiteralExp *>(e->e2);
-        initializeArrayLiteral(p, ale, DtoLVal(se->e1));
-        result = toElem(e->e1);
-        return;
-      }
+      SliceExp *se = static_cast<SliceExp *>(e->e1);
+      Type *sliceeBaseType = se->e1->type->toBasetype();
+      if (se->lwr == nullptr && sliceeBaseType->ty == Tsarray &&
+          se->type->toBasetype()->nextOf() == sliceeBaseType->nextOf())
+        rewrittenLhsStaticArray = toElem(se->e1, true);
     }
 
-    result = toElem(e->e1, true);
+    DValue *const lhs = (rewrittenLhsStaticArray ? rewrittenLhsStaticArray
+                                                 : toElem(e->e1, true));
+
+    // Set the result of the AssignExp to the lhs.
+    // Defer this to the end of this function, so that static arrays are
+    // rewritten (converted to a slice) after the assignment, primarily for a
+    // more intuitive IR order.
+    SCOPE_EXIT {
+      if (rewrittenLhsStaticArray) {
+        result =
+            new DSliceValue(e->e1->type, DtoArrayLen(rewrittenLhsStaticArray),
+                            DtoArrayPtr(rewrittenLhsStaticArray));
+      } else {
+        result = lhs;
+      }
+    };
 
     // try to construct the lhs in-place
-    if (result->isLVal() && e->op == TOKconstruct &&
-        toInPlaceConstruction(result->isLVal(), e->e2)) {
+    if (lhs->isLVal() && e->op == TOKconstruct &&
+        toInPlaceConstruction(lhs->isLVal(), e->e2)) {
       return;
     }
 
@@ -519,10 +527,11 @@ public:
     if (e->e1->type->toBasetype()->ty == Tstruct && e->e2->op == TOKint64) {
       Logger::println("performing aggregate zero initialization");
       assert(e->e2->toInteger() == 0);
-      DtoMemSetZero(DtoLVal(result));
+      LLValue *lval = DtoLVal(lhs);
+      DtoMemSetZero(lval);
       TypeStruct *ts = static_cast<TypeStruct *>(e->e1->type);
       if (ts->sym->isNested() && ts->sym->vthis)
-        DtoResolveNestedContext(e->loc, ts->sym, DtoLVal(result));
+        DtoResolveNestedContext(e->loc, ts->sym, lval);
       return;
     }
 
@@ -540,7 +549,7 @@ public:
 
     Logger::println("performing normal assignment (rhs has lvalue elems = %d)",
                     lvalueElem);
-    DtoAssign(e->loc, result, r, e->op, !lvalueElem);
+    DtoAssign(e->loc, lhs, r, e->op, !lvalueElem);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/tests/codegen/static_array_init.d
+++ b/tests/codegen/static_array_init.d
@@ -1,0 +1,112 @@
+// RUN: %ldc -output-ll %s -of=%t.ll
+// RUN: FileCheck %s < %t.ll
+
+void bytes_scalar()
+{
+    immutable(byte)[32] myBytes = 123;
+
+    // CHECK:      define {{.*}}_D17static_array_init12bytes_scalarFZv
+    // CHECK-NEXT:   %myBytes = alloca [32 x i8], align 1
+    // CHECK-NEXT:   %1 = bitcast [32 x i8]* %myBytes to i8*
+    // CHECK-NEXT:   call void @llvm.memset{{.*}}(i8* %1, i8 123, i{{(32|64)}} 32
+}
+
+void bytes_scalar(byte arg)
+{
+    immutable(byte)[32] myBytes = arg;
+
+    // CHECK:      define {{.*}}_D17static_array_init12bytes_scalarFgZv
+    // CHECK-NEXT:   %arg = alloca i8, align 1
+    // CHECK-NEXT:   %myBytes = alloca [32 x i8], align 1
+    // CHECK-NEXT:   store i8 %arg_arg, i8* %arg
+    // CHECK-NEXT:   %1 = bitcast [32 x i8]* %myBytes to i8*
+    // CHECK-NEXT:   %2 = load {{.*}}i8* %arg
+    // CHECK-NEXT:   call void @llvm.memset{{.*}}(i8* %1, i8 %2, i{{(32|64)}} 32
+}
+
+void ints_scalar()
+{
+    const(int[32]) myInts = 123;
+
+    // CHECK:      define {{.*}}_D17static_array_init11ints_scalarFZv
+    // CHECK:      arrayinit.cond:
+    // CHECK-NEXT:   %[[I1:[0-9]+]] = load {{.*i(32|64)}}* %arrayinit.itr
+    // CHECK-NEXT:   %arrayinit.condition = icmp ne i{{(32|64)}} %[[I1]], 32
+    // CHECK:        store i32 123, i32* %arrayinit.arrayelem
+}
+
+void ints_scalar(int arg)
+{
+    const(int[32]) myInts = arg;
+
+    // CHECK:      define {{.*}}_D17static_array_init11ints_scalarFiZv
+    // CHECK:      arrayinit.cond:
+    // CHECK-NEXT:   %[[I2:[0-9]+]] = load {{.*i(32|64)}}* %arrayinit.itr
+    // CHECK-NEXT:   %arrayinit.condition = icmp ne i{{(32|64)}} %[[I2]], 32
+    // CHECK:        %[[E2:[0-9]+]] = load {{.*}}i32* %arg
+    // CHECK-NEXT:   store i32 %[[E2]], i32* %arrayinit.arrayelem
+}
+
+void bytes()
+{
+    immutable(byte[4]) myBytes = [ 1, 2, 3, 4 ];
+
+    // CHECK:      define {{.*}}_D17static_array_init5bytesFZv
+    // CHECK-NEXT:   %myBytes = alloca [4 x i8], align 1
+    // CHECK-NEXT:   store [4 x i8] c"\01\02\03\04", [4 x i8]* %myBytes
+}
+
+void bytes(byte[] arg)
+{
+    const(byte)[4] myBytes = arg;
+
+    // CHECK:      define {{.*}}_D17static_array_init5bytesFAgZv
+    // CHECK:        %myBytes = alloca [4 x i8], align 1
+    // CHECK:        %1 = bitcast [4 x i8]* %myBytes to i8*
+    // CHECK:        call void @llvm.memcpy{{.*}}(i8* %1, i8* %.ptr, i{{(32|64)}} 4
+}
+
+void ints()
+{
+    immutable(int)[4] myInts = [ 1, 2, 3, 4 ];
+
+    // CHECK:      define {{.*}}_D17static_array_init4intsFZv
+    // CHECK-NEXT:   %myInts = alloca [4 x i32], align 4
+    // CHECK-NEXT:   store [4 x i32] [i32 1, i32 2, i32 3, i32 4], [4 x i32]* %myInts
+}
+
+void ints(ref int[4] arg)
+{
+    const(int[4]) myInts = arg;
+
+    // CHECK:      define {{.*}}_D17static_array_init4intsFKG4iZv
+    // CHECK-NEXT:   %myInts = alloca [4 x i32], align 4
+    // CHECK-NEXT:   %1 = bitcast [4 x i32]* %myInts to i32*
+    // CHECK-NEXT:   %2 = bitcast i32* %1 to i8*
+    // CHECK-NEXT:   %3 = bitcast [4 x i32]* %arg to i32*
+    // CHECK-NEXT:   %4 = bitcast i32* %3 to i8*
+    // CHECK-NEXT:   call void @llvm.memcpy{{.*}}(i8* %2, i8* %4, i{{(32|64)}} 16
+}
+
+void bytes_scalar_2d()
+{
+    immutable(byte)[4][8] myBytes = 123;
+
+    // CHECK:      define {{.*}}_D17static_array_init15bytes_scalar_2dFZv
+    // CHECK-NEXT:   %myBytes = alloca [8 x [4 x i8]], align 1
+    // CHECK-NEXT:   %1 = bitcast [8 x [4 x i8]]* %myBytes to [32 x i8]*
+    // CHECK-NEXT:   %2 = bitcast [32 x i8]* %1 to i8*
+    // CHECK-NEXT:   call void @llvm.memset{{.*}}(i8* %2, i8 123, i{{(32|64)}} 32
+}
+
+void ints_scalar_2d(immutable int arg)
+{
+    const(int[4])[8] myInts = arg;
+
+    // CHECK:      define {{.*}}_D17static_array_init14ints_scalar_2dFyiZv
+    // CHECK:      arrayinit.cond:
+    // CHECK-NEXT:   %[[I3:[0-9]+]] = load {{.*i(32|64)}}* %arrayinit.itr
+    // CHECK-NEXT:   %arrayinit.condition = icmp ne i{{(32|64)}} %[[I3]], 32
+    // CHECK:        %[[E3:[0-9]+]] = load {{.*}}i32* %arg
+    // CHECK-NEXT:   store i32 %[[E3]], i32* %arrayinit.arrayelem
+}


### PR DESCRIPTION
IR diff for the test case:

```diff
--- old.ll	2017-01-21 20:04:02.363883500 +0100
+++ new.ll	2017-01-21 20:03:44.422451300 +0100
@@ -36,118 +36,88 @@
 
 ; [#uses = 0]
 define void @_D17static_array_init12bytes_scalarFZv() #0 comdat {
-  %myBytes = alloca [32 x i8], align 1            ; [#uses = 1, size/byte = 32]
+  %myBytes = alloca [32 x i8], align 1            ; [#uses = 2, size/byte = 32]
   %1 = bitcast [32 x i8]* %myBytes to i8*         ; [#uses = 1]
-  %2 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %1, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i8* } %2, 1         ; [#uses = 1]
-  %.len = extractvalue { i64, i8* } %2, 0         ; [#uses = 1]
-  %3 = mul i64 1, %.len                           ; [#uses = 1]
-  %4 = udiv exact i64 %3, 1                       ; [#uses = 1]
-  call void @llvm.memset.p0i8.i64(i8* %.ptr, i8 123, i64 %4, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %1, i8 123, i64 32, i32 1, i1 false)
+  %2 = bitcast [32 x i8]* %myBytes to i8*         ; [#uses = 1]
+  %3 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %2, 1 ; [#uses = 0]
   ret void
 }
 
-; [#uses = 2]
+; [#uses = 3]
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; [#uses = 0]
 define void @_D17static_array_init12bytes_scalarFgZv(i8 signext %arg_arg) #0 comdat {
   %arg = alloca i8, align 1                       ; [#uses = 2, size/byte = 1]
-  %myBytes = alloca [32 x i8], align 1            ; [#uses = 1, size/byte = 32]
-  %arrayinit.itr = alloca i64                     ; [#uses = 4, size/byte = 8]
+  %myBytes = alloca [32 x i8], align 1            ; [#uses = 2, size/byte = 32]
   store i8 %arg_arg, i8* %arg
   %1 = bitcast [32 x i8]* %myBytes to i8*         ; [#uses = 1]
-  %2 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %1, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i8* } %2, 1         ; [#uses = 1]
-  %.len = extractvalue { i64, i8* } %2, 0         ; [#uses = 1]
-  %3 = mul i64 1, %.len                           ; [#uses = 1]
-  %4 = udiv exact i64 %3, 1                       ; [#uses = 1]
-  store i64 0, i64* %arrayinit.itr
-  br label %arrayinit.cond
-
-arrayinit.cond:                                   ; preds = %arrayinit.body, %0
-  %5 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
-  %arrayinit.condition = icmp ne i64 %5, %4       ; [#uses = 1]
-  br i1 %arrayinit.condition, label %arrayinit.body, label %arrayinit.end
-
-arrayinit.body:                                   ; preds = %arrayinit.cond
-  %6 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
-  %arrayinit.arrayelem = getelementptr inbounds i8, i8* %.ptr, i64 %6 ; [#uses = 1, type = i8*]
-  %7 = load i8, i8* %arg                          ; [#uses = 1]
-  store i8 %7, i8* %arrayinit.arrayelem
-  %arrayinit.new_itr = add i64 %6, 1              ; [#uses = 1]
-  store i64 %arrayinit.new_itr, i64* %arrayinit.itr
-  br label %arrayinit.cond
-
-arrayinit.end:                                    ; preds = %arrayinit.cond
+  %2 = load i8, i8* %arg                          ; [#uses = 1]
+  call void @llvm.memset.p0i8.i64(i8* %1, i8 %2, i64 32, i32 1, i1 false)
+  %3 = bitcast [32 x i8]* %myBytes to i8*         ; [#uses = 1]
+  %4 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %3, 1 ; [#uses = 0]
   ret void
 }
 
 ; [#uses = 0]
 define void @_D17static_array_init11ints_scalarFZv() #0 comdat {
-  %myInts = alloca [32 x i32], align 4            ; [#uses = 1, size/byte = 128]
+  %myInts = alloca [32 x i32], align 4            ; [#uses = 2, size/byte = 128]
   %arrayinit.itr = alloca i64                     ; [#uses = 4, size/byte = 8]
-  %1 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 1]
-  %2 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %1, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i32* } %2, 1        ; [#uses = 1]
-  %3 = bitcast i32* %.ptr to i8*                  ; [#uses = 1]
-  %.len = extractvalue { i64, i32* } %2, 0        ; [#uses = 1]
-  %4 = mul i64 4, %.len                           ; [#uses = 1]
-  %5 = bitcast i8* %3 to i32*                     ; [#uses = 1]
-  %6 = udiv exact i64 %4, 4                       ; [#uses = 1]
+  %1 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 2]
+  %2 = bitcast i32* %1 to i8*                     ; [#uses = 0]
   store i64 0, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.cond:                                   ; preds = %arrayinit.body, %0
-  %7 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
-  %arrayinit.condition = icmp ne i64 %7, %6       ; [#uses = 1]
+  %3 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
+  %arrayinit.condition = icmp ne i64 %3, 32       ; [#uses = 1]
   br i1 %arrayinit.condition, label %arrayinit.body, label %arrayinit.end
 
 arrayinit.body:                                   ; preds = %arrayinit.cond
-  %8 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
-  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %5, i64 %8 ; [#uses = 1, type = i32*]
+  %4 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
+  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %1, i64 %4 ; [#uses = 1, type = i32*]
   store i32 123, i32* %arrayinit.arrayelem
-  %arrayinit.new_itr = add i64 %8, 1              ; [#uses = 1]
+  %arrayinit.new_itr = add i64 %4, 1              ; [#uses = 1]
   store i64 %arrayinit.new_itr, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.end:                                    ; preds = %arrayinit.cond
+  %5 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 1]
+  %6 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %5, 1 ; [#uses = 0]
   ret void
 }
 
 ; [#uses = 0]
 define void @_D17static_array_init11ints_scalarFiZv(i32 %arg_arg) #0 comdat {
-  %arg = alloca i32, align 4                      ; [#uses = 2, size/byte = 4]
-  %myInts = alloca [32 x i32], align 4            ; [#uses = 1, size/byte = 128]
+  %arg = alloca i32, align 4                      ; [#uses = 3, size/byte = 4]
+  %myInts = alloca [32 x i32], align 4            ; [#uses = 2, size/byte = 128]
   %arrayinit.itr = alloca i64                     ; [#uses = 4, size/byte = 8]
   store i32 %arg_arg, i32* %arg
-  %1 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 1]
-  %2 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %1, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i32* } %2, 1        ; [#uses = 1]
-  %3 = bitcast i32* %.ptr to i8*                  ; [#uses = 1]
-  %.len = extractvalue { i64, i32* } %2, 0        ; [#uses = 1]
-  %4 = mul i64 4, %.len                           ; [#uses = 1]
-  %5 = bitcast i8* %3 to i32*                     ; [#uses = 1]
-  %6 = udiv exact i64 %4, 4                       ; [#uses = 1]
+  %1 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 2]
+  %2 = bitcast i32* %1 to i8*                     ; [#uses = 0]
+  %3 = load i32, i32* %arg                        ; [#uses = 0]
   store i64 0, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.cond:                                   ; preds = %arrayinit.body, %0
-  %7 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
-  %arrayinit.condition = icmp ne i64 %7, %6       ; [#uses = 1]
+  %4 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
+  %arrayinit.condition = icmp ne i64 %4, 32       ; [#uses = 1]
   br i1 %arrayinit.condition, label %arrayinit.body, label %arrayinit.end
 
 arrayinit.body:                                   ; preds = %arrayinit.cond
-  %8 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
-  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %5, i64 %8 ; [#uses = 1, type = i32*]
-  %9 = load i32, i32* %arg                        ; [#uses = 1]
-  store i32 %9, i32* %arrayinit.arrayelem
-  %arrayinit.new_itr = add i64 %8, 1              ; [#uses = 1]
+  %5 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
+  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %1, i64 %5 ; [#uses = 1, type = i32*]
+  %6 = load i32, i32* %arg                        ; [#uses = 1]
+  store i32 %6, i32* %arrayinit.arrayelem
+  %arrayinit.new_itr = add i64 %5, 1              ; [#uses = 1]
   store i64 %arrayinit.new_itr, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.end:                                    ; preds = %arrayinit.cond
+  %7 = bitcast [32 x i32]* %myInts to i32*        ; [#uses = 1]
+  %8 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %7, 1 ; [#uses = 0]
   ret void
 }
 
@@ -161,19 +131,16 @@
 ; [#uses = 0]
 define void @_D17static_array_init5bytesFAgZv({ i64, i8* } %arg_arg) #0 comdat {
   %arg = alloca { i64, i8* }, align 8             ; [#uses = 3, size/byte = 16]
-  %myBytes = alloca [4 x i8], align 1             ; [#uses = 1, size/byte = 4]
+  %myBytes = alloca [4 x i8], align 1             ; [#uses = 2, size/byte = 4]
   store { i64, i8* } %arg_arg, { i64, i8* }* %arg
   %1 = bitcast [4 x i8]* %myBytes to i8*          ; [#uses = 1]
-  %2 = insertvalue { i64, i8* } { i64 4, i8* undef }, i8* %1, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i8* } %2, 1         ; [#uses = 1]
-  %.len = extractvalue { i64, i8* } %2, 0         ; [#uses = 1]
-  %3 = getelementptr inbounds { i64, i8* }, { i64, i8* }* %arg, i32 0, i32 1 ; [#uses = 1, type = i8**]
-  %.ptr1 = load i8*, i8** %3                      ; [#uses = 1]
-  %4 = getelementptr inbounds { i64, i8* }, { i64, i8* }* %arg, i32 0, i32 0 ; [#uses = 1, type = i64*]
-  %.len2 = load i64, i64* %4                      ; [#uses = 1]
-  %5 = mul i64 1, %.len                           ; [#uses = 1]
-  %6 = mul i64 1, %.len2                          ; [#uses = 0]
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %.ptr, i8* %.ptr1, i64 %5, i32 1, i1 false)
+  %2 = getelementptr inbounds { i64, i8* }, { i64, i8* }* %arg, i32 0, i32 1 ; [#uses = 1, type = i8**]
+  %.ptr = load i8*, i8** %2                       ; [#uses = 1]
+  %3 = getelementptr inbounds { i64, i8* }, { i64, i8* }* %arg, i32 0, i32 0 ; [#uses = 1, type = i64*]
+  %.len = load i64, i64* %3                       ; [#uses = 0]
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %1, i8* %.ptr, i64 4, i32 1, i1 false)
+  %4 = bitcast [4 x i8]* %myBytes to i8*          ; [#uses = 1]
+  %5 = insertvalue { i64, i8* } { i64 4, i8* undef }, i8* %4, 1 ; [#uses = 0]
   ret void
 }
 
@@ -202,50 +169,44 @@
 ; [#uses = 0]
 define void @_D17static_array_init15bytes_scalar_2dFZv() #0 comdat {
   %myBytes = alloca [8 x [4 x i8]], align 1       ; [#uses = 1, size/byte = 32]
-  %1 = bitcast [8 x [4 x i8]]* %myBytes to [32 x i8]* ; [#uses = 1]
+  %1 = bitcast [8 x [4 x i8]]* %myBytes to [32 x i8]* ; [#uses = 2]
   %2 = bitcast [32 x i8]* %1 to i8*               ; [#uses = 1]
-  %3 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %2, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i8* } %3, 1         ; [#uses = 1]
-  %.len = extractvalue { i64, i8* } %3, 0         ; [#uses = 1]
-  %4 = mul i64 1, %.len                           ; [#uses = 1]
-  %5 = udiv exact i64 %4, 1                       ; [#uses = 1]
-  call void @llvm.memset.p0i8.i64(i8* %.ptr, i8 123, i64 %5, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %2, i8 123, i64 32, i32 1, i1 false)
+  %3 = bitcast [32 x i8]* %1 to i8*               ; [#uses = 1]
+  %4 = insertvalue { i64, i8* } { i64 32, i8* undef }, i8* %3, 1 ; [#uses = 0]
   ret void
 }
 
 ; [#uses = 0]
 define void @_D17static_array_init14ints_scalar_2dFyiZv(i32 %arg_arg) #0 comdat {
-  %arg = alloca i32, align 4                      ; [#uses = 2, size/byte = 4]
+  %arg = alloca i32, align 4                      ; [#uses = 3, size/byte = 4]
   %myInts = alloca [8 x [4 x i32]], align 4       ; [#uses = 1, size/byte = 128]
   %arrayinit.itr = alloca i64                     ; [#uses = 4, size/byte = 8]
   store i32 %arg_arg, i32* %arg
-  %1 = bitcast [8 x [4 x i32]]* %myInts to [32 x i32]* ; [#uses = 1]
-  %2 = bitcast [32 x i32]* %1 to i32*             ; [#uses = 1]
-  %3 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %2, 1 ; [#uses = 2]
-  %.ptr = extractvalue { i64, i32* } %3, 1        ; [#uses = 1]
-  %4 = bitcast i32* %.ptr to i8*                  ; [#uses = 1]
-  %.len = extractvalue { i64, i32* } %3, 0        ; [#uses = 1]
-  %5 = mul i64 4, %.len                           ; [#uses = 1]
-  %6 = bitcast i8* %4 to i32*                     ; [#uses = 1]
-  %7 = udiv exact i64 %5, 4                       ; [#uses = 1]
+  %1 = bitcast [8 x [4 x i32]]* %myInts to [32 x i32]* ; [#uses = 2]
+  %2 = bitcast [32 x i32]* %1 to i32*             ; [#uses = 2]
+  %3 = bitcast i32* %2 to i8*                     ; [#uses = 0]
+  %4 = load i32, i32* %arg                        ; [#uses = 0]
   store i64 0, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.cond:                                   ; preds = %arrayinit.body, %0
-  %8 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
-  %arrayinit.condition = icmp ne i64 %8, %7       ; [#uses = 1]
+  %5 = load i64, i64* %arrayinit.itr              ; [#uses = 1]
+  %arrayinit.condition = icmp ne i64 %5, 32       ; [#uses = 1]
   br i1 %arrayinit.condition, label %arrayinit.body, label %arrayinit.end
 
 arrayinit.body:                                   ; preds = %arrayinit.cond
-  %9 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
-  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %6, i64 %9 ; [#uses = 1, type = i32*]
-  %10 = load i32, i32* %arg                       ; [#uses = 1]
-  store i32 %10, i32* %arrayinit.arrayelem
-  %arrayinit.new_itr = add i64 %9, 1              ; [#uses = 1]
+  %6 = load i64, i64* %arrayinit.itr              ; [#uses = 2]
+  %arrayinit.arrayelem = getelementptr inbounds i32, i32* %2, i64 %6 ; [#uses = 1, type = i32*]
+  %7 = load i32, i32* %arg                        ; [#uses = 1]
+  store i32 %7, i32* %arrayinit.arrayelem
+  %arrayinit.new_itr = add i64 %6, 1              ; [#uses = 1]
   store i64 %arrayinit.new_itr, i64* %arrayinit.itr
   br label %arrayinit.cond
 
 arrayinit.end:                                    ; preds = %arrayinit.cond
+  %8 = bitcast [32 x i32]* %1 to i32*             ; [#uses = 1]
+  %9 = insertvalue { i64, i32* } { i64 32, i32* undef }, i32* %8, 1 ; [#uses = 0]
   ret void
 }
 
```