### PR TITLE
Add switch '-Xcc <ccflag>'. Fix #2093.

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -285,10 +285,13 @@ cl::list<std::string> transitions(
     cl::value_desc("idents"), cl::CommaSeparated);
 
 static StringsAdapter linkSwitchStore("L", global.params.linkswitches);
-static cl::list<std::string, StringsAdapter>
+cl::list<std::string, StringsAdapter>
     linkerSwitches("L", cl::desc("Pass <linkerflag> to the linker"),
                    cl::value_desc("linkerflag"), cl::location(linkSwitchStore),
                    cl::Prefix);
+
+cl::list<std::string> ccSwitches("Xcc", cl::Hidden,
+    cl::desc("Pass <ccflag> to GCC/Clang"), cl::value_desc("ccflag"));
 
 cl::opt<std::string>
     moduleDeps("deps",

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -289,7 +289,8 @@ cl::list<std::string> linkerSwitches("L",
     cl::value_desc("linkerflag"), cl::Prefix);
 
 cl::list<std::string> ccSwitches("Xcc", cl::CommaSeparated,
-    cl::desc("Pass <ccflag> to GCC/Clang"), cl::value_desc("ccflag"));
+    cl::desc("Pass <ccflag> to GCC/Clang for linking"),
+    cl::value_desc("ccflag"));
 
 cl::opt<std::string>
     moduleDeps("deps",

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -290,7 +290,7 @@ cl::list<std::string, StringsAdapter>
                    cl::value_desc("linkerflag"), cl::location(linkSwitchStore),
                    cl::Prefix);
 
-cl::list<std::string> ccSwitches("Xcc", cl::Hidden,
+cl::list<std::string> ccSwitches("Xcc", cl::CommaSeparated,
     cl::desc("Pass <ccflag> to GCC/Clang"), cl::value_desc("ccflag"));
 
 cl::opt<std::string>

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -284,11 +284,9 @@ cl::list<std::string> transitions(
         "Help with language change identified by <idents>, use ? for list"),
     cl::value_desc("idents"), cl::CommaSeparated);
 
-static StringsAdapter linkSwitchStore("L", global.params.linkswitches);
-cl::list<std::string, StringsAdapter>
-    linkerSwitches("L", cl::desc("Pass <linkerflag> to the linker"),
-                   cl::value_desc("linkerflag"), cl::location(linkSwitchStore),
-                   cl::Prefix);
+cl::list<std::string> linkerSwitches("L",
+    cl::desc("Pass <linkerflag> to the linker"),
+    cl::value_desc("linkerflag"), cl::Prefix);
 
 cl::list<std::string> ccSwitches("Xcc", cl::CommaSeparated,
     cl::desc("Pass <ccflag> to GCC/Clang"), cl::value_desc("ccflag"));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -66,7 +66,7 @@ extern cl::list<std::string> versions;
 extern cl::list<std::string> transitions;
 extern cl::opt<std::string> moduleDeps;
 extern cl::opt<std::string> cacheDir;
-extern cl::list<std::string, StringsAdapter> linkerSwitches;
+extern cl::list<std::string> linkerSwitches;
 extern cl::list<std::string> ccSwitches;
 
 extern cl::opt<std::string> mArch;

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -66,6 +66,8 @@ extern cl::list<std::string> versions;
 extern cl::list<std::string> transitions;
 extern cl::opt<std::string> moduleDeps;
 extern cl::opt<std::string> cacheDir;
