### PR TITLE
Add indirect call promotion pass when PGO info is available.

### DIFF
--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -212,9 +212,11 @@ static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
   PM.add(createThreadSanitizerPass());
 }
 
-static void addInstrProfilingPass(legacy::PassManagerBase &mpm) {
+// Adds PGO instrumentation generation and use passes.
+static void addPGOPasses(legacy::PassManagerBase &mpm, unsigned optLevel) {
 #if LDC_WITH_PGO
   if (global.params.genInstrProf) {
+    // We are generating PGO instrumented code.
     InstrProfOptions options;
     options.NoRedZone = global.params.disableRedZone;
     if (global.params.datafileInstrProf)
@@ -223,6 +225,14 @@ static void addInstrProfilingPass(legacy::PassManagerBase &mpm) {
     mpm.add(createInstrProfilingLegacyPass(options));
 #else
     mpm.add(createInstrProfilingPass(options));
+#endif
+  } else if (global.params.datafileInstrProf) {
+// We are generating code with PGO profile information available.
+#if LDC_LLVM_VER >= 500
+    // Do indirect call promotion from -O1
+    if (optLevel > 0) {
+      mpm.add(createPGOIndirectCallPromotionLegacyPass());
+    }
 #endif
   }
 #endif
@@ -325,7 +335,7 @@ static void addOptimizationPasses(PassManagerBase &mpm,
   builder.addExtension(PassManagerBuilder::EP_OptimizerLast,
                        addStripExternalsPass);
 
-  addInstrProfilingPass(mpm);
+  addPGOPasses(mpm, optLevel);
 
   builder.populateFunctionPassManager(fpm);
   builder.populateModulePassManager(mpm);


### PR DESCRIPTION
This pass was apparently implicit in LLVM < 5.0. Fixes test PGO/indirect_calls.d with LLVM 5.0.