### PR TITLE
Switch to special quiet NaN as init value for all FP types

### DIFF
--- a/ddmd/root/ctfloat.d
+++ b/ddmd/root/ctfloat.d
@@ -199,6 +199,13 @@ else
     static __gshared real_t one = real_t(1);
     static __gshared real_t minusone = real_t(-1);
     static __gshared real_t half = real_t(0.5);
+  version(IN_LLVM)
+  {
+    // Initialized via LLVM in C++.
+    static __gshared real_t initVal;
+    static __gshared real_t nan;
+    static __gshared real_t infinity;
+  }
 }
 
 version (IN_LLVM)

--- a/ddmd/root/ctfloat.d
+++ b/ddmd/root/ctfloat.d
@@ -110,6 +110,13 @@ extern (C++) struct CTFloat
         return !(r == r);
     }
 
+  version(IN_LLVM)
+  {
+    // LDC doesn't need isSNaN(). The upstream implementation is tailored for
+    // DMD/x86 and only supports double-precision and x87 real_t types.
+  }
+  else
+  {
     static bool isSNaN(real_t r)
     {
         static if (real_t.sizeof == 8)
@@ -121,12 +128,12 @@ extern (C++) struct CTFloat
     // the implementation of longdouble for MSVC is a struct, so mangling
     //  doesn't match with the C++ header.
     // add a wrapper just for isSNaN as this is the only function called from C++
-    // IN_LLVM replaced: version(CRuntime_Microsoft)
-    version(none)
+    version(CRuntime_Microsoft)
         static bool isSNaN(longdouble ld)
         {
             return isSNaN(ld.r);
         }
+  }
 
     static bool isInfinity(real_t r)
     {

--- a/ddmd/root/ctfloat.h
+++ b/ddmd/root/ctfloat.h
@@ -52,6 +52,7 @@ struct CTFloat
     // implemented in gen/ctfloat.cpp
     static void _init();
     static void toAPFloat(real_t src, llvm::APFloat &dst);
+    static real_t fromAPFloat(const llvm::APFloat &src);
 
     static bool isFloat32LiteralOutOfRange(const char *literal);
     static bool isFloat64LiteralOutOfRange(const char *literal);

--- a/ddmd/root/ctfloat.h
+++ b/ddmd/root/ctfloat.h
@@ -59,7 +59,9 @@ struct CTFloat
 
     static bool isIdentical(real_t a, real_t b);
     static bool isNaN(real_t r);
+#if !IN_LLVM
     static bool isSNaN(real_t r);
+#endif
     static bool isInfinity(real_t r);
 
     static real_t parse(const char *literal, bool *isOutOfRange = NULL);

--- a/ddmd/root/ctfloat.h
+++ b/ddmd/root/ctfloat.h
@@ -73,6 +73,11 @@ struct CTFloat
     static real_t one;
     static real_t minusone;
     static real_t half;
+#if IN_LLVM
+    static real_t initVal;
+    static real_t nan;
+    static real_t infinity;
+#endif
 };
 
 #endif

--- a/gen/ctfloat.cpp
+++ b/gen/ctfloat.cpp
@@ -80,13 +80,25 @@ void CTFloat::toAPFloat(const real_t src, APFloat &dst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-real_t CTFloat::parse(const char *literal, bool *isOutOfRange) {
-  const APFloat ap = parseLiteral(*apSemantics, literal, isOutOfRange);
-  const APInt bits = ap.bitcastToAPInt();
+real_t CTFloat::fromAPFloat(const APFloat &src_) {
+  APFloat src = src_;
+  if (&src.getSemantics() != apSemantics) {
+    bool ignored;
+    src.convert(*apSemantics, APFloat::rmNearestTiesToEven, &ignored);
+  }
+
+  const APInt bits = src.bitcastToAPInt();
 
   CTFloatUnion u;
   memcpy(u.bits, bits.getRawData(), bits.getBitWidth() / 8);
   return u.fp;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+real_t CTFloat::parse(const char *literal, bool *isOutOfRange) {
+  const APFloat ap = parseLiteral(*apSemantics, literal, isOutOfRange);
+  return fromAPFloat(ap);
 }
 
 bool CTFloat::isFloat32LiteralOutOfRange(const char *literal) {

--- a/gen/ctfloat.cpp
+++ b/gen/ctfloat.cpp
@@ -47,18 +47,26 @@ void CTFloat::_init() {
 
   if (sizeof(real_t) == 8) {
     apSemantics = &(APFloat::IEEEdouble AP_SEMANTICS_PARENS);
-    return;
+  } else {
+#if __i386__ || __x86_64__
+    apSemantics = &(APFloat::x87DoubleExtended AP_SEMANTICS_PARENS);
+#elif __aarch64__
+    apSemantics = &(APFloat::IEEEquad AP_SEMANTICS_PARENS);
+#elif __ppc__ || __ppc64__
+    apSemantics = &(APFloat::PPCDoubleDouble AP_SEMANTICS_PARENS);
+#else
+    llvm_unreachable("Unknown host real_t type for compile-time reals");
+#endif
   }
 
-#if __i386__ || __x86_64__
-  apSemantics = &(APFloat::x87DoubleExtended AP_SEMANTICS_PARENS);
-#elif __aarch64__
-  apSemantics = &(APFloat::IEEEquad AP_SEMANTICS_PARENS);
-#elif __ppc__ || __ppc64__
-  apSemantics = &(APFloat::PPCDoubleDouble AP_SEMANTICS_PARENS);
-#else
-  llvm_unreachable("Unknown host real_t type for compile-time reals");
-#endif
+  // init value: use a special quiet NaN (with 2nd-most significant mantissa bit
+  //             set too, like signalling NaNs)
+  APInt initMantissa(APFloat::getSizeInBits(*apSemantics), 0);
+  initMantissa.setBit(APFloat::semanticsPrecision(*apSemantics) -
+                      3); // #mantissaBits = precision - 1
+  initVal = fromAPFloat(APFloat::getQNaN(*apSemantics, false, &initMantissa));
+  nan = fromAPFloat(APFloat::getQNaN(*apSemantics));
+  infinity = fromAPFloat(APFloat::getInf(*apSemantics));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -55,12 +55,9 @@ void Target::_init() {
   const auto IEEEquad = &APFloat::IEEEquad;
 #endif
 
-  RealProperties.nan =
-      CTFloat::fromAPFloat(APFloat::getQNaN(*targetRealSemantics));
-  RealProperties.snan =
-      CTFloat::fromAPFloat(APFloat::getSNaN(*targetRealSemantics));
-  RealProperties.infinity =
-      CTFloat::fromAPFloat(APFloat::getInf(*targetRealSemantics));
+  RealProperties.nan = CTFloat::nan;
+  RealProperties.snan = CTFloat::initVal;
+  RealProperties.infinity = CTFloat::infinity;
 
   if (targetRealSemantics == IEEEdouble) {
     RealProperties.max = CTFloat::parse("0x1.fffffffffffffp+1023");

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -55,6 +55,13 @@ void Target::_init() {
   const auto IEEEquad = &APFloat::IEEEquad;
 #endif
 
+  RealProperties.nan =
+      CTFloat::fromAPFloat(APFloat::getQNaN(*targetRealSemantics));
+  RealProperties.snan =
+      CTFloat::fromAPFloat(APFloat::getSNaN(*targetRealSemantics));
+  RealProperties.infinity =
+      CTFloat::fromAPFloat(APFloat::getInf(*targetRealSemantics));
+
   if (targetRealSemantics == IEEEdouble) {
     RealProperties.max = CTFloat::parse("0x1.fffffffffffffp+1023");
     RealProperties.min_normal = CTFloat::parse("0x1p-1022");

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -397,31 +397,15 @@ LLConstant *DtoConstFP(Type *t, const real_t value) {
   LLType *llty = DtoType(t);
   assert(llty->isFloatingPointTy());
 
-  assert(sizeof(real_t) >= 8 && "real_t < 64 bits?");
-
-  if (llty->isFloatTy()) {
-    // let host narrow to single-precision target
-    return LLConstantFP::get(gIR->context(),
-                             APFloat(static_cast<float>(value)));
-  }
-
-  if (llty->isDoubleTy()) {
-    // let host (potentially) narrow to double-precision target
-    return LLConstantFP::get(gIR->context(),
-                             APFloat(static_cast<double>(value)));
-  }
-
-  // host real_t => target real
-
   // 1) represent host real_t as llvm::APFloat
-  const auto &targetRealSemantics = llty->getFltSemantics();
-  APFloat v(targetRealSemantics, APFloat::uninitialized);
+  const auto &targetSemantics = llty->getFltSemantics();
+  APFloat v(targetSemantics, APFloat::uninitialized);
   CTFloat::toAPFloat(value, v);
 
-  // 2) convert to target real
-  if (&v.getSemantics() != &targetRealSemantics) {
+  // 2) convert to target format
+  if (&v.getSemantics() != &targetSemantics) {
     bool ignored;
-    v.convert(targetRealSemantics, APFloat::rmNearestTiesToEven, &ignored);
+    v.convert(targetSemantics, APFloat::rmNearestTiesToEven, &ignored);
   }
 
   return LLConstantFP::get(gIR->context(), v);

--- a/tests/codegen/vector_init.d
+++ b/tests/codegen/vector_init.d
@@ -4,15 +4,11 @@
 alias D2 = __vector(double[2]);
 
 // CHECK: @_D11vector_init12ImplicitInit6__initZ =
-// double.init (as well as float.init) may be silenced from a signalling to a quiet NaN,
-// so don't check the most significant mantissa bit (quietness), but make sure the
-// second-most significant one is (still) set.
-// See https://github.com/ldc-developers/ldc/pull/2207.
-// CHECK-SAME: { <2 x double> <double 0x7FF{{4|C}}000000000000, double 0x7FF{{4|C}}000000000000> }
+// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
 struct ImplicitInit { D2 a; }
 
 // CHECK: @_D11vector_init12ExplicitInit6__initZ =
-// CHECK-SAME: { <2 x double> <double 0x7FF{{4|C}}000000000000, double 0x7FF{{4|C}}000000000000> }
+// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
 struct ExplicitInit { D2 a = D2.init; }
 
 // CHECK: @_D11vector_init10SplatValue6__initZ =

--- a/tests/codegen/vector_init.d
+++ b/tests/codegen/vector_init.d
@@ -4,11 +4,15 @@
 alias D2 = __vector(double[2]);
 
 // CHECK: @_D11vector_init12ImplicitInit6__initZ =
-// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
+// double.init (as well as float.init) may be silenced from a signalling to a quiet NaN,
+// so don't check the most significant mantissa bit (quietness), but make sure the
+// second-most significant one is (still) set.
+// See https://github.com/ldc-developers/ldc/pull/2207.
+// CHECK-SAME: { <2 x double> <double 0x7FF{{4|C}}000000000000, double 0x7FF{{4|C}}000000000000> }
 struct ImplicitInit { D2 a; }
 
 // CHECK: @_D11vector_init12ExplicitInit6__initZ =
-// CHECK-SAME: { <2 x double> <double 0x7FFC000000000000, double 0x7FFC000000000000> }
+// CHECK-SAME: { <2 x double> <double 0x7FF{{4|C}}000000000000, double 0x7FF{{4|C}}000000000000> }
 struct ExplicitInit { D2 a = D2.init; }
 
 // CHECK: @_D11vector_init10SplatValue6__initZ =


### PR DESCRIPTION
**Update**:

By letting LLVM truncate compile-time `real_t` values to float/double IR constants. We previously relied on the host, which turns signalling real_t NaNs to quiet float/double NaNs.

Signalling NaNs are characterized by their most-significant mantissa bit being 0 (and at least for D the 2nd-most-significant mantissa bit being set to distinguish them from infinity). The host truncation led to the MSB
getting set while keeping the rest of the mantissa (i.e., both MSBs set).

Here's the resulting bitpattern table in hex:

|           | float  |   double  |          x87 real |
| ------ | ----- | ---------- | --------------- |
| init old |  7f**e**00000   |7ff**c**000000000000  | 7fff**a**000000000000000 |
| init new |  7f**a**00000 |  7ff**4**000000000000 |  7fff**a**000000000000000 |
| qnan  |     7f**c**00000  | 7ff**8**000000000000 |  7fff**c**000000000000000 |

DMD 2.074.0 produces wrongly quiet float/double init values. It's known: https://forum.dlang.org/post/nsp1ql$ivu$1@digitalmars.com