### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2508,7 +2508,7 @@ struct AsmProcessor {
       if (ptrtype == Byte_Ptr) {
         return false;
       }
-    // drop through
+    // fallthrough
     case Int_Types:
       switch (ptrtype) {
       case Byte_Ptr:
@@ -2840,7 +2840,7 @@ struct AsmProcessor {
         // gas won't accept the two-operand form; skip to the source
         // operand
         i__ = 1;
-      // drop through
+      // fallthrough
       case Op_bound:
       case Op_enter:
         i = i__;
@@ -3938,7 +3938,7 @@ struct AsmProcessor {
 #define XFmode TFmode
 #endif
         mode = XFmode; // not TFmode
-        // drop through
+        // fallthrough
       do_float:
         if (token->value == TOKfloat32v || token->value == TOKfloat64v ||
             token->value == TOKfloat80v) {

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -221,9 +221,6 @@ void AsmStatement_toIR(AsmStatement *stmt, IRState *irs) {
         cns = mrw_cns;
         is_input = false;
         break;
-      default:
-        llvm_unreachable("Unknown inline asm reference mode.");
-        break;
       }
       break;
     case Arg_FrameRelative:

--- a/gen/dcompute/targetCUDA.cpp
+++ b/gen/dcompute/targetCUDA.cpp
@@ -13,6 +13,7 @@
 #include "gen/abi-nvptx.h"
 #include "gen/logger.h"
 #include "gen/optimizer.h"
+#include "gen/to_string.h"
 #include "llvm/Transforms/Scalar.h"
 #include "driver/targetmachine.h"
 #include <cstring>
@@ -47,12 +48,11 @@ public:
     // sm version?
   }
   void setGTargetMachine() override {
-    char buf[8];
-    bool is64 = global.params.is64bit;
-    snprintf(buf, sizeof(buf), "sm_%d", tversion / 10);
+    const bool is64 = global.params.is64bit;
+
     gTargetMachine = createTargetMachine(
         is64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda",
-        is64 ? "nvptx64" : "nvptx", buf, {},
+        is64 ? "nvptx64" : "nvptx", "sm_" + ldc::to_string(tversion / 10), {},
         is64 ? ExplicitBitness::M64 : ExplicitBitness::M32, ::FloatABI::Hard,
         llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(), false,
         false);

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -334,9 +334,10 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
     auto atomicOrdering =
         static_cast<llvm::AtomicOrdering>((*e->arguments)[0]->toInteger());
 #if LDC_LLVM_VER >= 500
-    llvm::SyncScope::ID scope = (e->arguments->dim == 2)
-                                    ? (*e->arguments)[1]->toInteger()
-                                    : llvm::SyncScope::System;
+    llvm::SyncScope::ID scope = llvm::SyncScope::System;
+    if (e->arguments->dim == 2) {
+      scope = static_cast<llvm::SyncScope::ID>((*e->arguments)[1]->toInteger());
+    }
 #else
     auto scope = llvm::SynchronizationScope::CrossThread;
     if (e->arguments->dim == 2) {


### PR DESCRIPTION
This fixes the warning "default label in switch which covers all enumeration values". We will already get a warning when _not_ all enumeration values are covered.
I think with this PR, all warnings are resolved and we can use `-Werror` on our CI systems.

Let's not debate about this change too long. I looked into disabling the warning for only this piece of code, but it is cumbersome. So let's either apply this change, or remove `-Wcovered-switch-default` from our build flags. Thanks.
