### PR TITLE
DMD-style inline asm: Add `s` suffix for fild etc. with 16-bit memory operand

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2535,7 +2535,7 @@ struct AsmProcessor {
     case FPInt_Types:
       switch (ptrtype) {
       case Short_Ptr:
-        type_suffix = "s";
+        type_suffix = 's';
         break;
       case Int_Ptr:
         type_suffix = 'l';

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2535,7 +2535,7 @@ struct AsmProcessor {
     case FPInt_Types:
       switch (ptrtype) {
       case Short_Ptr:
-        type_suffix = "";
+        type_suffix = "s";
         break;
       case Int_Ptr:
         type_suffix = 'l';


### PR DESCRIPTION
Needed for Win64 with 80-bit reals (i.e., MinGW) here (Win64-specific):
https://github.com/ldc-developers/phobos/blob/882449f7916031667e09fe7a203d305a60898641/std/math.d#L3691