### PR TITLE
Let LLVM parse floating-point literals instead of host C runtime

### DIFF
--- a/ddmd/lexer.d
+++ b/ddmd/lexer.d
@@ -2008,6 +2008,7 @@ class Lexer
         {
             assert(*p == '.' || isdigit(*p));
         }
+        bool isWellformedString = true;
         stringbuffer.reset();
         auto pstart = p;
         bool hex = false;
@@ -2069,12 +2070,18 @@ class Lexer
                     continue;
                 }
                 if (!anyexp)
+                {
                     error("missing exponent");
+                    isWellformedString = false;
+                }
                 break;
             }
         }
         else if (hex)
+        {
             error("exponent required for hex float");
+            isWellformedString = false;
+        }
         --p;
         while (pstart < p)
         {
@@ -2086,17 +2093,19 @@ class Lexer
         auto sbufptr = cast(const(char)*)stringbuffer.data;
         TOK result;
         bool isOutOfRange = false;
-        t.floatvalue = CTFloat.parse(sbufptr, &isOutOfRange);
+        t.floatvalue = (isWellformedString ? CTFloat.parse(sbufptr, &isOutOfRange) : CTFloat.zero);
         switch (*p)
         {
         case 'F':
         case 'f':
-            isOutOfRange = (isOutOfRange || Port.isFloat32LiteralOutOfRange(sbufptr));
+            if (isWellformedString && !isOutOfRange)
+                isOutOfRange = Port.isFloat32LiteralOutOfRange(sbufptr);
             result = TOKfloat32v;
             p++;
             break;
         default:
-            isOutOfRange = (isOutOfRange || Port.isFloat64LiteralOutOfRange(sbufptr));
+            if (isWellformedString && !isOutOfRange)
+                isOutOfRange = Port.isFloat64LiteralOutOfRange(sbufptr);
             result = TOKfloat64v;
             break;
         case 'l':

--- a/ddmd/root/ctfloat.d
+++ b/ddmd/root/ctfloat.d
@@ -81,6 +81,11 @@ extern (C++) struct CTFloat
     static real_t ceil(real_t x) { return std.math.ceil(x); }
     static real_t trunc(real_t x) { return std.math.trunc(x); }
     static real_t round(real_t x) { return std.math.round(x); }
+
+    static void _init();
+
+    static bool isFloat32LiteralOutOfRange(const(char)* literal);
+    static bool isFloat64LiteralOutOfRange(const(char)* literal);
   }
 
     static bool isIdentical(real_t a, real_t b)
@@ -118,6 +123,13 @@ extern (C++) struct CTFloat
         return r is real_t.infinity || r is -real_t.infinity;
     }
 
+version (IN_LLVM)
+{
+    // implemented in gen/ctfloat.cpp
+    static real_t parse(const(char)* literal, bool* isOutOfRange = null);
+}
+else
+{
     static real_t parse(const(char)* literal, bool* isOutOfRange = null)
     {
         errno = 0;
@@ -136,6 +148,7 @@ extern (C++) struct CTFloat
             *isOutOfRange = (errno == ERANGE);
         return r;
     }
+}
 
     static int sprint(char* str, char fmt, real_t x)
     {
@@ -169,4 +182,12 @@ extern (C++) struct CTFloat
     static __gshared real_t one = real_t(1);
     static __gshared real_t minusone = real_t(-1);
     static __gshared real_t half = real_t(0.5);
+}
+
+version (IN_LLVM)
+{
+    shared static this()
+    {
+        CTFloat._init();
+    }
 }

--- a/ddmd/root/ctfloat.h
+++ b/ddmd/root/ctfloat.h
@@ -50,7 +50,11 @@ struct CTFloat
     static real_t round(real_t x);
 
     // implemented in gen/ctfloat.cpp
+    static void _init();
     static void toAPFloat(real_t src, llvm::APFloat &dst);
+
+    static bool isFloat32LiteralOutOfRange(const char *literal);
+    static bool isFloat64LiteralOutOfRange(const char *literal);
 #endif
 
     static bool isIdentical(real_t a, real_t b);

--- a/ddmd/root/port.d
+++ b/ddmd/root/port.d
@@ -67,6 +67,13 @@ extern (C++) struct Port
 
     static bool isFloat32LiteralOutOfRange(const(char)* s)
     {
+      version (IN_LLVM)
+      {
+        import ddmd.root.ctfloat;
+        return CTFloat.isFloat32LiteralOutOfRange(s);
+      }
+      else
+      {
         errno = 0;
         version (CRuntime_DigitalMars)
         {
@@ -86,10 +93,18 @@ extern (C++) struct Port
         }
         version (CRuntime_DigitalMars) __locale_decpoint = save;
         return errno == ERANGE;
+      }
     }
 
     static bool isFloat64LiteralOutOfRange(const(char)* s)
     {
+      version (IN_LLVM)
+      {
+        import ddmd.root.ctfloat;
+        return CTFloat.isFloat64LiteralOutOfRange(s);
+      }
+      else
+      {
         errno = 0;
         version (CRuntime_DigitalMars)
         {
@@ -109,6 +124,7 @@ extern (C++) struct Port
         }
         version (CRuntime_DigitalMars) __locale_decpoint = save;
         return errno == ERANGE;
+      }
     }
 
     // Little endian


### PR DESCRIPTION
Rendering the parsing consistent across all platforms and resolving stuff like #2046. Visual Studio before 2015 couldn't handle hex literals and had some rounding quirks too.