### PR TITLE
cmake: use -of= instead of -of

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -299,7 +299,7 @@ macro(dc input_d d_flags output_dir output_suffix outlist_o outlist_bc)
     add_custom_command(
         OUTPUT
             ${outfiles}
-        COMMAND ${LDC_EXE} ${dc_flags} -c -I${RUNTIME_DIR}/src -I${RUNTIME_DIR}/src/gc ${input_d} -of${output_o} ${d_flags}
+        COMMAND ${LDC_EXE} ${dc_flags} -c -I${RUNTIME_DIR}/src -I${RUNTIME_DIR}/src/gc ${input_d} -of=${output_o} ${d_flags}
         WORKING_DIRECTORY ${PROJECT_PARENT_DIR}
         DEPENDS ${input_d}
                 ${LDC_EXE}
@@ -616,7 +616,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
         set(libarg "druntime-ldc-unittest${name_suffix}")
         add_test(NAME build-druntime-test-runner${name_suffix}
             COMMAND ${LDC_EXE}
-                -of${PROJECT_BINARY_DIR}/druntime-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
+                -of=${PROJECT_BINARY_DIR}/druntime-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
                 -defaultlib=${libarg} -debuglib=${libarg}
                 -singleobj ${flags} ${RUNTIME_DIR}/src/test_runner.d
         )
@@ -627,7 +627,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
             set(libarg "phobos2-ldc-unittest${name_suffix},druntime-ldc-unittest${name_suffix}")
             add_test(NAME build-phobos2-test-runner${name_suffix}
                 COMMAND ${LDC_EXE}
-                    -of${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
+                    -of=${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
                     -L--no-as-needed -defaultlib=${libarg} -debuglib=${libarg}
                     -singleobj ${flags} ${RUNTIME_DIR}/src/test_runner.d
             )
@@ -664,7 +664,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
 
         add_test(NAME build-druntime-test-runner${name_suffix}
             COMMAND ${LDC_EXE}
-                -of${PROJECT_BINARY_DIR}/druntime-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
+                -of=${PROJECT_BINARY_DIR}/druntime-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
                 -defaultlib=${druntime-casm} -debuglib=${druntime-casm}
                 -singleobj ${flags} ${druntime_o} ${RUNTIME_DIR}/src/test_runner.d
         )
@@ -695,7 +695,7 @@ macro(build_test_runner name_suffix d_flags c_flags)
 
             add_test(NAME build-phobos2-test-runner${name_suffix}
                 COMMAND ${LDC_EXE}
-                    -of${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
+                    -of=${PROJECT_BINARY_DIR}/phobos2-test-runner${name_suffix}${CMAKE_EXECUTABLE_SUFFIX}
                     -defaultlib=druntime-ldc,${phobos2-casm} -debuglib=druntime-ldc,${phobos2-casm}
                     -singleobj ${flags} ${phobos2_o} ${RUNTIME_DIR}/src/test_runner.d
             )


### PR DESCRIPTION
Building on mingw-w64 fails without it(shouldn't break other builds).