### PR TITLE
[MSVC] Error out if LLVM is built with MD[d]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,11 +145,9 @@ if(MSVC)
 
     # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
     # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
-    # NOTE: Requires LLVM to be built with CMake variable LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d].
-    if(${LLVM_CXXFLAGS} MATCHES "MD")
-        message(FATAL_ERROR "LLVM must be built with LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d], not MD[d]")
+    if(${LLVM_CXXFLAGS} MATCHES "(^| )/MDd?( |$)")
+        message(FATAL_ERROR "LLVM must be built with CMake option LLVM_USE_CRT_<CMAKE_BUILD_TYPE>=MT[d]")
     endif()
-
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(MSVC)
     # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
     # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
     # NOTE: Requires LLVM to be built with CMake variable LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d].
-    foreach(llvm_crt LLVM_USE_CRT_RELEASE LLVM_USE_CRT_DEBUG)
+    foreach(llvm_crt LLVM_USE_CRT_RELEASE LLVM_USE_CRT_DEBUG LLVM_USE_CRT_RELWITHDEBINFO LLVM_USE_CRT_MINSIZEREL)
         if(${llvm_crt} MATCHES "MD")
             message(FATAL_ERROR "LLVM must be built with LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d], not MD[d]")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,10 @@ if(MSVC)
     # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
     # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
     # NOTE: Requires LLVM to be built with CMake variable LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d].
-    foreach(llvm_crt LLVM_USE_CRT_RELEASE LLVM_USE_CRT_DEBUG LLVM_USE_CRT_RELWITHDEBINFO LLVM_USE_CRT_MINSIZEREL)
-        if(${llvm_crt} MATCHES "MD")
-            message(FATAL_ERROR "LLVM must be built with LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d], not MD[d]")
-        endif()
-    endforeach()
+    if(${LLVM_CXXFLAGS} MATCHES "MD")
+        message(FATAL_ERROR "LLVM must be built with LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d], not MD[d]")
+    endif()
+
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,11 @@ if(MSVC)
     # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
     # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
     # NOTE: Requires LLVM to be built with CMake variable LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d].
+    foreach(llvm_crt LLVM_USE_CRT_RELEASE LLVM_USE_CRT_DEBUG)
+        if(${llvm_crt} MATCHES "MD")
+            message(FATAL_ERROR "LLVM must be built with LLVM_USE_CRT_{RELEASE,DEBUG,...}=MT[d], not MD[d]")
+        endif()
+    endforeach()
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)


### PR DESCRIPTION
So people like me don't waste days staring at linker errors.