### PR TITLE
Fix bad import cycle error with `-cov`

### DIFF
--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -235,9 +235,11 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
 #if 0
   if (fgetmembers)
     flags |= MIxgetMembers;
+#endif
+
+  const auto fictor = getIrModule(m)->coverageCtor;
   if (fictor)
     flags |= MIictor;
-#endif
 
   const auto funittest = buildModuleUnittest(m);
   if (funittest) {
@@ -281,9 +283,10 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
 #if 0
     if (fgetmembers)
         b.push(fgetmembers);
-    if (fictor)
-        b.push(fictor);
 #endif
+  if (fictor) {
+    b.push(fictor);
+  }
   if (funittest) {
     b.push(funittest);
   }

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -572,17 +572,11 @@ void addCoverageAnalysis(Module *m) {
     builder.CreateRetVoid();
   }
 
-  // Add the ctor to the module's static ctors list. TODO: This is quite the
-  // hack.
+  // Add the ctor to the module's order-independent ctors list.
   {
-    IF_LOG Logger::println("Add %s to module's shared static constructor list",
+    IF_LOG Logger::println("Set %s as module's static constructor for coverage",
                            ctorname);
-    FuncDeclaration *fd =
-        FuncDeclaration::genCfunc(nullptr, Type::tvoid, ctorname);
-    fd->linkage = LINKd;
-    IrFunction *irfunc = getIrFunc(fd, true);
-    irfunc->setLLVMFunc(ctor);
-    getIrModule(m)->sharedCtors.push_back(fd);
+    getIrModule(m)->coverageCtor = ctor;
   }
 
   IF_LOG Logger::undent();

--- a/ir/irmodule.h
+++ b/ir/irmodule.h
@@ -21,6 +21,7 @@ class VarDeclaration;
 class Module;
 namespace llvm {
 class GlobalVariable;
+class Function;
 }
 
 struct IrModule {
@@ -41,6 +42,7 @@ struct IrModule {
   GatesList gates;
   GatesList sharedGates;
   FuncDeclList unitTests;
+  llvm::Function *coverageCtor = nullptr;
 
 private:
   llvm::GlobalVariable *moduleInfoVar = nullptr;

--- a/tests/codegen/coverage_cycle_gh2177.d
+++ b/tests/codegen/coverage_cycle_gh2177.d
@@ -1,0 +1,17 @@
+// Test that `-cov` does not lead to harmless import cycle errors.
+// Github issue 2177
+
+// RUN: %ldc -cov=100 -Iinputs %s %S/inputs/coverage_cycle_input.d -of=%t%exe
+// RUN: %t%exe
+
+module coverage_cycle_gh2177;
+
+import inputs.coverage_cycle_input;
+
+static this() {
+    int i;
+}
+
+int main () {
+    return 0;
+}

--- a/tests/codegen/inputs/coverage_cycle_input.d
+++ b/tests/codegen/inputs/coverage_cycle_input.d
@@ -1,0 +1,3 @@
+module inputs.coverage_cycle_input;
+
+import coverage_cycle_gh2177;


### PR DESCRIPTION
Move the call to the D-style code-coverage constructor (registration of code coverage for the current module) to the "ictor" constructors that are not included in cycle detection.

Resolves issue #2177.

Adding the coverage ctor call to `llvm.global_ctors` does not work, because the call must happen after D runtime's `rt.cover.gdata` has been properly initialized, i.e. after other D constructors in the ModuleInfo ctor list.
The code is intentionally kept somewhat similar to DMD's (variable naming).