### PR TITLE
[dcompute] compilation and behaviour fixes

### DIFF
--- a/driver/dcomputecodegenerator.cpp
+++ b/driver/dcomputecodegenerator.cpp
@@ -37,7 +37,7 @@ DComputeCodeGenManager::createComputeTarget(const std::string &s) {
 
   if (std::find(vaild_cuda_versions.begin(), vaild_cuda_versions.end(), v) !=
         vaild_cuda_versions.end()) {
-      return createOCLTarget(ctx, v);
+      return createCUDATarget(ctx, v);
     }
   }
 #define STR(x) #x

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -22,7 +22,11 @@ struct NVPTXTargetABI : TargetABI {
       return llvm::CallingConv::PTX_Device;
   }
   bool passByVal(Type *t) override {
-    return DtoIsInMemoryOnly(t);
+    Type *typ = type->toBasetype();
+    TY t = typ->ty;
+    if (t == Tstruct)
+      return !bool(toDcomputePointer(((TypeStruct*)typ)->sym));
+    return (t == Tsarray);
   }
   void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
     // Do nothing.

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -23,11 +23,11 @@ struct NVPTXTargetABI : TargetABI {
       return llvm::CallingConv::PTX_Device;
   }
   bool passByVal(Type *t) override {
-    Type *typ = type->toBasetype();
-    TY t = typ->ty;
-    if (t == Tstruct)
+    Type *typ = t->toBasetype();
+    TY ty = typ->ty;
+    if (ty == Tstruct)
       return !bool(toDcomputePointer(((TypeStruct*)typ)->sym));
-    return (t == Tsarray);
+    return (ty == Tsarray);
   }
   void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
     // Do nothing.

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -8,9 +8,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/abi.h"
+#include "gen/dcomputetypes.h"
 #include "gen/uda.h"
 #include "ddmd/declaration.h"
-#include "tollvm.h"
+#include "gen/tollvm.h"
 
 struct NVPTXTargetABI : TargetABI {
   llvm::CallingConv::ID callingConv(llvm::FunctionType *ft, LINK l,

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -22,8 +22,11 @@ struct SPIRVTargetABI : TargetABI {
       return llvm::CallingConv::SPIR_FUNC;
   }
   bool passByVal(Type *t) override {
-    return DtoIsInMemoryOnly(t);
-  }
+    Type *typ = type->toBasetype();
+    TY t = typ->ty;
+    if (t == Tstruct)
+      return !bool(toDcomputePointer(((TypeStruct*)typ)->sym));
+    return (t == Tsarray);  }
   void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
     // Do nothing.
   }

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -23,11 +23,11 @@ struct SPIRVTargetABI : TargetABI {
       return llvm::CallingConv::SPIR_FUNC;
   }
   bool passByVal(Type *t) override {
-    Type *typ = type->toBasetype();
-    TY t = typ->ty;
-    if (t == Tstruct)
+    Type *typ = t->toBasetype();
+    TY ty= typ->ty;
+    if (ty == Tstruct)
       return !bool(toDcomputePointer(((TypeStruct*)typ)->sym));
-    return (t == Tsarray);  }
+    return (ty == Tsarray);  }
   void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
     // Do nothing.
   }

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -8,9 +8,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/abi.h"
+#include "gen/dcomputetypes.h"
 #include "gen/uda.h"
 #include "ddmd/declaration.h"
