### PR TITLE
Switch Android onto the sectionELF style of module registry, but leave out the unused register_dso and friends

### DIFF
--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -120,8 +120,7 @@ RegistryStyle getModuleRegistryStyle() {
     return RegistryStyle::sectionDarwin;
   }
 
-  if ((t->isOSLinux() && t->getEnvironment() != llvm::Triple::Android) ||
-      t->isOSFreeBSD() ||
+  if (t->isOSLinux() || t->isOSFreeBSD() ||
 #if LDC_LLVM_VER > 305
       t->isOSNetBSD() || t->isOSOpenBSD() || t->isOSDragonFly()
 #else
@@ -376,7 +375,10 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
                                                                : "__minfo");
   gIR->usedArray.push_back(thismref);
 
-  if (!isFirst) {
+  // Android doesn't need register_dso and friends- see rt.sections_android-
+  // so bail out here.
+  if (!isFirst ||
+      global.params.targetTriple->getEnvironment() == llvm::Triple::Android) {
     // Nothing left to do.
     return;
   }


### PR DESCRIPTION
dmd moved from [the linked list at `_Dmodule_ref` to a bracketed section a couple years ago](https://github.com/dlang/druntime/commit/e91f59d2175c1056af5d2de59f4fd5dee7a1779d), so I've been reverting that druntime commit for ldc/Android till now.  Turns out I can use this `sectionELF` code just fine, as long as I take out the calls to `_d_dso_registry` and modify druntime to use the slightly different ldc symbols `__start___minfo` and `__stop___minfo`, druntime PR forthcoming.  Confirmed by cross-compiling the stdlib tests from linux/x64 to Android/ARM with ldc master, and running the stdlib and dmd testsuite natively with master and merge-2.074.

I didn't look very closely at `sectionELF` however, just hacked this in, so if David thinks anything else might cause issues, let me know.