### PR TITLE
MSVC hosts: Link LDC executables themselves against static CRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,21 +141,16 @@ if(MSVC)
         endif()
     endif()
 
-    # LDC and LDMD are both linked against the dynamic MSVC runtime by
-    # default (due to default CMAKE_C[XX]_FLAGS_*).
-    # Host DMD/LDMD will default to linking against the static MSVC runtime.
-    # So disable some default libs based on CMAKE_C_FLAGS_RELEASE.
-    if(CMAKE_C_FLAGS_RELEASE MATCHES "(^| )[/-]MD( |$)")
-        append("-L/NODEFAULTLIB:libcmt" DDMD_LFLAGS)
-        if(MSVC_VERSION GREATER 1800) # VS 2015+
-            append("-L/NODEFAULTLIB:libvcruntime" DDMD_LFLAGS)
-        endif()
-    else()
-        append("-L/NODEFAULTLIB:msvcrt" DDMD_LFLAGS)
-        if(MSVC_VERSION GREATER 1800) # VS 2015+
-            append("-L/NODEFAULTLIB:vcruntime" DDMD_LFLAGS)
-        endif()
-    endif()
+    # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
+    # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
+    # NOTE: Requires LLVM to be built with CMake variable LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d].
+    foreach(flag_var
+            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+       if(${flag_var} MATCHES "/MD")
+          string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+       endif()
+    endforeach()
 endif()
 
 append("-J${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -J${PROJECT_SOURCE_DIR}/res" DDMD_DFLAGS) # Needed for importing text files

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,9 +90,9 @@ install:
   # Download & extract a pre-built LLVM (CMAKE_BUILD_TYPE=Release, LLVM_ENABLE_ASSERTIONS=ON)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-            appveyor DownloadFile 'https://dl.dropboxusercontent.com/s/6jc2wld5wqgf1jg/LLVM-3.9.1-x64.7z?dl=0' -FileName llvm-x64.7z
+            appveyor DownloadFile 'https://dl.dropboxusercontent.com/s/phhwfs01jpcx74l/LLVM-3.9.1-x64-MT.7z?dl=0' -FileName llvm-x64.7z
         } Else {
-            appveyor DownloadFile 'https://dl.dropboxusercontent.com/s/zhlt3x8xyqlx2n4/LLVM-3.9.1-x86.7z?dl=0' -FileName llvm-x86.7z
+            appveyor DownloadFile 'https://dl.dropboxusercontent.com/s/cx5k09yablneyv3/LLVM-3.9.1-x86-MT.7z?dl=0' -FileName llvm-x86.7z
         }
   - md llvm-%APPVEYOR_JOB_ARCH%
   - cd llvm-%APPVEYOR_JOB_ARCH%


### PR DESCRIPTION
While LDC links binaries against the static Visual C++ runtime libs by default (analogous to the MS compiler), LDC/LDMD and misc. tools themselves were linked against the dynamic runtime, apparently because that's what the CMake C(++) flags default to.

This means that users may have had to install an appropriate Visual C++ runtime before being able to use our binaries, install the 2017 runtime as soon as our release packages are built with VS 2017 etc.

Compiling LLVM via CMake also makes it choose the dynamic runtime by default, so the CMake variable `LLVM_USE_CRT_{RELEASE,DEBUG,...}` (the suffix corresponding to the selected build configuration) must be set to either `MT` or `MTd` when building LLVM, otherwise linking errors result (import symbols...).

Executable size deltas for a `RelWithDebInfo` build on Win64 using LLVM 4.0:
```
ldc2.exe:            +291 KB (1%)
ldmd2.exe:           +283 KB (65%)
ldc-profdata.exe:    +930 KB (29%)
ldc-prune-cache.exe: unchanged
```