### PR TITLE
Replace hacky disabling of fp-elimination for functions with inline asm

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -997,14 +997,21 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
 
   emitInstrumentationFnEnter(fd);
 
-  // this hack makes sure the frame pointer elimination optimization is
-  // disabled.
-  // this this eliminates a bunch of inline asm related issues.
+  // disable frame-pointer-elimination for functions with inline asm
   if (fd->hasReturnExp & 8) // has inline asm
   {
-    // emit a call to llvm_eh_unwind_init
+#if LDC_LLVM_VER >= 309
+    func->addAttribute(
+        LLAttributeSet::FunctionIndex,
+        llvm::Attribute::get(gIR->context(), "no-frame-pointer-elim", "true"));
+    func->addAttribute(
+        LLAttributeSet::FunctionIndex,
+        llvm::Attribute::get(gIR->context(), "no-frame-pointer-elim-non-leaf"));
+#else
+    // hack: emit a call to llvm_eh_unwind_init
     LLFunction *hack = GET_INTRINSIC_DECL(eh_unwind_init);
     gIR->ir->CreateCall(hack, {});
+#endif
   }
 
   // give the 'this' parameter (an lvalue) storage and debug info


### PR DESCRIPTION
... by proper function attributes. Clang sets these 2 attributes if frame pointer elimination is to be fully disabled (see [here](https://github.com/llvm-mirror/clang/blob/b3d4dafef1d8deb0e748cc9625ff86c38735ca0d/lib/CodeGen/CGCall.cpp#L1706-L1707)).

[I only came across this by accident.]