### PR TITLE
toconstelem: Implement array literal VectorExps

### DIFF
--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -157,8 +157,8 @@ public:
                          e->type->toChars());
     LOG_SCOPE;
 
-    Type * const t = e->type->toBasetype();
-    Type * const cty = t->nextOf()->toBasetype();
+    Type *const t = e->type->toBasetype();
+    Type *const cty = t->nextOf()->toBasetype();
 
     auto _init = buildStringLiteralConstant(e, t->ty != Tsarray);
 
@@ -199,7 +199,8 @@ public:
     if (t->ty == Tpointer) {
       result = arrptr;
     } else if (t->ty == Tarray) {
-      LLConstant *clen = LLConstantInt::get(DtoSize_t(), e->numberOfCodeUnits(), false);
+      LLConstant *clen =
+          LLConstantInt::get(DtoSize_t(), e->numberOfCodeUnits(), false);
       result = DtoConstSlice(clen, arrptr, e->type);
     } else {
       llvm_unreachable("Unknown type for StringExp.");
@@ -437,8 +438,8 @@ public:
       StructLiteralExp *se = static_cast<StructLiteralExp *>(e->e1);
 
       if (se->globalVar) {
-        IF_LOG Logger::cout() << "Returning existing global: " << *se->globalVar
-                              << '\n';
+        IF_LOG Logger::cout()
+            << "Returning existing global: " << *se->globalVar << '\n';
         result = se->globalVar;
         return;
       }
@@ -545,7 +546,8 @@ public:
         gIR->module, initval->getType(), canBeConst,
         llvm::GlobalValue::InternalLinkage, initval, ".dynarrayStorage");
 #if LDC_LLVM_VER >= 309
-    gvar->setUnnamedAddr(canBeConst ? llvm::GlobalValue::UnnamedAddr::Global : llvm::GlobalValue::UnnamedAddr::None);
+    gvar->setUnnamedAddr(canBeConst ? llvm::GlobalValue::UnnamedAddr::Global
+                                    : llvm::GlobalValue::UnnamedAddr::None);
 #else
     gvar->setUnnamedAddr(canBeConst);
 #endif
@@ -614,8 +616,8 @@ public:
     StructLiteralExp *value = e->value;
 
     if (value->globalVar) {
-      IF_LOG Logger::cout() << "Using existing global: " << *value->globalVar
-                            << '\n';
+      IF_LOG Logger::cout()
+          << "Using existing global: " << *value->globalVar << '\n';
     } else {
       value->globalVar = new llvm::GlobalVariable(
           p->module, origClass->type->ctype->isClass()->getMemoryLLType(),

--- a/tests/codegen/vector_init.d
+++ b/tests/codegen/vector_init.d
@@ -1,0 +1,20 @@
+// Make sure vector initializer llvm::Constants are generated correctly (GitHub #2101).
+// RUN: %ldc -c -O3 -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+alias D2 = __vector(double[2]);
+
+// CHECK: @_D11vector_init12ImplicitInit6__initZ =
+// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
+struct ImplicitInit { D2 a; }
+
+// CHECK: @_D11vector_init12ExplicitInit6__initZ =
+// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
+struct ExplicitInit { D2 a = D2.init; }
+
+// CHECK: @_D11vector_init10SplatValue6__initZ =
+// CHECK-SAME: { <2 x double> <double 1.000000e+00, double 1.000000e+00> }
+struct SplatValue { D2 a = 1.0; }
+
+// CHECK: @_D11vector_init13ElementValues6__initZ =
+// CHECK-SAME: { <2 x double> <double 1.000000e+00, double 2.000000e+00> }
+struct ElementValues { D2 a = [1.0, 2.0]; }


### PR DESCRIPTION
Previously, we would always try to splat the given expression across the
whole vector. This hasn't been noticed earlier as DMD mostly generates
ArrayInitializers when initializing vectors to array literals (but
notably not when explicitly assigning VectorType.init).

GitHub: Fixes #2101.