### PR TITLE
Add LDC_TARGET_PRESET CMake variable for runtime, to make cross-compilation easier

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,6 +1,8 @@
-project(runtime)
+project(runtime C)
 
 cmake_minimum_required(VERSION 2.8.9)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(CheckIncludeFile)
 
@@ -42,11 +44,15 @@ set(COMPILE_ALL_D_FILES_AT_ONCE ON                            CACHE BOOL   "Comp
 set(RT_CFLAGS             ""                                  CACHE STRING "Runtime extra C compiler flags, separated by ' '")
 set(LD_FLAGS              ""                                  CACHE STRING "Runtime extra C linker flags, separated by ' '")
 set(C_SYSTEM_LIBS         AUTO                                CACHE STRING "C system libraries for linking shared libraries and test runners, separated by ';'")
-set(TARGET_SYSTEM         AUTO                                CACHE STRING "Targeted platform for cross-compilation (e.g., 'Linux;UNIX', 'Darwin;APPLE;UNIX', 'Windows;MSVC')")
+set(TARGET_SYSTEM         AUTO                                CACHE STRING "Target OS/toolchain for cross-compilation (e.g., 'Linux;UNIX', 'Darwin;APPLE;UNIX', 'Windows;MSVC')")
+set(LDC_TARGET_PRESET     ""                                  CACHE STRING "Use a preset target configuration for cross-compilation, by passing format OS-arch (e.g., 'Linux-arm', 'Mac-x64', 'Windows-aarch64', 'Android-x86')")
 
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
 
-# Auto-detect TARGET_SYSTEM
+# Use LDC_TARGET_PRESET to configure target runtime
+include(PresetRuntimeConfiguration)
+
+# Auto-detect TARGET_SYSTEM from host
 if("${TARGET_SYSTEM}" STREQUAL "AUTO")
     set(TARGET_SYSTEM ${CMAKE_SYSTEM_NAME})
     # Additionally add MSVC, APPLE and/or UNIX

--- a/runtime/PresetRuntimeConfiguration.cmake
+++ b/runtime/PresetRuntimeConfiguration.cmake
@@ -1,0 +1,97 @@
+# - Preset cross-compilation configurations for C/ASM and D compilation
+# and linking, for supported targets
+#
+# This module sets compiler flags for a few C and assembly files in
+# DRuntime and Phobos, and linker flags to link the standard library as
+# a shared library and build the test runners, for various
+# cross-compilation targets that the LDC developers have tried out.
+#
+# It is enabled by setting LDC_TARGET_PRESET to a supported platform,
+# after which the appropriate TARGET_SYSTEM is set and a target triple
+# is appended to D_FLAGS.
+#
+# You can pass in custom RT_CFLAGS and LD_FLAGS of your choosing, but
+# if they're left unconfigured, they will also be set to sensible
+# defaults.
+
+if(NOT LDC_TARGET_PRESET STREQUAL "")
+    if(LDC_TARGET_PRESET MATCHES "Android")
+        set(ANDROID_API "21")
+    endif()
+    # This initial RT_CFLAGS/LD_FLAGS configuration for Android is a
+    # convenience for natively compiling, because CMake cannot detect
+    # Android as a separate platform from Linux.
+    if(RT_CFLAGS STREQUAL "" AND LDC_TARGET_PRESET MATCHES "Android")
+        set(RT_CFLAGS_UNCONFIGURED True)
+        set(RT_CFLAGS "-ffunction-sections -funwind-tables -fstack-protector-strong -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -no-canonical-prefixes -g -DNDEBUG -DANDROID  -D__ANDROID_API__=${ANDROID_API} -Wa,--noexecstack -Wformat -Werror=format-security -fpie")
+
+        if(LDC_TARGET_PRESET MATCHES "arm")
+            append("-target armv7-none-linux-androideabi${ANDROID_API} -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -Os" RT_CFLAGS)
+        elseif(LDC_TARGET_PRESET MATCHES "aarch64")
+            append("-target aarch64-none-linux-android -O2" RT_CFLAGS)
+        endif()
+    endif()
+
+    if(LD_FLAGS STREQUAL "" AND LDC_TARGET_PRESET MATCHES "Android")
+        set(LD_FLAGS_UNCONFIGURED True)
+        set(LD_FLAGS "-Wl,--gc-sections -Wl,-z,nocopyreloc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings -fpie -pie")
+
+        if(LDC_TARGET_PRESET MATCHES "arm")
+            append("-target armv7-none-linux-androideabi${ANDROID_API} -Wl,--fix-cortex-a8" LD_FLAGS)
+        elseif(LDC_TARGET_PRESET MATCHES "aarch64")
+            append("-target aarch64-none-linux-android" LD_FLAGS)
+        endif()
+    endif()
+
+    if(LDC_TARGET_PRESET MATCHES "Windows")
+        set(TARGET_SYSTEM "Windows;MSVC")
+        if(LDC_TARGET_PRESET MATCHES "x64")
+            # stub example, fill in with the rest
+            list(APPEND D_FLAGS "-mtriple=x86_64-pc-windows-msvc")
+        endif()
+    elseif(LDC_TARGET_PRESET MATCHES "Android")
+        set(TARGET_SYSTEM "Android;Linux;UNIX")
+
+        # Check if we're using the NDK by looking for the toolchains
+        # directory in CC
+        if(CMAKE_C_COMPILER MATCHES "toolchains")
+            # Extract the NDK path and platform from CC
+            string(REGEX REPLACE ".toolchains.+" "" NDK_PATH ${CMAKE_C_COMPILER})
+            string(REGEX REPLACE ".+/prebuilt/([^/]+)/.+" "\\1" NDK_HOST_PLATFORM ${CMAKE_C_COMPILER})
+
+            if(LDC_TARGET_PRESET MATCHES "arm")
+                set(TARGET_ARCH "arm")
+                set(LLVM_TARGET_TRIPLE "armv7-none-linux-android")
+                set(TOOLCHAIN_TARGET_TRIPLE "arm-linux-androideabi")
+            elseif(LDC_TARGET_PRESET MATCHES "aarch64")
+                set(TARGET_ARCH "arm64")
+                set(LLVM_TARGET_TRIPLE "aarch64-none-linux-android")
+                set(TOOLCHAIN_TARGET_TRIPLE "aarch64-linux-android")
+            else()
+                message(FATAL_ERROR "Android platform ${LDC_TARGET_PRESET} is not supported.")
+            endif()
+            list(APPEND D_FLAGS "-mtriple=${LLVM_TARGET_TRIPLE}")
+            set(TOOLCHAIN_VERSION "4.9")
+
+            if(RT_CFLAGS_UNCONFIGURED)
+                append("-gcc-toolchain ${NDK_PATH}/toolchains/${TOOLCHAIN_TARGET_TRIPLE}-${TOOLCHAIN_VERSION}/prebuilt/${NDK_HOST_PLATFORM} --sysroot ${NDK_PATH}/sysroot -isystem ${NDK_PATH}/sysroot/usr/include/${TOOLCHAIN_TARGET_TRIPLE}" RT_CFLAGS)
+
+                if(LDC_TARGET_PRESET MATCHES "arm")
+                    append("-fno-integrated-as" RT_CFLAGS)
+                endif()
+            endif()
+
+            if(LD_FLAGS_UNCONFIGURED)
+                set(LD_BFD "-fuse-ld=bfd")
+                # work around Windows bug, android-ndk/ndk#75
+                if(NDK_HOST_PLATFORM MATCHES "windows")
+                    set(LD_BFD "${LD_BFD}.exe")
+                endif()
+
+                append("--sysroot=${NDK_PATH}/platforms/android-${ANDROID_API}/arch-${TARGET_ARCH} -gcc-toolchain ${NDK_PATH}/toolchains/${TOOLCHAIN_TARGET_TRIPLE}-${TOOLCHAIN_VERSION}/prebuilt/${NDK_HOST_PLATFORM} ${LD_BFD}" LD_FLAGS)
+            endif()
+        endif()
+    else()
+        message(FATAL_ERROR "LDC_TARGET_PRESET ${LDC_TARGET_PRESET} is not supported yet, pull requests to add common flags are welcome.")
+    endif()
+endif()

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -12,6 +12,8 @@ struct Config {
     string ldcSourceDir;
     bool ninja;
     bool buildTestrunners;
+    string targetPreset;
+    string[] targetSystem;
     string[] dFlags;
     string[] cFlags;
     string[] linkerFlags;
@@ -138,9 +140,16 @@ void prepareLdcSource() {
 }
 
 void runCMake() {
-    import std.array : byPair, join;
+    import std.array : empty, byPair, join;
+    import std.regex : matchFirst;
 
     const wd = WorkingDirScope(config.buildDir);
+
+    if(config.dFlags.empty)
+        config.dFlags ~= "-w";
+
+    if(config.targetSystem.empty)
+        config.targetSystem ~= "AUTO";
 
     string[] args = [
         "cmake",
@@ -148,10 +157,14 @@ void runCMake() {
         "-DD_VERSION=@D_VERSION@",
         "-DDMDFE_MINOR_VERSION=@DMDFE_MINOR_VERSION@",
         "-DDMDFE_PATCH_VERSION=@DMDFE_PATCH_VERSION@",
+        "-DLDC_TARGET_PRESET=" ~ config.targetPreset,
+        "-DTARGET_SYSTEM=" ~ config.targetSystem.join(";"),
         "-DD_FLAGS=" ~ config.dFlags.join(";"),
         "-DRT_CFLAGS=" ~ config.cFlags.join(" "),
         "-DLD_FLAGS=" ~ config.linkerFlags.join(" "),
     ];
+    if(config.targetPreset.matchFirst("^Android"))
+        args ~= ["-DCMAKE_SYSTEM_NAME=Linux", "-DCMAKE_C_COMPILER_WORKS=True"];
     foreach (pair; config.cmakeVars.byPair)
         args ~= "-D" ~ pair[0] ~ '=' ~ pair[1];
     if (config.ninja)
@@ -226,6 +239,8 @@ void parseCommandLine(string[] args) {
         "ldcSrcDir",   "Path to LDC source directory (if not specified: downloads & extracts source archive into '<buildDir>/ldc-src')", &config.ldcSourceDir,
         "ninja",       "Use Ninja as CMake build system", &config.ninja,
         "testrunners", "Build the testrunner executables too", &config.buildTestrunners,
+        "targetPreset","Target configuration preset by LDC devs, e.g. Android-arm", &config.targetPreset,
+        "targetSystem","Target OS/toolchain (separated by ';'), e.g. Windows;MSVC", &config.targetSystem,
         "dFlags",      "LDC flags for the D modules (separated by ';')", &config.dFlags,
         "cFlags",      "C/ASM compiler flags for the handful of C/ASM files (separated by ';')", &config.cFlags,
         "linkerFlags", "C linker flags for shared libraries and testrunner executables (separated by ';')", &config.linkerFlags,
@@ -251,6 +266,7 @@ void parseCommandLine(string[] args) {
             "  * CMake\n" ~
             "  * either Make or Ninja (recommended, enable with '--ninja')\n" ~
             "  * C toolchain (compiler and linker)\n" ~
+            "--targetPreset currently supports Android-arm or Android-aarch64.\n" ~
             "All arguments are optional.\n" ~
             "CMake variables (see runtime/CMakeLists.txt in LDC source) can be specified via arguments like 'VAR=value'.\n",
             helpInformation.options


### PR DESCRIPTION
The idea here is to be able to simply specify a dash-separated OS and CPU architecture and our CMake config will try to fill in the rest for you.  Probably best to stick this in another CMake file, where we can have common flags for all the cross-compilation platforms the ldc devs have tried out, ie Linux/PPC, Windows/AArch64, or whatever else.  You can always override `RT_CFLAGS` and `LD_FLAGS` by setting them manually, this logic will simply supply defaults for when the user doesn't.

Android is a little weird because CMake doesn't automatically detect if you're natively compiling on Android, and I can't set `CMAKE_SYSTEM_NAME=Android` because it will try to invoke the cross-compilation NDK toolchain.  Basically, Android native compilation is unsupported by CMake, to the point where it just assumes cross-compilation and complains that it can't find the NDK.

Here are the commands I use to configure CMake for Android/ARM with this PR: note that I have to specify ~~`TARGET_PLATFORM`~~ `LDC_TARGET_PRESET` for native compilation too, because CMake just thinks native Android/ARM is Linux/ARM.  These are the two use cases this PR currently supports, either natively compiling in the Termux Android app (tested by building ldc and running the druntime tests), or cross-compiling from linux/x64 (tested by building ldc and the druntime tests).

Native compilation
```
cmake .. -DLLVM_CONFIG=../../llvm-5.0.0rc2.src/build/bin/llvm-config -DTARGET_PLATFORM=Android-arm
```
Cross-compilation from linux/x64
```
CC=~/ndk-r15c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang DMD=~/bin/dmd2/bin/dmd NDK=~/ndk-r15c/ cmake .. -DLLVM_CONFIG=../../llvm/build/bin/llvm-config -DTARGET_PLATFORM=Android-arm
```
What I'm looking for right now with this incomplete PR is what other ldc devs think of this approach, before I spend more time fleshing it out and adding flags for other architectures like Android-aarch64. For example, it currently assumes you're cross-compiling from linux/x64 using that NDK, whereas we'll need to support Windows/Mac too.  I don't know if it's worth setting `CMAKE_CROSSCOMPILING=True`, which we haven't used yet, especially because ldc isn't cross-compiled so it may confuse CMake.