### PR TITLE
Re-add uwtable function attribute on Win64

### DIFF
--- a/gen/abi.h
+++ b/gen/abi.h
@@ -107,6 +107,14 @@ struct TargetABI {
     return name;
   }
 
+  /// Returns true if all functions require the LLVM uwtable attribute.
+  virtual bool needsUnwindTables() {
+    // Condensed logic of Clang implementations of
+    // `clang::ToolChain::IsUnwindTablesDefault()` based on early Clang 5.0.
+    return global.params.targetTriple->getArch() == llvm::Triple::x86_64 ||
+           global.params.targetTriple->getOS() == llvm::Triple::NetBSD;
+  }
+
   /// Returns true if the D function uses sret (struct return).
   ///
   /// A LL sret function doesn't really return a struct (in fact, it returns

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -944,10 +944,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
 
   assert(!func->hasDLLImportStorageClass());
 
-  // On x86_64, always set 'uwtable' for System V ABI compatibility.
-  // TODO: Find a better place for this.
-  if (global.params.targetTriple->getArch() == llvm::Triple::x86_64 &&
-      !global.params.isWindows) {
+  // function attributes
+  if (gABI->needsUnwindTables()) {
     func->addFnAttr(LLAttribute::UWTable);
   }
   if (opts::sanitize != opts::None) {


### PR DESCRIPTION
Apparently needed for x86_64 in general and NetBSD (possibly other BSD flavours too) based on `clang::ToolChain::IsUnwindTablesDefault()`.

Resolves issue #2048.