### PR TITLE
Make many std.math functions CTFE-able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       d: ldc-beta
       env: LLVM_VERSION=3.9.1 OPTS="-DBUILD_SHARED_LIBS=ON"
     - os: linux
-      d: ldc-0.17.2
+      d: ldc-0.17.5
       env: LLVM_VERSION=3.8.1 OPTS="-DBUILD_SHARED_LIBS=OFF -DLIB_SUFFIX=64"
     - os: linux
       d: dmd

--- a/ddmd/builtin.d
+++ b/ddmd/builtin.d
@@ -635,10 +635,6 @@ else
     add_builtin("_D3std4math15__T8isFiniteTdZ8isFiniteFNaNbNiNedZb", &eval_isfinite);
     add_builtin("_D3std4math15__T8isFiniteTfZ8isFiniteFNaNbNiNefZb", &eval_isfinite);
 
-    // @safe @nogc pure nothrow int function(uint)
-    add_builtin("_D4core5bitop3bsfFNaNbNiNfkZi", &eval_bsf);
-    add_builtin("_D4core5bitop3bsrFNaNbNiNfkZi", &eval_bsr);
-
 version(IN_LLVM)
 {
     // intrinsic llvm.sin.f32/f64/f80/f128/ppcf128

--- a/ddmd/builtin.d
+++ b/ddmd/builtin.d
@@ -555,6 +555,9 @@ else
     add_builtin("_D4core4math5atan2FNaNbNiNfeeZe", &eval_unimp);
     if (CTFloat.yl2x_supported)
     {
+        version(IN_LLVM) // @trusted
+            add_builtin("_D4core4math4yl2xFNaNbNiNeeeZe", &eval_yl2x);
+        else
         add_builtin("_D4core4math4yl2xFNaNbNiNfeeZe", &eval_yl2x);
     }
     else
@@ -563,6 +566,9 @@ else
     }
     if (CTFloat.yl2xp1_supported)
     {
+        version(IN_LLVM) // @trusted
+            add_builtin("_D4core4math6yl2xp1FNaNbNiNeeeZe", &eval_yl2xp1);
+        else
         add_builtin("_D4core4math6yl2xp1FNaNbNiNfeeZe", &eval_yl2xp1);
     }
     else

--- a/ddmd/builtin.d
+++ b/ddmd/builtin.d
@@ -237,6 +237,22 @@ extern (C++) Expression eval_llvmlog(Loc loc, FuncDeclaration fd, Expressions *a
     return new RealExp(loc, CTFloat.log(arg0.toReal()), type);
 }
 
+extern (C++) Expression eval_llvmlog2(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.log2(arg0.toReal()), type);
+}
+
+extern (C++) Expression eval_llvmlog10(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.log10(arg0.toReal()), type);
+}
+
 extern (C++) Expression eval_llvmfabs(Loc loc, FuncDeclaration fd, Expressions *arguments)
 {
     Type type = getTypeOfOverloadedIntrinsic(fd);
@@ -289,12 +305,50 @@ extern (C++) Expression eval_llvmtrunc(Loc loc, FuncDeclaration fd, Expressions 
     return new RealExp(loc, CTFloat.trunc(arg0.toReal()), type);
 }
 
+extern (C++) Expression eval_llvmrint(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.rint(arg0.toReal()), type);
+}
+
+extern (C++) Expression eval_llvmnearbyint(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.nearbyint(arg0.toReal()), type);
+}
+
 extern (C++) Expression eval_llvmround(Loc loc, FuncDeclaration fd, Expressions *arguments)
 {
     Type type = getTypeOfOverloadedIntrinsic(fd);
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.round(arg0.toReal()), type);
+}
+
+extern (C++) Expression eval_llvmfma(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOKfloat64);
+    Expression arg2 = (*arguments)[2];
+    assert(arg2.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.fma(arg0.toReal(), arg1.toReal(), arg2.toReal()), type);
+}
+
+extern (C++) Expression eval_llvmcopysign(Loc loc, FuncDeclaration fd, Expressions *arguments)
+{
+    Type type = getTypeOfOverloadedIntrinsic(fd);
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOKfloat64);
+    return new RealExp(loc, CTFloat.copysign(arg0.toReal(), arg1.toReal()), type);
 }
 
 extern (C++) Expression eval_cttz(Loc loc, FuncDeclaration fd, Expressions *arguments)
