### PR TITLE
Remove dependence on std::to_string, because it is not available on all systems.

### DIFF
--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -9,6 +9,7 @@
 #include "gen/irstate.h"
 #include "gen/logger.h"
 #include "gen/tollvm.h"
+#include "gen/to_string.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/AsmParser/Parser.h"
@@ -56,7 +57,7 @@ DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
   // always inlined, this name does not escape the current compiled module; not
   // even at -O0.
   static size_t namecounter = 0;
-  std::string mangled_name = "inline.ir." + std::to_string(namecounter++);
+  std::string mangled_name = "inline.ir." + ldc::to_string(namecounter++);
   TemplateInstance *tinst = fdecl->parent->isTemplateInstance();
   assert(tinst);
 

--- a/gen/mangling.cpp
+++ b/gen/mangling.cpp
@@ -19,6 +19,7 @@
 #include "ddmd/module.h"
 #include "gen/abi.h"
 #include "gen/irstate.h"
+#include "gen/to_string.h"
 #include "llvm/Support/MD5.h"
 
 namespace {
@@ -60,18 +61,18 @@ std::string hashSymbolName(llvm::StringRef name, Dsymbol *symb) {
     if (auto packages = moddecl->packages) {
       for (size_t i = 0; i < packages->dim; ++i) {
         llvm::StringRef str = (*packages)[i]->toChars();
-        ret += std::to_string(str.size());
+        ret += ldc::to_string(str.size());
         ret += str;
       }
     }
     llvm::StringRef str = moddecl->id->toChars();
-    ret += std::to_string(str.size());
+    ret += ldc::to_string(str.size());
     ret += str;
   }
 
   // source line number
-  auto lineNo = std::to_string(symb->loc.linnum);
-  ret += std::to_string(lineNo.size()+1);
+  auto lineNo = ldc::to_string(symb->loc.linnum);
+  ret += ldc::to_string(lineNo.size()+1);
   ret += 'L';
   ret += lineNo;
 
@@ -83,13 +84,13 @@ std::string hashSymbolName(llvm::StringRef name, Dsymbol *symb) {
   // top aggregate
   if (auto agg = symb->isMember()) {
     llvm::StringRef topaggr = agg->ident->toChars();
-    ret += std::to_string(topaggr.size());
+    ret += ldc::to_string(topaggr.size());
     ret += topaggr;
   }
 
   // identifier
   llvm::StringRef identifier = symb->toChars();
-  ret += std::to_string(identifier.size());
+  ret += ldc::to_string(identifier.size());
   ret += identifier;
 
   return ret;

--- a/gen/to_string.h
+++ b/gen/to_string.h
@@ -1,0 +1,31 @@
+//===-- gen/to_string.h - std::to_string replacement ------------*- C++ -*-===//
+//
+//                         LDC - the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Provide to_string because std::to_string is not available on some systems,
+// notably Android. See https://github.com/android-ndk/ndk/issues/82.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TO_STRING_H
+#define TO_STRING_H
+
+#include <sstream>
+#include <string>
+
+namespace ldc {
+
+template <class T> const std::string to_string(const T &val) {
+  std::ostringstream os;
+  os << val;
+  return os.str();
+}
+
+} // namespace ldc
+
+#endif // TO_STRING_H


### PR DESCRIPTION
This PR should enable native compilation on Android.

See https://gist.github.com/joakim-noah/4153662c68fb2ba9592c9cb0d7892624

@joakim-noah 