### PR TITLE
Adapt embedded llvm-ar to LLVM 5.0 final

### DIFF
--- a/driver/archiver.cpp
+++ b/driver/archiver.cpp
@@ -50,7 +50,7 @@ bool Symtab = true;
 bool Deterministic = true;
 bool Thin = false;
 
-void fail(Twine Error) { outs() << "llvm-ar: " << Error << ".\n"; }
+void fail(Twine Error) { errs() << "llvm-ar: " << Error << ".\n"; }
 
 void fail(std::error_code EC, std::string Context = {}) {
   if (Context.empty())
@@ -79,6 +79,12 @@ int addMember(std::vector<NewArchiveMember> &Members, StringRef FileName,
     fail(std::move(Error), FileName);
     return 1;
   }
+
+#if LDC_LLVM_VER >= 500
+  // Use the basename of the object path for the member name.
+  NMOrErr->MemberName = sys::path::filename(NMOrErr->MemberName);
+#endif
+
   if (Pos == -1)
     Members.push_back(std::move(*NMOrErr));
   else
@@ -221,7 +227,7 @@ int performWriteOperation() {
   auto Buf = MemoryBuffer::getFile(ArchiveName, -1, false);
   std::error_code EC = Buf.getError();
   if (EC && EC != errc::no_such_file_or_directory) {
-    fail("error opening '" + ArchiveName + "': " + EC.message() + "!");
+    fail("error opening '" + ArchiveName + "': " + EC.message());
     return 1;
   }
 
@@ -230,9 +236,7 @@ int performWriteOperation() {
     object::Archive Archive(Buf.get()->getMemBufferRef(), Err);
     EC = errorToErrorCode(std::move(Err));
     if (EC) {
-      fail(
-          EC,
-          ("error loading '" + ArchiveName + "': " + EC.message() + "!").str());
+      fail(EC, ("error loading '" + ArchiveName + "': " + EC.message()).str());
       return 1;
     }
     return performWriteOperation(&Archive, std::move(Buf.get()));


### PR DESCRIPTION
It was based on early LLVM 5.0, and there's been one notable change in the meantime, see https://reviews.llvm.org/D33575. I think @joakim-noah mentioned some issues wrt. object names in static libs. **Edit**: And @JohanEngelen something wrt. object names and LTO?