@@ -609,6 +663,20 @@ version(IN_LLVM)
     add_builtin("llvm.log.f128", &eval_llvmlog);
     add_builtin("llvm.log.ppcf128", &eval_llvmlog);
 
+    // intrinsic llvm.log2.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.log2.f32", &eval_llvmlog2);
+    add_builtin("llvm.log2.f64", &eval_llvmlog2);
+    add_builtin("llvm.log2.f80", &eval_llvmlog2);
+    add_builtin("llvm.log2.f128", &eval_llvmlog2);
+    add_builtin("llvm.log2.ppcf128", &eval_llvmlog2);
+
+    // intrinsic llvm.log10.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.log10.f32", &eval_llvmlog10);
+    add_builtin("llvm.log10.f64", &eval_llvmlog10);
+    add_builtin("llvm.log10.f80", &eval_llvmlog10);
+    add_builtin("llvm.log10.f128", &eval_llvmlog10);
+    add_builtin("llvm.log10.ppcf128", &eval_llvmlog10);
+
     // intrinsic llvm.fabs.f32/f64/f80/f128/ppcf128
     add_builtin("llvm.fabs.f32", &eval_llvmfabs);
     add_builtin("llvm.fabs.f64", &eval_llvmfabs);
@@ -651,12 +719,40 @@ version(IN_LLVM)
     add_builtin("llvm.trunc.f128", &eval_llvmtrunc);
     add_builtin("llvm.trunc.ppcf128", &eval_llvmtrunc);
 
+    // intrinsic llvm.rint.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.rint.f32", &eval_llvmrint);
+    add_builtin("llvm.rint.f64", &eval_llvmrint);
+    add_builtin("llvm.rint.f80", &eval_llvmrint);
+    add_builtin("llvm.rint.f128", &eval_llvmrint);
+    add_builtin("llvm.rint.ppcf128", &eval_llvmrint);
+
+    // intrinsic llvm.nearbyint.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.nearbyint.f32", &eval_llvmnearbyint);
+    add_builtin("llvm.nearbyint.f64", &eval_llvmnearbyint);
+    add_builtin("llvm.nearbyint.f80", &eval_llvmnearbyint);
+    add_builtin("llvm.nearbyint.f128", &eval_llvmnearbyint);
+    add_builtin("llvm.nearbyint.ppcf128", &eval_llvmnearbyint);
+
     // intrinsic llvm.round.f32/f64/f80/f128/ppcf128
     add_builtin("llvm.round.f32", &eval_llvmround);
     add_builtin("llvm.round.f64", &eval_llvmround);
     add_builtin("llvm.round.f80", &eval_llvmround);
     add_builtin("llvm.round.f128", &eval_llvmround);
     add_builtin("llvm.round.ppcf128", &eval_llvmround);
+
+    // intrinsic llvm.fma.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.fma.f32", &eval_llvmfma);
+    add_builtin("llvm.fma.f64", &eval_llvmfma);
+    add_builtin("llvm.fma.f80", &eval_llvmfma);
+    add_builtin("llvm.fma.f128", &eval_llvmfma);
+    add_builtin("llvm.fma.ppcf128", &eval_llvmfma);
+
+    // intrinsic llvm.copysign.f32/f64/f80/f128/ppcf128
+    add_builtin("llvm.copysign.f32", &eval_llvmcopysign);
+    add_builtin("llvm.copysign.f64", &eval_llvmcopysign);
+    add_builtin("llvm.copysign.f80", &eval_llvmcopysign);
+    add_builtin("llvm.copysign.f128", &eval_llvmcopysign);
+    add_builtin("llvm.copysign.ppcf128", &eval_llvmcopysign);
 
     // intrinsic llvm.bswap.i16/i32/i64/i128
     add_builtin("llvm.bswap.i16", &eval_bswap);

