### PR TITLE
Fix misleading comment in config file

### DIFF
--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -4,8 +4,7 @@
 // The default group is required
 default:
 {
-    // 'switches' holds array of string that are appends to the command line
-    // arguments before they are parsed.
+    // default switches injected before all explicit command-line switches
     switches = [
         "-I@RUNTIME_DIR@/src",
         "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@

--- a/ldc2_install.conf.in
+++ b/ldc2_install.conf.in
@@ -4,8 +4,7 @@
 // The default group is required
 default:
 {
-    // 'switches' holds array of string that are appends to the command line
-    // arguments before they are parsed.
+    // default switches injected before all explicit command-line switches
     switches = [
         "-I@INCLUDE_INSTALL_DIR@/ldc",
         "-I@INCLUDE_INSTALL_DIR@",

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -4,8 +4,7 @@
 // The default group is required
 default:
 {
-    // 'switches' holds array of string that are appends to the command line
-    // arguments before they are parsed.
+    // default switches injected before all explicit command-line switches
     switches = [
         "-I@RUNTIME_DIR@/src",
         "-I@PROFILERT_DIR@/d",


### PR DESCRIPTION
The default switches are injected right after argv[0], not appended to the command line.