### PR TITLE
Use LLVM headers for shared codegen command-line options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             export HOST_LDMD=$PWD/ldc2-$HOST_LDC_VERSION-linux-x86_64/bin/ldmd2
             mkdir bootstrap
             cd bootstrap
-            cmake -G Ninja -DLDC_WITH_LLD=OFF -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DBUILD_SHARED_LIBS=OFF -DD_COMPILER=$HOST_LDMD ..
+            cmake -G Ninja -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DBUILD_SHARED_LIBS=OFF -DD_COMPILER=$HOST_LDMD ..
             ninja -j3
             bin/ldc2 -version
             cd ..
@@ -68,7 +68,7 @@ jobs:
             export HOST_LDMD=$PWD/bootstrap/bin/ldmd2
             mkdir build
             cd build
-            cmake -G Ninja -DLDC_WITH_LLD=OFF -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON -DD_COMPILER=$HOST_LDMD ..
+            cmake -G Ninja -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON -DD_COMPILER=$HOST_LDMD ..
             ninja -j3 all all-test-runners
             bin/ldc2 -version
             cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - os: linux
       d: ldc
-      env: LLVM_VERSION=5.0.0 OPTS="-DLIB_SUFFIX=64 -DLDC_WITH_LLD=OFF"
+      env: LLVM_VERSION=5.0.0 OPTS="-DLIB_SUFFIX=64"
     - os: linux
       d: ldc
       env: LLVM_VERSION=4.0.1 OPTS="-DLIB_SUFFIX=64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,7 @@ set(DRV_SRC
     driver/cache.cpp
     driver/cl_options.cpp
     driver/cl_options_sanitizers.cpp
+    driver/cl_options-llvm.cpp
     driver/codegenerator.cpp
     driver/configfile.cpp
     driver/dcomputecodegenerator.cpp
