### PR TITLE
Work around host compiler issues with VS 2017 Update 15.3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,12 @@ else()
     if(MSVC)
         # Issue 1297 – set LDC's stack to 8 MiB like on Linux and Mac (default: 1 MiB).
         list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L/STACK:8388608")
+        # VS 2017+: Use undocumented /NOOPTTLS MS linker switch to keep on emitting
+        # a .tls section. Required for older host druntime versions, otherwise the
+        # GC TLS ranges are garbage starting with VS 2017 Update 15.3.
+        if(MSVC_VERSION GREATER 1900) # VS 2017+
+            list(APPEND LDC_TRANSLATED_LINKER_FLAGS "-L/NOOPTTLS")
+        endif()
     endif()
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ skip_tags: true
 environment:
   matrix:
     - APPVEYOR_JOB_ARCH:   x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       D_COMPILER:          ldc
     - APPVEYOR_JOB_ARCH:   x86
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015


### PR DESCRIPTION
Thanks to @rainers' X-ray capabilities. :)

We still need the [upstream druntime fix](https://github.com/dlang/druntime/pull/1910) to make LDC produce working binaries out of the box.