### PR TITLE
Add `post-switches` to config file sections

### DIFF
--- a/driver/configfile.cpp
+++ b/driver/configfile.cpp
@@ -203,6 +203,17 @@ bool ConfigFile::read(const char *explicitConfFile, const char *section) {
 }
 
 void ConfigFile::extendCommandLine(llvm::SmallVectorImpl<const char *> &args) {
-  // insert switches from config file before all explicit ones
+  // insert 'switches' before all user switches
   args.insert(args.begin() + 1, switches.begin(), switches.end());
+
+  // append 'post-switches', but before a first potential '-run'
+  size_t runIndex = 0;
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (strcmp(args[i], "-run") == 0 || strcmp(args[i], "--run") == 0) {
+      runIndex = i;
+      break;
+    }
+  }
+  args.insert(runIndex == 0 ? args.end() : args.begin() + runIndex,
+              postSwitches.begin(), postSwitches.end());
 }

--- a/driver/configfile.cpp
+++ b/driver/configfile.cpp
@@ -201,3 +201,8 @@ bool ConfigFile::read(const char *explicitConfFile, const char *section) {
 
   return readConfig(pathcstr, section, binpath.c_str());
 }
+
+void ConfigFile::extendCommandLine(llvm::SmallVectorImpl<const char *> &args) {
+  // insert switches from config file before all explicit ones
+  args.insert(args.begin() + 1, switches.begin(), switches.end());
+}

--- a/driver/configfile.d
+++ b/driver/configfile.d
@@ -30,16 +30,13 @@ string prepareBinDir(const(char)* binDir)
 }
 
 
-ArraySetting findSwitches(Setting s)
+ArraySetting findArraySetting(GroupSetting section, string name)
 {
-    auto grp = cast(GroupSetting)s;
-    if (!grp) return null;
-    foreach (c; grp.children)
+    if (!section) return null;
+    foreach (c; section.children)
     {
-        if (c.name == "switches")
-        {
-            return cast(ArraySetting)c;
-        }
+        if (c.type == Setting.Type.array && c.name == name)
+            return cast(ArraySetting) c;
     }
     return null;
 }
@@ -97,59 +94,70 @@ private:
 
     const(char)* pathcstr;
     Array!(const(char)*) switches;
+    Array!(const(char)*) postSwitches;
 
-    bool readConfig(const(char)* cfPath, const(char)* section, const(char)* binDir)
+    bool readConfig(const(char)* cfPath, const(char)* sectionName, const(char)* binDir)
     {
         switches.setDim(0);
+        postSwitches.setDim(0);
 
         immutable dBinDir = prepareBinDir(binDir);
-        const dSec = section[0 .. strlen(section)];
+        const dSec = sectionName[0 .. strlen(sectionName)];
 
         try
         {
-            auto settingSections = parseConfigFile(cfPath);
-
-            bool sectionFound;
-            ArraySetting secSwitches;
-            ArraySetting defSwitches;
-
-            foreach (s; settingSections)
+            GroupSetting section, defaultSection;
+            foreach (s; parseConfigFile(cfPath))
             {
+                if (s.type != Setting.Type.group)
+                    continue;
                 if (s.name == dSec)
-                {
-                    sectionFound = true;
-                    secSwitches = findSwitches(s);
-                }
+                    section = cast(GroupSetting) s;
                 else if (s.name == "default")
-                {
-                    sectionFound = true;
-                    defSwitches = findSwitches(s);
-                }
+                    defaultSection = cast(GroupSetting) s;
             }
 
-            if (!sectionFound)
+            if (!section && !defaultSection)
             {
                 const dCfPath = cfPath[0 .. strlen(cfPath)];
-                if (section)
+                if (sectionName)
                     throw new Exception("Could not look up section '" ~ cast(string) dSec
                                         ~ "' nor the 'default' section in " ~ cast(string) dCfPath);
                 else
                     throw new Exception("Could not look up 'default' section in " ~ cast(string) dCfPath);
             }
 
-            auto usedSwitches = secSwitches ? secSwitches : defSwitches;
-            if (!usedSwitches)
+            ArraySetting findArray(string name)
+            {
+                auto r = findArraySetting(section, name);
+                if (!r)
+                    r = findArraySetting(defaultSection, name);
+                return r;
+            }
+
+            auto switches = findArray("switches");
+            auto postSwitches = findArray("post-switches");
+            if (!switches && !postSwitches)
             {
                 const dCfPath = cfPath[0 .. strlen(cfPath)];
                 throw new Exception("Could not look up switches in " ~ cast(string) dCfPath);
             }
 
-            switches.reserve(usedSwitches.vals.length);
-            foreach (i, sw; usedSwitches.vals)
+            void applyArray(ref Array!(const(char)*) output, ArraySetting input)
             {
-                const finalSwitch = sw.replace("%%ldcbinarypath%%", dBinDir) ~ '\0';
-                switches.push(finalSwitch.ptr);
+                if (!input)
+                    return;
+
+                output.reserve(input.vals.length);
+                foreach (sw; input.vals)
+                {
+                    const finalSwitch = sw.replace("%%ldcbinarypath%%", dBinDir) ~ '\0';
+                    output.push(finalSwitch.ptr);
+                }
             }
+
+            applyArray(this.switches, switches);
+            applyArray(this.postSwitches, postSwitches);
 
             return true;
         }

--- a/driver/configfile.h
+++ b/driver/configfile.h
@@ -35,6 +35,7 @@ private:
 
   const char *pathcstr = nullptr;
   Array<const char *> switches;
+  Array<const char *> postSwitches;
 };
 
 #endif // LDC_DRIVER_CONFIGFILE_H

