### PR TITLE
AddressSanitizer, Darwin: add support for linking with correct library when found in LDC's lib dir.

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -17,7 +17,7 @@
 #include "gen/optimizer.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/Support/FileSystem.h"
-#include <llvm/Support/Path.h>
+#include "llvm/Support/Path.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -17,6 +17,7 @@
 #include "gen/optimizer.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/Support/FileSystem.h"
+#include <llvm/Support/Path.h>
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 
@@ -43,6 +44,8 @@ public:
 
 private:
   virtual void addSanitizers();
+  virtual void addASanLinkFlags();
+
   virtual void addUserSwitches();
   void addDefaultLibs();
   virtual void addArch();
@@ -171,6 +174,71 @@ void ArgsBuilder::addLTOLinkFlags() {
 
 //////////////////////////////////////////////////////////////////////////////
 
+// Returns true on success.
+bool addDarwinASanLinkFlags(std::vector<std::string> &args) {
+  std::string searchPaths[] = {
+    exe_path::prependLibDir("libldc.asan_osx_dynamic.dylib"),
+    exe_path::prependLibDir("libclang_rt.asan_osx_dynamic.dylib"),
+  };
+
+  for (const auto &filepath : searchPaths) {
+    if (llvm::sys::fs::exists(filepath)) {
+      args.push_back(filepath);
+
+      // Add @executable_path to rpath to support having the dylib copied with
+      // the executable.
+      args.push_back("-rpath");
+      args.push_back("@executable_path");
+
+      // Add the path to the resource dir to rpath to support using the dylib
+      // from the default location without copying.
+      args.push_back("-rpath");
+      args.push_back(llvm::sys::path::parent_path(filepath));
+
+      return true;
+    }
+  }
+
+  // We did not find the library.
+  return false;
+}
+
+void ArgsBuilder::addASanLinkFlags() {
+  bool success = false;
+  if (global.params.targetTriple->isOSDarwin()) {
+    success = addDarwinASanLinkFlags(args);
+  } else {
+    success = false; // TODO: implement
+  }
+
+  if (!success) {
+    // Fallback, requires Clang. The asan library contains a versioned symbol
+    // name and a linker error will happen when the LDC-LLVM and Clang-LLVM
+    // versions don't match.
+    args.push_back("-fsanitize=address");
+  }
+}
+
+void ArgsBuilder::addSanitizers() {
+  if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
+    addASanLinkFlags();
+  }
+
+  // TODO: instead of this, we should link with our own sanitizer libraries
+  // because LDC's LLVM version could be different from the system clang.
+  if (opts::isSanitizerEnabled(opts::MemorySanitizer)) {
+    args.push_back("-fsanitize=memory");
+  }
+
+  // TODO: instead of this, we should link with our own sanitizer libraries
+  // because LDC's LLVM version could be different from the system clang.
+  if (opts::isSanitizerEnabled(opts::ThreadSanitizer)) {
+    args.push_back("-fsanitize=thread");
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 void ArgsBuilder::build(llvm::StringRef outputPath,
                         llvm::cl::boolOrDefault fullyStaticFlag) {
   // object files
@@ -237,25 +305,6 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
   addDefaultLibs();
 
   addArch();
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-// Requires clang.
-void ArgsBuilder::addSanitizers() {
-  // TODO: instead of this, we should link with our own sanitizer libraries
-  // because LDC's LLVM version could be different from the system clang.
-  if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
-    args.push_back("-fsanitize=address");
-  }
-
-  if (opts::isSanitizerEnabled(opts::MemorySanitizer)) {
-    args.push_back("-fsanitize=memory");
-  }
-
-  if (opts::isSanitizerEnabled(opts::ThreadSanitizer)) {
-    args.push_back("-fsanitize=thread");
-  }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -177,7 +177,7 @@ void ArgsBuilder::addLTOLinkFlags() {
 // Returns true on success.
 bool addDarwinASanLinkFlags(std::vector<std::string> &args) {
   std::string searchPaths[] = {
-    exe_path::prependLibDir("libldc.asan_osx_dynamic.dylib"),
+    exe_path::prependLibDir("libldc_rt.asan_osx_dynamic.dylib"),
     exe_path::prependLibDir("libclang_rt.asan_osx_dynamic.dylib"),
   };
 


### PR DESCRIPTION
This PR is only meant to change Darwin link line with -fsanitize=address. With this PR, I can use addresssanitizer successfully (and easily) on my Mac. 
The PR finds a `libldc_rt.asan_osx_dynamic.dylib` or `libclang_rt.asan_osx_dynamic.dylib` in LDC's lib dir, and falls back to the old behavior (passing `-fsanitize=address` to the linker driver) if nothing is found. So now the user can copy his self-built library to LDC's lib dir and be happy :-)
(the cmake script could copy+rename the library to the lib dir when the library is found in the LLVM binaries)