### PR TITLE
To check magic LDC UDAs parameter types, convert them to their basetype first.

### DIFF
--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -78,7 +78,7 @@ void checkStructElems(StructLiteralExp *sle, ArrayParam<Type *> elemTypes) {
   }
 
   for (size_t i = 0; i < sle->elements->dim; ++i) {
-    if ((*sle->elements)[i]->type != elemTypes[i]) {
+    if ((*sle->elements)[i]->type->toBasetype() != elemTypes[i]) {
       sle->error("invalid field type in 'ldc.attributes.%s'; does druntime not "
                  "match compiler version?",
                  sle->sd->ident->string);


### PR DESCRIPTION
With this, you can check enums with Type::tint32, instead of constructing the enum type. For example: `checkStructElems(sle, {Type::tint32})` for this UDA:
```
enum E {a,b,c};
struct exampleUDA
{
   E e;
}
```

Needed for e.g. #1993