### PR TITLE
CMake: Use LDC as (cross-)archiver for static runtime libs

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -39,6 +39,7 @@ set(D_FLAGS               -w                                  CACHE STRING "Runt
 set(D_FLAGS_DEBUG         -g;-link-debuglib                   CACHE STRING "Runtime D compiler flags (debug libraries), separated by ';'")
 set(D_FLAGS_RELEASE       -O3;-release                        CACHE STRING "Runtime D compiler flags (release libraries), separated by ';'")
 set(COMPILE_ALL_D_FILES_AT_ONCE ON                            CACHE BOOL   "Compile all D files for a lib in a single command line instead of separately")
+set(RT_ARCHIVE_WITH_LDC   AUTO                                CACHE STRING "Whether to archive the static runtime libs via LDC instead of CMake archiver")
 set(RT_CFLAGS             ""                                  CACHE STRING "Runtime extra C compiler flags, separated by ' '")
 set(LD_FLAGS              ""                                  CACHE STRING "Runtime extra C linker flags, separated by ' '")
 set(C_SYSTEM_LIBS         AUTO                                CACHE STRING "C system libraries for linking shared libraries and test runners, separated by ';'")
@@ -75,6 +76,16 @@ if(${ptr_size} MATCHES "^8$") ## if it's 64-bit OS
 else()
     set(HOST_BITNESS 32)
     set(MULTILIB_SUFFIX 64)
+endif()
+
+if(${RT_ARCHIVE_WITH_LDC} STREQUAL "AUTO")
+    # LLVM's MSVC archiver (v4.0.1) apparently has issues with objects with debuginfos,
+    # leading to MS linker warnings when linking against the static debug runtime libs.
+    if("${TARGET_SYSTEM}" MATCHES "MSVC")
+        set(RT_ARCHIVE_WITH_LDC OFF)
+    else()
+        set(RT_ARCHIVE_WITH_LDC ON)
+    endif()
 endif()
 
 set(SHARED_LIBS_SUPPORTED OFF)
@@ -427,13 +438,24 @@ macro(compile_phobos2 d_flags lib_suffix path_suffix all_at_once outlist_o outli
     )
 endmacro()
 
+# Define an optional 'D' CMake linker language for the static runtime libs,
+# using LDC as archiver. LDC handles (cross-)archiving internally via LLVM
+# and supports LTO objects.
+set(CMAKE_D_CREATE_STATIC_LIBRARY "${LDC_EXE_FULL} -lib -of=<TARGET> <OBJECTS>")
+foreach(f ${D_FLAGS})
+    append("\"${f}\"" CMAKE_D_CREATE_STATIC_LIBRARY)
+endforeach()
+
 # Sets the common properties for all library targets.
-function(set_common_library_properties target)
+function(set_common_library_properties target is_shared)
     set_target_properties(${target} PROPERTIES
         VERSION ${DMDFE_VERSION}
         SOVERSION ${DMDFE_PATCH_VERSION}
         LINKER_LANGUAGE C
     )
+    if(RT_ARCHIVE_WITH_LDC AND NOT is_shared)
+        set_target_properties(${target} PROPERTIES LINKER_LANGUAGE D)
+    endif()
 
     # ldc2 defaults to position-independent code on Linux to match the implicit
     # linker default on Ubuntu 16.10 and above. As we might be building on an
@@ -468,7 +490,7 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
         COMPILE_FLAGS               "${c_flags}"
         LINK_FLAGS                  "${ld_flags}"
     )
-    set_common_library_properties(druntime-ldc${target_suffix})
+    set_common_library_properties(druntime-ldc${target_suffix} "${is_shared}")
 
     # When building a shared library, we need to link in all the default
     # libraries otherwise implicitly added by LDC to make it loadable from
@@ -491,7 +513,7 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
             COMPILE_FLAGS               "${c_flags}"
             LINK_FLAGS                  "${ld_flags}"
         )
-        set_common_library_properties(phobos2-ldc${target_suffix})
+        set_common_library_properties(phobos2-ldc${target_suffix} "${is_shared}")
 
         if("${is_shared}" STREQUAL "ON")
             target_link_libraries(phobos2-ldc${target_suffix}
@@ -605,7 +627,7 @@ macro(build_all_runtime_variants d_flags c_flags ld_flags path_suffix outlist_ta
         # static profile-rt
         build_profile_runtime("${d_flags};${D_FLAGS};${D_FLAGS_RELEASE}" "${c_flags}" "${ld_flags}" "" "${path_suffix}" ${outlist_targets})
         get_target_suffix("" "${path_suffix}" target_suffix)
-        set_common_library_properties(ldc-profile-rt${target_suffix})
+        set_common_library_properties(ldc-profile-rt${target_suffix} OFF)
     endif()
 endmacro()
 


### PR DESCRIPTION
Attempt to fix #2309.