### PR TITLE
Travis: Replace make by ninja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ addons:
     - libcurl3:i386
     - cmake
     - cmake-data
+    - ninja-build
 before_install:
   -
     if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
@@ -77,6 +78,7 @@ before_install:
     export LLVM_CONFIG="llvm-$LLVM_VERSION/bin/llvm-config";
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export CC="gcc-4.9"; export CXX="g++-4.9"; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew install ninja; fi;
   - eval "${DC} --version"
   - pip install --user lit
   - python -c "import lit; lit.main();" --version | head -n 1
@@ -84,19 +86,19 @@ install:
 
 script:
   - cmake --version
-  - cmake -DLLVM_CONFIG=$(which ${LLVM_CONFIG}) $OPTS .
-  - make -j3
+  - cmake -G Ninja -DLLVM_CONFIG=$(which ${LLVM_CONFIG}) $OPTS .
+  - ninja -j3
   # Outputs some environment info, plus makes sure we only run the test suite
   # if we could actually build the executable.
   - bin/ldc2 -version || exit 1
   # Build Phobos & druntime unittest modules.
   -
     if [[ "${OPTS}" == *-DMULTILIB?ON* ]]; then
-      make -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest phobos2-ldc-unittest-debug_32 phobos2-ldc-unittest_32;
-      make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest druntime-ldc-unittest-debug_32 druntime-ldc-unittest_32;
+      ninja -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest phobos2-ldc-unittest-debug_32 phobos2-ldc-unittest_32;
+      ninja -j3 druntime-ldc-unittest-debug druntime-ldc-unittest druntime-ldc-unittest-debug_32 druntime-ldc-unittest_32;
     else
-      make -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest;
-      make -j3 druntime-ldc-unittest-debug druntime-ldc-unittest;
+      ninja -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest;
+      ninja -j3 druntime-ldc-unittest-debug druntime-ldc-unittest;
     fi
   # Run dmd-testsuite.
   - CC="" DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"


### PR DESCRIPTION
Ever since building both static and shared runtime libs (and static/shared Phobos sharing their object files), the CI systems spuriously failed when generating the libraries, e.g., `std/xml.o: file not recognized: File truncated`.

~~Try writing to a temporary object file and rename it as soon as it is fully written.~~ Switching from make to ninja apparently fixes this problem and also reduces the Travis log verbosity (as Travis supports line-updates, simulating an interactive shell experience, kinda neat).