-#include "tollvm.h"
+#include "gen/tollvm.h"
 
 struct SPIRVTargetABI : TargetABI {
   llvm::CallingConv::ID callingConv(llvm::FunctionType *ft, LINK l,

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -372,7 +372,7 @@ void AsmStatement_toIR(AsmStatement *stmt, IRState *irs) {
     llvmInConstraints += ",";
   }
 
-  std::string clobstr;
+  llvm::SmallString<10> clobstr;
   for (const auto &c : clobbers) {
     clobstr = "~{" + c + "},";
     asmblock->clobs.insert(clobstr);

--- a/gen/dcomputetargetCUDA.cpp
+++ b/gen/dcomputetargetCUDA.cpp
@@ -25,7 +25,7 @@ public:
 
             // Map from nominal DCompute address space to NVPTX address space.
             // see $LLVM_ROOT/docs/docs/NVPTXUsage.rst section Address Spaces
-            {5, 1, 3, 4, 0}) {
+            {{5, 1, 3, 4, 0}}) {
     std::string dl;
     if (global.params.is64bit) {
       dl = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-"

--- a/gen/dcomputetargetOCL.cpp
+++ b/gen/dcomputetargetOCL.cpp
@@ -38,7 +38,7 @@ public:
       : DComputeTarget(c, oclversion, OpenCL, "ocl", "spv", createSPIRVABI(),
                        // Map from nomimal DCompute address space to OpenCL
                        // address. For OpenCL this is a no-op.
-                       {0, 1, 2, 3, 4}) {
+                       {{0, 1, 2, 3, 4}}) {
 
     _ir = new IRState("dcomputeTargetOCL", ctx);
     _ir->module.setTargetTriple(global.params.is64bit ? SPIR_TARGETTRIPLE64
@@ -135,7 +135,7 @@ public:
             (t = ((TypeStruct *)(ty))->sym->isInstantiated()) &&
             isFromLDC_DComputeTypes(((TypeStruct *)(ty))->sym)) {
           IF_LOG Logger::println("From dcompute.types");
-          if (!strcmp(t->tempdecl->ident->string, "Pointer")) {
+          if (!strcmp(t->tempdecl->ident->toChars(), "Pointer")) {
             // We have a pointer in an address space
             // struct Pointer(uint addrspace, T)
             addrspace = isExpression((*t->tiargs)[0])->toInteger();

--- a/gen/dcomputetypes.cpp
+++ b/gen/dcomputetypes.cpp
@@ -31,16 +31,16 @@ bool isFromLDC_DComputeTypes(Dsymbol *sym) {
     return false;
   if (moduleDecl->packages->dim != 2)
     return false;
-  if (strcmp("ldc", (*moduleDecl->packages)[0]->string))
+  if (strcmp("ldc", (*moduleDecl->packages)[0]->toChars()))
     return false;
-  if (strcmp("dcomputetypes", (*moduleDecl->packages)[1]->string))
+  if (strcmp("dcomputetypes", (*moduleDecl->packages)[1]->toChars()))
     return false;
   return true;
 }
 
 llvm::Optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd)
 {
-  if (!isFromLDC_DComputeTypes(sd) || strcmp(sd->ident->string, "Pointer")) {
+  if (!isFromLDC_DComputeTypes(sd) || strcmp(sd->ident->toChars(), "Pointer")) {
       return llvm::Optional<DcomputePointer>(llvm::None);
   }
 

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -77,12 +77,14 @@ llvm::StringRef uniqueIdent(Type* t) {
 
 bool ldc::DIBuilder::mustEmitFullDebugInfo() {
   // only for -g and -gc
-  return global.params.symdebug == 1 || global.params.symdebug == 2;
+  return IR->dcomputetarget == nullptr &&
+         (global.params.symdebug == 1 || global.params.symdebug == 2);
 }
 
 bool ldc::DIBuilder::mustEmitLocationsDebugInfo() {
   // for -g -gc and -gline-tables-only
-  return global.params.symdebug > 0;
+  return IR->dcomputetarget == nullptr &&
+         global.params.symdebug > 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -26,6 +26,7 @@
 #include "ir/iraggr.h"
 #include "ir/irvar.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/IR/CallSite.h"
 
@@ -88,7 +89,7 @@ struct IRAsmStmt {
 
 struct IRAsmBlock {
   std::deque<IRAsmStmt *> s;
-  std::set<std::string> clobs;
+  std::set<llvm::SmallString<10>> clobs;
   size_t outputcount;
 
   // stores the labels within the asm block

--- a/gen/recursivevisitor.h
+++ b/gen/recursivevisitor.h
@@ -286,7 +286,7 @@ public:
 
   using Visitor::visit;
     
-  void visit(AttribDeclaration* ad) {
+  void visit(AttribDeclaration* ad) override {
     call_visitor(ad) || recurse(ad->decl);
   }
 

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -140,7 +140,7 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     if (stmt->condition->op == TOKcall) {
       auto ce = (CallExp *)stmt->condition;
       if (ce->f && ce->f->ident &&
-          !strcmp(ce->f->ident->string, "__dcompute_reflect"))
+          !strcmp(ce->f->ident->toChars(), "__dcompute_reflect"))
       {
         auto arg1 = (DComputeTarget::ID)(*ce->arguments)[0]->toInteger();
         if (arg1 == DComputeTarget::Host)

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -33,9 +33,7 @@
 // allowed, but while the alias appears in the symbol table of the module of the
 // template declaration, it's module of origin is the module at the point of
 // instansiation so we need to check for that.
-FuncDeclaration *currentKernel;
-
-bool isNonComputeCallExpVaild(CallExp *ce) {
+bool isNonComputeCallExpVaild(CallExp *ce,FuncDeclaration *currentKernel) {
   if (currentKernel == nullptr)
     return false;
 
@@ -66,6 +64,7 @@ bool isNonComputeCallExpVaild(CallExp *ce) {
 }
 
 struct DComputeSemanticAnalyser : public StoppableVisitor {
+  FuncDeclaration *currentKernel;
 
   void visit(InterfaceDeclaration *decl) override {
     decl->error("interfaces and classes not allowed in @compute code");
@@ -208,7 +207,7 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
       return;
     Module *m = e->f->getModule();
     if (m == nullptr || ((hasComputeAttr(m) == DComputeCompileFor::hostOnly)
-        && !isNonComputeCallExpVaild(e))) {
+        && !isNonComputeCallExpVaild(e,currentKernel))) {
       e->error("can only call functions from other @compute modules in "
                "@compute code");
       stop = true;
@@ -244,7 +243,7 @@ void dcomputeSemanticAnalysis(Module *m) {
     IF_LOG Logger::println("dcomputeSema: %s: %s", m->toPrettyChars(),
                            dsym->toPrettyChars());
     LOG_SCOPE
-    currentKernel = nullptr;
+    v.currentKernel = nullptr;
     dsym->accept(&r);
   }
 }

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -66,8 +66,6 @@ bool isNonComputeCallExpVaild(CallExp *ce) {
 }
 
 struct DComputeSemanticAnalyser : public StoppableVisitor {
-  // Keep track of the outermost (i.e. not nested) function
-
 
   void visit(InterfaceDeclaration *decl) override {
     decl->error("interfaces and classes not allowed in @compute code");

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -344,12 +344,22 @@ public:
         auto arg1 = (DComputeTarget::ID)(*ce->arguments)[0]->toInteger();
         auto arg2 = (*ce->arguments)[1]->toInteger();
         auto dct = irs->dcomputetarget;
-        if ((arg1 == DComputeTarget::Host && !irs->dcomputetarget)
-            || (arg1 == dct->target
-            && (!arg2 || arg2 == dct->tversion))) {
-          stmt->ifbody->accept(this);
-        } else if (stmt->elsebody) {
-          stmt->elsebody->accept(this);
+        Logger::println("here %p, %d, %d",dct,arg1,arg2);
+        if (!dct) {
+          if (arg1 == DComputeTarget::Host)
+            stmt->ifbody->accept(this);
+          else if (stmt->elsebody)
+            stmt->elsebody->accept(this);
+
+        }
+        else {
+          if (arg1 == dct->target && (!arg2 || arg2 == dct->tversion)) {
+            Logger::println("here1");
+            stmt->ifbody->accept(this);
+          } else if (stmt->elsebody) {
+            Logger::println("here2");
+            stmt->elsebody->accept(this);
+          }
         }
         return;
       }

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -344,13 +344,11 @@ public:
         auto arg1 = (DComputeTarget::ID)(*ce->arguments)[0]->toInteger();
         auto arg2 = (*ce->arguments)[1]->toInteger();
         auto dct = irs->dcomputetarget;
-        Logger::println("here %p, %d, %d",dct,arg1,arg2);
         if (!dct) {
           if (arg1 == DComputeTarget::Host)
             stmt->ifbody->accept(this);
           else if (stmt->elsebody)
             stmt->elsebody->accept(this);
-
         }
         else {
           if (arg1 == dct->target && (!arg2 || arg2 == dct->tversion)) {

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -339,7 +339,7 @@ public:
     // pass through the front end.
     if (stmt->condition->op == TOKcall) {
       auto ce = (CallExp *)stmt->condition;
-      if (ce->f && ce->f->ident && ! strcmp(ce->f->ident->string,
+      if (ce->f && ce->f->ident && ! strcmp(ce->f->ident->toChars(),
                                             "__dcompute_reflect")) {
         auto arg1 = (DComputeTarget::ID)(*ce->arguments)[0]->toInteger();
         auto arg2 = (*ce->arguments)[1]->toInteger();


### PR DESCRIPTION
Update `ident->string` to `ident-toChars()`

Fix `__dcompute _reflect` code generation

Actually target CUDA

Disable debug info.

17421c4 is NFC, but I could not for the life of me get the insert on line 378 of asmsstmt.cpp to not crash with `set<string>`, however this works and should be of comparable performance.

Don't pass `Pointer!(n,T)` in memory.
