### PR TITLE
Add -mscrtlib cmdline option and support -static on Windows

### DIFF
--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -210,11 +210,9 @@ Where:\n\
 "  -map             generate linker .map file\n"
 #endif
 "  -mcpu=<id>       generate instructions for architecture identified by 'id'\n\
-  -mcpu=?          list all architecture options\n"
-#if 0
-"  -mscrtlib=<name> MS C runtime library to reference from main/WinMain/DllMain\n"
-#endif
-"  -mv=<package.module>=<filespec>  use <filespec> as source file for <package.module>\n\
+  -mcpu=?          list all architecture options\n\
+  -mscrtlib=<name> MS C runtime library to reference from main/WinMain/DllMain\n\
+  -mv=<package.module>=<filespec>  use <filespec> as source file for <package.module>\n\
   -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)\n\
   -O               optimize\n\
   -o-              do not write object file\n\
@@ -421,9 +419,10 @@ void translateArgs(size_t originalArgc, char **originalArgv,
        */
       else if (strcmp(p + 1, "m32mscoff") == 0) {
         ldcArgs.push_back("-m32");
-      } else if (strncmp(p + 1, "mscrtlib=", 9) == 0) {
-        goto Lnot_in_ldc;
-      } else if (strcmp(p + 1, "profile") == 0) {
+      }
+      /* -mscrtlib
+       */
+      else if (strcmp(p + 1, "profile") == 0) {
         goto Lnot_in_ldc;
       }
       /* -v

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -15,9 +15,6 @@ set(BUILD_SHARED_LIBS     AUTO                                      CACHE STRING
 set(D_FLAGS               -w                                        CACHE STRING  "Runtime build flags, separated by ;")
 set(D_FLAGS_DEBUG         -g;-link-debuglib                         CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
 set(D_FLAGS_RELEASE       -O3;-release                              CACHE STRING  "Runtime build flags (release libraries), separated by ;")
-if(MSVC)
-    set(LINK_WITH_MSVCRT  OFF                                       CACHE BOOL    "Link with MSVCRT.lib (DLL) instead of LIBCMT.lib (static)")
-endif()
 
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
 
@@ -246,17 +243,10 @@ endforeach()
 # of what the user chose for LDC itself.
 # 1) Set up CMAKE_C_FLAGS_RELEASE
 if(MSVC)
-    if(NOT LINK_WITH_MSVCRT)
-        string(REGEX REPLACE "(^| )[/-]MD( |$)" "\\2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-        if(NOT CMAKE_C_FLAGS_RELEASE MATCHES "(^| )[/-]MT( |$)")
-            append("/MT" CMAKE_C_FLAGS_RELEASE)
-        endif()
-    else()
-        string(REGEX REPLACE "(^| )[/-]MT( |$)" "\\2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-        if(NOT CMAKE_C_FLAGS_RELEASE MATCHES "(^| )[/-]MD( |$)")
-            append("/MD" CMAKE_C_FLAGS_RELEASE)
-        endif()
-    endif()
+    # Omit all references to the default C runtime libs.
+    # We want to be able to link against all 4 C runtime variants (libcmt[d] / msvcrt[d]).
+    string(REGEX REPLACE "(^| )[/-]M[TD]d?( |$)" "\\2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+    append("/MT /Zl" CMAKE_C_FLAGS_RELEASE)
     # warning C4996: zlib uses 'deprecated' POSIX names
     append("/wd4996" CMAKE_C_FLAGS_RELEASE)
 endif()


### PR DESCRIPTION
The default MS C runtime library doesn't depend on the `LINK_WITH_MSVCRT` CMake variable anymore.

The user can freely choose among the 4 variants libcmt[d] / msvcrt[d] via -mscrtlib or choose between static/dynamic release variant via -static.

~~As LINK_WITH_MSVCRT defaulted to OFF and -static defaults to false, produced Windows executables/DLLs will now be linked against the runtime DLLs by default (and thus shrink in size).~~ LDC keeps on defaulting to the static release C runtime, so `-static=false` or `-mscrtlib=msvcrt[d]` must be used explicitly in order to link against the runtime DLLs.