### PR TITLE
An attempt to fix runnable/gdb4149.d test: correct debuginfo for `ref` parameters.

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1042,10 +1042,16 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
 
   if (vd->isRef() || vd->isOut()) {
 #if LDC_LLVM_VER >= 308
+/*
     auto T = DtoType(type);
-    TD = DBuilder.createReferenceType(llvm::dwarf::DW_TAG_reference_type, TD,
-                                      getTypeAllocSize(T) * 8, // size (bits)
-                                      DtoAlignment(type) * 8); // align (bits)
+    // Note: createReferenceType has to be applied to a pointer to the passed
+    // byref (pointer) value (i.e. the alloca that we do for normal pointer params).
+    // It also expects the size to be the size of a pointer.
+    TD = DBuilder.createReferenceType(
+        llvm::dwarf::DW_TAG_reference_type, TD,
+        gDataLayout->getPointerSizeInBits(), // size (bits)
+        DtoAlignment(type) * 8);             // align (bits)
+*/
 #else
     TD = DBuilder.createReferenceType(llvm::dwarf::DW_TAG_reference_type, TD);
 #endif

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1060,8 +1060,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
     // llvm.dbg.declare cannot be used. Their values are constant though, so we
     // don't have to attach the debug information to a memory location and can
     // use llvm.dbg.value instead.
-    assert(!llvm::dyn_cast<llvm::AllocaInst>(ll));
-    useDbgValueIntrinsic = true;
+    useDbgValueIntrinsic = !llvm::dyn_cast<llvm::AllocaInst>(ll);
 #if LDC_LLVM_VER >= 308
     // Note: createReferenceType expects the size to be the size of a pointer,
     // not the size of the type the reference refers to.

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -141,6 +141,8 @@ private:
   DIScope GetCurrentScope();
   void Declare(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
                ldc::DIExpression diexpr);
+  void DbgValue(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
+                ldc::DIExpression diexpr);
   void AddFields(AggregateDeclaration *sd, ldc::DIFile file,
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);
   DIFile CreateFile(Loc &loc);


### PR DESCRIPTION
We currently do not create an `alloca` for a `ref` parameter (this is in contrast to what clang does, and in contrast to what we do for pointer parameters). The `llvm.dbg.declare` call that attaches debuginfo to the parameter expects to receive a pointer to the ref parameter: in the case of `ref int` it expects to receive a pointer of type `int**`, which is what the alloca type would be if we would have created it.

I think a proper fix is to treat `ref` parameters simply as pointer parameters (or to teach LLVM to deal with function parameters passed directly into `llvm.dbg.declare`). And thus we would create an alloca, etc. That's not so easy and is a big change. So first I am trying this fix, where we say that the parameter is of type `int` instead of telling the debugger/users that it is `int&`.

(tested on OSX with LLVM 5.0 + LLDB 5.0)
