### PR TITLE
Cherry-pick DMD commit 2e6c7ac3af5ec52aff63a779e781cab1a802dfa5

### DIFF
--- a/ddmd/expression.d
+++ b/ddmd/expression.d
@@ -8500,6 +8500,7 @@ extern (C++) final class DotIdExp : UnaExp
 {
     Identifier ident;
     bool noderef;       // true if the result of the expression will never be dereferenced
+    bool wantsym;       // do not replace Symbol with its initializer during semantic()
 
     extern (D) this(Loc loc, Expression e, Identifier ident)
     {
@@ -8751,8 +8752,12 @@ extern (C++) final class DotIdExp : UnaExp
                     if (v.type.ty == Terror)
                         return new ErrorExp();
 
-                    if ((v.storage_class & STCmanifest) && v._init)
+                    if ((v.storage_class & STCmanifest) && v._init && !wantsym)
                     {
+                        /* Normally, the replacement of a symbol with its initializer is supposed to be in semantic2().
+                         * Introduced by https://github.com/dlang/dmd/pull/5588 which should probably
+                         * be reverted. `wantsym` is the hack to work around the problem.
+                         */
                         if (v.inuse)
                         {
                             .error(loc, "circular initialization of %s '%s'", v.kind(), v.toPrettyChars());

--- a/ddmd/expression.h
+++ b/ddmd/expression.h
@@ -798,6 +798,8 @@ class DotIdExp : public UnaExp
 {
 public:
     Identifier *ident;
+    bool noderef;       // true if the result of the expression will never be dereferenced
+    bool wantsym;       // do not replace Symbol with its initializer during semantic()
 
     static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);

--- a/ddmd/traits.d
+++ b/ddmd/traits.d
@@ -724,6 +724,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else if (e.ident == Id.getMember)
         {
+            if (ex.op == TOKdotid)
+                // Prevent semantic() from replacing Symbol with its initializer
+                (cast(DotIdExp)ex).wantsym = true;
             ex = ex.semantic(scx);
             return ex;
         }


### PR DESCRIPTION
DMD PR https://github.com/dlang/dmd/pull/6949

fix Issue 17545 - [REG2.072] __traits(getAttributes, name) evaluates name to value prematurely

(needed for Weka, so was easy to cherry-pick for us too)