### PR TITLE
druntime: Fix mangling issue #1970 for rt.config on Win32 and OSX

### DIFF
--- a/tests/linking/rt_options.d
+++ b/tests/linking/rt_options.d
@@ -1,0 +1,9 @@
+// RUN: %ldc -run %s
+
+extern(C) __gshared string[] rt_options = [ "key=value" ];
+
+void main()
+{
+    import rt.config;
+    assert(rt_configOption("key") == "value");
+}


### PR DESCRIPTION
~~LDC's~~ `pragma(mangle, …)` allows specifying a 'base' mangle for the symbol's linkage. So by using `extern(C) pragma(mangle, …)`, a base C mangle can be specified, without having to take care of a platform-specific prefix.