@@ -358,6 +359,7 @@ set(DRV_HDR
     driver/cache_pruning.h
     driver/cl_options.h
     driver/cl_options_sanitizers.h
+    driver/cl_options-llvm.h
     driver/codegenerator.h
     driver/configfile.h
     driver/dcomputecodegenerator.h

--- a/driver/cache.cpp
+++ b/driver/cache.cpp
@@ -302,14 +302,18 @@ void outputIR2ObjRelevantCmdlineArgs(llvm::raw_ostream &hash_os) {
   // sharing the cache).
   outputOptimizationSettings(hash_os);
   opts::outputSanitizerSettings(hash_os);
-  hash_os << opts::mCPU;
-  for (auto &attr : opts::mAttrs) {
-    hash_os << attr;
-  }
-  hash_os << opts::mFloatABI;
-  hash_os << opts::mRelocModel;
-  hash_os << opts::mCodeModel;
-  hash_os << opts::disableFpElim;
+  hash_os << opts::getCPUStr();
+  hash_os << opts::getFeaturesStr();
+  hash_os << opts::floatABI;
+#if LDC_LLVM_VER >= 309
+  const auto relocModel = opts::getRelocModel();
+  if (relocModel.hasValue())
+    hash_os << relocModel.getValue();
+#else
+  hash_os << opts::getRelocModel();
+#endif
+  hash_os << opts::getCodeModel();
+  hash_os << opts::disableFPElim();
 }
 
 // Output to `hash_os` all environment flags that influence object code output

--- a/driver/cl_options-llvm.cpp
+++ b/driver/cl_options-llvm.cpp
@@ -1,0 +1,64 @@
+//===-- cl_options-llvm.cpp -----------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "driver/cl_options-llvm.h"
+
+// Pull in command-line options and helper functions from special LLVM header
+// shared by multiple LLVM tools.
+#include "llvm/CodeGen/CommandFlags.h"
+
+static cl::opt<bool>
+    DisableRedZone("disable-red-zone", cl::ZeroOrMore,
+                   cl::desc("Do not emit code that uses the red zone."));
+
+// Now expose the helper functions (with static linkage) via external wrappers
+// in the opts namespace, including some additional helper functions.
+namespace opts {
+
+std::string getArchStr() { return ::MArch; }
+
+#if LDC_LLVM_VER >= 309
+Optional<Reloc::Model> getRelocModel() { return ::getRelocModel(); }
+#else
+Reloc::Model getRelocModel() { return ::RelocModel; }
+#endif
+
+CodeModel::Model getCodeModel() { return ::CMModel; }
+
+bool disableFPElim() { return ::DisableFPElim; }
+
+bool disableRedZone() { return ::DisableRedZone; }
+
+bool printTargetFeaturesHelp() {
+  if (MCPU == "help")
+    return true;
+  return std::any_of(MAttrs.begin(), MAttrs.end(),
+                     [](const std::string &a) { return a == "help"; });
+}
+
+TargetOptions InitTargetOptionsFromCodeGenFlags() {
+  return ::InitTargetOptionsFromCodeGenFlags();
+}
+
+std::string getCPUStr() { return ::getCPUStr(); }
+std::string getFeaturesStr() { return ::getFeaturesStr(); }
+} // namespace opts
+
+#if LDC_WITH_LLD && LDC_LLVM_VER >= 500
+// LLD 5.0 uses the shared header too (for LTO) and exposes some wrappers in
+// the lld namespace. Define them here to prevent the LLD object from being
+// linked in with its conflicting command-line options.
+namespace lld {
+TargetOptions InitTargetOptionsFromCodeGenFlags() {
+  return ::InitTargetOptionsFromCodeGenFlags();
+}
+
+CodeModel::Model GetCodeModelFromCMModel() { return CMModel; }
+}
+#endif // LDC_WITH_LLD && LDC_LLVM_VER >= 500

--- a/driver/cl_options-llvm.h
+++ b/driver/cl_options-llvm.h
@@ -1,0 +1,36 @@
+//===-- driver/cl_options-llvm.h - LLVM command line options ----*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LDC_DRIVER_CL_OPTIONS_LLVM_H
+#define LDC_DRIVER_CL_OPTIONS_LLVM_H
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/CodeGen.h"
+#include "llvm/Target/TargetOptions.h"
+
+namespace opts {
+
+std::string getArchStr();
+#if LDC_LLVM_VER >= 309
+llvm::Optional<llvm::Reloc::Model> getRelocModel();
+#else
+llvm::Reloc::Model getRelocModel();
+#endif
+llvm::CodeModel::Model getCodeModel();
+bool disableFPElim();
+bool disableRedZone();
+bool printTargetFeaturesHelp();
+
+llvm::TargetOptions InitTargetOptionsFromCodeGenFlags();
+std::string getCPUStr();
+std::string getFeaturesStr();
+}
+
+#endif

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -15,6 +15,7 @@
 #ifndef LDC_DRIVER_CL_OPTIONS_H
 #define LDC_DRIVER_CL_OPTIONS_H
 
+#include "driver/cl_options-llvm.h"
 #include "driver/targetmachine.h"
 #include "gen/cl_helpers.h"
 #include "llvm/ADT/SmallVector.h"
@@ -69,24 +70,18 @@ extern cl::opt<std::string> cacheDir;
 extern cl::list<std::string> linkerSwitches;
 extern cl::list<std::string> ccSwitches;
 
-extern cl::opt<std::string> mArch;
 extern cl::opt<bool> m32bits;
 extern cl::opt<bool> m64bits;
-extern cl::opt<std::string> mCPU;
-extern cl::list<std::string> mAttrs;
 extern cl::opt<std::string> mTargetTriple;
 extern cl::opt<std::string> mABI;
-extern cl::opt<llvm::Reloc::Model> mRelocModel;
-extern cl::opt<llvm::CodeModel::Model> mCodeModel;
-extern cl::opt<bool> disableFpElim;
-extern cl::opt<FloatABI::Type> mFloatABI;
+extern FloatABI::Type floatABI;
 extern cl::opt<bool> linkonceTemplates;
 extern cl::opt<bool> disableLinkerStripDead;
 
 // Math options
 extern bool fFastMath;
 extern llvm::FastMathFlags defaultFMF;
-void setDefaultMathOptions(llvm::TargetMachine &target);
+void setDefaultMathOptions(llvm::TargetOptions &targetOptions);
 
 extern cl::opt<BOUNDSCHECK> boundsCheck;
 extern bool nonSafeBoundsChecks;

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -118,8 +118,9 @@ void ArgsBuilder::addLTOGoldPluginFlags() {
   if (opts::isUsingThinLTO())
     addLdFlag("-plugin-opt=thinlto");
 
-  if (!opts::mCPU.empty())
-    addLdFlag(llvm::Twine("-plugin-opt=mcpu=") + opts::mCPU);
+  const auto cpu = gTargetMachine->getTargetCPU();
+  if (!cpu.empty())
+    addLdFlag(llvm::Twine("-plugin-opt=mcpu=") + cpu);
 
   // Use the O-level passed to LDC as the O-level for LTO, but restrict it to
   // the [0, 3] range that can be passed to the linker plugin.

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -104,18 +104,6 @@ static cl::opt<bool> linkDebugLib(
     "link-debuglib", cl::ZeroOrMore,
     cl::desc("Link with libraries specified in -debuglib, not -defaultlib"));
 
-#if LDC_LLVM_VER >= 309
-static inline llvm::Optional<llvm::Reloc::Model> getRelocModel() {
-  if (mRelocModel.getNumOccurrences()) {
-    llvm::Reloc::Model R = mRelocModel;
-    return R;
-  }
-  return llvm::None;
-}
-#else
-static inline llvm::Reloc::Model getRelocModel() { return mRelocModel; }
-#endif
-
 // This function exits the program.
 void printVersion(llvm::raw_ostream &OS) {
   OS << "LDC - the LLVM D compiler (" << global.ldc_version << "):\n";
@@ -372,8 +360,7 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
                               const_cast<char **>(allArguments.data()),
                               "LDC - the LLVM D compiler\n");
 
-  helpOnly = mCPU == "help" ||
-             (std::find(mAttrs.begin(), mAttrs.end(), "help") != mAttrs.end());
+  helpOnly = opts::printTargetFeaturesHelp();
   if (helpOnly) {
     auto triple = llvm::Triple(cfg_triple);
     std::string errMsg;
@@ -599,19 +586,12 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
     error(Loc(), "-lib and -shared switches cannot be used together");
   }
 
-#if LDC_LLVM_VER >= 309
-  if (global.params.dll && !mRelocModel.getNumOccurrences()) {
-#else
-  if (global.params.dll && mRelocModel == llvm::Reloc::Default) {
-#endif
-    mRelocModel = llvm::Reloc::PIC_;
-  }
-
   if (soname.getNumOccurrences() > 0 && !global.params.dll) {
     error(Loc(), "-soname can be used only when building a shared library");
   }
 
   global.params.hdrStripPlainFunctions = !opts::hdrKeepAllBodies;
+  global.params.disableRedZone = opts::disableRedZone();
 }
 
 void initializePasses() {
@@ -1010,7 +990,8 @@ int cppmain(int argc, char **argv) {
   }
 
   // Set up the TargetMachine.
-  if ((m32bits || m64bits) && (!mArch.empty() || !mTargetTriple.empty())) {
+  const auto arch = getArchStr();
+  if ((m32bits || m64bits) && (!arch.empty() || !mTargetTriple.empty())) {
     error(Loc(), "-m32 and -m64 switches cannot be used together with -march "
                  "and -mtriple switches");
   }
@@ -1025,9 +1006,21 @@ int cppmain(int argc, char **argv) {
     fatal();
   }
 
+  auto relocModel = getRelocModel();
+#if LDC_LLVM_VER >= 309
+  if (global.params.dll && !relocModel.hasValue()) {
+#else
+  if (global.params.dll && relocModel == llvm::Reloc::Default) {
+#endif
+    relocModel = llvm::Reloc::PIC_;
+  }
+
   gTargetMachine = createTargetMachine(
-      mTargetTriple, mArch, mCPU, mAttrs, bitness, mFloatABI, getRelocModel(),
-      mCodeModel, codeGenOptLevel(), disableFpElim, disableLinkerStripDead);
+      mTargetTriple, arch, opts::getCPUStr(), opts::getFeaturesStr(), bitness,
+      floatABI, relocModel, opts::getCodeModel(), codeGenOptLevel(),
+      disableLinkerStripDead);
+
+  opts::setDefaultMathOptions(gTargetMachine->Options);
 
 #if LDC_LLVM_VER >= 308
   static llvm::DataLayout DL = gTargetMachine->createDataLayout();
@@ -1043,14 +1036,13 @@ int cppmain(int argc, char **argv) {
     global.params.isLP64 = gDataLayout->getPointerSizeInBits() == 64;
     global.params.is64bit = triple->isArch64Bit();
     global.params.hasObjectiveC = objc_isSupported(*triple);
+    global.params.dwarfVersion = gTargetMachine->Options.MCOptions.DwarfVersion;
     // mscoff enables slightly different handling of interface functions
     // in the front end
     global.params.mscoff = triple->isKnownWindowsMSVCEnvironment();
     if (global.params.mscoff)
       global.obj_ext = "obj";
   }
-
-  opts::setDefaultMathOptions(*gTargetMachine);
 
   // allocate the target abi
   gABI = TargetABI::getTarget();

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -52,18 +52,19 @@ ComputeBackend::Type getComputeTargetType(llvm::Module*);
  * parameters and the host platform defaults.
  *
  * Does not depend on any global state.
- */
-llvm::TargetMachine *createTargetMachine(
-    std::string targetTriple, std::string arch, std::string cpu,
-    std::vector<std::string> attrs, ExplicitBitness::Type bitness,
-    FloatABI::Type floatABI,
+*/
+llvm::TargetMachine *
+createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
+                    std::string featuresString, ExplicitBitness::Type bitness,
+                    FloatABI::Type floatABI,
 #if LDC_LLVM_VER >= 309
-    llvm::Optional<llvm::Reloc::Model> relocModel,
+                    llvm::Optional<llvm::Reloc::Model> relocModel,
 #else
-    llvm::Reloc::Model relocModel,
+                    llvm::Reloc::Model relocModel,
 #endif
-    llvm::CodeModel::Model codeModel, llvm::CodeGenOpt::Level codeGenOptLevel,
-    bool noFramePointerElim, bool noLinkerStripDead);
+                    llvm::CodeModel::Model codeModel,
+                    llvm::CodeGenOpt::Level codeGenOptLevel,
+                    bool noLinkerStripDead);
 
 /**
  * Returns the Mips ABI which is used for code generation.

--- a/gen/dcompute/targetCUDA.cpp
+++ b/gen/dcompute/targetCUDA.cpp
@@ -56,7 +56,7 @@ public:
         is64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda",
         is64 ? "nvptx64" : "nvptx", "sm_" + ldc::to_string(tversion / 10), {},
         is64 ? ExplicitBitness::M64 : ExplicitBitness::M32, ::FloatABI::Hard,
-        llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(), false,
+        llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(),
         false);
   }
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -460,7 +460,7 @@ void applyTargetMachineAttributes(llvm::Function &func,
 
   // Frame pointer elimination
   func.addFnAttr("no-frame-pointer-elim",
-                 opts::disableFpElim ? "true" : "false");
+                 opts::disableFPElim() ? "true" : "false");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
I.e., [llvm/CodeGen/CommandFlags.h](https://github.com/llvm-mirror/llvm/blob/release_40/include/llvm/CodeGen/CommandFlags.h) which in turn includes [llvm/MC/MCTargetOptionsCommandFlags.h](https://github.com/llvm-mirror/llvm/blob/release_40/include/llvm/MC/MCTargetOptionsCommandFlags.h).

This gets rid of a few duplicates on our side and includes about 35 (depending on LLVM version) new command-line options. LLVM provides a helper function to set up the TargetOptions according to (most of) these options.
Newer LLVM versions may add new options and we'll automatically inherit them, including setting up the TargetOptions accordingly.

I did my best (TM) to remove a few unused/undesirable options and hide all remaining new ones except for `-fp-contract`. The lists will need to be tweaked from time to time.