### PR TITLE
Use https URLs for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "druntime"]
 	path = runtime/druntime
-	url = git://github.com/ldc-developers/druntime.git
+	url = https://github.com/ldc-developers/druntime.git
 [submodule "phobos"]
 	path = runtime/phobos
-	url = git://github.com/ldc-developers/phobos.git
+	url = https://github.com/ldc-developers/phobos.git
 [submodule "tests/d2/dmd-testsuite"]
 	path = tests/d2/dmd-testsuite
-	url = git://github.com/ldc-developers/dmd-testsuite.git
+	url = https://github.com/ldc-developers/dmd-testsuite.git


### PR DESCRIPTION
Switching from `git://` URLs to `https://` should make it easier to avoid some CI-related issues encountered with the LDC snap package:
https://github.com/ldc-developers/ldc2.snap/issues/21#issuecomment-287575769

Note, assuming this is acceptable in the first place, I'd ideally like to make this change also to the 0.17.x series and (if possible) the 1.1.x series.  If that would be OK, which branch(es) should I submit against?