### PR TITLE
Add helper function `append` to runtime cmakescript

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -12,6 +12,17 @@ if(NOT LDC_EXE)
     endif()
 endif()
 
+# Helper function
+function(append value)
+    foreach(variable ${ARGN})
+        if(${variable} STREQUAL "")
+            set(${variable} "${value}" PARENT_SCOPE)
+        else()
+            set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
+        endif()
+    endforeach(variable)
+endfunction()
+
 #
 # Main configuration.
 #


### PR DESCRIPTION
The `append` function is missing when the runtime cmakescript is used directly (instead of included by the main LDC cmakescript).
With this PR, the `build-ldc-runtime.sh` works for me straight from my `build/bin` dir and specifying my git checkout as `LDC_SRC_DIR`, nice!