### PR TITLE
Lit: stop using `%T` and use `%t-dir` instead.

### DIFF
--- a/tests/codegen/attr_weak.d
+++ b/tests/codegen/attr_weak.d
@@ -1,7 +1,7 @@
 // Test linking+running a program with @weak function
 
-// RUN: %ldc -O3 %S/inputs/attr_weak_input.d -c -of=%T/attr_weak_input%obj
-// RUN: %ldc -O3 %T/attr_weak_input%obj %s -of=%t%exe
+// RUN: %ldc -O3 %S/inputs/attr_weak_input.d -c -of=%t-dir/attr_weak_input%obj
+// RUN: %ldc -O3 %t-dir/attr_weak_input%obj %s -of=%t%exe
 // RUN: %t%exe
 
 

--- a/tests/codegen/discard_value_names_ir2obj_cache.d
+++ b/tests/codegen/discard_value_names_ir2obj_cache.d
@@ -3,10 +3,10 @@
 // REQUIRES: atleast_llvm309
 
 // Create and then empty the cache for correct testing when running the test multiple times.
-// RUN: %ldc %s -c -of=%t%obj -cache=%T/dvni2oc \
-// RUN:   && %prunecache -f %T/dvni2oc --max-bytes=1 \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/dvni2oc -d-version=FIRST -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/dvni2oc -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir
+// RUN: %prunecache -f %t-dir --max-bytes=1
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -d-version=FIRST -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -vv | FileCheck --check-prefix=MUST_HIT %s
 
 // MUST_HIT: Cache object found!
 // NO_HIT-NOT: Cache object found!

--- a/tests/codegen/inferred_outputname.d
+++ b/tests/codegen/inferred_outputname.d
@@ -6,10 +6,10 @@
 // REQUIRES: Windows
 
 // 1) 2 object files compiled separately:
-// RUN: %ldc -c %S/inputs/foo.d -of=%T/foo%obj
-// RUN: %ldc %s %T/foo%obj -vv | FileCheck %s
+// RUN: %ldc -c %S/inputs/foo.d -of=%t-dir/foo%obj
+// RUN: %ldc %s %t-dir/foo%obj -vv | FileCheck %s
 // 2) singleObj build with external object file and 2 source files:
-// RUN: %ldc %T/foo%obj %s %S/inputs/attr_weak_input.d -vv | FileCheck %s
+// RUN: %ldc %t-dir/foo%obj %s %S/inputs/attr_weak_input.d -vv | FileCheck %s
 
 // CHECK: Linking with:
 // CHECK-NEXT: '/OUT:inferred_outputname.exe'

