### PR TITLE
Add option to avoid recursing in get_git_head_revision cmake function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(NOT TAG MATCHES "NOTFOUND")
         set(LDC_VERSION "${TAG}")
     endif()
 else()
-    get_git_head_revision(REFSPEC HASH)
+    get_git_head_revision(REFSPEC HASH FALSE)
     if(NOT HASH STREQUAL "GITDIR-NOTFOUND")
         # Append git hash to LDC_VERSION
         string(SUBSTRING "${HASH}" 0 7 LDC_VERSION_HASH)

--- a/cmake/Modules/GetGitRevisionDescription.cmake
+++ b/cmake/Modules/GetGitRevisionDescription.cmake
@@ -39,9 +39,18 @@ set(__get_git_revision_description YES)
 # to find the path to this module rather than the path to a calling list file
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-function(get_git_head_revision _refspecvar _hashvar)
+function(get_git_head_revision _refspecvar _hashvar _use_recursion)
 	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	# if we're not recursing and GIT_DIR does not exist,
+	# we are not in git
+	if(NOT _use_recursion AND NOT EXISTS "${GIT_DIR}")
+		set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+		set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	# otherwise, either GIT_DIR exists, or we recurse
+	# until we find it or we reach the root dir
 	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
 		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
 		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)


### PR DESCRIPTION
~~**Add IGNORE_GIT_REVISION cmake option to ignore git revision description**~~

~~This option allows users to override the default behaviour of comparing `LDC_VERSION` to the output of `git describe` and preferring the latter in the case of any difference.~~

~~This should obviously be used with caution but allows the user to avoid issues that can arise when e.g. building from a source tarball that has been extracted in a subdirectory of an independent git tree (!).  This is unfortunately a real possibility: apart from folks who use git to version their home directory [1], it's also proven an issue when trying to use source tarballs to build the LDC snap package [2].~~

~~[1]https://stackoverflow.com/questions/21266948/use-git-to-manage-home-directory/42946460~~
~~[2]https://github.com/ldc-developers/ldc2.snap/issues/21#issuecomment-287575769~~

~~This provides a workaround for https://github.com/ldc-developers/ldc/issues/2042.~~

Since the `get_git_head_revision` function is only ever invoked from the base directory of the LDC source tree, it does not need to recurse in order to get the correct git revision for LDC.  This patch therefore adds a parameter that can be set to `TRUE` or `FALSE` depending on whether one wants to use recursion or not, and sets it to false in when calling `get_git_head_revision` in LDC's own `CMakeLists.txt`.

This should prevent issues that arise when building from source tarballs that have been extracted into a subdirectory of another git tree (!).  This is unfortunately a real possibility: apart from folks using git to
version their home directory [1], it has also proven an issue when using source tarballs to build the LDC snap package [2].

[1]https://stackoverflow.com/questions/21266948/use-git-to-manage-home-directory/42946460
[2]https://github.com/ldc-developers/ldc2.snap/issues/21#issuecomment-287575769

Fixes https://github.com/ldc-developers/ldc/issues/2042.