### PR TITLE
support int vector multiplication

### DIFF
--- a/ddmd/expression.d
+++ b/ddmd/expression.d
@@ -8227,9 +8227,6 @@ extern (C++) class BinAssignExp : BinExp
 
         int isvector = type.toBasetype().ty == Tvector;
 
-        if (op == TOKmulass && isvector && !e2.type.isfloating() && (cast(TypeVector)type.toBasetype()).elementType().size(loc) != 2)
-            return incompatibleTypes(); // Only short[8] and ushort[8] work with multiply
-
         if (op == TOKdivass && isvector && !e1.type.isfloating())
             return incompatibleTypes();
 
@@ -14478,11 +14475,6 @@ extern (C++) final class MulExp : BinExp
             {
                 type = t1; // t1 is complex
             }
-        }
-        else if (tb.ty == Tvector && (cast(TypeVector)tb).elementType().size(loc) != 2)
-        {
-            // Only short[8] and ushort[8] work with multiply
-            return incompatibleTypes();
         }
         return this;
     }

--- a/ddmd/expression.d
+++ b/ddmd/expression.d
@@ -8227,6 +8227,12 @@ extern (C++) class BinAssignExp : BinExp
 
         int isvector = type.toBasetype().ty == Tvector;
 
+      version (IN_LLVM) {} else
+      {
+        if (op == TOKmulass && isvector && !e2.type.isfloating() && (cast(TypeVector)type.toBasetype()).elementType().size(loc) != 2)
+            return incompatibleTypes(); // Only short[8] and ushort[8] work with multiply
+      }
+
         if (op == TOKdivass && isvector && !e1.type.isfloating())
             return incompatibleTypes();
 
@@ -14476,6 +14482,14 @@ extern (C++) final class MulExp : BinExp
                 type = t1; // t1 is complex
             }
         }
+        else if (tb.ty == Tvector && (cast(TypeVector)tb).elementType().size(loc) != 2)
+        {
+          version (IN_LLVM) {} else
+          {
+            // Only short[8] and ushort[8] work with multiply
+            return incompatibleTypes();
+          }
+        }        
         return this;
     }
 

--- a/ddmd/expression.d
+++ b/ddmd/expression.d
@@ -14489,7 +14489,7 @@ extern (C++) final class MulExp : BinExp
             // Only short[8] and ushort[8] work with multiply
             return incompatibleTypes();
           }
-        }        
+        }
         return this;
     }
 

--- a/tests/compilable/vector_ops.d
+++ b/tests/compilable/vector_ops.d
@@ -1,0 +1,18 @@
+alias TT(Args...) = Args;
+
+static if (is(__vector(void[16])))
+    enum N = 16;
+else static if (is(__vector(void[32])))
+    enum N = 32;
+else
+    enum N = 0;
+
+static if (N > 0) void test()
+{
+    foreach (T; TT!(byte, short, int, long, ubyte, ushort, uint, ulong))
+    {
+        __vector(T[N / T.sizeof]) a, b, c;
+        a *= b;
+        a = b * c;
+    }
+}


### PR DESCRIPTION
- turns out clang/llvm allow those directly and don't have intrinsics

See [_mm_mullo_epi32](http://clang.llvm.org/doxygen/smmintrin_8h_source.html#l00581) for example.
Could also add div and others, but those hardly map to dedicated SIMD instructions.

Mostly interested in supporting https://github.com/MartinNowak/druntime/blob/7ac278655505d79d8d94ef2ffbc5200691e54918/src/core/internal/arrayop.d#L165.