### PR TITLE
Add search logic for AddressSanitizer library on Linuxes.

### DIFF
--- a/driver/exe_path.cpp
+++ b/driver/exe_path.cpp
@@ -52,13 +52,13 @@ string exe_path::getLibDir() {
   return r.str();
 }
 
-string exe_path::prependBinDir(const char *suffix) {
+string exe_path::prependBinDir(const llvm::Twine &suffix) {
   llvm::SmallString<128> r(getBinDir());
   path::append(r, suffix);
   return r.str();
 }
 
-string exe_path::prependLibDir(const char *suffix) {
+string exe_path::prependLibDir(const llvm::Twine &suffix) {
   llvm::SmallString<128> r(getLibDir());
   path::append(r, suffix);
   return r.str();

--- a/driver/exe_path.h
+++ b/driver/exe_path.h
@@ -15,6 +15,8 @@
 #ifndef LDC_DRIVER_EXE_PATH_H
 #define LDC_DRIVER_EXE_PATH_H
 
+#include "llvm/ADT/Twine.h"
+
 #include <string>
 
 namespace exe_path {
@@ -25,8 +27,8 @@ const std::string &getExePath();               // <baseDir>/bin/ldc2
 std::string getBinDir();                       // <baseDir>/bin
 std::string getBaseDir();                      // <baseDir>
 std::string getLibDir();                       // <baseDir>/lib
-std::string prependBinDir(const char *suffix); // <baseDir>/bin/<suffix>
-std::string prependLibDir(const char *suffix); // <baseDir>/lib/<suffix>
+std::string prependBinDir(const llvm::Twine &suffix); // <baseDir>/bin/<suffix>
+std::string prependLibDir(const llvm::Twine &suffix); // <baseDir>/lib/<suffix>
 }
 
 #endif // LDC_DRIVER_EXE_PATH_H


### PR DESCRIPTION
Only tested on mac with -mtriple=x86_64-pc-linux, which does the correct thing.
As least on Ubuntu, the libs are called: `libclang_rt.asan-x86_64.a` and `libclang_rt.asan-x86_64.so`.

The shared lib support is halfbaked. I put in some code to make it easy for someone to make that work in the future.