--- a/driver/configfile.h
+++ b/driver/configfile.h
@@ -14,19 +14,18 @@
 #ifndef LDC_DRIVER_CONFIGFILE_H
 #define LDC_DRIVER_CONFIGFILE_H
 
+#include "llvm/ADT/SmallVector.h"
 #include <string>
-#include <vector>
+
+#include "array.h"
 
 class ConfigFile {
 public:
-  using s_iterator = const char **;
-
   bool read(const char *explicitConfFile, const char *section);
 
-  s_iterator switches_begin() { return switches_b; }
-  s_iterator switches_end() { return switches_e; }
-
   std::string path() { return std::string(pathcstr); }
+
+  void extendCommandLine(llvm::SmallVectorImpl<const char *> &args);
 
 private:
   bool locate(std::string &pathstr);
@@ -35,8 +34,7 @@ private:
   bool readConfig(const char *cfPath, const char *section, const char *binDir);
 
   const char *pathcstr = nullptr;
-  s_iterator switches_b = nullptr;
-  s_iterator switches_e = nullptr;
+  Array<const char *> switches;
 };
 
 #endif // LDC_DRIVER_CONFIGFILE_H

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -354,9 +354,7 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
   // just ignore errors for now, they are still printed
   cfg_file.read(explicitConfFile, cfg_triple.c_str());
 
-  // insert switches from config file before all explicit ones
-  allArguments.insert(allArguments.begin() + 1, cfg_file.switches_begin(),
-                      cfg_file.switches_end());
+  cfg_file.extendCommandLine(allArguments);
 
   // finalize by expanding response files specified in config file
   expandResponseFiles(allocator, allArguments);

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -396,7 +396,7 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
     fprintf(global.stdmsg, "binary    %s\n", exe_path::getExePath().c_str());
     fprintf(global.stdmsg, "version   %s (DMD %s, LLVM %s)\n",
             global.ldc_version, global.version, global.llvm_version);
