### PR TITLE
OSX: Use external archiver by default, require `-ar=` for internal one

### DIFF
--- a/driver/archiver.cpp
+++ b/driver/archiver.cpp
@@ -299,7 +299,11 @@ int createStaticLibrary() {
       global.params.targetTriple->isWindowsMSVCEnvironment();
 
 #if LDC_LLVM_VER >= 309
-  const bool useInternalArchiver = ar.empty();
+  const bool useInternalArchiver =
+      ar.empty() &&
+      // require an explicit empty `-ar=` for OSX targets due to Xcode 9 ranlib
+      // bug (https://github.com/ldc-developers/ldc/issues/2350)
+      (!global.params.targetTriple->isOSDarwin() || ar.getNumOccurrences() > 0);
 #else
   const bool useInternalArchiver = false;
 #endif


### PR DESCRIPTION
Works around issue #2350.