### PR TITLE
Pooled IDs

### DIFF
--- a/ddmd/idgen.d
+++ b/ddmd/idgen.d
@@ -397,6 +397,25 @@ Msgtable[] msgtable =
     // IN_LLVM: LDC-specific traits.
     { "targetCPU" },
     { "targetHasFeature" },
+    
+    // IN_LLVM: LDC-specific attributes
+    { "ldc" },
+    { "attributes" },
+    { "udaAllocSize", "allocSize" },
+    // fastmath is an AliasSeq of llvmAttr and llvmFastMathFlag
+    { "udaOptStrategy", "optStrategy" },
+    { "udaLlvmAttr", "llvmAttr" },
+    { "udaLlvmFastMathFlag", "llvmFastMathFlag" },
+    { "udaSection", "section" },
+    { "udaTarget", "target" },
+    { "udaWeak", "_weak" },
+    { "udaCompute", "compute" },
+    { "udaKernel", "_kernel" },
+    
+    // IN_LLVM: DCompute specific types and functionss
+    { "dcompute" },
+    { "dcPointer", "Pointer" },
+    { "dcReflect", "__dcompute_reflect" },
 ];
 
 

--- a/ddmd/idgen.d
+++ b/ddmd/idgen.d
@@ -404,8 +404,8 @@ Msgtable[] msgtable =
     { "udaAllocSize", "allocSize" },
     // fastmath is an AliasSeq of llvmAttr and llvmFastMathFlag
     { "udaOptStrategy", "optStrategy" },
-    { "udaLlvmAttr", "llvmAttr" },
-    { "udaLlvmFastMathFlag", "llvmFastMathFlag" },
+    { "udaLLVMAttr", "llvmAttr" },
+    { "udaLLVMFastMathFlag", "llvmFastMathFlag" },
     { "udaSection", "section" },
     { "udaTarget", "target" },
     { "udaWeak", "_weak" },

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -434,7 +434,7 @@ bool hasKernelAttr(Dsymbol *sym) {
 
   if (!sym->isFuncDeclaration() && !hasComputeAttr(sym->getModule()))
     sym->error("@ldc.dcompute.kernel can only be applied to functions"
-               " in modules marked @lcd.dcompute.compute");
+               " in modules marked @ldc.dcompute.compute");
 
   return true;
 }

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -25,7 +25,7 @@ bool isMagicModule(const ModuleDeclaration *moduleDecl) {
   }
 
   if (moduleDecl->packages->dim != 1 ||
-      (*moduleDecl->packages)[0] != Id::ldc)) {
+      (*moduleDecl->packages)[0] != Id::ldc) {
     return false;
   }
   return true;

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -93,10 +93,10 @@ StructLiteralExp *getMagicAttribute(Dsymbol *sym, const Identifier* id,
   expandTuples(attrs);
   for (auto &attr : *attrs) {
     if (attr->op != TOKstructliteral)
-        continue;
+      continue;
     auto sle = static_cast<StructLiteralExp *>(attr);
     if (!isFromMagicModule(sle,from))
-        continue;
+      continue;
 
     if (id == sle->sd->ident) {
       return sle;

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -50,7 +50,7 @@ StructLiteralExp *getLdcAttributesStruct(Expression *attr) {
     return nullptr;
   }
 
-  auto sle = static_cast<StructLiteralExp *>(attr);
+  auto sle = static_cast<StructLiteralExp *>(e);
   if (isFromMagicModule(sle,Id::attributes)) {
     return sle;
   }
@@ -90,7 +90,7 @@ StructLiteralExp *getMagicAttribute(Dsymbol *sym, const Identifier* id,
   for (auto &attr : *attrs) {
     if (attr->op != TOKstructliteral)
         continue;
-    auto sle = static_cast<StructLiteralExp *>(e);
+    auto sle = static_cast<StructLiteralExp *>(attr);
     if (!isFromMagicModule(sle,from))
         continue;
 

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -8,7 +8,7 @@
 #include "expression.h"
 #include "ir/irfunction.h"
 #include "module.h"
-#include "ddmd/id.h"
+#include "id.h"
 
 #include "llvm/ADT/StringExtras.h"
 

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -64,7 +64,7 @@ void checkStructElems(StructLiteralExp *sle, ArrayParam<Type *> elemTypes) {
     sle->error(
         "unexpected field count in 'ldc.%s.%s'; does druntime not "
         "match compiler version?",
-        sle->->sd->getModule()->md->id->toChars(),
+        sle->sd->getModule()->md->id->toChars(),
         sle->sd->ident->toChars());
     fatal();
   }
@@ -73,7 +73,7 @@ void checkStructElems(StructLiteralExp *sle, ArrayParam<Type *> elemTypes) {
     if ((*sle->elements)[i]->type->toBasetype() != elemTypes[i]) {
       sle->error("invalid field type in 'ldc.%s.%s'; does druntime not "
                  "match compiler version?",
-                 sle->->sd->getModule()->md->id->toChars(),
+                 sle->sd->getModule()->md->id->toChars(),
                  sle->sd->ident->toChars());
       fatal();
     }

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -50,7 +50,7 @@ StructLiteralExp *getLdcAttributesStruct(Expression *attr) {
     return nullptr;
   }
 
-  auto sle = static_cast<StructLiteralExp *>(e);
+  auto sle = static_cast<StructLiteralExp *>(attr);
   if (isFromMagicModule(sle,Id::attributes)) {
     return sle;
   }

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -15,11 +15,12 @@
 namespace {
 
 /// Checks whether `moduleDecl` is the ldc.attributes module.
-bool isLdcAttibutes(const ModuleDeclaration *moduleDecl) {
+bool isMagicModule(const ModuleDeclaration *moduleDecl) {
   if (!moduleDecl)
     return false;
 
-  if (moduleDecl->id != Id::attributes) {
+  if (moduleDecl->id != Id::attributes &&
+      moduleDecl->id != Id::dcompute) {
     return false;
   }
 
@@ -31,9 +32,9 @@ bool isLdcAttibutes(const ModuleDeclaration *moduleDecl) {
 }
 
 /// Checks whether the type of `e` is a struct from the ldc.attributes module.
-bool isFromLdcAttibutes(const StructLiteralExp *e) {
+bool isFromMagicModule(const StructLiteralExp *e) {
   auto moduleDecl = e->sd->getModule()->md;
-  return isLdcAttibutes(moduleDecl);
+  return isMagicModule(moduleDecl);
 }
 
 StructLiteralExp *getLdcAttributesStruct(Expression *attr) {
@@ -51,7 +52,7 @@ StructLiteralExp *getLdcAttributesStruct(Expression *attr) {
   }
 
   auto sle = static_cast<StructLiteralExp *>(e);
-  if (isFromLdcAttibutes(sle)) {
+  if (isFromMagicModule(sle)) {
     return sle;
   }
 

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -27,5 +27,7 @@ void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc);
 void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar);
 
 bool hasWeakUDA(Dsymbol *sym);
+int hasComputeAttr(Dsymbol *sym);
+bool hasKernelAttr(Dsymbol *sym)
 
 #endif

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -28,6 +28,6 @@ void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar);
 
 bool hasWeakUDA(Dsymbol *sym);
 int hasComputeAttr(Dsymbol *sym);
-bool hasKernelAttr(Dsymbol *sym)
+bool hasKernelAttr(Dsymbol *sym);
 
 #endif


### PR DESCRIPTION
add LDC specific magic UDAs and magic dcompute suff to the pooled ID table.
Make uda.cpp use them.