### PR TITLE
Print -mcpu=help / -mattr=help output only once

### DIFF
--- a/tests/driver/gh2073.d
+++ b/tests/driver/gh2073.d
@@ -1,0 +1,7 @@
+// RUN: %ldc -mcpu=help 2>&1 | FileCheck %s
+// RUN: %ldc -mattr=help 2>&1 | FileCheck %s
+// RUN: %ldc -mcpu=help -mattr=help 2>&1 | FileCheck %s
+
+// CHECK: Available CPUs for this target:
+// CHECK: Available features for this target:
+// CHECK-NOT: Available CPUs for this target:


### PR DESCRIPTION
When creating LLVM's TargetMachine, `llvm::SubtargetFeatures::getFeatureBits()` is called 3 times, and the help is printed 3 times (or even 6 times when specifying both `-mcpu=help -mattr=help`).

So use some new code making sure the help is printed only once and return 0 early without trying to compile anything (and so erroring if no source files have been specified etc.).

Fixes issue #2073.