### PR TITLE
Fix compilation with LLVM trunk

### DIFF
--- a/gen/attributes.cpp
+++ b/gen/attributes.cpp
@@ -91,9 +91,13 @@ AttrSet &AttrSet::add(unsigned index, const AttrBuilder &builder) {
 
 AttrSet &AttrSet::merge(const AttrSet &other) {
   auto &os = other.set;
+#if LDC_LLVM_VER >= 500
+  set = LLAttributeSet::get(gIR->context(), {set,os});
+#else
   for (unsigned i = 0; i < os.getNumSlots(); ++i) {
     unsigned index = os.getSlotIndex(i);
     set = set.addAttributes(gIR->context(), index, os.getSlotAttributes(i));
   }
+#endif
   return *this;
 }


### PR DESCRIPTION
In preparation for the testing for dcompute I was building against very recent trunk and hit the following.
```
/Users/nicholaswilson/d/ldc/gen/attributes.cpp:94:31: error: no member named 'getNumSlots' in 'llvm::AttributeList'
  for (unsigned i = 0; i < os.getNumSlots(); ++i) {
                           ~~ ^
/Users/nicholaswilson/d/ldc/gen/attributes.cpp:95:25: error: no member named 'getSlotIndex' in 'llvm::AttributeList'
    unsigned index = os.getSlotIndex(i);
                     ~~ ^
/Users/nicholaswilson/d/ldc/gen/attributes.cpp:96:55: error: no member named 'getSlotAttributes' in 'llvm::AttributeList'; did you mean
      'getAttributes'?
    set = set.addAttributes(gIR->context(), index, os.getSlotAttributes(i));
                                                      ^~~~~~~~~~~~~~~~~
                                                      getAttributes
/Users/nicholaswilson/d/llvm/include/llvm/IR/Attributes.h:455:16: note: 'getAttributes' declared here
  AttributeSet getAttributes(unsigned Index) const;
```
The patch silences this error although I'm not sure that it fixes it. I feel like it should work though.