### PR TITLE
Don't test fuzzer before LLVM 5.0, because it has known problems.

### DIFF
--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -1,5 +1,6 @@
 // Test Fuzz+ASan functionality
 
+// REQUIRES: atleast_llvm500
 // REQUIRES: Fuzzer, ASan
 
 // See https://github.com/ldc-developers/ldc/issues/2222 for -disable-fp-elim

--- a/tests/sanitizers/fuzz_basic.d
+++ b/tests/sanitizers/fuzz_basic.d
@@ -1,5 +1,6 @@
 // Test basic fuzz test crash
 
+// REQUIRES: atleast_llvm500
 // REQUIRES: Fuzzer
 
 // RUN: %ldc -g -fsanitize=fuzzer %s -of=%t%exe

--- a/tests/sanitizers/link_fuzzer.d
+++ b/tests/sanitizers/link_fuzzer.d
@@ -1,5 +1,6 @@
 // Test linking C++ stdlib (or not) with -fsanitize=fuzzer
 
+// REQUIRES: atleast_llvm500
 // REQUIRES: Fuzzer
 
 // RUN: %ldc -v -fsanitize=fuzzer %s | FileCheck %s


### PR DESCRIPTION
See discussion #2287 