### PR TITLE
Travis: Reduce #parallel build jobs to reduce sporadic failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
 script:
   - cmake -G Ninja -DLLVM_CONFIG=$(which ${LLVM_CONFIG}) -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON $OPTS .
   # Build LDC and stdlib unittest runners.
-  - ninja -j3 all all-test-runners
+  - ninja -j2 all all-test-runners
   # Output some environment info, plus make sure we only run the test suite
   # if we could actually build the executable.
   - bin/ldc2 -version || exit 1


### PR DESCRIPTION
... due to killed processes when exhausting the worker's memory (4 GB **max** on Linux, unfortunately).