### PR TITLE
[MSVC] CMake: Prepare for LLVM 5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,10 @@ if(MSVC)
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-       if(${flag_var} MATCHES "/MD")
-          string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-       endif()
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        # CMake defaults to /W3, LLVM uses /W4 => MS compiler warns about cmdline mismatch.
+        # Simply replace with /W4.
+        string(REGEX REPLACE "/W[0-3]" "/W4" ${flag_var} "${${flag_var}}")
     endforeach()
 endif()
 
@@ -189,16 +190,13 @@ elseif(MSVC)
     # warning C4101: unreferenced local variable
     # warning C4102: unreferenced label
     # warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # warning C4201: nonstandard extension used: nameless struct/union
     # warnings C4244 and C4267: conversion from '...' to '...', possible loss of data
     # warnings C4456-4459: declaration of '...' hides ...
     # warning C4624: destructor was implicitly defined as deleted because a base class destructor is inaccessible or deleted
     # warning C4800: forcing value to bool 'true' or 'false' (performance warning)
     # warning C4996: we're not using Microsoft's secure stringOp_s() functions
-    append("/wd4018 /wd4101 /wd4102 /wd4146 /wd4244 /wd4267 /wd4456 /wd4457 /wd4458 /wd4459 /wd4624 /wd4800 /wd4996" LDC_CXXFLAGS)
-    if(LDC_LLVM_VER GREATER 307)
-        # Suppress noisy warning C4141 'modifier' used more than once', because of __forceinline combined with inline in LLVM headers
-        append("/wd4141" LDC_CXXFLAGS)
-    endif()
+    append("/wd4018 /wd4101 /wd4102 /wd4146 /wd4201 /wd4244 /wd4267 /wd4456 /wd4457 /wd4458 /wd4459 /wd4624 /wd4800 /wd4996" LDC_CXXFLAGS)
 endif()
 # Append -mminimal-toc for gcc 4.0.x - 4.5.x on ppc64
 if( CMAKE_COMPILER_IS_GNUCXX
@@ -232,6 +230,14 @@ if (UNIX AND NOT "${LLVM_LDFLAGS}" STREQUAL "")
 endif()
 if(MSVC)
     separate_arguments(LLVM_LDFLAGS WINDOWS_COMMAND "${LLVM_LDFLAGS}")
+    # LLVM 5.0+ requires diaguids.lib from MS Debug Interface Access SDK
+    if(NOT (LDC_LLVM_VER LESS 500))
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            list(APPEND LLVM_LDFLAGS "$ENV{VSINSTALLDIR}DIA SDK\\lib\\amd64\\diaguids.lib")
+        else()
+            list(APPEND LLVM_LDFLAGS "$ENV{VSINSTALLDIR}DIA SDK\\lib\\diaguids.lib")
+        endif()
+    endif()
 else()
     separate_arguments(LLVM_LDFLAGS UNIX_COMMAND "${LLVM_LDFLAGS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,48 +608,47 @@ else()
     set(LDC_TRANSLATED_LINKER_FLAGS "")
     foreach(f ${LDC_LINKERFLAG_LIST})
         string(REPLACE "-LIBPATH:" "/LIBPATH:" f ${f})
-        append("\"-L${f}\"" LDC_TRANSLATED_LINKER_FLAGS)
+        list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L${f}")
     endforeach()
 
     if(MSVC)
         # Issue 1297 – set LDC's stack to 8 MiB like on Linux and Mac (default: 1 MiB).
-        append("-L/STACK:8388608" LDC_TRANSLATED_LINKER_FLAGS)
+        list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L/STACK:8388608")
     endif()
 endif()
 
 function(build_d_executable output_exe compiler_args linker_args compile_deps link_deps)
+    # Compile all D modules to a single object.
+    set(object_file ${output_exe}${CMAKE_CXX_OUTPUT_EXTENSION})
+    set(dflags "${D_COMPILER_FLAGS} ${DDMD_DFLAGS}")
+    if(UNIX)
+      separate_arguments(dflags UNIX_COMMAND "${dflags}")
+    else()
+      separate_arguments(dflags WINDOWS_COMMAND "${dflags}")
+    endif()
+    add_custom_command(
+        OUTPUT ${object_file}
+        COMMAND ${D_COMPILER} -c ${dflags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${object_file} ${compiler_args}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        DEPENDS ${compile_deps}
+    )
+    # Link to an executable.
     if(LDC_LINK_MANUALLY)
-        set(object_file ${output_exe}${CMAKE_CXX_OUTPUT_EXTENSION})
-        separate_arguments(dmd_flags UNIX_COMMAND "${D_COMPILER_FLAGS} ${DDMD_DFLAGS}")
-        add_custom_command(
-            OUTPUT ${object_file}
-            COMMAND ${D_COMPILER} -c ${dmd_flags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${object_file} ${compiler_args}
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            DEPENDS ${compile_deps}
-        )
         add_custom_command(
             OUTPUT ${output_exe}
             COMMAND ${CMAKE_CXX_COMPILER} -o ${output_exe} ${object_file} ${linker_args} ${LDC_LINKERFLAG_LIST}
             DEPENDS ${object_file} ${link_deps}
         )
     else()
-        set(dflags "${D_COMPILER_FLAGS} ${DDMD_DFLAGS} ${DDMD_LFLAGS}")
-        set(lflags ${LDC_TRANSLATED_LINKER_FLAGS})
-        if(UNIX)
-          separate_arguments(dflags UNIX_COMMAND "${dflags}")
-          separate_arguments(lflags UNIX_COMMAND "${lflags}")
-        else()
-          separate_arguments(dflags WINDOWS_COMMAND "${dflags}")
-          separate_arguments(lflags WINDOWS_COMMAND "${lflags}")
-        endif()
+        set(translated_linker_flags "")
         foreach(f ${linker_args})
-            append("\"-L${f}\"" lflags)
+            list(APPEND translated_linker_flags "-L${f}")
         endforeach()
         add_custom_command(
             OUTPUT ${output_exe}
-            COMMAND ${D_COMPILER} ${dflags} ${lflags} -I${PROJECT_SOURCE_DIR}/${DDMDFE_PATH} -of${output_exe} ${compiler_args} ${linker_args}
+            COMMAND ${D_COMPILER} ${dflags} ${DDMD_LFLAGS} -of${output_exe} ${object_file} ${translated_linker_flags} ${LDC_TRANSLATED_LINKER_FLAGS}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            DEPENDS ${compile_deps} ${link_deps}
+            DEPENDS ${object_file} ${link_deps}
         )
     endif()
 endfunction()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,13 @@ skip_tags: true
 #    environment configuration    #
 #---------------------------------#
 
-# Operating system (build VM template)
-os: Visual Studio 2017
-
 environment:
   matrix:
     - APPVEYOR_JOB_ARCH:   x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2017
       D_COMPILER:          ldc
     - APPVEYOR_JOB_ARCH:   x86
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       D_COMPILER:          ldc
 
 #matrix:
@@ -61,7 +60,7 @@ install:
   # Download & extract D compiler
   - ps: |
         If ($Env:D_COMPILER -eq 'dmd') {
-            $dmdVersion = '2.071.2'
+            $dmdVersion = '2.075.1'
             appveyor DownloadFile "http://downloads.dlang.org/releases/2.x/$dmdVersion/dmd.$dmdVersion.windows.7z" -FileName dmd2.7z
             7z x dmd2.7z > $null
             Set-Item -path env:DMD -value c:\projects\dmd2\windows\bin\dmd.exe
@@ -94,8 +93,8 @@ install:
   - cd ..
   # Set environment variables
   - set PATH=%CD%\ninja;%CD%\make;%PATH%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%APPVEYOR_JOB_ARCH%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %APPVEYOR_JOB_ARCH%
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%APPVEYOR_JOB_ARCH%
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %APPVEYOR_JOB_ARCH%
   # Print environment info
   - set
   - msbuild /version

--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -52,74 +52,9 @@ macro(_LLVM_FAIL _msg)
 endmacro()
 
 
-if ((WIN32 AND NOT(MINGW OR CYGWIN)) OR NOT LLVM_CONFIG)
-    if (WIN32)
-        # A bit of a sanity check:
-        if( NOT EXISTS ${LLVM_ROOT_DIR}/include/llvm )
-            message(FATAL_ERROR "LLVM_ROOT_DIR (${LLVM_ROOT_DIR}) is not a valid LLVM install")
-        endif()
-        # We incorporate the CMake features provided by LLVM:
-        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${LLVM_ROOT_DIR}/share/llvm/cmake;${LLVM_ROOT_DIR}/lib/cmake/llvm")
-        include(LLVMConfig)
-        # Set properties
-        set(LLVM_HOST_TARGET ${TARGET_TRIPLE})
-        set(LLVM_VERSION_STRING ${LLVM_PACKAGE_VERSION})
-        set(LLVM_CXXFLAGS ${LLVM_DEFINITIONS})
-        set(LLVM_LDFLAGS "")
-        list(REMOVE_ITEM LLVM_FIND_COMPONENTS "all-targets" index)
-        list(APPEND LLVM_FIND_COMPONENTS ${LLVM_TARGETS_TO_BUILD})
-        # Work around LLVM bug 21016
-        list(FIND LLVM_TARGETS_TO_BUILD "X86" TARGET_X86)
-        if(TARGET_X86 GREATER -1)
-            list(APPEND LLVM_FIND_COMPONENTS x86utils)
-        endif()
-        # Similar to the work around above, but for AArch64
-        list(FIND LLVM_TARGETS_TO_BUILD "AArch64" TARGET_AArch64)
-        if(TARGET_AArch64 GREATER -1)
-            list(APPEND LLVM_FIND_COMPONENTS AArch64Utils)
-        endif()
-        # Similar to the work around above, but for AMDGPU
-        list(FIND LLVM_TARGETS_TO_BUILD "AMDGPU" TARGET_AMDGPU)
-        if(TARGET_AMDGPU GREATER -1)
-            list(APPEND LLVM_FIND_COMPONENTS AMDGPUUtils)
-        endif()
-        if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-8][\\.0-9A-Za-z]*")
-            # Versions below 3.9 do not support components debuginfocodeview, globalisel
-            list(REMOVE_ITEM LLVM_FIND_COMPONENTS "debuginfocodeview" index)
-            list(REMOVE_ITEM LLVM_FIND_COMPONENTS "globalisel" index)
-        endif()
-        if(NOT ${LLVM_VERSION_STRING} MATCHES "^3\\.[0-7][\\.0-9A-Za-z]*")
-            # Versions beginning with 3.8 do not support component ipa
-            list(REMOVE_ITEM LLVM_FIND_COMPONENTS "ipa" index)
-        endif()
-        if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-9][\\.0-9A-Za-z]*")
-            # Versions below 4.0 do not support component debuginfomsf
-            list(REMOVE_ITEM LLVM_FIND_COMPONENTS "debuginfomsf" index)
-        endif()
-
-        llvm_map_components_to_libnames(tmplibs ${LLVM_FIND_COMPONENTS})
-        if(MSVC)
-            set(LLVM_LDFLAGS "-LIBPATH:\"${LLVM_LIBRARY_DIRS}\"")
-            foreach(lib ${tmplibs})
-                list(APPEND LLVM_LIBRARIES "${lib}.lib")
-            endforeach()
-        else()
-            # Rely on the library search path being set correctly via -L on
-            # MinGW and others, as the library list returned by
-            # llvm_map_components_to_libraries also includes imagehlp and psapi.
-            set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIRS}")
-            set(LLVM_LIBRARIES ${tmplibs})
-        endif()
-
-        # When using the CMake LLVM module, LLVM_DEFINITIONS is a list
-        # instead of a string. Later, the list seperators would entirely
-        # disappear, replace them by spaces instead. A better fix would be
-        # to switch to add_definitions() instead of throwing strings around.
-        string(REPLACE ";" " " LLVM_CXXFLAGS "${LLVM_CXXFLAGS}")
-    else()
-        if (NOT LLVM_FIND_QUIETLY)
-            message(WARNING "Could not find llvm-config (LLVM >= ${LLVM_FIND_VERSION}). Try manually setting LLVM_CONFIG to the llvm-config executable of the installation to use.")
-        endif()
+if(NOT LLVM_CONFIG)
+    if(NOT LLVM_FIND_QUIETLY)
+        message(WARNING "Could not find llvm-config (LLVM >= ${LLVM_FIND_VERSION}). Try manually setting LLVM_CONFIG to the llvm-config executable of the installation to use.")
     endif()
 else()
     macro(llvm_set var flag)

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -292,7 +292,7 @@ bool setupMsvcEnvironmentImpl() {
    * be parsed properly.
    */
 
-  auto comspecEnv = getenv("ComSpec");
+  const char *comspecEnv = getenv("ComSpec");
   if (!comspecEnv) {
     warning(Loc(),
             "'ComSpec' environment variable is not set, assuming 'cmd.exe'.");

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -300,8 +300,10 @@ if("${TARGET_SYSTEM}" MATCHES "MSVC")
     # We want to be able to link against all 4 C runtime variants (libcmt[d] / msvcrt[d]).
     string(REGEX REPLACE "(^| )[/-]M[TD]d?( |$)" "\\2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
     append("/MT /Zl" CMAKE_C_FLAGS_RELEASE)
+    # warning C4131: uses old-style declarator
+    # warning C4206: nonstandard extension used: translation unit is empty
     # warning C4996: zlib uses 'deprecated' POSIX names
-    append("/wd4996" CMAKE_C_FLAGS_RELEASE)
+    append("/wd4131 /wd4206 /wd4996" CMAKE_C_FLAGS_RELEASE)
 endif()
 # 2) Set all other CMAKE_C_FLAGS variants to CMAKE_C_FLAGS_RELEASE
 set(variables


### PR DESCRIPTION
Some LLVM libs were missing from the linker flags for current LLVM 5.0. It was only during troubleshooting that I noticed the MSVC special case in `FindLLVM.cmake`. Getting rid of it entirely made the issues disappear. I checked `llvm-config.exe`, and it's returning appropriate switches for the MS toolchain, no need for special processing.

This apparently also leads to `LLVM_CXXFLAGS` being used for the first time when building with MSVC. These include `/W4`, a level further up from CMake's default `/W3`, so I disabled a few more frequent warnings.

I also had to link in a lib from Microsoft's Debug Info Access SDK manually. As the VS command prompt unfortunately doesn't even include the DIA SDK dir in the `LIBPATH` environment variable, I even had to specify a full path, relying on the `VSINSTALLDIR` environment variable.