### PR TITLE
Don't crash when trying to repaint static arrays

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -727,8 +727,12 @@ DValue *DtoPaintType(Loc &loc, DValue *val, Type *to) {
     LLValue *ptr = DtoBitCast(DtoRVal(val), DtoType(b));
     return new DImValue(to, ptr);
   }
-  // assert(!val->isLVal()); TODO: what is it needed for?
-  assert(DtoType(to) == DtoType(to));
+  if (from->ty == Tsarray) {
+    assert(to->toBasetype()->ty == Tsarray);
+    LLValue *ptr = DtoBitCast(DtoLVal(val), DtoPtrToType(to));
+    return new DLValue(to, ptr);
+  }
+  assert(DtoType(from) == DtoType(to));
   return new DImValue(to, DtoRVal(val));
 }
 

--- a/tests/compilable/gh2033.d
+++ b/tests/compilable/gh2033.d
@@ -1,0 +1,11 @@
+// RUN: %ldc -c %s
+
+void foo(const(uint)[4] arg)
+{
+    // The front-end coerces the explicit and following implicit cast
+    // (implicit: int[4] -> const(int[4])) into a single CastExp with
+    // differing types CastExp::to and CastExp::type.
+    // Make sure the repainting code performing the implicit cast
+    // handles static arrays.
+    const copy = cast(int[4]) arg;
+}


### PR DESCRIPTION
Fixes issue #2033.

See testcase for more details.