### PR TITLE
DI: Don't use llvm.dbg.declare with non-alloca storage

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -113,22 +113,23 @@ ldc::DIScope ldc::DIBuilder::GetCurrentScope() {
   return fn->diLexicalBlocks.top();
 }
 
-void ldc::DIBuilder::Declare(const Loc &loc, llvm::Value *var,
+// Use this to set the memory address for a debuginfo variable.
+// LLVM requires the storage to be an alloca.
+void ldc::DIBuilder::Declare(const Loc &loc, llvm::Value *storage,
                              ldc::DILocalVariable divar,
                              ldc::DIExpression diexpr) {
   unsigned charnum = (loc.linnum ? loc.charnum : 0);
   auto debugLoc = llvm::DebugLoc::get(loc.linnum, charnum, GetCurrentScope());
-  DBuilder.insertDeclare(var, divar, diexpr, debugLoc, IR->scopebb());
+  DBuilder.insertDeclare(storage, divar, diexpr, debugLoc, IR->scopebb());
 }
 
-// Use this to tag debuginfo onto a non-alloca LLVM value, e.g. a function
-// parameter.
-void ldc::DIBuilder::DbgValue(const Loc &loc, llvm::Value *var,
+// Use this to set the (current) value for a debuginfo variable.
+void ldc::DIBuilder::SetValue(const Loc &loc, llvm::Value *value,
                               ldc::DILocalVariable divar,
                               ldc::DIExpression diexpr) {
   unsigned charnum = (loc.linnum ? loc.charnum : 0);
   auto debugLoc = llvm::DebugLoc::get(loc.linnum, charnum, GetCurrentScope());
-  DBuilder.insertDbgValueIntrinsic(var,
+  DBuilder.insertDbgValueIntrinsic(value,
 #if LDC_LLVM_VER < 600
                                    0,
 #endif
@@ -1149,7 +1150,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
   variableMap[vd] = debugVariable;
 
   if (useDbgValueIntrinsic) {
-    DbgValue(vd->loc, ll, debugVariable,
+    SetValue(vd->loc, ll, debugVariable,
              addr.empty() ? DBuilder.createExpression()
                           : DBuilder.createExpression(addr));
   } else {

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1042,10 +1042,16 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
 
   if (vd->isRef() || vd->isOut()) {
 #if LDC_LLVM_VER >= 308
+/*
     auto T = DtoType(type);
-    TD = DBuilder.createReferenceType(llvm::dwarf::DW_TAG_reference_type, TD,
-                                      getTypeAllocSize(T) * 8, // size (bits)
-                                      DtoAlignment(type) * 8); // align (bits)
+    // Note: createReferenceType has to be applied to a pointer to the passed
+    // byref (pointer) value (i.e. the alloca that we do for normal pointer params).
+    // It also expects the size to be the size of a pointer.
+    TD = DBuilder.createReferenceType(
+        llvm::dwarf::DW_TAG_reference_type, TD,
+        gDataLayout->getPointerSizeInBits(), // size (bits)
+        DtoAlignment(type) * 8);             // align (bits)
+*/
 #else
     TD = DBuilder.createReferenceType(llvm::dwarf::DW_TAG_reference_type, TD);
 #endif

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1060,8 +1060,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
     // llvm.dbg.declare cannot be used. Their values are constant though, so we
     // don't have to attach the debug information to a memory location and can
     // use llvm.dbg.value instead.
-    assert(!llvm::dyn_cast<llvm::AllocaInst>(ll));
-    useDbgValueIntrinsic = true;
+    useDbgValueIntrinsic = !llvm::dyn_cast<llvm::AllocaInst>(ll);
 #if LDC_LLVM_VER >= 308
     // Note: createReferenceType expects the size to be the size of a pointer,
     // not the size of the type the reference refers to.

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1058,7 +1058,9 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
   // llvm.dbg.declare only works properly with local allocas.
   // Represent variables with non-alloca LL storage as DI references, like `ref`
   // and `out` parameters.
-  const bool storedInAlloca = llvm::dyn_cast<llvm::AllocaInst>(ll);
+  const bool storedInAlloca =
+      llvm::dyn_cast<llvm::AllocaInst>(ll) ||
+      (isaArgument(ll) && isaArgument(ll)->hasByValAttr());
   bool useDbgValueIntrinsic = false;
   if (!storedInAlloca || vd->isRef() || vd->isOut()) {
     // With the exception of special-ref loop variables, the reference/pointer

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1067,7 +1067,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
     // itself is constant. So we don't have to attach the debug information to a
     // memory location and can use llvm.dbg.value to set the constant pointer
     // for the DI reference.
-    useDbgValueIntrinsic = !storedInAlloca;
+    useDbgValueIntrinsic = !isSpecialRefVar(vd);
 #if LDC_LLVM_VER >= 308
     // Note: createReferenceType expects the size to be the size of a pointer,
     // not the size of the type the reference refers to.

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -141,6 +141,8 @@ private:
   DIScope GetCurrentScope();
   void Declare(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
                ldc::DIExpression diexpr);
+  void DbgValue(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
+                ldc::DIExpression diexpr);
   void AddFields(AggregateDeclaration *sd, ldc::DIFile file,
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);
   DIFile CreateFile(Loc &loc);

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -115,12 +115,17 @@ public:
 
   /// \brief Emits all things necessary for making debug info for a local
   /// variable vd.
-  /// \param ll       LL lvalue of the variable.
+  /// \param ll       LL value which, in combination with `addr`, yields the
+  /// storage/lvalue of the variable (not treating ref/out params as special
+  /// case; what's needed is the lvalue of the original variable).
+  /// For special-ref loop variables, specify the lvalue of the reference/
+  /// pointer.
   /// \param vd       Variable declaration to emit debug info for.
   /// \param type     Type of variable if different from vd->type
   /// \param isThisPtr Variable is hidden this pointer
   /// \param forceAsLocal Emit as local even if the variable is a parameter
-  /// \param addr     An array of complex address operations.
+  /// \param addr     An array of complex address operations encoding a DWARF
+  /// expression.
   void
   EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd, Type *type = nullptr,
                     bool isThisPtr = false, bool forceAsLocal = false,

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -139,9 +139,9 @@ private:
   llvm::LLVMContext &getContext();
   Module *getDefinedModule(Dsymbol *s);
   DIScope GetCurrentScope();
-  void Declare(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
+  void Declare(const Loc &loc, llvm::Value *storage, ldc::DILocalVariable divar,
                ldc::DIExpression diexpr);
-  void DbgValue(const Loc &loc, llvm::Value *var, ldc::DILocalVariable divar,
+  void SetValue(const Loc &loc, llvm::Value *value, ldc::DILocalVariable divar,
                 ldc::DIExpression diexpr);
   void AddFields(AggregateDeclaration *sd, ldc::DIFile file,
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -768,7 +768,8 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
       ++llArgIdx;
     }
 
-    // the debuginfo for captured params is handled by nested.cpp
+    // The debuginfos for captured params are handled later by
+    // DtoCreateNestedContext().
     if (global.params.symdebug && vd->nestedrefs.dim == 0)
       gIR->DBuilder.EmitLocalVariable(irparam->value, vd, paramType);
   }

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -768,7 +768,8 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
       ++llArgIdx;
     }
 
-    if (global.params.symdebug)
+    // the debuginfo for captured params is handled by nested.cpp
+    if (global.params.symdebug && vd->nestedrefs.dim == 0)
       gIR->DBuilder.EmitLocalVariable(irparam->value, vd, paramType);
   }
 }

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1037,7 +1037,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     assert(getIrParameter(fd->vthis)->value == thisvar);
     getIrParameter(fd->vthis)->value = thismem;
 
-    gIR->DBuilder.EmitLocalVariable(thismem, fd->vthis, nullptr, true);
+    gIR->DBuilder.EmitLocalVariable(thismem, fd->vthis, nullptr,
+                                    /*isThisPtr=*/true);
   }
 
   // give the 'nestArg' parameter (an lvalue) storage

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -56,13 +56,16 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     return makeVarDValue(astype, vd);
   }
 
+  ldc::DwarfExpression<8> dwarfExp;
+
   // get the nested context
   LLValue *ctx = nullptr;
-  bool skipDIDeclaration = false;
+  LLValue *diStorage = nullptr;
   auto currentCtx = gIR->funcGen().nestedVar;
   if (currentCtx) {
     Logger::println("Using own nested context of current function");
     ctx = currentCtx;
+    diStorage = ctx;
   } else if (irfunc->decl->isMember2()) {
     Logger::println(
         "Current function is member of nested class, loading vthis");
@@ -73,11 +76,12 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
       val = DtoLoad(val);
     }
     ctx = DtoLoad(DtoGEPi(val, 0, getVthisIdx(cd), ".vthis"));
-    skipDIDeclaration = true;
+    // skip the DI declaration by leaving diStorage = null
   } else {
     Logger::println("Regular nested function, loading context arg");
-
     ctx = DtoLoad(irfunc->nestArg);
+    diStorage = irfunc->nestArg;
+    dwarfExp.deref();
   }
 
   assert(ctx);
@@ -111,6 +115,8 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   } else {
     // Load frame pointer and index that...
     IF_LOG Logger::println("Lower depth");
+    dwarfExp.offset(val, vardepth);
+    dwarfExp.deref();
     val = DtoGEPi(val, 0, vardepth);
     IF_LOG Logger::cout() << "Frame index: " << *val << '\n';
     val = DtoAlignedLoad(
@@ -121,24 +127,28 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   const auto idx = irLocal->nestedIndex;
   assert(idx != -1 && "Nested context not yet resolved for variable.");
 
-  LLValue *gep = DtoGEPi(val, 0, idx, vd->toChars());
-  val = gep;
+  dwarfExp.offset(val, idx);
+  val = DtoGEPi(val, 0, idx, vd->toChars());
   IF_LOG {
     Logger::cout() << "Addr: " << *val << '\n';
     Logger::cout() << "of type: " << *val->getType() << '\n';
   }
   const bool isRefOrOut = vd->isRef() || vd->isOut();
-  if (!isSpecialRefVar(vd) && (byref || isRefOrOut)) {
+  if (isSpecialRefVar(vd)) {
+    dwarfExp.deref();
+    dwarfExp.deref();
+  } else if (byref || isRefOrOut) {
     val = DtoAlignedLoad(val);
+    dwarfExp.deref();
     IF_LOG {
       Logger::cout() << "Was byref, now: " << *irLocal->value << '\n';
       Logger::cout() << "of type: " << *irLocal->value->getType() << '\n';
     }
   }
 
-  if (!skipDIDeclaration && global.params.symdebug) {
-    gIR->DBuilder.EmitLocalVariable(val, vd, nullptr, false,
-                                    /*forceAsLocal=*/true);
+  if (diStorage && global.params.symdebug) {
+    gIR->DBuilder.EmitLocalVariable(diStorage, vd, nullptr, false,
+                                    /*forceAsLocal=*/true, dwarfExp);
   }
 
   return makeVarDValue(astype, vd, val);
@@ -462,6 +472,9 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
 
       IrLocal *irLocal = getIrLocal(vd);
       LLValue *gep = DtoGEPi(frame, 0, irLocal->nestedIndex, vd->toChars());
+      ldc::DwarfExpression<4> dwarfExp;
+      dwarfExp.offset(frame, irLocal->nestedIndex);
+
       if (vd->isParameter()) {
         IF_LOG Logger::println("nested param: %s", vd->toChars());
         LOG_SCOPE
@@ -471,6 +484,7 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
         if (vd->isRef() || vd->isOut()) {
           Logger::println("Captured by reference, copying pointer to nested frame");
           DtoAlignedStore(irLocal->value, gep);
+          dwarfExp.deref();
         } else {
           Logger::println("Copying to nested frame");
           // The parameter value is an alloca'd stack slot.
@@ -487,7 +501,8 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
       }
 
       if (global.params.symdebug) {
-        gIR->DBuilder.EmitLocalVariable(irLocal->value, vd);
+        gIR->DBuilder.EmitLocalVariable(frame, vd, nullptr, false, false,
+                                        dwarfExp);
       }
     }
   }

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -133,11 +133,14 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     Logger::cout() << "Addr: " << *val << '\n';
     Logger::cout() << "of type: " << *val->getType() << '\n';
   }
-  const bool isRefOrOut = vd->isRef() || vd->isOut();
   if (isSpecialRefVar(vd)) {
-    dwarfExp.deref();
-    dwarfExp.deref();
-  } else if (byref || isRefOrOut) {
+    // Handled appropriately by makeVarDValue() and
+    // DIBuilder::EmitLocalVariable(), pass storage of pointer (reference
+    // lvalue).
+  } else if (byref || vd->isRef() || vd->isOut()) {
+    // makeVarDValue() and DIBuilder::EmitLocalVariable() expect the original
+    // variable's lvalue for ref/out params too (i.e., the reference rvalue),
+    // so always dereference.
     val = DtoAlignedLoad(val);
     dwarfExp.deref();
     IF_LOG {

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -46,12 +46,13 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: <function> * fun = {{0x[0-9a-f`]*}}
 // x86: struct int[] slice =
 // CHECK: unsigned char * aa = {{0x[0-9a-f`]*}}
-// CHECK: unsigned char (*)[16] fa
+// x64: unsigned char (*)[16] fa
+// x86: unsigned char [16] fa
 // x86: float [4] f4 = float [4]
 // x86: double [4] d4 = double [4]
-// x64: Small small
-// x86: Small * small
-// CHECK: Large * large
+// CHECK: Small small
+// x64: Large * large
+// x86: Large large
 // CHECK: struct TypeInfo_Class * ti = {{0x[0-9a-f`]*}}
 // CHECK: void * np = {{0x[0`]*}}
 
@@ -80,7 +81,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 
 // CDB: ?? (*fa)[1]
 // x64: unsigned char 0x0e
-// no-x86: unsigned char 0x0e (displays garbage)
+// no-x86: would be fa[1], but displays garbage anyway
 
 // CDB: ?? f4[1]
 // CHECK: float 16
@@ -111,7 +112,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
           Small* small, Large* large,
           TypeInfo_Class* ti, typeof(null)* np)
 {
-// CDB: bp `args_cdb.d:114`
+// CDB: bp `args_cdb.d:115`
 // CDB: g
     return 3;
 // CHECK: !args_cdb.byPtr
@@ -176,7 +177,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
           ref Small small, ref Large large,
           ref TypeInfo_Class ti, ref typeof(null) np)
 {
-// CDB: bp `args_cdb.d:179`
+// CDB: bp `args_cdb.d:180`
 // CDB: g
 // CHECK: !args_cdb.byRef
 

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -6,18 +6,25 @@
 // CHECK-SAME: !dbg
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.value{{.*}}%enc_n{{.*}}enc_n
+    // CHECK: %.frame = alloca %nest.encloser
+    // CHECK: %arg0 = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = arg0]
+    // CHECK: %arg1 = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = arg1]
+    // CHECK: %enc_n = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = enc_n]
     int enc_n;
 
     // CHECK-LABEL: define {{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: %arg0 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%arg0
-        // CHECK: %arg1 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%arg1
-        // CHECK: %enc_n = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%enc_n
+        // CHECK: %nestedFrame = alloca i8*
+        // CHECK: %arg0 = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = arg0]
+        // CHECK: %arg1 = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = arg1]
+        // CHECK: %enc_n = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = enc_n]
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
 
         // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -6,18 +6,18 @@
 // CHECK-SAME: !dbg
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%enc_n{{.*}}enc_n
+    // CHECK: @llvm.dbg.value{{.*}}%enc_n{{.*}}enc_n
     int enc_n;
 
     // CHECK-LABEL: define {{.*}}encloser{{.*}}nested
     void nested(int nes_i)
     {
         // CHECK: %arg0 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%arg0
+        // CHECK: @llvm.dbg.value{{.*}}%arg0
         // CHECK: %arg1 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%arg1
+        // CHECK: @llvm.dbg.value{{.*}}%arg1
         // CHECK: %enc_n = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%enc_n
+        // CHECK: @llvm.dbg.value{{.*}}%enc_n
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
 
         // nes_i and arg1 have the same parameter index in the generated IR, if both get declared as

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -5,18 +5,18 @@
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.declare{{.*}}%enc_n{{.*}}enc_n
+    // CHECK: @llvm.dbg.value{{.*}}%enc_n{{.*}}enc_n
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested
     void nested(int nes_i)
     {
         // CHECK: %arg0 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%arg0
+        // CHECK: @llvm.dbg.value{{.*}}%arg0
         // CHECK: %arg1 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%arg1
+        // CHECK: @llvm.dbg.value{{.*}}%arg1
         // CHECK: %enc_n = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.declare{{.*}}%enc_n
+        // CHECK: @llvm.dbg.value{{.*}}%enc_n
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
     }
 }

--- a/tests/debuginfo/nested_llvm307.d
+++ b/tests/debuginfo/nested_llvm307.d
@@ -5,18 +5,25 @@
 // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser
 void encloser(int arg0, int arg1)
 {
-    // CHECK: @llvm.dbg.value{{.*}}%enc_n{{.*}}enc_n
+    // CHECK: %.frame = alloca %nest.encloser
+    // CHECK: %arg0 = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = arg0]
+    // CHECK: %arg1 = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = arg1]
+    // CHECK: %enc_n = getelementptr inbounds{{.*}} %nest.encloser* %.frame
+    // CHECK: @llvm.dbg.declare{{.*}} %.frame, {{.*}} [debug variable = enc_n]
     int enc_n;
 
     // CHECK-LABEL: define {{.*}} @_D{{.*}}8encloser{{.*}}nested
     void nested(int nes_i)
     {
-        // CHECK: %arg0 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%arg0
-        // CHECK: %arg1 = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%arg1
-        // CHECK: %enc_n = getelementptr inbounds %nest.encloser
-        // CHECK: @llvm.dbg.value{{.*}}%enc_n
+        // CHECK: %nestedFrame = alloca i8*
+        // CHECK: %arg0 = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = arg0]
+        // CHECK: %arg1 = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = arg1]
+        // CHECK: %enc_n = getelementptr inbounds{{.*}} %nest.encloser*
+        // CHECK: @llvm.dbg.declare{{.*}} %nestedFrame, {{.*}} [debug variable = enc_n]
         arg0 = arg1 = enc_n = nes_i; // accessing arg0, arg1 and enc_n from a nested function turns them into closure variables
     }
 }


### PR DESCRIPTION
An alternative to #2292.