### PR TITLE
[Don't pull] A hack to attempt to fix GH issue 1990

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1074,7 +1074,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   Statement_toIR(fd->fbody, gIR);
 
   // D varargs: emit the cleanup block that calls va_end.
-  if (f->linkage == LINKd && f->varargs == 1) {
+  //if (f->linkage == LINKd && f->varargs == 1) {
+  if (funcGen.scopes.currentCleanupScope() > 0) {
     if (!gIR->scopereturned()) {
       if (!funcGen.retBlock)
         funcGen.retBlock = gIR->insertBB("return");

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -302,15 +302,21 @@ public:
 
     emitCoverageLinecountInc(stmt->loc);
 
-    if (stmt->exp) {
+    auto expr = stmt->exp;
+
+    // A cast(void) around the expression is allowed, but doesn't require any
+    // code
+    if (expr && expr->op == TOKcast && expr->type == Type::tvoid) {
+      CastExp *cexp = static_cast<CastExp *>(expr);
+      expr = cexp->e1;
+    }
+
+    if (expr) {
       elem *e;
-      // a cast(void) around the expression is allowed, but doesn't require any
-      // code
-      if (stmt->exp->op == TOKcast && stmt->exp->type == Type::tvoid) {
-        CastExp *cexp = static_cast<CastExp *>(stmt->exp);
-        e = toElemDtor(cexp->e1);
+      if (expr->op == TOKdeclaration) {
+        e = toElem(expr);
       } else {
-        e = toElemDtor(stmt->exp);
+        e = toElemDtor(expr);
       }
       delete e;
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -278,7 +278,7 @@ public:
 
     if (auto vd = e->declaration->isVarDeclaration()) {
       if (!vd->isDataseg() && vd->needsScopeDtor()) {
-        pushVarDtorCleanup(p, vd);
+        //pushVarDtorCleanup(p, vd);
       }
     }
   }

--- a/tests/codegen/tupledtor_gh1990.d
+++ b/tests/codegen/tupledtor_gh1990.d
@@ -1,0 +1,27 @@
+// RUN: %ldc -run %s
+
+int checksum = 1;
+
+struct Foo
+{
+    int val = 0;
+    ~this()
+    {
+        checksum = (checksum + val) * 3;
+    }
+}
+
+void bar(ARGS...)()
+{
+    ARGS tup;
+    checksum = 7;
+    tup[0].val = 1; // this one's dtor must be called second
+    tup[1].val = 2; // this one's dtor must be called first
+}
+
+void main()
+{
+    bar!(Foo, Foo)();
+
+    assert(checksum == ((7 + 2) * 3 + 1) * 3);
+}


### PR DESCRIPTION
This is a hackfix to show the problem exposed by #1990 .
It "fixes" #1990 , but I'm sure it will break other code badly.

The basic problem is that usually the DMD frontend adds destructor calls explicitly, so we don't have to generate dtor calls. However, in the case of Tuple, the frontend sets the `edtor` field of VarDeclaration and we have to explicitly generate the dtor call from that (run `toElem` on `edtor` and place the code in an appropriate scope cleanup block).
The Tuple declaration is inside an ExpStatement, and that one does cleanup of all cleanup blocks added inside of the ExpStatement codegen. So it would do the cleanup at the end of the Tuple decl, running the dtors right after the variables have been declared (current DMD behavior, which is wrong).  To have the cleanup blocks run after the scope closes in which the ExpStatement sits, I changed `toElemDtor` to `toElem`. (and then had to do a fixup inside DtoDefineFunction)

Here is part of the `-vv` output, so you can see how the Tuple is put in the AST:

```
* TemplateInstance::codegen: 'dtor.bar!(Foo, Foo)'
* * DtoDefineFunction(dtor.bar!(Foo, Foo).bar): dtor.d(11)
* * * Doing function body for: bar
* * * DtoCreateNestedContext for dtor.bar!(Foo, Foo).bar
* * * * DtoCreateNestedContextType for dtor.bar!(Foo, Foo).bar
* * * CompoundStatement::toIR(): 
* * * * CompoundStatement::toIR(): dtor.d(11)
* * * * * ExpStatement::toIR(): dtor.d(12)
* * * * * * DeclarationExp::toElem: ((Foo, Foo) johan;) | T=void
* * * * * * * DtoDeclarationExp: johan
* * * * * * * * VarDeclaration
* * * * * * * * DtoDeclarationExp: johan
* * * * * * * * * TupleDeclaration
* * * * * * * * * DtoDeclarationExp: __johan_field_0
* * * * * * * * * * VarDeclaration
* * * * * * * * * * DtoVarDeclaration(vdtype = Foo)
* * * * * * * * * * * llvm value for decl:   %__johan_field_0 = alloca %dtor.Foo, align 4
* * * * * * * * * * * expression initializer
* * * * * * * * * * * AssignExp::toElem: __johan_field_0 = Foo | (Foo)(Foo = Foo)
* * * * * * * * * * * * VarExp::toElem: __johan_field_0 @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('__johan_field_0' of type 'Foo')
* * * * * * * * * * * * * * a normal variable
* * * * * * * * * * * * VarExp::toElem: Foo @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('Foo' of type 'Foo')
* * * * * * * * * * * * * * Sym: type=Foo
* * * * * * * * * * * * performing normal assignment (rhs has lvalue elems = 0)
* * * * * * * * * * * * DtoAssign()
* * * * * * * * * * CallExp::toElem: __johan_field_0.~this() @ void
* * * * * * * * * * * DotVarExp::toElem: __johan_field_0.~this @ void()
* * * * * * * * * * * * VarExp::toElem: __johan_field_0 @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('__johan_field_0' of type 'Foo')
* * * * * * * * * * * * * * a normal variable
* * * * * * * * * * * DtoCallFunction()
* * * * * * * * * * * * doing normal arguments
* * * * * * * * * * * * Arguments so far: (1)
* * * * * * * * * * * * *   %__johan_field_0 = alloca %dtor.Foo, align 4
* * * * * * * * * * * * Function type: void()
TryCatchFinallyScopes::pushCleanup
* * * * * * * * * DtoDeclarationExp: __johan_field_1
* * * * * * * * * * VarDeclaration
* * * * * * * * * * DtoVarDeclaration(vdtype = Foo)
* * * * * * * * * * * llvm value for decl:   %__johan_field_1 = alloca %dtor.Foo, align 4
* * * * * * * * * * * expression initializer
* * * * * * * * * * * AssignExp::toElem: __johan_field_1 = Foo | (Foo)(Foo = Foo)
* * * * * * * * * * * * VarExp::toElem: __johan_field_1 @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('__johan_field_1' of type 'Foo')
* * * * * * * * * * * * * * a normal variable
* * * * * * * * * * * * VarExp::toElem: Foo @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('Foo' of type 'Foo')
* * * * * * * * * * * * * * Sym: type=Foo
* * * * * * * * * * * * performing normal assignment (rhs has lvalue elems = 0)
* * * * * * * * * * * * DtoAssign()
* * * * * * * * * * CallExp::toElem: __johan_field_1.~this() @ void
* * * * * * * * * * * DotVarExp::toElem: __johan_field_1.~this @ void()
* * * * * * * * * * * * VarExp::toElem: __johan_field_1 @ Foo
* * * * * * * * * * * * * DtoSymbolAddress ('__johan_field_1' of type 'Foo')
* * * * * * * * * * * * * * a normal variable
* * * * * * * * * * * DtoCallFunction()
* * * * * * * * * * * * doing normal arguments
* * * * * * * * * * * * Arguments so far: (1)
* * * * * * * * * * * * *   %__johan_field_1 = alloca %dtor.Foo, align 4
* * * * * * * * * * * * Function type: void()
```