### PR TITLE
Don't eliminate frame pointer by default for debuginfo builds

### DIFF
--- a/driver/cache.cpp
+++ b/driver/cache.cpp
@@ -310,7 +310,7 @@ void outputIR2ObjRelevantCmdlineArgs(llvm::raw_ostream &hash_os)
   hash_os << opts::mFloatABI;
   hash_os << opts::mRelocModel;
   hash_os << opts::mCodeModel;
-  hash_os << opts::disableFpElim;
+  hash_os << global.params.alwaysframe;
 }
 
 // Output to `hash_os` all environment flags that influence object code output

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -370,10 +370,10 @@ cl::opt<FloatABI::Type> mFloatABI(
         clEnumValN(FloatABI::Hard, "hard",
                    "Hardware floating-point ABI and instructions")));
 
-cl::opt<bool>
+cl::opt<bool, true>
     disableFpElim("disable-fp-elim", cl::ZeroOrMore,
                   cl::desc("Disable frame pointer elimination optimization"),
-                  cl::init(false));
+                  cl::location(global.params.alwaysframe));
 
 static cl::opt<bool, true, FlagParser<bool>>
     asserts("asserts", cl::desc("(*) Enable assertions"),

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -78,7 +78,7 @@ extern cl::opt<std::string> mABI;
 #endif
 extern cl::opt<llvm::Reloc::Model> mRelocModel;
 extern cl::opt<llvm::CodeModel::Model> mCodeModel;
-extern cl::opt<bool> disableFpElim;
+extern cl::opt<bool, true> disableFpElim;
 extern cl::opt<FloatABI::Type> mFloatABI;
 extern cl::opt<bool> linkonceTemplates;
 extern cl::opt<bool> disableLinkerStripDead;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -541,11 +541,6 @@ static int linkObjToBinaryMSVC(bool sharedLib) {
     args.push_back("/DEBUG");
   }
 
-  // enable Link-time Code Generation (aka. whole program optimization)
-  if (isOptimizationEnabled()) {
-    args.push_back("/LTCG");
-  }
-
   // remove dead code and fold identical COMDATs
   if (opts::disableLinkerStripDead) {
     args.push_back("/OPT:NOREF");
@@ -677,11 +672,6 @@ int createStaticLibrary() {
   // ask lib to be quiet
   if (isTargetMSVC) {
     args.push_back("/NOLOGO");
-  }
-
-  // enable Link-time Code Generation (aka. whole program optimization)
-  if (isTargetMSVC && isOptimizationEnabled()) {
-    args.push_back("/LTCG");
   }
 
   // output filename

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -542,7 +542,7 @@ static int linkObjToBinaryMSVC(bool sharedLib) {
   }
 
   // enable Link-time Code Generation (aka. whole program optimization)
-  if (global.params.optimize) {
+  if (isOptimizationEnabled()) {
     args.push_back("/LTCG");
   }
 
@@ -680,7 +680,7 @@ int createStaticLibrary() {
   }
 
   // enable Link-time Code Generation (aka. whole program optimization)
-  if (isTargetMSVC && global.params.optimize) {
+  if (isTargetMSVC && isOptimizationEnabled()) {
     args.push_back("/LTCG");
   }
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -579,6 +579,11 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
   }
 
   global.params.hdrStripPlainFunctions = !opts::hdrKeepAllBodies;
+
+  if (opts::disableFpElim.getNumOccurrences() == 0) {
+    global.params.alwaysframe =
+        global.params.symdebug && !isOptimizationEnabled();
+  }
 }
 
 void initializePasses() {
@@ -987,7 +992,8 @@ int cppmain(int argc, char **argv) {
 
   gTargetMachine = createTargetMachine(
       mTargetTriple, mArch, mCPU, mAttrs, bitness, mFloatABI, getRelocModel(),
-      mCodeModel, codeGenOptLevel(), disableFpElim, disableLinkerStripDead);
+      mCodeModel, codeGenOptLevel(), global.params.alwaysframe,
+      disableLinkerStripDead);
 
 #if LDC_LLVM_VER >= 308
   static llvm::DataLayout DL = gTargetMachine->createDataLayout();

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -465,7 +465,7 @@ void applyTargetMachineAttributes(llvm::Function &func,
 
   // Frame pointer elimination
   func.addFnAttr("no-frame-pointer-elim",
-                 opts::disableFpElim ? "true" : "false");
+                 global.params.alwaysframe ? "true" : "false");
 }
 
 } // anonymous namespace

--- a/tests/codegen/frame_pointer.d
+++ b/tests/codegen/frame_pointer.d
@@ -1,0 +1,13 @@
+// RUN: %ldc -c -output-ll -of=%t1.ll                  %s && FileCheck %s --check-prefix=NO_FP   < %t1.ll
+// RUN: %ldc -c -output-ll -of=%t2.ll -g               %s && FileCheck %s --check-prefix=WITH_FP < %t2.ll
+// RUN: %ldc -c -output-ll -of=%t3.ll -g -O3           %s && FileCheck %s --check-prefix=NO_FP   < %t3.ll
+// RUN: %ldc -c -output-ll -of=%t4.ll -disable-fp-elim %s && FileCheck %s --check-prefix=WITH_FP < %t4.ll
+
+int foo(int a)
+{
+    int x = a * a;
+    return x;
+}
+
+// WITH_FP: "no-frame-pointer-elim"="true"
+// NO_FP:   "no-frame-pointer-elim"="false"


### PR DESCRIPTION
As long as no optimization level (i.e., 0) is used. Should make the OSX backtraces work by default for debug builds and may improve the debuginfo experience in general.