### PR TITLE
[2.075] Be more forgiving wrt. multiple function declarations/definitions

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -533,11 +533,10 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
     func = LLFunction::Create(functype, llvm::GlobalValue::ExternalLinkage,
                               mangledName, &gIR->module);
   } else if (func->getFunctionType() != functype) {
-    error(fdecl->loc,
-          "Function type does not match previously declared "
-          "function with the same mangled name: `%s`",
-          mangleExact(fdecl));
-    fatal();
+    warning(fdecl->loc,
+            "type of function `%s` does not match previously declared "
+            "function with the same mangled name: %s",
+            fdecl->toPrettyChars(), mangleExact(fdecl));
   }
 
   func->setCallingConv(gABI->callingConv(func->getFunctionType(), link, fdecl));
@@ -915,7 +914,16 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     return;
   }
 
-  IrFunction *irFunc = getIrFunc(fd);
+  IrFunction *const irFunc = getIrFunc(fd);
+  llvm::Function *const func = irFunc->getLLVMFunc();
+
+  if (!func->empty()) {
+    warning(fd->loc,
+            "skipping definition of function `%s` due to previous definition "
+            "for the same mangled name: %s",
+            fd->toPrettyChars(), mangleExact(fd));
+    return;
+  }
 
   // debug info
   irFunc->diSubprogram = gIR->DBuilder.EmitSubProgram(fd);
@@ -934,7 +942,6 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
 
   const auto f = static_cast<TypeFunction *>(fd->type->toBasetype());
   IrFuncTy &irFty = irFunc->irFty;
-  llvm::Function *func = irFunc->getLLVMFunc();
 
   const auto lwc = lowerFuncLinkage(fd);
   if (linkageAvailableExternally) {


### PR DESCRIPTION
... sharing a common mangled name. [compilable/test17352.d](https://github.com/ldc-developers/dmd-testsuite/blob/ldc-merge-2.075/compilable/test17352.d) tests that the compiler accepts 2 identical templated function instantiations.
See https://issues.dlang.org/show_bug.cgi?id=17352.

Clashes for function *declarations* are more common, mainly wrt. multiple identically looking `extern(C++)` forward declarations in different D modules:

a.d:
```D
extern(C++) struct S {}
extern(C++) void foo(S s); // type: (a.S) => void
```

b.d:
```D
extern(C++) struct S {}
extern(C++) void foo(S s); // type: (b.S) => void
```