### PR TITLE
fuzz_asan.d test: make it easier for fuzzer to find the bug.

### DIFF
--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -8,18 +8,15 @@
 
 bool FuzzMe(ubyte* data, size_t dataSize)
 {
-    return dataSize >= 6 &&
+    return dataSize >= 3 &&
            data[0] == 'F' &&
            data[1] == 'U' &&
            data[2] == 'Z' &&
-           data[3] == 'F' &&
-           data[4] == 'U' &&
-           data[5] == 'Z' &&
     // CHECK: stack-buffer-overflow
     // CHECK-NEXT: READ of size 1
     // CHECK-NEXT: #0 {{.*}} in {{.*fuzz_asan6FuzzMe.*}} {{.*}}fuzz_asan.d:
     // FIXME, debug line info is wrong (Github issue #2090). Once fixed, add [[@LINE+1]]
-           data[6] == 'Z'; // :‑<
+           data[3] == 'Z'; // :‑<
 }
 
 extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)
@@ -33,7 +30,7 @@ extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)
         init = true;
     }
 
-    ubyte[6] stackdata;
+    ubyte[3] stackdata;
     if (data)
     {
         for (auto i = 0; (i < size) && (i < stackdata.length); ++i)
@@ -45,5 +42,5 @@ extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)
     return 0;
 }
 
-// The test unit should start with "FUZFUZ"
-// CHECK: FUZFUZ
+// The test unit should start with "FUZ"
+// CHECK: FUZ


### PR DESCRIPTION
This test would sometimes fail, where the fuzzer is not able to find the bug quickly enough.