--- a/ddmd/root/ctfloat.d
+++ b/ddmd/root/ctfloat.d
@@ -80,12 +80,18 @@ extern (C++) struct CTFloat
     static import std.math;
 
     static real_t log(real_t x) { return std.math.log(x); }
+    static real_t log2(real_t x) { return std.math.log2(x); }
+    static real_t log10(real_t x) { return std.math.log10(x); }
     static real_t fmin(real_t l, real_t r) { return std.math.fmin(l, r); }
     static real_t fmax(real_t l, real_t r) { return std.math.fmax(l, r); }
     static real_t floor(real_t x) { return std.math.floor(x); }
     static real_t ceil(real_t x) { return std.math.ceil(x); }
     static real_t trunc(real_t x) { return std.math.trunc(x); }
+    static real_t rint(real_t x) { return std.math.rint(x); }
+    static real_t nearbyint(real_t x) { return std.math.nearbyint(x); }
     static real_t round(real_t x) { return std.math.round(x); }
+    static real_t fma(real_t x, real_t y, real_t z) { return std.math.fma(x, y, z); }
+    static real_t copysign(real_t to, real_t from) { return std.math.copysign(to, from); }
 
     static void _init();
 

--- a/ddmd/root/ctfloat.d
+++ b/ddmd/root/ctfloat.d
@@ -24,6 +24,11 @@ version(IN_LLVM_MSVC)
 else
     alias real_t = real;
 
