### PR TITLE
Add the -fsanitize-blacklist option for the sanitizers.

### DIFF
--- a/driver/cl_options_sanitizers.cpp
+++ b/driver/cl_options_sanitizers.cpp
@@ -35,6 +35,8 @@ cl::list<std::string> fSanitizeBlacklist(
     cl::desc("Add <file> to the blacklist files for the sanitizers."),
     cl::value_desc("file"));
 
+std::unique_ptr<llvm::SpecialCaseList> sanitizerBlacklist;
+
 #ifdef ENABLE_COVERAGE_SANITIZER
 cl::list<std::string> fSanitizeCoverage(
     "fsanitize-coverage", cl::CommaSeparated,
@@ -131,7 +133,6 @@ void parseFSanitizeCoverageCmdlineParameter(llvm::SanitizerCoverageOptions &opts
 namespace opts {
 
 SanitizerBits enabledSanitizers = 0;
-std::unique_ptr<llvm::SpecialCaseList> sanitizerBlacklist;
 
 void initializeSanitizerOptionsFromCmdline()
 {

--- a/driver/cl_options_sanitizers.cpp
+++ b/driver/cl_options_sanitizers.cpp
@@ -158,12 +158,11 @@ void initializeSanitizerOptionsFromCmdline()
 #endif
 
   if (isAnySanitizerEnabled() && !fSanitizeBlacklist.empty()) {
-    std::string blacklistLoadError;
+    std::string loadError;
     sanitizerBlacklist =
-        llvm::SpecialCaseList::create(fSanitizeBlacklist, blacklistLoadError);
+        llvm::SpecialCaseList::create(fSanitizeBlacklist, loadError);
     if (!sanitizerBlacklist)
-      error(Loc(), "-fsanitize-blacklist error: %s",
-            blacklistLoadError.c_str());
+      error(Loc(), "-fsanitize-blacklist error: %s", loadError.c_str());
   }
 }
 

--- a/driver/cl_options_sanitizers.cpp
+++ b/driver/cl_options_sanitizers.cpp
@@ -15,6 +15,7 @@
 #include "driver/cl_options_sanitizers.h"
 
 #include "ddmd/errors.h"
+#include "ddmd/dsymbol.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SpecialCaseList.h"
@@ -195,8 +196,9 @@ void outputSanitizerSettings(llvm::raw_ostream &hash_os) {
 #endif
 }
 
-bool functionIsInSanitizerBlacklist(llvm::StringRef funcName) {
-  return sanitizerBlacklist && sanitizerBlacklist->inSection("fun", funcName);
+bool functionIsInSanitizerBlacklist(FuncDeclaration &funcDecl) {
+  return sanitizerBlacklist &&
+         sanitizerBlacklist->inSection("fun", mangleExact(&funcDecl));
 }
 
 } // namespace opts

--- a/driver/cl_options_sanitizers.cpp
+++ b/driver/cl_options_sanitizers.cpp
@@ -196,9 +196,9 @@ void outputSanitizerSettings(llvm::raw_ostream &hash_os) {
 #endif
 }
 
-bool functionIsInSanitizerBlacklist(FuncDeclaration &funcDecl) {
+bool functionIsInSanitizerBlacklist(FuncDeclaration *funcDecl) {
   return sanitizerBlacklist &&
-         sanitizerBlacklist->inSection("fun", mangleExact(&funcDecl));
+         sanitizerBlacklist->inSection("fun", mangleExact(funcDecl));
 }
 
 } // namespace opts

--- a/driver/cl_options_sanitizers.h
+++ b/driver/cl_options_sanitizers.h
@@ -23,9 +23,9 @@
 #define ENABLE_COVERAGE_SANITIZER
 #endif
 
+class FuncDeclaration;
 namespace llvm {
 class raw_ostream;
-class StringRef;
 }
 
 namespace opts {
@@ -55,7 +55,7 @@ llvm::SanitizerCoverageOptions getSanitizerCoverageOptions();
 
 void outputSanitizerSettings(llvm::raw_ostream &hash_os);
 
-bool functionIsInSanitizerBlacklist(llvm::StringRef funcName);
+bool functionIsInSanitizerBlacklist(FuncDeclaration &funcDecl);
 
 } // namespace opts
 

--- a/driver/cl_options_sanitizers.h
+++ b/driver/cl_options_sanitizers.h
@@ -55,7 +55,7 @@ llvm::SanitizerCoverageOptions getSanitizerCoverageOptions();
 
 void outputSanitizerSettings(llvm::raw_ostream &hash_os);
 
-bool functionIsInSanitizerBlacklist(FuncDeclaration &funcDecl);
+bool functionIsInSanitizerBlacklist(FuncDeclaration *funcDecl);
 
 } // namespace opts
 

--- a/driver/cl_options_sanitizers.h
+++ b/driver/cl_options_sanitizers.h
@@ -25,6 +25,7 @@
 
 namespace llvm {
 class raw_ostream;
+class StringRef;
 }
 
 namespace opts {
@@ -53,6 +54,8 @@ llvm::SanitizerCoverageOptions getSanitizerCoverageOptions();
 #endif
 
 void outputSanitizerSettings(llvm::raw_ostream &hash_os);
+
+bool functionIsInSanitizerBlacklist(llvm::StringRef funcName);
 
 } // namespace opts
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -955,7 +955,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     func->addFnAttr(LLAttribute::UWTable);
   }
   if (opts::isAnySanitizerEnabled() &&
-      !opts::functionIsInSanitizerBlacklist(func->getName())) {
+      !opts::functionIsInSanitizerBlacklist(*fd)) {
     // Set the required sanitizer attribute.
     if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
       func->addFnAttr(LLAttribute::SanitizeAddress);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -955,7 +955,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     func->addFnAttr(LLAttribute::UWTable);
   }
   if (opts::isAnySanitizerEnabled() &&
-      !opts::functionIsInSanitizerBlacklist(*fd)) {
+      !opts::functionIsInSanitizerBlacklist(fd)) {
     // Set the required sanitizer attribute.
     if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
       func->addFnAttr(LLAttribute::SanitizeAddress);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -954,7 +954,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   if (gABI->needsUnwindTables()) {
     func->addFnAttr(LLAttribute::UWTable);
   }
-  if (opts::isAnySanitizerEnabled()) {
+  if (opts::isAnySanitizerEnabled() &&
+      !opts::functionIsInSanitizerBlacklist(func->getName())) {
     // Set the required sanitizer attribute.
     if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
       func->addFnAttr(LLAttribute::SanitizeAddress);

--- a/tests/sanitizers/fsanitize_blacklist.d
+++ b/tests/sanitizers/fsanitize_blacklist.d
@@ -1,0 +1,63 @@
+// Test sanitizer blacklist functionality
+
+// RUN: %ldc -c -output-ll -fsanitize=address \
+// RUN: -fsanitize-blacklist=%S/inputs/fsanitize_blacklist.txt \
+// RUN: -fsanitize-blacklist=%S/inputs/fsanitize_blacklist2.txt \
+// RUN: -of=%t.ll %s && FileCheck %s < %t.ll
+
+// Don't attempt to load the blacklist when no sanitizer is active
+// RUN: %ldc -o- -fsanitize-blacklist=%S/thisfilecertainlydoesnotexist %s
+
+// CHECK-LABEL: define {{.*}}9foofoofoo
+// CHECK-SAME: #[[ATTR_WITHASAN:[0-9]+]]
+void foofoofoo(int* i)
+{
+    // CHECK: call {{.*}}_asan
+    *i = 1;
+}
+
+// CHECK-LABEL: define {{.*}}blacklisted
+// CHECK-SAME: #[[ATTR_NOASAN:[0-9]+]]
+extern (C) void blacklisted(int* i)
+{
+    // CHECK-NOT: call {{.*}}_asan
+    *i = 1;
+}
+
+// Test blacklisted wildcard
+// CHECK-LABEL: define {{.*}}10black_set1
+// CHECK-SAME: #[[ATTR_NOASAN:[0-9]+]]
+void black_set1(int* i)
+{
+    // CHECK-NOT: call {{.*}}_asan
+    *i = 1;
+}
+// CHECK-LABEL: define {{.*}}10black_set2
+// CHECK-SAME: #[[ATTR_NOASAN:[0-9]+]]
+void black_set2(int* i)
+{
+    // CHECK-NOT: call {{.*}}_asan
+    *i = 1;
+}
+
+//  Test blacklisting of template class methods
+class ABCDEF(T)
+{
+    void method(int* i)
+    {
+        *i = 1;
+    }
+}
+
+// CHECK-LABEL: define {{.*}}TiZ6ABCDEF6method
+// CHECK-SAME: #[[ATTR_NOASAN:[0-9]+]]
+ABCDEF!int ofBlacklistedType;
+
+// CHECK-LABEL: define {{.*}}TAyaZ6ABCDEF6method
+// CHECK-SAME: #[[ATTR_WITHASAN:[0-9]+]]
+ABCDEF!string ofInstrumentedType;
+
+//CHECK: attributes #[[ATTR_WITHASAN]] ={{.*}}sanitize_address
+//CHECK: attributes #[[ATTR_NOASAN]]
+//CHECK-NOT: sanitize_address
+//CHECK-SAME: }

--- a/tests/sanitizers/inputs/fsanitize_blacklist.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist.txt
@@ -12,4 +12,4 @@
 fun:blacklisted
 fun:*black_set*
 
-fun:_D*TiZ6ABCDEF6method*
+fun:*TiZ6ABCDEF6method*

--- a/tests/sanitizers/inputs/fsanitize_blacklist.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist.txt
@@ -1,0 +1,15 @@
+# Blacklist for the sanitizers. Turns off instrumentation of particular
+# functions or sources. Use with care. You may set location of blacklist
+# at compile-time using -fsanitize-blacklist=<path> flag.
+
+# Example usage:
+# fun:*bad_function_name*
+# src:file_with_tricky_code.cc
+# global:*global_with_bad_access_or_initialization*
+# global:*global_with_initialization_issues*=init
+# type:*Namespace::ClassName*=init
+
+fun:blacklisted
+fun:*black_set*
+
+fun:_D*TiZ6ABCDEF6method*

--- a/tests/sanitizers/inputs/fsanitize_blacklist.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist.txt
@@ -11,5 +11,3 @@
 
 fun:blacklisted
 fun:*black_set*
-
-fun:*TiZ6ABCDEF6method*

--- a/tests/sanitizers/inputs/fsanitize_blacklist2.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist2.txt
@@ -1,1 +1,1 @@
-fun:*TiZ6ABCDEF6method*
+fun:_D*TiZ6ABCDEF6method*

--- a/tests/sanitizers/inputs/fsanitize_blacklist2.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist2.txt
@@ -1,1 +1,1 @@
-fun:_D*TiZ6ABCDEF6method*
+fun:*TiZ6ABCDEF6method*

--- a/tests/sanitizers/inputs/fsanitize_blacklist2.txt
+++ b/tests/sanitizers/inputs/fsanitize_blacklist2.txt
@@ -1,0 +1,1 @@
+fun:_D*TiZ6ABCDEF6method*


### PR DESCRIPTION
Having fun with ASan :)
Blacklisting is necessary for some druntime functions, and LLVM/Clang already provides just the right functionality.

Will add the actual needed blacklist in a later PR.