### PR TITLE
Travis OSX: Save almost 2 minutes (by skipping brew)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,13 @@ before_install:
 
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export CC="gcc-4.9"; export CXX="g++-4.9"; fi
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew install ninja; fi
+  -
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      wget -O ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-mac.zip;
+      mkdir ninja;
+      tar -xf ninja-mac.zip -C ninja;
+      export PATH="$PWD/ninja:$PATH";
+    fi
   - pip install --user lit
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ld --version; gdb --version; fi
   - cmake --version


### PR DESCRIPTION
Installing an official pre-built ninja binary (73KB zipped) instead.