### PR TITLE
Fix compilation error with DMD 2.074

### DIFF
--- a/ddmd/root/rmem.d
+++ b/ddmd/root/rmem.d
@@ -189,8 +189,8 @@ else
 
         extern (C) Object _d_newclass(const ClassInfo ci) nothrow
         {
-            auto p = allocmemory(ci.init.length);
-            p[0 .. ci.init.length] = cast(void[])ci.init[];
+            auto p = allocmemory(ci.initializer.length);
+            p[0 .. ci.initializer.length] = cast(void[])ci.initializer[];
             return cast(Object)p;
         }
 
@@ -198,22 +198,30 @@ else
         {
             extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
             {
-                return cast(Object)allocmemory(ci.init.length);
+                return cast(Object)allocmemory(ci.initializer.length);
             }
         }
 
         extern (C) void* _d_newitemT(TypeInfo ti) nothrow
         {
             auto p = allocmemory(ti.tsize);
-            (cast(ubyte*)p)[0 .. ti.init.length] = 0;
+            (cast(ubyte*)p)[0 .. ti.initializer.length] = 0;
             return p;
         }
 
         extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
         {
             auto p = allocmemory(ti.tsize);
-            p[0 .. ti.init.length] = ti.init[];
+            p[0 .. ti.initializer.length] = ti.initializer[];
             return p;
+        }
+
+        // TypeInfo.initializer for compilers older than 2.070
+        static if(!__traits(hasMember, TypeInfo, "initializer"))
+        private const(void[]) initializer(T : TypeInfo)(const T t)
+        nothrow pure @safe @nogc
+        {
+            return t.init;
         }
     }
 }


### PR DESCRIPTION
TypeInfo.init is now @disabled. Retain backwards-compatibility for ltsmaster.

Note: already used by the Travis LLVM 3.5 job.