### PR TITLE
Initial support for targeting RISC-V architectures: defining version identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,16 @@ if(GENERATE_OFFTI)
     append("-DGENERATE_OFFTI" CMAKE_CXX_FLAGS)
 endif()
 
+option(RISCV_LLVM_DEV, "full RISC-V support with riscv-llvm")
+mark_as_advanced(RISCV_LLVM_DEV)
+
+#
+# Enable building with riscv-llvm, for full RISC-V support.
+#
+if(RISCV_LLVM_DEV)
+    append("-DRISCV_LLVM_DEV" CMAKE_CXX_FLAGS)
+endif()
+
 # if llvm was built with assertions we have to do the same
 # as there are some headers with differing behavior based on NDEBUG
 if(LLVM_ENABLE_ASSERTIONS)

--- a/ddmd/cond.d
+++ b/ddmd/cond.d
@@ -297,6 +297,8 @@ extern (C++) final class VersionCondition : DVCondition
             "MIPS_HardFloat",
             "NVPTX",
             "NVPTX64",
+            "RISCV32",
+            "RISCV64",
             "SPARC",
             "SPARC_V8Plus",
             "SPARC_SoftFloat",

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -726,6 +726,18 @@ void registerPredefinedTargetVersions() {
     registerPredefinedFloatABI("MIPS_SoftFloat", "MIPS_HardFloat");
     registerMipsABI();
     break;
+#if defined RISCV_LLVM_DEV || LDC_LLVM_VER >= 400
+#if defined RISCV_LLVM_DEV
+  case llvm::Triple::riscv:
+#else
+  case llvm::Triple::riscv32:
+#endif
+    VersionCondition::addPredefinedGlobalIdent("RISCV32");
+    break;
+  case llvm::Triple::riscv64:
+    VersionCondition::addPredefinedGlobalIdent("RISCV64");
+    break;
+#endif
   case llvm::Triple::sparc:
     // FIXME: Detect SPARC v8+ (SPARC_V8Plus).
     VersionCondition::addPredefinedGlobalIdent("SPARC");


### PR DESCRIPTION
This PR adds the RISCV32 and RISCV64 version identifiers to ddmd/cond.d as reserved identifiers, and allows selecting these architectures as the target.

LLVM 4.0 has defined the architectures as `llvm::Triple::riscv32` and `llvm::Triple::riscv64`, but does not yet have support for producing binaries for RISC-V. riscv/riscv-llvm has support for producing binaries, but defines 32 bit as `llvm::Triple::riscv` instead. Therefore, a cmake option was added for building with riscv-llvm (`-DRISCV_LLVM_DEV=ON`). The plan is to remove this option once LLVM has full RISC-V support.

The next step is determining the features of the target CPU.