### PR TITLE
Fix ICE when using `-main -cov`

### DIFF
--- a/tests/codegen/gh2163.d
+++ b/tests/codegen/gh2163.d
@@ -1,0 +1,1 @@
+// RUN: %ldc -main -cov %s


### PR DESCRIPTION
Coverage analysis isn't enabled for the special `-main` module in codegenModule(), so Module::d_cover_data is null in that case.

Fixes issue #2163.