+extern cl::list<std::string, StringsAdapter> linkerSwitches;
+extern cl::list<std::string> ccSwitches;
 
 extern cl::opt<std::string> mArch;
 extern cl::opt<bool> m32bits;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -601,8 +601,7 @@ static int linkObjToBinaryMSVC(bool sharedLib) {
   CreateDirectoryOnDisk(gExePath);
 
   // additional linker switches
-  for (unsigned i = 0; i < global.params.linkswitches->dim; i++) {
-    std::string str = global.params.linkswitches->data[i];
+  auto addSwitch = [&](std::string str) {
     if (str.length() > 2) {
       // rewrite common -L and -l switches
       if (str[0] == '-' && str[1] == 'L') {
@@ -612,6 +611,14 @@ static int linkObjToBinaryMSVC(bool sharedLib) {
       }
     }
     args.push_back(str);
+  };
+
+  for (const auto& str : opts::linkerSwitches) {
+    addSwitch(str);
+  }
+
+  for (unsigned i = 0; i < global.params.linkswitches->dim; i++) {
+    addSwitch(global.params.linkswitches->data[i]);
   }
 
   // default libs

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -535,6 +535,11 @@ static void addMscrtLibs(std::vector<std::string> &args) {
 static int linkObjToBinaryMSVC(bool sharedLib) {
   Logger::println("*** Linking executable ***");
 
+  if (!opts::ccSwitches.empty()) {
+    error(Loc(), "-Xcc is not supported for MSVC");
+    fatal();
+  }
+
 #ifdef _WIN32
   windows::setupMsvcEnvironment();
 #endif

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -357,14 +357,14 @@ static int linkObjToBinaryGcc(bool sharedLib) {
 
   // additional linker and cc switches (preserve order across both lists)
   for (unsigned ilink = 0, icc = 0;;) {
-    unsigned linkpos = ilink < global.params.linkswitches->dim
+    unsigned linkpos = ilink < opts::linkerSwitches.size()
       ? opts::linkerSwitches.getPosition(ilink)
       : std::numeric_limits<unsigned>::max();
     unsigned ccpos = icc < opts::ccSwitches.size()
       ? opts::ccSwitches.getPosition(icc)
       : std::numeric_limits<unsigned>::max();
     if (linkpos < ccpos) {
-      const char *p = (*global.params.linkswitches)[ilink++];
+      const std::string& p = opts::linkerSwitches[ilink++];
       // Don't push -l and -L switches using -Xlinker, but pass them indirectly
       // via GCC. This makes sure user-defined paths take precedence over
       // GCC's builtin LIBRARY_PATHs.
@@ -382,6 +382,11 @@ static int linkObjToBinaryGcc(bool sharedLib) {
     } else {
       break;
     }
+  }
+
+  // libs added via pragma(lib, libname)
+  for (unsigned i = 0; i < global.params.linkswitches->dim; i++) {
+    args.push_back((*global.params.linkswitches)[i]);
   }
 
   // default libs

--- a/tests/linking/linker_switches.d
+++ b/tests/linking/linker_switches.d
@@ -1,0 +1,13 @@
+// Test if global order of flags passed with -Xcc, -L and pragma(lib) is preserved
+
+// REQUIRES: Linux
+
+// RUN: %ldc %s -of=%t -Xcc -DOPT1,-DOPT2 -L-L/usr/lib -L--defsym -Lfoo=5 -Xcc -DOPT3 -v | FileCheck %s
+
+// CHECK: -DOPT1 -DOPT2 -L/usr/lib -Xlinker --defsym -Xlinker foo=5 -DOPT3 {{.*}}-lpthread
+
+pragma(lib, "pthread");
+
+void main()
+{
+}

--- a/tests/linking/linker_switches.d
+++ b/tests/linking/linker_switches.d
@@ -1,6 +1,6 @@
 // Test if global order of flags passed with -Xcc, -L and pragma(lib) is preserved
 
-// REQUIRES: Linux
+// UNSUPPORTED: Windows
 
 // RUN: %ldc %s -of=%t -Xcc -DOPT1,-DOPT2 -L-L/usr/lib -L--defsym -Lfoo=5 -Xcc -DOPT3 -v | FileCheck %s
 

--- a/tests/linking/linker_switches.d
+++ b/tests/linking/linker_switches.d
@@ -2,7 +2,7 @@
 
 // UNSUPPORTED: Windows
 
-// RUN: %ldc %s -of=%t -Xcc -DOPT1,-DOPT2 -L-L/usr/lib -L--defsym -Lfoo=5 -Xcc -DOPT3 -v | FileCheck %s
+// RUN: /bin/sh -c '%ldc %s -of=%t -Xcc -DOPT1,-DOPT2 -L-L/usr/lib -L--defsym -Lfoo=5 -Xcc -DOPT3 -v 2>/dev/null || true' | FileCheck %s
 
 // CHECK: -DOPT1 -DOPT2 -L/usr/lib -Xlinker --defsym -Xlinker foo=5 -DOPT3 {{.*}}-lpthread
 


### PR DESCRIPTION
Implemented as discussed in comments to #2093.

There's `assert(optnum < this->size() && "Invalid option index")` in `cl::list::getPosition`, and `size()` doesn't seem to be present for `opts::linkerSwitches`, so this assert shouldn't compile.
In what circumstances are asserts enabled when building LDC? I've tried both Release and Debug builds and it compiled.