### PR TITLE
Dcompute semantic

### DIFF
--- a/ddmd/mars.d
+++ b/ddmd/mars.d
@@ -53,6 +53,7 @@ import ddmd.root.rmem;
 import ddmd.root.stringtable;
 import ddmd.target;
 import ddmd.tokens;
+version (IN_LLVM) import gen.semantic : extraLDCSpecificSemanticAnalysis;
 
 
 /**
@@ -1578,6 +1579,10 @@ extern (C++) int mars_mainBody(ref Strings files, ref Strings libmodules)
     Module.runDeferredSemantic3();
     if (global.errors)
         fatal();
+  version (IN_LLVM)
+  {
+    extraLDCSpecificSemanticAnalysis(modules);
+  }
   version (IN_LLVM) {} else
   {
     // Scan for functions to inline

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -16,151 +16,152 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "gen/recursivevisitor.h"
+#include "gen/uda.h"
+#include "gen/dcomputetarget.h"
+#include "ddmd/declaration.h"
+#include "ddmd/module.h"
+#include "ddmd/identifier.h"
+#include "id.h"
 
 struct DComputeSemantic : public StoppableVisitor {
-    // InterfaceDeclaration
-    // ClassDeclaration
-    // VarDeclaration : isDataSeg (global variable)
-    // PragmaDeclaration : pragma(lib, "...")
-    // nogc
-    // nothrow
-    // no typeid
-    // no string switches
-    // no synchronized
+  // InterfaceDeclaration
+  // ClassDeclaration
+  // VarDeclaration : isDataSeg (global variable)
+  // PragmaDeclaration : pragma(lib, "...")
+  // nogc
+  // nothrow
+  // no typeid
+  // no string switches
+  // no synchronized
+
+  void visit(InterfaceDeclaration *decl) override {
+    decl->error("interfaces and classes not allowed in @compute code");
+    stop = true;
+  }
+  void visit(ClassDeclaration *decl) override {
+    decl->error("interfaces and classes not allowed in @compute code");
+    stop = true;
+  }
+  void visit(VarDeclaration *decl) override {
+    if (decl->isDataseg()) {
+      decl->error("global variables not allowed in @compute code");
+      stop = true;
+    }
+    if (decl->type->ty == Taarray) {
+      decl->error("associative arrays not allowed in @compute code");
+      stop = true;
+    }
+  }
+  void visit(PragmaDeclaration *decl) override {
+    if (decl->ident == Id::lib) {
+      decl->error(
+          "linking additional libraries not supported in @compute code");
+      stop = true;
+    }
+  }
+
+  // Nogc enforcement.
+  // No need to check AssocArrayLiteral because AA's are benned anyway
+  void visit(ArrayLiteralExp *e) override {
+    if (e->type->ty != Tarray || !e->elements || !e->elements->dim)
+      return;
+    e->error("array literal in @compute code not allowed");
+    stop = true;
+  }
+  void visit(NewExp *e) override {
+    e->error("cannot use 'new' in @compute code");
+    stop = true;
+  }
+
+  void visit(DeleteExp *e) override {
+    e->error("cannot use 'delete' in @compute code");
+    stop = true;
+  }
+  // No need to check IndexExp because AA's are banned anyway
+  void visit(AssignExp *e) override {
+    if (e->e1->op == TOKarraylength) {
+      e->error("setting 'length' in @compute code not allowed");
+      stop = true;
+    }
+  }
+
+  void visit(CatAssignExp *e) override {
+    e->error("cannot use operator ~= in @compute code");
+    stop = true;
+  }
+  void visit(CatExp *e) override {
+    e->error("cannot use operator ~ in @compute code");
+    stop = true;
+  }
+  // Ban typeid(T)
+  void visit(TypeidExp *e) override {
+    e->error("typeinfo not available in @compute code");
+    stop = true;
+  }
+  void visit(SynchronizedStatement *e) override {
+    e->error("cannot use 'synchronized' in @compute code");
+    stop = true;
+  }
+
+  void visit(StringExp *e) override {
+    e->error("string literals not allowed in @compue code");
+    stop = true;
+  }
+  void visit(CompoundAsmStatement *e) override {
+    e->error("asm not allowed in @compute code");
+    stop = true;
+  }
+  void visit(AsmStatement *e) override {
+    e->error("asm not allowed in @compute code");
+    stop = true;
+  }
+  // nothrow
+
+  void visit(TryCatchStatement *e) override {
+    e->error("no exceptions in @compute code");
+    stop = true;
+  }
+  void visit(ThrowStatement *e) override {
+    e->error("no exceptions in @compute code");
+    stop = true;
+  }
+  void visit(SwitchStatement *e) override {
+    if (!e->condition->type->isintegral()) {
+      e->error("cannot switch on strings in @compute code");
+      stop = true;
+    }
+  }
     
-    void visit(InterfaceDeclaration *decl) {
-        decl->error("interfaces and classes not allowed in @compute code");
-        stop = true;
-    }
-    void visit(ClassDeclaration *decl) {
-        decl->error("interfaces and classes not allowed in @compute code");
-        stop = true;
-    }
-    void visit(VarDeclaration *decl) {
-        if (decl->isDataseg())
-        {
-            decl->error("global variables not allowed in @compute code");
+  void visit(IfStatement *stmt) override {
+    if (stmt->condition->op == TOKcall) {
+      auto ce = (CallExp *)stmt->condition;
+      if (ce->f && ce->f->ident && ! strcmp(ce->f->ident->string,
+                                            "__dcompute_reflect")) {
+        auto arg1 = (DComputeTarget::ID)(*ce->arguments)[0]->toInteger();
+        if (arg1 == DComputeTarget::Host)
+            // Alllow code explicily for host to bypass the call only @conpute
+            // restriction below.
             stop = true;
-        }
-        if (decl->type->ty == Taarray)
-        {
-            decl->error("associative arrays not allowed in @compute code");
-            stop = true;
-        }
+      }
     }
-    void visit(PragmaDeclaration *decl) {
-        if (decl->ident == Id::lib)
-        {
-            decl->error("linking additional libraries not supported in @compute code");
-            stop = true;
-        }
+  }
+  void visit(CallExp *e) override {
+    if (!hasComputeAttr(e->f->getModule())) {
+      e->error("can only call functions from other @compute modules in "
+                "@compute code");
+      stop = true;
     }
-    
-    // Nogc enforcement.
-    // No need to check AssocArrayLiteral because AA's are benned anyway
-    void visit(ArrayLiteralExp* e) override
-    {
-        if (e->type.ty != Tarray || !e->elements || !e->elements->dim)
-            return;
-        e->error("array literal in @compute code not allowed");
-        stop = true;
-    }
-    void visit(NewExp* e) override
-    {
-        e->error("cannot use 'new' in @compute code");
-        stop = true;
-    }
-    
-    void visit(DeleteExp* e) override
-    {
-        e->error("cannot use 'delete' in @compute code");
-        stop = true;
-    }
-    // No need to check IndexExp because AA's are banned anyway
-    void visit(AssignExp* e) override
-    {
-        if (e->e1->op == TOKarraylength)
-        {
-            e->error("setting 'length' in @compute code not allowed");
-            stop = true;
-        }
-    }
-    
-    void visit(CatAssignExp* e) override
-    {
-        e->error("cannot use operator ~= in @compute code");
-        stop = true;
-    }
-    void visit(CatExp* e) override
-    {
-        e->error("cannot use operator ~ in @compute code");
-        stop = true;
-    }
-    // Ban typeid(T)
-    void visit(TypeIdExpression *e) override
-    {
-        e->error("typeinfo not available in @compute code");
-        stop = true;
-    }
-    void visit(SynchronizedStatement *e)
-    {
-        e->error("cannot use 'synchronized' in @compute code");
-        stop = true;
-    }
-    
-    void visit(CallExp *e)
-    {
-        if (!hasComputeAttr(e->f->getModule())) {
-            e->error("can only call functions from other @compute modules in @compute code");
-            stop = true;
-        }
-    }
-    void visit(StringLiteralExp *e)
-    {
-        e->error("string literals not allowed in @compue code");
-        stop = true;
-    }
-    void visit(CompoundAsmStatement *e)
-    {
-        e->error("asm not allowed in @compute code");
-        stop = true;
-    }
-    void visit(AsmStatement *e)
-    {
-        e->error("asm not allowed in @compute code");
-        stop = true;
-    }
-    // nothrow
-    
-    void visit(TryCatchStatement *e)
-    {
-        e->error("no exceptions in @compute code");
-        stop = true;
-    }
-    void visit(ThrowStatement *e)
-    {
-        e->error("no exceptions in @compute code");
-        stop = true;
-    }
-    void visit(SwitchStatement *e)
-    {
-        if (!s->condition->type->isintegral())
-        {
-            e->error("cannot switch on strings in @compute code");
-            stop = true;
-        }
-    }
-}
+  }
+};
 
 void dcomputeSemanticAnalysis(Module * m)
 {
-    DComputeSemantic v;
-    RecursiveWalker r(&v);
-    for (unsigned k = 0; k < m->members->dim; k++) {
-        Dsymbol *dsym = (*m->members)[k];
-        assert(dsym);
-        dsym->accept(&r);
-    }
+  DComputeSemantic v;
+  RecursiveWalker r(&v);
+  for (unsigned k = 0; k < m->members->dim; k++) {
+    Dsymbol *dsym = (*m->members)[k];
+    assert(dsym);
+    dsym->accept(&r);
+  }
 }

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -1,0 +1,166 @@
+//===-- dcomputevailditychecker.cpp ---------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Validation for @compute code:
+//      enforce: @nogc, nothrow, all function calls are to modules that are also
+//          @compute. The enforcemnt of nothrow is simpler because all functions
+//          are assumed to not throw. We only need to check for ThrowStatement
+//
+//      ban: classes, interfaces, asm, typeid, global variables
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "gen/recursivevisitor.h"
+
+struct DComputeSemantic : public StoppableVisitor {
+    // InterfaceDeclaration
+    // ClassDeclaration
+    // VarDeclaration : isDataSeg (global variable)
+    // PragmaDeclaration : pragma(lib, "...")
+    // nogc
+    // nothrow
+    // no typeid
+    // no string switches
+    // no synchronized
+    
+    void visit(InterfaceDeclaration *decl) {
+        decl->error("interfaces and classes not allowed in @compute code");
+        stop = true;
+    }
+    void visit(ClassDeclaration *decl) {
+        decl->error("interfaces and classes not allowed in @compute code");
+        stop = true;
+    }
+    void visit(VarDeclaration *decl) {
+        if (decl->isDataseg())
+        {
+            decl->error("global variables not allowed in @compute code");
+            stop = true;
+        }
+        if (decl->type->ty == Taarray)
+        {
+            decl->error("associative arrays not allowed in @compute code");
+            stop = true;
+        }
+    }
+    void visit(PragmaDeclaration *decl) {
+        if (decl->ident == Id::lib)
+        {
+            decl->error("linking additional libraries not supported in @compute code");
+            stop = true;
+        }
+    }
+    
+    // Nogc enforcement.
+    // No need to check AssocArrayLiteral because AA's are benned anyway
+    void visit(ArrayLiteralExp* e) override
+    {
+        if (e->type.ty != Tarray || !e->elements || !e->elements->dim)
+            return;
+        e->error("array literal in @compute code not allowed");
+        stop = true;
+    }
+    void visit(NewExp* e) override
+    {
+        e->error("cannot use 'new' in @compute code");
+        stop = true;
+    }
+    
+    void visit(DeleteExp* e) override
+    {
+        e->error("cannot use 'delete' in @compute code");
+        stop = true;
+    }
+    // No need to check IndexExp because AA's are banned anyway
+    void visit(AssignExp* e) override
+    {
+        if (e->e1->op == TOKarraylength)
+        {
+            e->error("setting 'length' in @compute code not allowed");
+            stop = true;
+        }
+    }
+    
+    void visit(CatAssignExp* e) override
+    {
+        e->error("cannot use operator ~= in @compute code");
+        stop = true;
+    }
+    void visit(CatExp* e) override
+    {
+        e->error("cannot use operator ~ in @compute code");
+        stop = true;
+    }
+    // Ban typeid(T)
+    void visit(TypeIdExpression *e) override
+    {
+        e->error("typeinfo not available in @compute code");
+        stop = true;
+    }
+    void visit(SynchronizedStatement *e)
+    {
+        e->error("cannot use 'synchronized' in @compute code");
+        stop = true;
+    }
+    
+    void visit(CallExp *e)
+    {
+        if (!hasComputeAttr(e->f->getModule())) {
+            e->error("can only call functions from other @compute modules in @compute code");
+            stop = true;
+        }
+    }
+    void visit(StringLiteralExp *e)
+    {
+        e->error("string literals not allowed in @compue code");
+        stop = true;
+    }
+    void visit(CompoundAsmStatement *e)
+    {
+        e->error("asm not allowed in @compute code");
+        stop = true;
+    }
+    void visit(AsmStatement *e)
+    {
+        e->error("asm not allowed in @compute code");
+        stop = true;
+    }
+    // nothrow
+    
+    void visit(TryCatchStatement *e)
+    {
+        e->error("no exceptions in @compute code");
+        stop = true;
+    }
+    void visit(ThrowStatement *e)
+    {
+        e->error("no exceptions in @compute code");
+        stop = true;
+    }
+    void visit(SwitchStatement *e)
+    {
+        if (!s->condition->type->isintegral())
+        {
+            e->error("cannot switch on strings in @compute code");
+            stop = true;
+        }
+    }
+}
+
+void dcomputeSemanticAnalysis(Module * m)
+{
+    DComputeSemantic v;
+    RecursiveWalker r(&v);
+    for (unsigned k = 0; k < m->members->dim; k++) {
+        Dsymbol *dsym = (*m->members)[k];
+        assert(dsym);
+        dsym->accept(&r);
+    }
+}

--- a/gen/semantic.d
+++ b/gen/semantic.d
@@ -1,0 +1,27 @@
+//===-- gen/semantic.d - Additional LDC semantic analysis ---------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+module gen.semantic;
+
+import ddmd.arraytypes;
+import gen.semanticdcompute;
+
+extern(C++) void dcomputeSemanticAnalysis(Module m);
+extern(C++) int 
+
+void extraLDCSpecificSemanticAnalysis(Modules modules)
+{
+    for (size_t i = 0; i < modules.dim; i++)
+    {
+        Module m = modules[i];
+        if (hasComputeAttr(m)
+            dcomputeSemanticAnalysis(m);
+    }
+    
+}

--- a/gen/semantic.d
+++ b/gen/semantic.d
@@ -10,17 +10,18 @@
 module gen.semantic;
 
 import ddmd.arraytypes;
-import gen.semanticdcompute;
+import ddmd.dsymbol;
+import ddmd.dmodule;
 
 extern(C++) void dcomputeSemanticAnalysis(Module m);
-extern(C++) int 
+extern(C++) int hasComputeAttr(Dsymbol m);
 
-void extraLDCSpecificSemanticAnalysis(Modules modules)
+extern(C++) void extraLDCSpecificSemanticAnalysis(ref Modules modules)
 {
     for (size_t i = 0; i < modules.dim; i++)
     {
         Module m = modules[i];
-        if (hasComputeAttr(m)
+        if (hasComputeAttr(m))
             dcomputeSemanticAnalysis(m);
     }
     

--- a/tests/semantic/dcompute.d
+++ b/tests/semantic/dcompute.d
@@ -1,0 +1,85 @@
+// RUN: not %ldc -o- %s 2>&1 | FileCheck %s
+
+
+@compute(deviceOnly) module tests.semantic.dcompute;
+import ldc.attributes;
+import tests.semantic.inputs.notatcompute : somefunc;
+
+extern(C) bool perhaps();
+//CHECK: Error: interfaces and classes not allowed in @compute code
+interface I {}
+
+//CHECK: Error: interfaces and classes not allowed in @compute code
+class C : Throwable {}
+
+//CHECK: Error: global variables not allowed in @compute code
+C c;
+
+void func()
+{
+    //CHECK: Error: associative arrays not allowed in @compute code
+    int[int] foo;
+    //CHECK: Error: array literal in @compute code not allowed
+    auto bar = [0, 1, 2];
+    //CHECK: Error: cannot use 'new' in @compute code
+    auto baz = new int;
+    //CHECK: Error cannot use 'delete' in @compute code
+    delete baz;
+    
+    int[] quux;
+    //CHECK: Error: setting 'length' in @compute code not allowed
+    quux.length = 1;
+    //CHECK: Error: cannot use operator ~= in @compute code
+    quux ~= 42;
+    //CHECK: Error: cannot use operator ~ in @compute code
+    cast(void) (quux ~ 1);
+    //CHECK: Error: typeinfo not available in @compute code
+    cast(void) typeid(int);
+    synchronized {}
+    //CHECK: Error: string literals not allowed in @compue code
+    auto s = "geaxsese";
+    //CHECK: Error: cannot switch on strings in @compute code
+    switch(s)
+    {
+        default:
+            break;
+    }
+    
+    //CHECK: Error: can only call functions from other @compute modules in @compute code
+    somefunc();
+    
+    //CHECK: Error: no exceptions in @compute code
+    try
+    {
+        func1();
+    }
+    catch(...)
+    {
+    }
+    
+    if (perhaps())
+        //CHECK: Error: no exceptions in @compute code
+        throw c;
+
+    //CHECK-NOT: Error: no exceptions in @compute code
+    try
+    {
+        func1();
+    }
+    finally
+    {
+        func2();
+    }
+    //CHECK-NOT: Error: no exceptions in @compute code
+    scope(exit)
+        func2();
+
+    //CHECK: Error: asm not allowed in @compute code
+    asm {ret;}
+}
+
+void func1() {}
+void func2() {}
+
+//CHECK: Error: linking additional libraries not supported in @compute code
+pragma(lib, "bar");

--- a/tests/semantic/dcompute.d
+++ b/tests/semantic/dcompute.d
@@ -6,6 +6,7 @@ import ldc.attributes;
 import tests.semantic.inputs.notatcompute : somefunc;
 
 extern(C) bool perhaps();
+extern(C) bool __dcompute_reflect(int,int);
 //CHECK: Error: interfaces and classes not allowed in @compute code
 interface I {}
 
@@ -47,6 +48,9 @@ void func()
     
     //CHECK: Error: can only call functions from other @compute modules in @compute code
     somefunc();
+    if (__dcompute_reflect(0,0))
+        //CHECK-NOT: Error: can only call functions from other @compute modules in @compute code
+        somefunc();
     
     //CHECK: Error: no exceptions in @compute code
     try

--- a/tests/semantic/inputs/notatcompute.d
+++ b/tests/semantic/inputs/notatcompute.d
@@ -1,0 +1,3 @@
+module tests.semantic.inputs.notatcompute;
+
+void somefunc() {}


### PR DESCRIPTION
This will need to be rebased for ldc-developers/druntime#87 once ldc-developers/ldc:dcompute tracks ldc-developers/druntime:dcompute.

See the comments in https://github.com/ldc-developers/ldc/pull/1953 for the reasons for the horrible hack in the if statement visitor.

I am inexperienced in lit so I hope that this is the right format for and that the errors match.
(the tests are expected to fail until tracking druntime:dcompute)