### PR TITLE
Make cache pruning test more robust by sleeping longer between invokes.

### DIFF
--- a/tests/linking/ir2obj_cache_pruning2.d
+++ b/tests/linking/ir2obj_cache_pruning2.d
@@ -33,6 +33,6 @@ void main()
     {
         // Sleep for 2 seconds, so we are sure that the cache object file timestamps are "aging".
         import core.thread;
-        Thread.sleep( dur!"seconds"(2) );
+        Thread.sleep( dur!"seconds"(4) );
     }
 }

--- a/tests/linking/ir2obj_cache_pruning2.d
+++ b/tests/linking/ir2obj_cache_pruning2.d
@@ -31,7 +31,7 @@ void main()
 
     version (SLEEP)
     {
-        // Sleep for 2 seconds, so we are sure that the cache object file timestamps are "aging".
+        // Sleep for 4 seconds, so we are sure that the cache object file timestamps are "aging".
         import core.thread;
         Thread.sleep( dur!"seconds"(4) );
     }


### PR DESCRIPTION
I think there is a spurious case where things happen right before / after second elapses. This should fix that.

@kinke Hope this fixes the spurious failures like https://travis-ci.org/ldc-developers/ldc/jobs/258653490#L3431