### PR TITLE
Set up SemaphoreCI, tweak Travis config, speed up dmd-testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       d: ldc
-      env: LLVM_VERSION=4.0.0
+      env: LLVM_VERSION=4.0.1
     - os: linux
       d: ldc-beta
       env: LLVM_VERSION=3.9.1 OPTS="-DLIB_SUFFIX=64"
@@ -26,16 +26,15 @@ matrix:
       env: LLVM_VERSION=5.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON
     - os: osx
       d: ldc
-      env: LLVM_VERSION=4.0.0 OPTS="-DBUILD_SHARED_LIBS=ON"
+      env: LLVM_VERSION=4.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
   allow_failures:
     #- env: LLVM_VERSION=3.9
 
 cache:
   directories:
     - llvm-spirv-5.0.0
-    - llvm-4.0.0
+    - llvm-4.0.1
     - llvm-3.9.1
-    - llvm-3.9.0
     - llvm-3.8.1
     - llvm-3.7.1
     - llvm-3.6.2
@@ -62,7 +61,7 @@ addons:
 before_install:
   -
     if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-      if [ "${LLVM_VERSION}" = "3.9.1" ]; then
+      if [ "${LLVM_VERSION}" = "4.0.1" ]; then
         export LLVM_ARCH="x86_64-linux-gnu-debian8";
       else
         export LLVM_ARCH="x86_64-linux-gnu-ubuntu-14.04";

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ matrix:
       d: ldc
       env: LLVM_VERSION=4.0.0
     - os: linux
-      d: ldc
-      env: LLVM_VERSION=3.9.1
-    - os: linux
       d: ldc-beta
-      env: LLVM_VERSION=3.8.1
+      env: LLVM_VERSION=3.9.1 OPTS="-DLIB_SUFFIX=64"
     - os: linux
       d: ldc
-      env: LLVM_VERSION=3.7.1 OPTS="-DMULTILIB=ON -DBUILD_SHARED_LIBS=OFF -DLIB_SUFFIX=64"
+      env: LLVM_VERSION=3.8.1 OPTS="-DBUILD_SHARED_LIBS=ON"
+    - os: linux
+      d: ldc
+      env: LLVM_VERSION=3.7.1 OPTS="-DBUILD_SHARED_LIBS=OFF -DLIB_SUFFIX=64"
     - os: linux
       d: ldc-0.17.2
-      env: LLVM_VERSION=3.6.2 OPTS="-DBUILD_SHARED_LIBS=ON"
+      env: LLVM_VERSION=3.6.2
     - os: linux
       d: dmd
-      env: LLVM_VERSION=3.5.2 OPTS="-DBUILD_SHARED_LIBS=OFF -DTEST_COVERAGE=ON"
+      env: LLVM_VERSION=3.5.2 OPTS="-DTEST_COVERAGE=ON"
     - os: osx
       d: ldc-beta
       env: LLVM_VERSION=5.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: LLVM_VERSION=5.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON
     - os: osx
       d: ldc
-      env: LLVM_VERSION=4.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
+      env: LLVM_VERSION=4.0.0 OPTS="-DBUILD_SHARED_LIBS=ON"
   allow_failures:
     #- env: LLVM_VERSION=3.9
 
@@ -34,6 +34,7 @@ cache:
   directories:
     - llvm-spirv-5.0.0
     - llvm-4.0.1
+    - llvm-4.0.0
     - llvm-3.9.1
     - llvm-3.8.1
     - llvm-3.7.1

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -49,10 +49,10 @@ string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
 add_testsuite("-debug" "-g -link-debuglib" "${gdb_flags}" ${host_model})
-add_testsuite("" -O3 "OFF" ${host_model})
+add_testsuite("" -O "OFF" ${host_model})
 
 if(MULTILIB AND host_model EQUAL 64)
     # Also test in 32 bit mode on x86_64 multilib builds.
     add_testsuite("-debug_32" "-g -link-debuglib" "${gdb_flags}" 32)
-    add_testsuite("_32" -O3 "OFF" 32)
+    add_testsuite("_32" -O "OFF" 32)
 endif()


### PR DESCRIPTION
Increase test coverage by including 32-bit shared libs, which for instance led to ldc-developers/druntime@a3af613.