### PR TITLE
Provide explicit template instantiation definitions for FPTypeProperties<T> static members

### DIFF
--- a/ddmd/target.h
+++ b/ddmd/target.h
@@ -83,4 +83,22 @@ struct Target
     static LINK systemLinkage();
 };
 
+#if IN_LLVM
+// Provide explicit template instantiation definitions for FPTypeProperties<T>
+// static members. See:
+// https://stackoverflow.com/questions/43439862/c-template-instantiation-of-variable-required-here-but-no-definition-is-ava
+template <typename T> real_t Target::FPTypeProperties<T>::max;
+template <typename T> real_t Target::FPTypeProperties<T>::min_normal;
+template <typename T> real_t Target::FPTypeProperties<T>::nan;
+template <typename T> real_t Target::FPTypeProperties<T>::snan;
+template <typename T> real_t Target::FPTypeProperties<T>::infinity;
+template <typename T> real_t Target::FPTypeProperties<T>::epsilon;
+template <typename T> d_int64 Target::FPTypeProperties<T>::dig;
+template <typename T> d_int64 Target::FPTypeProperties<T>::mant_dig;
+template <typename T> d_int64 Target::FPTypeProperties<T>::max_exp;
+template <typename T> d_int64 Target::FPTypeProperties<T>::min_exp;
+template <typename T> d_int64 Target::FPTypeProperties<T>::max_10_exp;
+template <typename T> d_int64 Target::FPTypeProperties<T>::min_10_exp;
+#endif
+
 #endif


### PR DESCRIPTION
Fixes compile warnings with XCode 9.

`gen/target.cpp:59:18: warning: instantiation of variable 'Target::FPTypeProperties<long double>::nan' required here, but no definition is available [-Wundefined-var-template]`

See https://stackoverflow.com/questions/43439862/c-template-instantiation-of-variable-required-here-but-no-definition-is-ava

No need to upstream because the warning is caused by the LDC-specific modification in the same file.