### PR TITLE
Add support for MSP430 / 16-bit targets

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -818,13 +818,10 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("BigEndian");
   }
 
-  // a generic 64bit version
+  // Set versions for arch bitwidth
   if (global.params.isLP64) {
     VersionCondition::addPredefinedGlobalIdent("D_LP64");
-  }
-
-  // 16 bit version for 16 bit targets
-  if(arch == llvm::Triple::msp430) {
+  } else if (global.params.targetTriple->isArch16Bit()) {
     VersionCondition::addPredefinedGlobalIdent("D_P16");
   }
 
@@ -909,7 +906,7 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("Posix");
     break;
   case llvm::Triple::UnknownOS:
-    if(arch == llvm::Triple::msp430)
+    if (arch == llvm::Triple::msp430)
       break;
     // fallthrough
   default:

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -767,6 +767,9 @@ void registerPredefinedTargetVersions() {
     registerPredefinedFloatABI("MIPS_SoftFloat", "MIPS_HardFloat");
     registerMipsABI();
     break;
+  case llvm::Triple::msp430:
+    VersionCondition::addPredefinedGlobalIdent("MSP430");
+    break;
 #if defined RISCV_LLVM_DEV || LDC_LLVM_VER >= 400
 #if defined RISCV_LLVM_DEV
   case llvm::Triple::riscv:
@@ -818,6 +821,11 @@ void registerPredefinedTargetVersions() {
   // a generic 64bit version
   if (global.params.isLP64) {
     VersionCondition::addPredefinedGlobalIdent("D_LP64");
+  }
+
+  // 16 bit version for 16 bit targets
+  if(arch == llvm::Triple::msp430) {
+    VersionCondition::addPredefinedGlobalIdent("D_P16");
   }
 
   if (gTargetMachine->getRelocationModel() == llvm::Reloc::PIC_) {
@@ -900,6 +908,10 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("AIX");
     VersionCondition::addPredefinedGlobalIdent("Posix");
     break;
+  case llvm::Triple::UnknownOS:
+    if(arch == llvm::Triple::msp430)
+      break;
+    // fallthrough
   default:
     switch (global.params.targetTriple->getEnvironment()) {
     case llvm::Triple::Android:

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -261,14 +261,11 @@ LLIntegerType *DtoSize_t() {
 
     if (triple->isArch64Bit()) {
       t = LLType::getInt64Ty(gIR->context());
-    }
-    else if (triple->isArch32Bit()) {
+    } else if (triple->isArch32Bit()) {
       t = LLType::getInt32Ty(gIR->context());
-    }
-    else if (triple->isArch16Bit()) {
+    } else if (triple->isArch16Bit()) {
       t = LLType::getInt16Ty(gIR->context());
-    }
-    else {
+    } else {
       llvm_unreachable("Unsupported size_t width");
     }
   }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -257,8 +257,20 @@ LLIntegerType *DtoSize_t() {
   // the type of size_t does not change once set
   static LLIntegerType *t = nullptr;
   if (t == nullptr) {
-    t = (global.params.isLP64) ? LLType::getInt64Ty(gIR->context())
-                               : LLType::getInt32Ty(gIR->context());
+    auto triple = global.params.targetTriple;
+
+    if (triple->isArch64Bit()) {
+      t = LLType::getInt64Ty(gIR->context());
+    }
+    else if (triple->isArch32Bit()) {
+      t = LLType::getInt32Ty(gIR->context());
+    }
+    else if (triple->isArch16Bit()) {
+      t = LLType::getInt16Ty(gIR->context());
+    }
+    else {
+      llvm_unreachable("Unsupported size_t width");
+    }
   }
   return t;
 }

--- a/tests/codegen/ptr_16_bit.d
+++ b/tests/codegen/ptr_16_bit.d
@@ -5,5 +5,10 @@
 void* ptr;
 static assert(ptr.sizeof == 2);
 
+static assert (size_t.sizeof == 2);
+
 version(D_P16) {}
+else static assert(0);
+
+version(MSP430) {}
 else static assert(0);

--- a/tests/codegen/ptr_16_bit.d
+++ b/tests/codegen/ptr_16_bit.d
@@ -5,8 +5,6 @@
 void* ptr;
 static assert(ptr.sizeof == 2);
 
-static assert (size_t.sizeof == 2);
-
 version(D_P16) {}
 else static assert(0);
 

--- a/tests/codegen/ptr_16_bit.d
+++ b/tests/codegen/ptr_16_bit.d
@@ -1,0 +1,9 @@
+// REQUIRES: target_MSP430
+
+// RUN: %ldc -mtriple=msp430 -o- %s
+
+void* ptr;
+static assert(ptr.sizeof == 2);
+
+version(D_P16) {}
+else static assert(0);


### PR DESCRIPTION
`global.params` doesn't have a flag for the condition of being a 16-bit target. We have two options: 1) add that flag, or 2) compute 16-bitness from the target triple each time `DtoSize_t` is called. Since adding fields to `struct Params` might be disruptive, I opted for the latter. Please say if you prefer the former.

I avoid calling `isArch16Bit` unless the target is not 64-bit, which should be the most common target, and therefore avoid unnecessary work. Having a flag for 16-bitness would be slightly cheapter, but I'm guessing the speed penalty is not noticeable.