### PR TITLE
Cherrypick DMD PR #6582.

### DIFF
--- a/ddmd/aggregate.d
+++ b/ddmd/aggregate.d
@@ -640,15 +640,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         if (!isunion)
             *nextoffset = ofs;
 
-        if (alignment == STRUCTALIGN_DEFAULT)
-        {
-            if ((global.params.is64bit || global.params.isOSX) && memalignsize == 16)
-            {
-            }
-            else if (8 < memalignsize)
-                memalignsize = 8;
-        }
-        else
+        if (alignment != STRUCTALIGN_DEFAULT)
         {
             if (memalignsize < alignment)
                 memalignsize = alignment;

--- a/ddmd/target.d
+++ b/ddmd/target.d
@@ -240,7 +240,12 @@ struct Target
      */
     extern (C++) static uint fieldalign(Type type)
     {
-        return type.alignsize();
+        const size = type.alignsize();
+
+        if ((global.params.is64bit || global.params.isOSX) && (size == 16 || size == 32))
+            return size;
+
+        return (8 < size) ? 8 : size;
     }
 
     /***********************************

--- a/tests/codegen/simd_alignment.d
+++ b/tests/codegen/simd_alignment.d
@@ -1,0 +1,27 @@
+// RUN: %ldc -c -output-ll -O3 -of=%t.ll %s && FileCheck %s < %t.ll
+
+import core.simd;
+
+struct S17237
+{
+    bool a;
+    struct
+    {
+        bool b;
+        int8 c;
+    }
+}
+
+int4 globalIntFour;
+// CHECK-DAG: globalIntFour{{.*}} = {{.*}} align 16
+S17237 globalStruct;
+// CHECK-DAG: constant %{{.*}}.S17237 zeroinitializer{{(, comdat)?}}, align 32
+// CHECK-DAG: @{{.*}}globalStruct{{.*}}S17237 = {{.*}} zeroinitializer{{(, comdat)?}}, align 32
+
+// CHECK-LABEL: define <8 x i32> @foo(
+extern(C) int8 foo(S17237* s)
+{
+    // CHECK: %[[GEP:[0-9]]] = getelementptr {{.*}}S17237* %s_arg
+    // CHECK: = load <8 x i32>, <8 x i32>* %[[GEP]], align 32
+    return s.c;
+}

--- a/tests/codegen/simd_alignment.d
+++ b/tests/codegen/simd_alignment.d
@@ -22,6 +22,6 @@ S17237 globalStruct;
 extern(C) int8 foo(S17237* s)
 {
     // CHECK: %[[GEP:[0-9]]] = getelementptr {{.*}}S17237* %s_arg
-    // CHECK: = load <8 x i32>, <8 x i32>* %[[GEP]], align 32
+    // CHECK: = load {{.*}}<8 x i32>* %[[GEP]], align 32
     return s.c;
 }


### PR DESCRIPTION
Fix dlang Issue 17237 - Wrong alignment for 256-bit vectors.

https://forum.dlang.org/post/dehxjddmuyzoyqkbdzwn@forum.dlang.org
https://issues.dlang.org/show_bug.cgi?id=17237