### PR TITLE
Add -linker command-line option

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -52,6 +52,7 @@ private:
   virtual void addFuzzLinkFlags();
   virtual void addCppStdlibLinkFlags();
 
+  virtual void addLinker();
   virtual void addUserSwitches();
   void addDefaultLibs();
   virtual void addTargetFlags();
@@ -366,6 +367,7 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
     addLTOLinkFlags();
 #endif
 
+  addLinker();
   addUserSwitches();
 
   // libs added via pragma(lib, libname)
@@ -386,6 +388,13 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
   addDefaultLibs();
 
   addTargetFlags();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void ArgsBuilder::addLinker() {
+  if (!opts::linker.empty())
+    args.push_back("-fuse-ld=" + opts::linker);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -485,6 +494,8 @@ void ArgsBuilder::addTargetFlags() {
 
 class LdArgsBuilder : public ArgsBuilder {
   void addSanitizers() override {}
+
+  void addLinker() override {}
 
   void addUserSwitches() override {
     if (!opts::ccSwitches.empty()) {

--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -62,8 +62,6 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath, bool useInternalLinker,
   windows::setupMsvcEnvironment();
 #endif
 
-  const std::string tool = "link.exe";
-
   // build arguments
   std::vector<std::string> args;
 
@@ -180,5 +178,9 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath, bool useInternalLinker,
 #endif
 
   // try to call linker
-  return executeToolAndWait(tool, args, global.params.verbose);
+  std::string linker = opts::linker;
+  if (linker.empty())
+    linker = "link.exe";
+
+  return executeToolAndWait(linker, args, global.params.verbose);
 }

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -22,6 +22,12 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
+namespace opts {
+llvm::cl::opt<std::string>
+    linker("linker", llvm::cl::ZeroOrMore, llvm::cl::desc("Linker to use"),
+           llvm::cl::value_desc("lld-link|lld|gold|bfd|..."));
+}
+
 static llvm::cl::opt<std::string>
     gcc("gcc", llvm::cl::desc("GCC to use for assembling and linking"),
         llvm::cl::Hidden, llvm::cl::ZeroOrMore);

--- a/driver/tool.h
+++ b/driver/tool.h
@@ -20,6 +20,10 @@
 
 #include "llvm/Support/CommandLine.h"
 
+namespace opts {
+extern llvm::cl::opt<std::string> linker;
+}
+
 std::string getGcc();
 void appendTargetArgsForGcc(std::vector<std::string> &args);
 


### PR DESCRIPTION
Needed for LTO via external `lld-link.exe` (v5.0+).