### PR TITLE
[CircleCI] Add LLVM 4.0 apt repo.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ dependencies:
   pre:
     # LLVM's official APT repo:
     - sudo add-apt-repository -y 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main'
+    - sudo add-apt-repository -y 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
     - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
     - sudo apt-get update
 


### PR DESCRIPTION
LLVM 4.0 was branched off. So now it lives in its own APT repo.