--- a/tests/linking/ir2obj_cache_pruning.d
+++ b/tests/linking/ir2obj_cache_pruning.d
@@ -1,12 +1,12 @@
 // Test recognition of -cache-prune-* commandline flags
 
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune-interval=10 -cache-prune-maxbytes=10000
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune -cache-prune-interval=0
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune -cache-prune-maxbytes=10000
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune -cache-prune-expiration=10000
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune-maxpercentage=50
-// RUN: %ldc %s -cache=%T/prunecache1 -cache-prune -cache-prune-maxpercentage=150
+// RUN: %ldc %s -cache=%t-dir -cache-prune
+// RUN: %ldc %s -cache=%t-dir -cache-prune-interval=10 -cache-prune-maxbytes=10000
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-maxbytes=10000
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-expiration=10000
+// RUN: %ldc %s -cache=%t-dir -cache-prune-maxpercentage=50
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-maxpercentage=150
 
 void main()
 {

--- a/tests/linking/ir2obj_cache_pruning2.d
+++ b/tests/linking/ir2obj_cache_pruning2.d
@@ -3,18 +3,18 @@
 // This test assumes that the `void main(){}` object file size is below 200_000 bytes and above 200_000/2,
 // such that rebuilding with version(NEW_OBJ_FILE) will clear the cache of all but the latest object file.
 
-// RUN: %ldc %s -cache=%T/prunecache2 \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune -cache-prune-interval=0 -d-version=SLEEP \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune -cache-prune-interval=0 -vv -d-version=NEW_OBJ_FILE | FileCheck --check-prefix=NO_HIT %s \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %ldc %s -c -of=%t%obj -cache=%T/prunecache2 -cache-prune-interval=0 -cache-prune-maxbytes=200000 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %t%obj \
-// RUN: && %ldc %s -cache=%T/prunecache2 -d-version=SLEEP -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune-interval=1 -cache-prune-maxbytes=200000 -d-version=NEW_OBJ_FILE \
-// RUN: && %ldc %s -cache=%T/prunecache2 -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -cache=%t-dir
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0 -d-version=SLEEP
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0 -vv -d-version=NEW_OBJ_FILE | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -cache-prune-interval=0 -cache-prune-maxbytes=200000 -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %t%obj
+// RUN: %ldc %s -cache=%t-dir -d-version=SLEEP -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %ldc %s -cache=%t-dir -cache-prune-interval=1 -cache-prune-maxbytes=200000 -d-version=NEW_OBJ_FILE
+// RUN: %ldc %s -cache=%t-dir -cache-prune -cache-prune-interval=0 -vv | FileCheck --check-prefix=NO_HIT %s
 
 // MUST_HIT: Cache object found!
 // NO_HIT-NOT: Cache object found!

--- a/tests/linking/ir2obj_caching.d
+++ b/tests/linking/ir2obj_caching.d
@@ -1,13 +1,13 @@
 // Test recognition of -cache commandline flag
 
-// RUN: %ldc -cache=%T/cachedirectory %s -vv | FileCheck --check-prefix=FIRST %s \
-// RUN: && %ldc -cache=%T/cachedirectory %s -vv | FileCheck --check-prefix=SECOND %s
+// RUN: %ldc -cache=%t-dir %s -vv | FileCheck --check-prefix=FIRST  %s
+// RUN: %ldc -cache=%t-dir %s -vv | FileCheck --check-prefix=SECOND %s
 
 
-// FIRST: Use IR-to-Object cache in {{.*}}cachedirectory
+// FIRST: Use IR-to-Object cache in {{.*}}-dir
 // Don't check whether the object is in the cache on the first run, because if this test is ran twice the cache will already be there.
 
-// SECOND: Use IR-to-Object cache in {{.*}}cachedirectory
+// SECOND: Use IR-to-Object cache in {{.*}}-dir
 // SECOND: Cache object found!
 
 void main()

--- a/tests/linking/ir2obj_caching_flags1.d
+++ b/tests/linking/ir2obj_caching_flags1.d
@@ -3,36 +3,36 @@
 // Note that the NO_HIT tests should change the default setting of the tested flag.
 
 // Create and then empty the cache for correct testing when running the test multiple times.
-// RUN: %ldc %s -c -of=%t%obj -cache=%T/flag1cache \
-// RUN:   && %prunecache -f %T/flag1cache --max-bytes=1 \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -g                               -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache                                  -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -O                               -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -O3                              -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -O2                              -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -O4                              -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc -O5 %s -c -of=%t%obj -cache=%T/flag1cache                              -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -Os                              -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -Oz                              -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-d-passes                -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-simplify-drtcalls       -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-simplify-libcalls       -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-gc2stack                -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -enable-inlining                 -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -unit-at-a-time=false            -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -strip-debug                     -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-loop-unrolling          -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-loop-vectorization      -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -disable-slp-vectorization       -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -vectorize-loops                 -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -v -wi -d                        -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -D -H -I. -J.                    -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -d-version=Irrelevant            -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -unittest                        -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s               -cache=%T/flag1cache -lib                             -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc                  -cache=%T/flag1cache -vv -run %s                          | FileCheck --check-prefix=COULD_HIT %s \
-// RUN:   && %ldc                  -cache=%T/flag1cache -vv -run %s a b                      | FileCheck --check-prefix=MUST_HIT %s \
-// RUN:   && %ldc %s -c -of=%t%obj -cache=%T/flag1cache -g                               -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir
+// RUN: %prunecache -f %t-dir --max-bytes=1
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -g                               -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir                                  -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -O                               -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -O3                              -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -O2                              -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -O4                              -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc -O5 %s -c -of=%t%obj -cache=%t-dir                              -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -Os                              -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -Oz                              -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-d-passes                -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-simplify-drtcalls       -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-simplify-libcalls       -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-gc2stack                -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -enable-inlining                 -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -unit-at-a-time=false            -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -strip-debug                     -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-loop-unrolling          -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-loop-vectorization      -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-slp-vectorization       -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -vectorize-loops                 -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -v -wi -d                        -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -D -H -I. -J.                    -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -d-version=Irrelevant            -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -unittest                        -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s               -cache=%t-dir -lib                             -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc                  -cache=%t-dir -vv -run %s                          | FileCheck --check-prefix=COULD_HIT %s
+// RUN: %ldc                  -cache=%t-dir -vv -run %s a b                      | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -g                               -vv | FileCheck --check-prefix=MUST_HIT %s
 // The last test is a MUST_HIT test (hits with the first compile invocation), to make sure that the cache wasn't pruned somehow which could effectively disable some NO_HIT tests.
 
 // MUST_HIT: Cache object found!

--- a/tests/linking/ir2obj_caching_retrieval.d
+++ b/tests/linking/ir2obj_caching_retrieval.d
@@ -1,17 +1,17 @@
 // Test recognition of -cache-retrieval commandline flag
 
-// RUN: %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -vv | FileCheck --check-prefix=FIRST %s \
-// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=copy -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %t%obj \
-// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=link -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %t%obj \
-// RUN: && %ldc -c -of=%t%obj -cache=%T/cachedirectory %s -cache-retrieval=hardlink -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %t%obj
+// RUN: %ldc -c -of=%t%obj -cache=%t-dir %s -vv | FileCheck --check-prefix=FIRST %s
+// RUN: %ldc -c -of=%t%obj -cache=%t-dir %s -cache-retrieval=copy -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %t%obj
+// RUN: %ldc -c -of=%t%obj -cache=%t-dir %s -cache-retrieval=link -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %t%obj
+// RUN: %ldc -c -of=%t%obj -cache=%t-dir %s -cache-retrieval=hardlink -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %t%obj
 
-// FIRST: Use IR-to-Object cache in {{.*}}cachedirectory
+// FIRST: Use IR-to-Object cache in {{.*}}-dir
 // Don't check whether the object is in the cache on the first run, because if this test is ran twice the cache will already be there.
 
-// MUST_HIT: Use IR-to-Object cache in {{.*}}cachedirectory
+// MUST_HIT: Use IR-to-Object cache in {{.*}}-dir
 // MUST_HIT: Cache object found!
 
 void main()

--- a/tests/tools/ldc_prune_cache_1.d
+++ b/tests/tools/ldc_prune_cache_1.d
@@ -3,26 +3,26 @@
 // This test assumes that the `void main(){}` object file size is below 200_000 bytes and above 200_000/2,
 // such that rebuilding with version(NEW_OBJ_FILE) will clear the cache of all but the latest object file.
 
-// RUN: %ldc %s -cache=%T/tempcache1 \
-// RUN: && %ldc %s -cache=%T/tempcache1 -d-version=SLEEP \
-// RUN: && %prunecache -f %T/tempcache1 \
-// RUN: && %ldc %s -cache=%T/tempcache1 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc %s -cache=%T/tempcache1 -vv -d-version=NEW_OBJ_FILE | FileCheck --check-prefix=NO_HIT %s \
-// RUN: && %prunecache %T/tempcache1 -f \
-// RUN: && %ldc %s -cache=%T/tempcache1 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %ldc %s -c -of=%t%obj -cache=%T/tempcache1 -vv | FileCheck --check-prefix=MUST_HIT %s \
-// RUN: && %prunecache --force --max-bytes=200000 %T/tempcache1 \
-// RUN: && %ldc %t%obj \
-// RUN: && %ldc %s -cache=%T/tempcache1 -d-version=SLEEP -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %ldc %s -cache=%T/tempcache1 -d-version=NEW_OBJ_FILE \
-// RUN: && %prunecache --interval=0 %T/tempcache1 --max-bytes=200000 \
-// RUN: && %ldc %s -cache=%T/tempcache1 -vv | FileCheck --check-prefix=NO_HIT %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %ldc -d-version=SLEEP -run %s \
-// RUN: && %prunecache %T/tempcache1 -f --expiry=2  \
-// RUN: && %ldc %s -cache=%T/tempcache1 -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -cache=%t-dir
+// RUN: %ldc %s -cache=%t-dir -d-version=SLEEP
+// RUN: %prunecache -f %t-dir
+// RUN: %ldc %s -cache=%t-dir -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc %s -cache=%t-dir -vv -d-version=NEW_OBJ_FILE | FileCheck --check-prefix=NO_HIT %s
+// RUN: %prunecache %t-dir -f
+// RUN: %ldc %s -cache=%t-dir -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -vv | FileCheck --check-prefix=MUST_HIT %s
+// RUN: %prunecache --force --max-bytes=200000 %t-dir
+// RUN: %ldc %t%obj
+// RUN: %ldc %s -cache=%t-dir -d-version=SLEEP -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %ldc %s -cache=%t-dir -d-version=NEW_OBJ_FILE
+// RUN: %prunecache --interval=0 %t-dir --max-bytes=200000
+// RUN: %ldc %s -cache=%t-dir -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %ldc -d-version=SLEEP -run %s
+// RUN: %prunecache %t-dir -f --expiry=2
+// RUN: %ldc %s -cache=%t-dir -vv | FileCheck --check-prefix=NO_HIT %s
 
 // MUST_HIT: Cache object found!
 // NO_HIT-NOT: Cache object found!


### PR DESCRIPTION
The %T substitution will be removed from Lit.
Resolves issue #2274