-    const std::string &path = cfg_file.path();
+    const std::string path = cfg_file.path();
     if (!path.empty()) {
       fprintf(global.stdmsg, "config    %s (%s)\n", path.c_str(),
               cfg_triple.c_str());

--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -6,9 +6,12 @@ default:
 {
     // default switches injected before all explicit command-line switches
     switches = [
-        "-I@RUNTIME_DIR@/src",
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
+        "-I@RUNTIME_DIR@/src",@SHARED_LIBS_RPATH@
         "-defaultlib=druntime-ldc",
         "-debuglib=druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
+    ];
+    // default switches appended after all explicit command-line switches
+    post-switches = [
+        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@
     ];
 };

--- a/ldc2_install.conf.in
+++ b/ldc2_install.conf.in
@@ -8,8 +8,11 @@ default:
     switches = [
         "-I@INCLUDE_INSTALL_DIR@/ldc",
         "-I@INCLUDE_INSTALL_DIR@",
-        "-L-L@CMAKE_INSTALL_LIBDIR@", @MULTILIB_ADDITIONAL_INSTALL_PATH@
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
+    ];
+    // default switches appended after all explicit command-line switches
+    post-switches = [
+        "-L-L@CMAKE_INSTALL_LIBDIR@",@MULTILIB_ADDITIONAL_INSTALL_PATH@
     ];
 };

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -8,9 +8,12 @@ default:
     switches = [
         "-I@RUNTIME_DIR@/src",
         "-I@PROFILERT_DIR@/d",
-        "-I@PHOBOS2_DIR@",
-        "-L-L@CMAKE_BINARY_DIR@/lib@LIB_SUFFIX@", @MULTILIB_ADDITIONAL_PATH@@SHARED_LIBS_RPATH@
+        "-I@PHOBOS2_DIR@",@SHARED_LIBS_RPATH@
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
+    ];
+    // default switches appended after all explicit command-line switches
+    post-switches = [
+        "-L-L@CMAKE_BINARY_DIR@/lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@
     ];
 };

--- a/tests/driver/inputs/post_switches.conf
+++ b/tests/driver/inputs/post_switches.conf
@@ -1,0 +1,11 @@
+default:
+{
+    switches = [
+        "-L-normal-switch",
+        "-L-normal-two-switch"
+    ];
+    post-switches = [
+        "-L-post-switch",
+        "-L-post-two-switch"
+    ];
+};

--- a/tests/driver/post_switches.d
+++ b/tests/driver/post_switches.d
@@ -1,0 +1,21 @@
+// RUN: not %ldc -I=%runtimedir/src -conf=%S/inputs/post_switches.conf %s -v -L-user-passed-switch | FileCheck %s
+
+// CHECK: -normal-switch
+// CHECK-SAME: -normal-two-switch
+// CHECK-SAME: -user-passed-switch
+// CHECK-SAME: -post-switch
+// CHECK-SAME: -post-two-switch
+
+
+// RUN: not %ldc -I=%runtimedir/src -conf=%S/inputs/post_switches.conf -v -L-user-passed-switch -run %s -L-after-run | FileCheck %s --check-prefix=WITHrUN
+
+// WITHrUN: -normal-switch
+// WITHrUN-SAME: -normal-two-switch
+// WITHrUN-SAME: -user-passed-switch
+// WITHrUN-SAME: -post-switch
+// WITHrUN-SAME: -post-two-switch
+// WITHrUN-NOT: -after-run
+
+void main()
+{
+}

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -14,6 +14,7 @@ config.ldcprofdata_bin     = "@LDCPROFDATA_BIN@"
 config.ldcprunecache_bin   = "@LDCPRUNECACHE_BIN@"
 config.ldc2_bin_dir        = "@LDC2_BIN_DIR@"
 config.ldc2_lib_dir        = "@LDC2_LIB_DIR@"
+config.ldc2_runtime_dir    = "@RUNTIME_DIR@"
 config.test_source_root    = "@TESTS_IR_DIR@"
 config.llvm_tools_dir      = "@LLVM_TOOLS_DIR@"
 config.llvm_version        = @LDC_LLVM_VER@
@@ -110,6 +111,7 @@ config.substitutions.append( ('%ldc', config.ldc2_bin) )
 config.substitutions.append( ('%profdata', config.ldcprofdata_bin) )
 config.substitutions.append( ('%prunecache', config.ldcprunecache_bin) )
 config.substitutions.append( ('%llvm-spirv', os.path.join(config.llvm_tools_dir, 'llvm-spirv')) )
+config.substitutions.append( ('%runtimedir', config.ldc2_runtime_dir ) )
 
 # Add platform-dependent file extension substitutions
 if (platform.system() == 'Windows'):


### PR DESCRIPTION
For switches to be appended after the user switches (or right before the first `-run` switch).

The sections inherit it (as well as `switches`) from the `default` section if it isn't overridden explicitly.

Fixes issue #2186.