### PR TITLE
CMake: Fix racey Phobos compilation when building static+shared libs

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -465,8 +465,8 @@ endmacro()
 
 # Builds a static and/or shared copy of druntime/Phobos.
 macro(build_runtime_variant d_flags c_flags ld_flags lib_suffix path_suffix outlist_targets)
-    # Only build Phobos module once. If a shared Phobos lib is generated (too),
-    # compile explicitly with `-relocation-model=pic`.
+    # Only compile Phobos modules once for static+shared libs.
+    # If a shared Phobos lib is generated (too), compile explicitly with `-relocation-model=pic`.
     set(phobos2_d_flags "${d_flags}")
     if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
         list(APPEND ${phobos2_d_flags} -relocation-model=pic)
@@ -475,6 +475,13 @@ macro(build_runtime_variant d_flags c_flags ld_flags lib_suffix path_suffix outl
     set(phobos2_o "")
     set(phobos2_bc "")
     compile_phobos2("${phobos2_d_flags}" "${lib_suffix}" "${path_suffix}" phobos2_o phobos2_bc)
+
+    # Use a dummy custom target ('phobos2-ldc…-common') depending solely on the Phobos D objects
+    # (custom commands) as dependency for static+shared Phobos libs.
+    # Otherwise building both libs in parallel may result in conflicting Phobos module compilations
+    # (at least with the make generator), a known CMake issue.
+    set(phobos2_common phobos2-ldc${target_suffix}-common)
+    add_custom_target(${phobos2_common} DEPENDS ${phobos2_o} ${phobos2_bc})
 
     # static druntime/Phobos
     if(NOT ${BUILD_SHARED_LIBS} STREQUAL "ON")
@@ -485,6 +492,7 @@ macro(build_runtime_variant d_flags c_flags ld_flags lib_suffix path_suffix outl
         build_runtime_libs("${druntime_o}" "${druntime_bc}" "${phobos2_o}" "${phobos2_bc}"
                            "${c_flags}" "${ld_flags}" "${lib_suffix}" "${path_suffix}" "OFF"
                            ${outlist_targets})
+        add_dependencies(phobos2-ldc${target_suffix} ${phobos2_common})
     endif()
     # shared druntime/Phobos
     if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
@@ -495,6 +503,7 @@ macro(build_runtime_variant d_flags c_flags ld_flags lib_suffix path_suffix outl
         build_runtime_libs("${druntime_o}" "${druntime_bc}" "${phobos2_o}" "${phobos2_bc}"
                            "${c_flags}" "${ld_flags}" "${lib_suffix}${SHARED_LIB_SUFFIX}" "${path_suffix}" "ON"
                            ${outlist_targets})
+        add_dependencies(phobos2-ldc${target_suffix} ${phobos2_common})
     endif()
 endmacro()
 


### PR DESCRIPTION
Results in a `make -j3` sequence like this, `phobos2-ldc…-common` being the new dummy custom targets:

```
Line 120: Scanning dependencies of target phobos2-ldc-debug-common
Line 993: Scanning dependencies of target phobos2-ldc-common
Line 1314: [ 60%] Built target phobos2-ldc-debug-common
Line 1396: Scanning dependencies of target phobos2-ldc-debug-shared
Line 1408: Scanning dependencies of target phobos2-ldc-debug
Line 1465: [ 66%] Linking C shared library ../lib/libphobos2-ldc-debug-shared.so
Line 1476: [ 66%] Linking C static library ../lib/libphobos2-ldc-debug.a
Line 1477: [ 74%] Built target phobos2-ldc-debug
Line 1481: [ 82%] Built target phobos2-ldc-debug-shared
Line 1546: [ 84%] Built target phobos2-ldc-common
Line 1547: Scanning dependencies of target phobos2-ldc-shared
Line 1548: Scanning dependencies of target phobos2-ldc
Line 1614: [ 84%] Linking C shared library ../lib/libphobos2-ldc-shared.so
Line 1626: [ 84%] Linking C static library ../lib/libphobos2-ldc.a
Line 1627: [ 92%] Built target phobos2-ldc
Line 1628: [100%] Built target phobos2-ldc-shared
```