+version(IN_LLVM)
+    private enum LDC_host_has_yl2x = is(real_t == real) && __traits(compiles, core.math.yl2x(1.0L, 2.0L));
+else
+    private enum LDC_host_has_yl2x = false;
+
 private
 {
     version(CRuntime_DigitalMars) __gshared extern (C) extern const(char)* __locale_decpoint;
@@ -41,7 +46,7 @@ private
 extern (C++) struct CTFloat
 {
     // IN_LLVM replaced: version(DigitalMars)
-    version(none)
+    static if (LDC_host_has_yl2x)
     {
         static __gshared bool yl2x_supported = true;
         static __gshared bool yl2xp1_supported = true;
@@ -54,7 +59,8 @@ extern (C++) struct CTFloat
 
     static void yl2x(const real_t* x, const real_t* y, real_t* res)
     {
-        version(DigitalMars)
+        // IN_LLVM replaced: version(DigitalMars)
+        static if (LDC_host_has_yl2x)
             *res = core.math.yl2x(*x, *y);
         else
             assert(0);
@@ -62,7 +68,8 @@ extern (C++) struct CTFloat
 
     static void yl2xp1(const real_t* x, const real_t* y, real_t* res)
     {
-        version(DigitalMars)
+        // IN_LLVM replaced: version(DigitalMars)
+        static if (LDC_host_has_yl2x)
             *res = core.math.yl2xp1(*x, *y);
         else
             assert(0);

--- a/ddmd/root/ctfloat.h
+++ b/ddmd/root/ctfloat.h
@@ -43,12 +43,18 @@ struct CTFloat
 
 #if IN_LLVM
     static real_t log(real_t x);
+    static real_t log2(real_t x);
+    static real_t log10(real_t x);
     static real_t fmin(real_t l, real_t r);
     static real_t fmax(real_t l, real_t r);
     static real_t floor(real_t x);
     static real_t ceil(real_t x);
     static real_t trunc(real_t x);
+    static real_t rint(real_t x);
+    static real_t nearbyint(real_t x);
     static real_t round(real_t x);
+    static real_t fma(real_t x, real_t y, real_t z);
+    static real_t copysign(real_t to, real_t from);
 
     // implemented in gen/ctfloat.cpp
     static void _init();

--- a/tests/compilable/ctfe_math.d
+++ b/tests/compilable/ctfe_math.d
@@ -1,0 +1,85 @@
+// Tests CTFE-ability of some common std.math functions.
+
+// RUN: %ldc -c %s
+
+import std.math;
+
+mixin template Func1(string name) {
+    enum r = mixin(name ~ "(0.5L)");
+    pragma(msg, name ~ "(0.5L) = " ~ r.stringof);
+    enum d = mixin(name ~ "(0.5)");
+    pragma(msg, name ~ "(0.5)  = " ~ d.stringof);
+    enum f = mixin(name ~ "(0.5f)");
+    pragma(msg, name ~ "(0.5f) = " ~ f.stringof);
+}
+
+mixin template Func2(string name) {
+    enum r = mixin(name ~ "(0.5L, -2.5L)");
+    pragma(msg, name ~ "(0.5L, -2.5L) = " ~ r.stringof);
+    enum d = mixin(name ~ "(0.5, -2.5)");
+    pragma(msg, name ~ "(0.5,  -2.5)  = " ~ d.stringof);
+    enum f = mixin(name ~ "(0.5f, -2.5f)");
+    pragma(msg, name ~ "(0.5f, -2.5f) = " ~ f.stringof);
+}
+
+mixin template Func2_int(string name) {
+    enum r = mixin(name ~ "(0.5L, 2)");
+    pragma(msg, name ~ "(0.5L, 2) = " ~ r.stringof);
+    enum d = mixin(name ~ "(0.5, 2)");
+    pragma(msg, name ~ "(0.5,  2) = " ~ d.stringof);
+    enum f = mixin(name ~ "(0.5f, 2)");
+    pragma(msg, name ~ "(0.5f, 2) = " ~ f.stringof);
+}
+
+mixin template Func3(string name) {
+    enum r = mixin(name ~ "(0.5L, -2.5L, 6.25L)");
+    pragma(msg, name ~ "(0.5L, -2.5L, 6.25L) = " ~ r.stringof);
+    enum d = mixin(name ~ "(0.5, -2.5, 6.25)");
+    pragma(msg, name ~ "(0.5,  -2.5,  6.25)  = " ~ d.stringof);
+    enum f = mixin(name ~ "(0.5f, -2.5f, 6.25f)");
+    pragma(msg, name ~ "(0.5f, -2.5f, 6.25f) = " ~ f.stringof);
+}
+
+void main()
+{
+    { mixin Func1!"isNaN"; }
+    { mixin Func1!"isInfinity"; }
+    { mixin Func1!"isFinite"; }
+
+    { mixin Func1!"abs"; }
+    { mixin Func1!"fabs"; }
+    { mixin Func1!"sqrt"; }
+
+    { mixin Func1!"sin"; }
+    { mixin Func1!"cos"; }
+    { mixin Func1!"tan"; }
+    { mixin Func1!"cosh"; }
+    { mixin Func1!"asinh"; }
+    { mixin Func1!"acosh"; }
+    { mixin Func1!"atanh"; }
+
+    { mixin Func1!"ceil"; }
+    { mixin Func1!"floor"; }
+    { mixin Func1!"round"; }
+    { mixin Func1!"trunc"; }
+    { mixin Func1!"rint"; }
+    { mixin Func1!"nearbyint"; }
+
+    { mixin Func1!"exp"; }
+    { mixin Func1!"exp2"; }
+    { mixin Func2_int!"ldexp"; }
+    { mixin Func1!"log"; }
+    { mixin Func1!"log2"; }
+    { mixin Func1!"log10"; }
+
+    { mixin Func2!"pow"; }
+    { mixin Func2_int!"pow"; }
+
+    { mixin Func2!"fmin"; }
+    { mixin Func2!"fmax"; }
+    { mixin Func2!"copysign"; }
+
+    { mixin Func3!"fma"; }
+
+    static assert(2.0 ^^ 8 == 256.0);
+}


### PR DESCRIPTION
E.g., all LLVM intrinsics currently used in `{core,std}.math`.