### PR TITLE
Don't let Target::RealProperties alias Target::DoubleProperties

### DIFF
--- a/ddmd/target.d
+++ b/ddmd/target.d
@@ -40,40 +40,42 @@ struct Target
     extern (C++) static __gshared int classinfosize;        // size of 'ClassInfo'
     extern (C++) static __gshared ulong maxStaticDataSize;  // maximum size of static data
 
-    extern (C++) struct FPTypeProperties(T)
-    {
-        static __gshared
-        {
-            real_t max = T.max;
-            real_t min_normal = T.min_normal;
-            real_t nan = T.nan;
-            real_t snan = T.init;
-            real_t infinity = T.infinity;
-            real_t epsilon = T.epsilon;
+  version(IN_LLVM)
+  {
+    extern (C++):
 
-            d_int64 dig = T.dig;
-            d_int64 mant_dig = T.mant_dig;
-            d_int64 max_exp = T.max_exp;
-            d_int64 min_exp = T.min_exp;
-            d_int64 max_10_exp = T.max_10_exp;
-            d_int64 min_10_exp = T.min_10_exp;
+    struct FPTypeProperties
+    {
+        real_t max, min_normal, nan, snan, infinity, epsilon;
+        d_int64 dig, mant_dig, max_exp, min_exp, max_10_exp, min_10_exp;
+
+        static FPTypeProperties fromDHostCompiler(T)()
+        {
+            FPTypeProperties p;
+
+            p.max = T.max;
+            p.min_normal = T.min_normal;
+            p.nan = T.nan;
+            p.snan = T.init;
+            p.infinity = T.infinity;
+            p.epsilon = T.epsilon;
+
+            p.dig = T.dig;
+            p.mant_dig = T.mant_dig;
+            p.max_exp = T.max_exp;
+            p.min_exp = T.min_exp;
+            p.max_10_exp = T.max_10_exp;
+            p.min_10_exp = T.min_10_exp;
+
+            return p;
         }
     }
 
-    alias FloatProperties = FPTypeProperties!float;
-    alias DoubleProperties = FPTypeProperties!double;
-  version(IN_LLVM) {
-    // host real_t may be double => make sure not to alias target's DoubleProperties
-    extern (C++) static __gshared FPTypeProperties!real_t RealProperties;
-  } else {
-    alias RealProperties = FPTypeProperties!real_t;
-  }
+    static __gshared FPTypeProperties FloatProperties = FPTypeProperties.fromDHostCompiler!float();
+    static __gshared FPTypeProperties DoubleProperties = FPTypeProperties.fromDHostCompiler!double();
+    static __gshared FPTypeProperties RealProperties = FPTypeProperties.fromDHostCompiler!real_t();
 
-  version(IN_LLVM)
-  {
     // implemented in gen/target.cpp:
-    extern (C++):
-
     static void _init();
     // Type sizes and support.
     static uint alignsize(Type type);
@@ -106,6 +108,30 @@ struct Target
   }
   else // !IN_LLVM
   {
+    extern (C++) struct FPTypeProperties(T)
+    {
+        static __gshared
+        {
+            real_t max = T.max;
+            real_t min_normal = T.min_normal;
+            real_t nan = T.nan;
+            real_t snan = T.init;
+            real_t infinity = T.infinity;
+            real_t epsilon = T.epsilon;
+
+            d_int64 dig = T.dig;
+            d_int64 mant_dig = T.mant_dig;
+            d_int64 max_exp = T.max_exp;
+            d_int64 min_exp = T.min_exp;
+            d_int64 max_10_exp = T.max_10_exp;
+            d_int64 min_10_exp = T.min_10_exp;
+        }
+    }
+
+    alias FloatProperties = FPTypeProperties!float;
+    alias DoubleProperties = FPTypeProperties!double;
+    alias RealProperties = FPTypeProperties!real_t;
+
     extern (C++) static void _init()
     {
         // These have default values for 32 bit code, they get

--- a/ddmd/target.h
+++ b/ddmd/target.h
@@ -38,6 +38,17 @@ struct Target
     static int classinfosize;        // size of 'ClassInfo'
     static unsigned long long maxStaticDataSize;  // maximum size of static data
 
+#if IN_LLVM
+    struct FPTypeProperties
+    {
+        real_t max, min_normal, nan, snan, infinity, epsilon;
+        d_int64 dig, mant_dig, max_exp, min_exp, max_10_exp, min_10_exp;
+    };
+
+    static FPTypeProperties FloatProperties;
+    static FPTypeProperties DoubleProperties;
+    static FPTypeProperties RealProperties;
+#else
     template <typename T>
     struct FPTypeProperties
     {
@@ -58,9 +69,6 @@ struct Target
 
     typedef FPTypeProperties<float> FloatProperties;
     typedef FPTypeProperties<double> DoubleProperties;
-#if IN_LLVM
-    static FPTypeProperties<real_t> RealProperties;
-#else
     typedef FPTypeProperties<real_t> RealProperties;
 #endif
 
@@ -82,23 +90,5 @@ struct Target
     static const char *cppTypeMangle(Type *t);
     static LINK systemLinkage();
 };
-
-#if IN_LLVM
-// Provide explicit template instantiation definitions for FPTypeProperties<T>
-// static members. See:
-// https://stackoverflow.com/questions/43439862/c-template-instantiation-of-variable-required-here-but-no-definition-is-ava
-template <typename T> real_t Target::FPTypeProperties<T>::max;
-template <typename T> real_t Target::FPTypeProperties<T>::min_normal;
-template <typename T> real_t Target::FPTypeProperties<T>::nan;
-template <typename T> real_t Target::FPTypeProperties<T>::snan;
-template <typename T> real_t Target::FPTypeProperties<T>::infinity;
-template <typename T> real_t Target::FPTypeProperties<T>::epsilon;
-template <typename T> d_int64 Target::FPTypeProperties<T>::dig;
-template <typename T> d_int64 Target::FPTypeProperties<T>::mant_dig;
-template <typename T> d_int64 Target::FPTypeProperties<T>::max_exp;
-template <typename T> d_int64 Target::FPTypeProperties<T>::min_exp;
-template <typename T> d_int64 Target::FPTypeProperties<T>::max_10_exp;
-template <typename T> d_int64 Target::FPTypeProperties<T>::min_10_exp;
-#endif
 
 #endif

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -98,7 +98,7 @@ void Target::_init() {
     RealProperties.min_10_exp = -4931;
   } else {
     // leave initialized with host real_t values
-    warning(Loc(), "unknown properties for target `real` type, reyling on D "
+    warning(Loc(), "unknown properties for target `real` type, relying on D "
                    "host compiler");
   }
 }

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -43,6 +43,10 @@ void Target::_init() {
   classinfosize = 0; // unused
   maxStaticDataSize = std::numeric_limits<unsigned long long>::max();
 
+  // {Float,Double,Real}Properties have been initialized with the D host
+  // compiler's properties.
+  // Now finalize RealProperties for the target's `real` type.
+
   const auto targetRealSemantics = &real->getFltSemantics();
 #if LDC_LLVM_VER >= 400
   const auto IEEEdouble = &APFloat::IEEEdouble();
@@ -94,7 +98,8 @@ void Target::_init() {
     RealProperties.min_10_exp = -4931;
   } else {
     // leave initialized with host real_t values
-    warning(Loc(), "unknown properties for target `real` type");
+    warning(Loc(), "unknown properties for target `real` type, reyling on D "
+                   "host compiler");
   }
 }
 


### PR DESCRIPTION
Which is a serious problem if the host real_t is a double and the target `real` features a higher precision (cross-compilation). `Target::RealProperties` are set up for the target's `real`, so max/min_normal/epsilon may over/underflow, and so would `DoubleProperties` if aliased.