### PR TITLE
Debug info fixes for class types

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -440,6 +440,8 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type) {
   // Use the actual type associated with the declaration, ignoring any
   // const/wrappers.
   LLType *T = DtoType(sd->type);
+  if (t->ty == Tclass)
+    T = llvm::cast<llvm::PointerType>(T)->getElementType();
   IrTypeAggr *ir = sd->type->ctype->isAggr();
   assert(ir);
 

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -276,7 +276,7 @@ ldc::DIType ldc::DIBuilder::CreateEnumType(Type *type) {
       getTypeAllocSize(T) * 8,               // size (bits)
       getABITypeAlign(T) * 8,                // align (bits)
       DBuilder.getOrCreateArray(subscripts), // subscripts
-      CreateTypeDescription(te->sym->memtype, false));
+      CreateTypeDescription(te->sym->memtype));
 }
 
 ldc::DIType ldc::DIBuilder::CreatePointerType(Type *type) {
@@ -296,7 +296,7 @@ ldc::DIType ldc::DIBuilder::CreatePointerType(Type *type) {
   const llvm::Optional<unsigned> DWARFAddressSpace = llvm::None;
 #endif
 
-  return DBuilder.createPointerType(CreateTypeDescription(nt, false),
+  return DBuilder.createPointerType(CreateTypeDescription(nt),
                                     getTypeAllocSize(T) * 8, // size (bits)
                                     getABITypeAlign(T) * 8,  // align (bits)
 #if LDC_LLVM_VER >= 500
@@ -323,7 +323,7 @@ ldc::DIType ldc::DIBuilder::CreateVectorType(Type *type) {
   return DBuilder.createVectorType(
       getTypeAllocSize(T) * 8,              // size (bits)
       getABITypeAlign(T) * 8,               // align (bits)
-      CreateTypeDescription(te, false),     // element type
+      CreateTypeDescription(te),            // element type
       DBuilder.getOrCreateArray(subscripts) // subscripts
       );
 }
@@ -381,7 +381,7 @@ ldc::DIType ldc::DIBuilder::CreateMemberType(unsigned linnum, Type *type,
   llvm::Type *T = DtoType(t);
 
   // find base type
-  ldc::DIType basetype = CreateTypeDescription(t, true);
+  ldc::DIType basetype = CreateTypeDescription(t);
 
   auto Flags = DIFlagZero;
   switch (prot) {
@@ -600,7 +600,7 @@ ldc::DIType ldc::DIBuilder::CreateSArrayType(Type *type) {
   return DBuilder.createArrayType(
       getTypeAllocSize(T) * 8,              // size (bits)
       getABITypeAlign(T) * 8,               // align (bits)
-      CreateTypeDescription(t, false),      // element type
+      CreateTypeDescription(t),             // element type
       DBuilder.getOrCreateArray(subscripts) // subscripts
       );
 }
@@ -618,7 +618,7 @@ ldc::DISubroutineType ldc::DIBuilder::CreateFunctionType(Type *type) {
   Type *retType = t->next;
 
   // Create "dummy" subroutine type for the return type
-  LLMetadata *params = {CreateTypeDescription(retType, true)};
+  LLMetadata *params = {CreateTypeDescription(retType)};
 #if LDC_LLVM_VER == 305
   auto paramsArray = DBuilder.getOrCreateArray(params);
 #else
@@ -683,16 +683,12 @@ bool isOpaqueEnumType(Type *type) {
   return !te->sym->memtype;
 }
 
-ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type, bool derefclass) {
+ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type) {
   // Check for opaque enum first, Bugzilla 13792
   if (isOpaqueEnumType(type))
     return DBuilder.createUnspecifiedType(type->toChars());
 
   Type *t = type->toBasetype();
-  if (derefclass && t->ty == Tclass) {
-    type = type->pointerTo();
-    t = type->toBasetype();
-  }
 
   if (t->ty == Tvoid)
 #if LDC_LLVM_VER >= 309
@@ -701,7 +697,7 @@ ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type, bool derefclass) {
     return DBuilder.createUnspecifiedType(t->toChars());
 #endif
   if (t->ty == Tnull) // display null as void*
-    return DBuilder.createPointerType(CreateTypeDescription(Type::tvoid, false),
+    return DBuilder.createPointerType(CreateTypeDescription(Type::tvoid),
                                       8, 8,
 #if LDC_LLVM_VER >= 500
                                       /* DWARFAddressSpace */ llvm::None,
@@ -723,8 +719,17 @@ ldc::DIType ldc::DIBuilder::CreateTypeDescription(Type *type, bool derefclass) {
     return CreateSArrayType(type);
   if (t->ty == Taarray)
     return CreateAArrayType(type);
-  if (t->ty == Tstruct || t->ty == Tclass)
+  if (t->ty == Tstruct)
     return CreateCompositeType(type);
+  if (t->ty == Tclass) {
+    LLType* T = DtoType(t);
+    return DBuilder.createPointerType(CreateCompositeType(type),
+                                      getTypeAllocSize(T) * 8, getABITypeAlign(T) * 8,
+#if LDC_LLVM_VER >= 500
+                                      llvm::None,
+#endif
+                                      t->toChars());
+  }
   if (t->ty == Tfunction)
     return CreateFunctionType(type);
   if (t->ty == Tdelegate)
@@ -932,7 +937,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitModuleCTor(llvm::Function *Fn,
   ldc::DIFile file = CreateFile();
 
   // Create "dummy" subroutine type for the return type
-  LLMetadata *params = {CreateTypeDescription(Type::tvoid, true)};
+  LLMetadata *params = {CreateTypeDescription(Type::tvoid)};
 #if LDC_LLVM_VER >= 306
   auto paramsArray = DBuilder.getOrCreateTypeArray(params);
 #else
@@ -1100,7 +1105,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
   // get type description
   if (!type)
     type = vd->type;
-  ldc::DIType TD = CreateTypeDescription(type, true);
+  ldc::DIType TD = CreateTypeDescription(type);
   if (static_cast<llvm::MDNode *>(TD) == nullptr)
     return; // unsupported
 
@@ -1244,7 +1249,7 @@ void ldc::DIBuilder::EmitGlobalVariable(llvm::GlobalVariable *llVar,
       mangleBuf.peekString(),                 // linkage name
       CreateFile(vd),                         // file
       vd->loc.linnum,                         // line num
-      CreateTypeDescription(vd->type, false), // type
+      CreateTypeDescription(vd->type),        // type
       vd->protection.kind == PROTprivate,     // is local to unit
 #if LDC_LLVM_VER >= 400
       nullptr // relative location of field

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -198,7 +198,7 @@ private:
   DISubroutineType CreateFunctionType(Type *type);
   DISubroutineType CreateEmptyFunctionType();
   DIType CreateDelegateType(Type *type);
-  DIType CreateTypeDescription(Type *type, bool derefclass = false);
+  DIType CreateTypeDescription(Type *type);
 
   bool mustEmitFullDebugInfo();
   bool mustEmitLocationsDebugInfo();

--- a/tests/debuginfo/classtypes_gdb.d
+++ b/tests/debuginfo/classtypes_gdb.d
@@ -1,0 +1,76 @@
+// REQUIRES: atleast_llvm308
+// REQUIRES: gdb
+// RUN: %ldc %_gdb_dflags -g -of=%t %s
+// RUN: sed -e "/^\\/\\/ GDB:/!d" -e "s,// GDB:,," %s >%t.gdb
+// RUN: gdb %t --batch -x %t.gdb >%t.out 2>&1
+// RUN: FileCheck %s -check-prefix=CHECK < %t.out
+module classtypes_gdb;
+
+class uv
+{
+    uint i;
+}
+
+class xyz : uv
+{
+    float f;
+    double d;
+
+    this(uint i, float f) { this.i = i; this.f = f; }
+}
+
+// There are debug info issues with TLS variables when LDC is built within older environments (incl. Travis).
+__gshared uv gvar;
+static this() { gvar = new xyz(12, 34.56); }
+
+int main()
+{
+    xyz[4] sarr;
+    xyz* ptr;
+    xyz lvar;
+
+    lvar = new xyz(99, 88.77);
+    lvar.d = 624.351;
+    sarr[2] = new xyz(2, 2.0);
+    sarr[2].d = 0.987;
+    ptr = &lvar;
+    // BP
+
+// GDB: b classtypes_gdb.d:37
+// GDB: r
+    return 0;
+// CHECK: D main
+
+// GDB: p lvar
+// CHECK: xyz{{ *}}*)
+
+// GDB: p *lvar
+// CHECK: i = 99}
+// CHECK-SAME: f = 88.7
+// CHECK-SAME: d = 624.35
+
+// GDB: p *ptr
+// CHECK: xyz{{ *}}*)
+
+// GDB: p **ptr
+// CHECK: i = 99}
+// CHECK-SAME: f = 88.7
+// CHECK-SAME: d = 624.35
+
+// GDB: p sarr
+// CHECK: {0x0,{{ *}}0x0,{{ *}}0x{{[0-9a-f][0-9a-f]+}},{{ *}}0x0}
+
+// GDB: p *sarr[2]
+// CHECK: i = 2}
+// CHECK-SAME: f = 2
+// CHECK-SAME: d = 0.98
+
+// GDB: p 'classtypes_gdb.gvar'
+// CHECK: uv{{ *}}*)
+// GDB: p *'classtypes_gdb.gvar'
+// CHECK: i = 12}{{$}}
+}
+
+// GDB: c
+// GDB: q
+// CHECK: exited normally

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -1,9 +1,12 @@
 import lit.formats
+import lit.util
 import os
 import sys
 import platform
 import string
+import re
 import subprocess
+from distutils.version import LooseVersion
 
 ## Auto-initialized variables by cmake:
 config.ldc2_bin            = "@LDC2_BIN@"
@@ -129,3 +132,18 @@ if (platform.system() == 'Windows') and (config.default_target_bits == 64):
 if (platform.system() == 'Windows') and os.path.isfile( cdb ):
     config.available_features.add('cdb')
     config.substitutions.append( ('%cdb', '"' + string.replace( cdb, '\\', '\\\\') + '"') )
+
+# Check whether GDB is present
+if lit.util.which('gdb', config.environment['PATH']):
+    config.available_features.add('gdb')
+    gdb_dflags = ''
+    command = ['gdb', '--version']
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, universal_newlines=True)
+    text = p.stdout.readline()
+    m = re.compile('[^0-9]*([0-9]+[0-9.]*).*').match(text)
+    if m is not None:
+        gdb_version = m.group(1)
+        if LooseVersion(gdb_version) < LooseVersion('7.8'):
+            gdb_dflags = '-dwarf-version=2'
+    config.substitutions.append( ('%_gdb_dflags', gdb_dflags) )


### PR DESCRIPTION
Fix the `DIType` produced for static arrays of classes and pointer to classes, and fix the size of class types in `DIBuilder::CreateCompositeType`.

Ex.: `Array!FuncDeclaration` was causing an infinite recursion crash in GDB, because for its « `FuncDeclaration[SMALLARRAYCAP] smallarray` » field `DIBuilder::CreateSArrayType()` had DIBuilder return a value type instead of a reference type for FuncDeclaration. 

---
With these two simple fixes debugging LDC 1.x+Calypso built by LDC went from a painful experience into a smooth one, I've had no other crash/garbage value so far.

(BTW sorry to have put Calypso's development in slumber, it's back at full blast now, and the transition to DDMD isn't going too bad)