### PR TITLE
Travis Linux: Try to work around memory limitations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,10 @@ jobs:
             cd ..
       - run:
           name: Compile stdlib unittests
-          command: cd build && ninja -j3 phobos2-ldc-unittest-debug phobos2-ldc-unittest druntime-ldc-unittest-debug druntime-ldc-unittest
+          command: |
+            cd build
+            ninja -j3 phobos2-ldc-unittest-debug phobos2-ldc-unittest druntime-ldc-unittest-debug druntime-ldc-unittest
+            ninja -j3 phobos2-ldc-unittest-debug-shared phobos2-ldc-unittest-shared druntime-ldc-unittest-debug-shared druntime-ldc-unittest-shared
       - run:
           name: Run LDC unittests
           command: cd build && ctest --output-on-failure -R ldc2-unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,10 @@ script:
   - bin/ldc2 -version || exit 1
   # Build Phobos & druntime unittest modules.
   - ninja -j3 phobos2-ldc-unittest-debug phobos2-ldc-unittest druntime-ldc-unittest-debug druntime-ldc-unittest
+  -
+    if [[ ! "${OPTS}" == *-DBUILD_SHARED_LIBS* ]]; then
+      ninja -j3 phobos2-ldc-unittest-debug-shared phobos2-ldc-unittest-shared druntime-ldc-unittest-debug-shared druntime-ldc-unittest-shared;
+    fi
   # Build and run LDC D unittests.
   - ctest --output-on-failure -R "ldc2-unittest"
   # Run LIT testsuite.


### PR DESCRIPTION
The workers may have less than 4 GB of memory and some jobs seem to get killed due to this, particularly when building the stdlib test runners.

So try precompiling the shared unittest objects manually with `-j3` too.
If compiled as part of the testrunner tests, ninja apparently defaults to a high number of parallel jobs based on the CPU and not on the available CPU cores for the Docker container.