### PR TITLE
Escape linker flags passed to dmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,7 +610,7 @@ else()
     set(LDC_TRANSLATED_LINKER_FLAGS "")
     foreach(f ${LDC_LINKERFLAG_LIST})
         string(REPLACE "-LIBPATH:" "/LIBPATH:" f ${f})
-        list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L${f}")
+        list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L\"\\\"${f}\\\"\"")
     endforeach()
 
     if(MSVC)


### PR DESCRIPTION
This should fix issues when we have paths with spaces (e.g. path to diaguids.lib)