### PR TITLE
[CMake] Add option to build LDC using LTO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(FindDCompiler)
 include(CheckIncludeFile)
 include(CheckLibraryExists)
 include(CheckCXXCompilerFlag)
+include(CheckDSourceCompiles)
 
 # The script currently only supports the DMD-style commandline interface
 if (NOT D_COMPILER_DMD_COMPAT)
@@ -396,6 +397,11 @@ source_group("Source Files\\ir" FILES ${IR_SRC})
 source_group("Header Files\\ir" FILES ${IR_HDR})
 source_group("Generated Files" REGULAR_EXPRESSION "(id\\.[cdh]|impcnvtab\\.c)$")
 
+
+#
+# Configure the build system to use LTO and/or PGO while building LDC
+#
+include(HandleLTOPGOBuildOptions)
 
 #
 # Enable PGO if supported for this platform and LLVM version.

--- a/cmake/Modules/CheckDSourceCompiles.cmake
+++ b/cmake/Modules/CheckDSourceCompiles.cmake
@@ -1,0 +1,70 @@
+# This file is modified from CMake's CheckCxxSourceCompiles.cmake.
+# Distributed under the OSI-approved BSD 3-Clause License.  See https://cmake.org/licensing for details.
+
+# Check if given D source compiles and links into an executable
+#
+# CHECK_D_SOURCE_COMPILES(<code> <var> [FLAGS <flags>])
+#
+# ::
+#
+#   <code>       - source code to try to compile
+#   <var>        - variable to store whether the source code compiled
+#                  Will be created as an internal cache variable.
+#   <flags>      - Extra commandline flags passed to the compiler.
+#
+# The D_COMPILER variable is read and must point to the D compiler executable.
+
+macro(CHECK_D_SOURCE_COMPILES SOURCE VAR)
+  if(NOT DEFINED "${VAR}")
+    set(_FLAGS)
+    set(_key)
+    foreach(arg ${ARGN})
+      if("${arg}" MATCHES "^(FLAGS)$")
+        set(_key "${arg}")
+      elseif(_key)
+        list(APPEND _${_key} "${arg}")
+        set(_key 0)
+      else()
+        message(FATAL_ERROR "Unknown argument:\n  ${arg}\n")
+      endif()
+    endforeach()
+
+    file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.d"
+      "${SOURCE}\n")
+
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Performing Test ${VAR}")
+    endif()
+
+    execute_process(COMMAND ${D_COMPILER} ${_FLAGS} ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.d
+                OUTPUT_VARIABLE OUTPUT
+                ERROR_VARIABLE OUTPUT
+                RESULT_VARIABLE RETVAL)
+
+    if(${RETVAL})
+      set(${VAR} 0)
+    else()
+      set(${VAR} 1)
+    endif()
+
+    if(${VAR})
+      set(${VAR} 1 CACHE INTERNAL "Test ${VAR}")
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Success")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Performing D SOURCE FILE Test ${VAR} succeeded with the following output:\n"
+        "${OUTPUT}\n"
+        "Source was:\n${SOURCE}\n")
+    else()
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Failed")
+      endif()
+      set(${VAR} "" CACHE INTERNAL "Test ${VAR}")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Performing D SOURCE FILE Test ${VAR} failed with the following output:\n"
+        "${OUTPUT}\n"
+        "Source was:\n${SOURCE}\n")
+    endif()
+  endif()
+endmacro()

--- a/cmake/Modules/HandleLTOPGOBuildOptions.cmake
+++ b/cmake/Modules/HandleLTOPGOBuildOptions.cmake
@@ -1,0 +1,46 @@
+# Handles the LDC_BUILD_WITH_LTO build option.
+# For example `cmake -DLDC_BUILD_WITH_LTO=thin`.
+#
+# LTO is enabled for the C++ and D compilers, provided that they accept the `-flto` flag.
+
+# TODO: implement a LDC_BUILD_WITH_PGO build option (or something similar) to generate/use an LDC PGO profile.
+
+set(__LTO_FLAG)
+set(LDC_BUILD_WITH_LTO OFF CACHE STRING "Build LDC with LTO. May be specified as Thin or Full to use a particular kind of LTO")
+string(TOUPPER "${LDC_BUILD_WITH_LTO}" uppercase_LDC_BUILD_WITH_LTO)
+if(uppercase_LDC_BUILD_WITH_LTO STREQUAL "THIN")
+    set(__LTO_FLAG "-flto=thin")
+elseif(uppercase_LDC_BUILD_WITH_LTO STREQUAL "FULL")
+    set(__LTO_FLAG "-flto=full")
+elseif(LDC_BUILD_WITH_LTO)
+    set(__LTO_FLAG "-flto")
+endif()
+if(__LTO_FLAG)
+    message(STATUS "Building LDC using LTO: ${__LTO_FLAG}")
+    check_cxx_compiler_flag(${__LTO_FLAG} CXX_COMPILER_ACCEPTS_FLTO_${uppercase_LDC_BUILD_WITH_LTO})
+    if (CXX_COMPILER_ACCEPTS_FLTO_${uppercase_LDC_BUILD_WITH_LTO})
+        append(${__LTO_FLAG} CMAKE_CXX_FLAGS CMAKE_C_FLAGS CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
+
+    check_d_source_compiles("void main(){}" D_COMPILER_ACCEPTS_FLTO_${uppercase_LDC_BUILD_WITH_LTO} FLAGS ${__LTO_FLAG})
+    if(D_COMPILER_ACCEPTS_FLTO_${uppercase_LDC_BUILD_WITH_LTO})
+        append(${__LTO_FLAG} DDMD_DFLAGS)
+    endif()
+
+    if(uppercase_LDC_BUILD_WITH_LTO STREQUAL "THIN")
+        # On darwin, enable the lto cache.
+        if(APPLE)
+            append("-Wl,-cache_path_lto,${PROJECT_BINARY_DIR}/lto.cache" CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+        endif()
+    endif()
+    if(uppercase_LDC_BUILD_WITH_LTO MATCHES "^(THIN|FULL)$")
+        if (APPLE)
+            # Explicitly use the LTO library that shipped with the host LDC, assuming it is newer than the system-installed lib.
+            get_filename_component(HOST_LDC_BINDIR ${D_COMPILER} DIRECTORY)
+            if(EXISTS ${HOST_LDC_BINDIR}/../lib/libLTO-ldc.dylib)
+                message(STATUS "Using ${HOST_LDC_BINDIR}/../lib/libLTO-ldc.dylib for LTO")
+                append("-Wl,-lto_library,${HOST_LDC_BINDIR}/../lib/libLTO-ldc.dylib" CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+            endif()
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
[CMake] Add option to build LDC using LTO: `-DLDC_BUILD_WITH_LTO={OFF, ON, FULL, THIN}`.

When `LDC_BUILD_WITH_LTO` is set, the script adds -flto switch for the C++ compiler and D compiler, but only if they can create an executable with it.

Tested on OSX with ThinLTO (both with and without ThinLTO LLVM build). Some extra work is probably needed on Linux. On Windows, it won't do anything as the cmdline flag checks will fail.
On Linux, we should also enable the thinlto cache if possible.
Quick measurements indicate ~3% percent increased performance for `-O0` and `-O3` compilation (with ThinLTO LLVM too). Future step is adding PGO ;-)