### PR TITLE
Don't use -m32/-m64 for external ARM assembler

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -102,45 +102,7 @@ static void assemble(const std::string &asmpath, const std::string &objpath) {
   args.push_back("-o");
   args.push_back(objpath);
 
-  // Only specify -m32/-m64 for architectures where the two variants actually
-  // exist (as e.g. the GCC ARM toolchain doesn't recognize the switches).
-  // MIPS does not have -m32/-m64 but requires -mabi=.
-  if (global.params.targetTriple->get64BitArchVariant().getArch() !=
-          llvm::Triple::UnknownArch &&
-      global.params.targetTriple->get32BitArchVariant().getArch() !=
-          llvm::Triple::UnknownArch) {
-    if (global.params.targetTriple->get64BitArchVariant().getArch() ==
-            llvm::Triple::mips64 ||
-        global.params.targetTriple->get64BitArchVariant().getArch() ==
-            llvm::Triple::mips64el) {
-      switch (getMipsABI()) {
-      case MipsABI::EABI:
-        args.push_back("-mabi=eabi");
-        args.push_back("-march=mips32r2");
-        break;
-      case MipsABI::O32:
-        args.push_back("-mabi=32");
-        args.push_back("-march=mips32r2");
-        break;
-      case MipsABI::N32:
-        args.push_back("-mabi=n32");
-        args.push_back("-march=mips64r2");
-        break;
-      case MipsABI::N64:
-        args.push_back("-mabi=64");
-        args.push_back("-march=mips64r2");
-        break;
-      case MipsABI::Unknown:
-        break;
-      }
-    } else {
-      if (global.params.is64bit) {
-        args.push_back("-m64");
-      } else {
-        args.push_back("-m32");
-      }
-    }
-  }
+  appendTargetArgsForGcc(args);
 
   // Run the compiler to assembly the program.
   int R = executeToolAndWait(getGcc(), args, global.params.verbose);

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -74,22 +74,21 @@ std::string getGcc() {
 ////////////////////////////////////////////////////////////////////////////////
 
 void appendTargetArgsForGcc(std::vector<std::string> &args) {
+  using llvm::Triple;
+
+  const auto &triple = *global.params.targetTriple;
+  const auto arch64 = triple.get64BitArchVariant().getArch();
+  const auto arch32 = triple.get32BitArchVariant().getArch();
+
   // Only specify -m32/-m64 for architectures where the two variants actually
   // exist (as e.g. the GCC ARM toolchain doesn't recognize the switches).
-  const auto archVariant64 =
-      global.params.targetTriple->get64BitArchVariant().getArch();
-  const auto archVariant32 =
-      global.params.targetTriple->get32BitArchVariant().getArch();
-  if (archVariant64 == llvm::Triple::UnknownArch ||
-      archVariant32 == llvm::Triple::UnknownArch ||
-      archVariant64 == llvm::Triple::aarch64 ||
-      archVariant64 == llvm::Triple::aarch64_be) {
+  if (arch64 == Triple::UnknownArch || arch32 == Triple::UnknownArch ||
+      arch64 == Triple::aarch64 || arch64 == Triple::aarch64_be) {
     return;
   }
 
   // MIPS does not have -m32/-m64 but requires -mabi=.
-  if (archVariant64 == llvm::Triple::mips64 ||
-      archVariant64 == llvm::Triple::mips64el) {
+  if (arch64 == Triple::mips64 || arch64 == Triple::mips64el) {
     switch (getMipsABI()) {
     case MipsABI::EABI:
       args.push_back("-mabi=eabi");
@@ -110,11 +109,11 @@ void appendTargetArgsForGcc(std::vector<std::string> &args) {
     case MipsABI::Unknown:
       break;
     }
-  } else if (global.params.is64bit) {
-    args.push_back("-m64");
-  } else {
-    args.push_back("-m32");
+
+    return;
   }
+
+  args.push_back(triple.isArch64Bit() ? "-m64" : "-m32");
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -10,6 +10,7 @@
 #include "driver/tool.h"
 #include "mars.h"
 #include "driver/exe_path.h"
+#include "driver/targetmachine.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -68,6 +69,52 @@ std::string getGcc() {
 #else
   return getProgram("gcc", &gcc, "CC");
 #endif
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void appendTargetArgsForGcc(std::vector<std::string> &args) {
+  // Only specify -m32/-m64 for architectures where the two variants actually
+  // exist (as e.g. the GCC ARM toolchain doesn't recognize the switches).
+  const auto archVariant64 =
+      global.params.targetTriple->get64BitArchVariant().getArch();
+  const auto archVariant32 =
+      global.params.targetTriple->get32BitArchVariant().getArch();
+  if (archVariant64 == llvm::Triple::UnknownArch ||
+      archVariant32 == llvm::Triple::UnknownArch ||
+      archVariant64 == llvm::Triple::aarch64 ||
+      archVariant64 == llvm::Triple::aarch64_be) {
+    return;
+  }
+
+  // MIPS does not have -m32/-m64 but requires -mabi=.
+  if (archVariant64 == llvm::Triple::mips64 ||
+      archVariant64 == llvm::Triple::mips64el) {
+    switch (getMipsABI()) {
+    case MipsABI::EABI:
+      args.push_back("-mabi=eabi");
+      args.push_back("-march=mips32r2");
+      break;
+    case MipsABI::O32:
+      args.push_back("-mabi=32");
+      args.push_back("-march=mips32r2");
+      break;
+    case MipsABI::N32:
+      args.push_back("-mabi=n32");
+      args.push_back("-march=mips64r2");
+      break;
+    case MipsABI::N64:
+      args.push_back("-mabi=64");
+      args.push_back("-march=mips64r2");
+      break;
+    case MipsABI::Unknown:
+      break;
+    }
+  } else if (global.params.is64bit) {
+    args.push_back("-m64");
+  } else {
+    args.push_back("-m32");
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/driver/tool.h
+++ b/driver/tool.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/CommandLine.h"
 
 std::string getGcc();
+void appendTargetArgsForGcc(std::vector<std::string> &args);
 
 std::string getProgram(const char *name,
                        const llvm::cl::opt<std::string> *opt = nullptr,

--- a/tests/compilable/no-integrated-as.d
+++ b/tests/compilable/no-integrated-as.d
@@ -1,0 +1,12 @@
+// RUN: %ldc -no-integrated-as %s
+
+// We currently rely on gcc/clang; no MSVC toolchain support yet.
+// UNSUPPORTED: Windows
+
+module noIntegratedAs;
+
+void main()
+{
+    import std.stdio;
+    writeln("This object is assembled externally and linked to an executable.");
+}


### PR DESCRIPTION
And merge the two out-of-sync copies for adding gcc target flags. The flag was omitted for gcc as linker already, but not for gcc as external assembler.