### PR TITLE
Disassemble resulting jit module and output asm to debug handler

### DIFF
--- a/runtime/jit-rt/DefineBuildJitRT.cmake
+++ b/runtime/jit-rt/DefineBuildJitRT.cmake
@@ -39,7 +39,8 @@ if(LDC_DYNAMIC_COMPILE)
         # to do find_package(LLVM CONFIG) for it so here is a hackish way to get it
         include("${LLVM_LIBRARY_DIRS}/cmake/llvm/LLVMConfig.cmake")
         include("${LLVM_LIBRARY_DIRS}/cmake/llvm/LLVM-Config.cmake")
-        llvm_map_components_to_libnames(JITRT_LLVM_LIBS core support irreader executionengine passes nativecodegen orcjit target)
+        llvm_map_components_to_libnames(JITRT_LLVM_LIBS core support irreader executionengine passes nativecodegen orcjit target
+            "${LLVM_NATIVE_ARCH}disassembler" "${LLVM_NATIVE_ARCH}asmprinter")
 
         foreach(libname ${JITRT_LLVM_LIBS})
             unset(JITRT_TEMP_LIB CACHE)

--- a/runtime/jit-rt/cpp-so/disassembler.cpp
+++ b/runtime/jit-rt/cpp-so/disassembler.cpp
@@ -268,11 +268,11 @@ void disassemble(const llvm::TargetMachine &tm,
 
   asmStreamer->InitSections(false);
 
-  for (auto symbol : object.symbols()) {
-    auto name = llvm::cantFail(symbol.getName());
-    auto secIt = llvm::cantFail(symbol.getSection());
+  for (const auto& symbol : object.symbols()) {
+    const auto name = llvm::cantFail(symbol.getName());
+    const auto secIt = llvm::cantFail(symbol.getSection());
     if (object.section_end() != secIt) {
-      auto sec = *secIt;
+      const auto sec = *secIt;
       llvm::StringRef data;
       sec.getContents(data);
       llvm::ArrayRef<uint8_t> buff(
@@ -280,11 +280,11 @@ void disassemble(const llvm::TargetMachine &tm,
       if (llvm::object::SymbolRef::ST_Function ==
           llvm::cantFail(symbol.getType())) {
         symTable.reset();
-        symTable.addLabel(0, 0, name);
+        symTable.addLabel(0, 0, name); // Function start
         for (auto reloc : sec.relocations()) {
-          auto symIt = reloc.getSymbol();
+          const auto symIt = reloc.getSymbol();
           if (object.symbol_end() != symIt) {
-            auto sym = *symIt;
+            const auto sym = *symIt;
             symTable.addExternalSymbolRel(reloc.getOffset(),
                                           llvm::cantFail(sym.getName()));
           }
@@ -298,7 +298,7 @@ void disassemble(const llvm::TargetMachine &tm,
 }
 #else
 void disassemble(const llvm::TargetMachine & /*tm*/,
-                 const llvm::object::ObjectFile &object,
+                 const llvm::object::ObjectFile &/*object*/,
                  llvm::raw_ostream &os) {
   os << "Asm output not supported";
   os.flush();

--- a/runtime/jit-rt/cpp-so/disassembler.cpp
+++ b/runtime/jit-rt/cpp-so/disassembler.cpp
@@ -1,0 +1,306 @@
+//===-- disassembler.cpp --------------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the Boost Software License. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "disassembler.h"
+
+#include <unordered_map>
+
+#include <llvm/ADT/Triple.h>
+#include <llvm/MC/MCAsmBackend.h>
+#include <llvm/MC/MCAsmInfo.h>
+#include <llvm/MC/MCCodeEmitter.h>
+#include <llvm/MC/MCContext.h>
+#include <llvm/MC/MCDisassembler/MCDisassembler.h>
+#include <llvm/MC/MCDisassembler/MCSymbolizer.h>
+#include <llvm/MC/MCInst.h>
+#include <llvm/MC/MCInstPrinter.h>
+#include <llvm/MC/MCInstrAnalysis.h>
+#include <llvm/MC/MCObjectFileInfo.h>
+#include <llvm/MC/MCRegisterInfo.h>
+#include <llvm/MC/MCStreamer.h>
+#include <llvm/MC/MCSubtargetInfo.h>
+#include <llvm/Object/ObjectFile.h>
+#include <llvm/Support/Error.h>
+#include <llvm/Support/TargetRegistry.h>
+#include <llvm/Target/TargetMachine.h>
+
+#if LDC_LLVM_VER >= 500
+namespace {
+template <typename T> std::unique_ptr<T> unique(T *ptr) {
+  return std::unique_ptr<T>(ptr);
+}
+
+enum class Stage {
+  Scan,
+  Emit,
+};
+
+class SymTable final {
+  llvm::MCContext &context;
+  Stage stage;
+  std::unordered_map<uint64_t, llvm::MCSymbol *> labelsPos;
+  std::unordered_map<uint64_t, llvm::MCSymbol *> labelsTargets;
+  std::unordered_map<uint64_t, llvm::MCSymbol *> externalSymbols;
+
+public:
+  SymTable(llvm::MCContext &ctx) : context(ctx) {}
+
+  llvm::MCContext &getContext() { return context; }
+
+  void setStage(Stage s) { stage = s; }
+
+  Stage getStage() const { return stage; }
+
+  void reset() {
+    labelsPos.clear();
+    labelsTargets.clear();
+    externalSymbols.clear();
+  }
+
+  void addLabel(uint64_t pos, uint64_t target, llvm::StringRef name = {}) {
+    if (auto label = getTargetLabel(target)) {
+      labelsPos.insert({pos, label});
+      return;
+    }
+    auto sym = name.empty() ? context.createTempSymbol("", false)
+                            : context.getOrCreateSymbol(name);
+    assert(nullptr != sym);
+    labelsPos.insert({pos, sym});
+    labelsTargets.insert({target, sym});
+  }
+
+  llvm::MCSymbol *getPosLabel(uint64_t pos) const {
+    auto it = labelsPos.find(pos);
+    if (labelsPos.end() != it) {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  llvm::MCSymbol *getTargetLabel(uint64_t target) const {
+    auto it = labelsTargets.find(target);
+    if (labelsTargets.end() != it) {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  void addExternalSymbolRel(uint64_t pos, llvm::StringRef name) {
+    auto sym = context.getOrCreateSymbol(name);
+    assert(nullptr != sym);
+    externalSymbols.insert({pos, sym});
+  }
+
+  llvm::MCSymbol *getExternalSymbolRel(uint64_t pos) const {
+    auto it = externalSymbols.find(pos);
+    if (externalSymbols.end() != it) {
+      return it->second;
+    }
+    return nullptr;
+  }
+};
+
+void printFunction(const llvm::MCDisassembler &disasm,
+                   const llvm::MCInstrAnalysis &mcia,
+                   llvm::ArrayRef<uint8_t> data, SymTable &symTable,
+                   const llvm::MCSubtargetInfo &sti,
+                   llvm::MCStreamer &streamer) {
+  const Stage stages[] = {Stage::Scan, Stage::Emit};
+  for (auto stage : stages) {
+    symTable.setStage(stage);
+    uint64_t size = 0;
+    for (uint64_t pos = 0; pos < static_cast<uint64_t>(data.size());
+         pos += size) {
+      llvm::MCInst inst;
+
+      auto status = disasm.getInstruction(inst, size, data.slice(pos), pos,
+                                          llvm::nulls(), llvm::nulls());
+
+      switch (status) {
+      case llvm::MCDisassembler::Fail:
+        streamer.EmitRawText("failed to disassemble");
+        return;
+
+      case llvm::MCDisassembler::SoftFail:
+        streamer.EmitRawText("potentially undefined instruction encoding:");
+        LLVM_FALLTHROUGH;
+
+      case llvm::MCDisassembler::Success:
+        if (Stage::Scan == stage) {
+          if (mcia.isBranch(inst) || mcia.isCall(inst)) {
+            uint64_t target = 0;
+            if (mcia.evaluateBranch(inst, pos, size, target)) {
+              symTable.addLabel(pos, target);
+            }
+          }
+        } else if (Stage::Emit == stage) {
+          if (auto label = symTable.getTargetLabel(pos)) {
+            streamer.EmitLabel(label);
+          }
+          streamer.EmitInstruction(inst, sti);
+        }
+        break;
+      }
+      assert(0 != size);
+    }
+  }
+}
+
+class Symbolizer final : public llvm::MCSymbolizer {
+  SymTable &symTable;
+
+  const llvm::MCExpr *createExpr(llvm::MCSymbol *sym, int64_t offset = 0) {
+    assert(nullptr != sym);
+    auto &ctx = symTable.getContext();
+    auto expr = llvm::MCSymbolRefExpr::create(sym, ctx);
+    if (0 == offset) {
+      return expr;
+    }
+    auto off = llvm::MCConstantExpr::create(offset, ctx);
+    return llvm::MCBinaryExpr::createAdd(expr, off, ctx);
+  }
+
+public:
+  Symbolizer(llvm::MCContext &Ctx,
+             std::unique_ptr<llvm::MCRelocationInfo> RelInfo,
+             SymTable &symtable)
+      : MCSymbolizer(Ctx, std::move(RelInfo)), symTable(symtable) {}
+
+  virtual bool tryAddingSymbolicOperand(llvm::MCInst &Inst,
+                                        llvm::raw_ostream & /*cStream*/,
+                                        int64_t Value, uint64_t Address,
+                                        bool IsBranch, uint64_t Offset,
+                                        uint64_t /*InstSize*/) override {
+    if (Stage::Emit == symTable.getStage()) {
+      if (IsBranch) {
+        if (auto label = symTable.getPosLabel(Address)) {
+          Inst.addOperand(llvm::MCOperand::createExpr(createExpr(label)));
+          return true;
+        }
+      }
+
+      if (auto sym = symTable.getExternalSymbolRel(Address + Offset)) {
+        Inst.addOperand(llvm::MCOperand::createExpr(createExpr(sym, Value)));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  virtual void tryAddingPcLoadReferenceComment(llvm::raw_ostream & /*cStream*/,
+                                               int64_t /*Value*/,
+                                               uint64_t /*Address*/) override {
+    // Nothing
+  }
+};
+}
+
+void disassemble(const llvm::TargetMachine &tm,
+                 const llvm::object::ObjectFile &object,
+                 llvm::raw_ostream &os) {
+  auto &target = tm.getTarget();
+
+  auto mri = tm.getMCRegisterInfo();
+  auto mai = tm.getMCAsmInfo();
+  auto sti = tm.getMCSubtargetInfo();
+  auto mii = tm.getMCInstrInfo();
+
+  if (nullptr == mri || nullptr == mai || nullptr == sti || nullptr == mii) {
+    // TODO: proper error handling
+    return;
+  }
+
+  llvm::MCObjectFileInfo mofi;
+  llvm::MCContext ctx(mai, mri, &mofi);
+#if LDC_LLVM_VER >= 600
+  mofi.InitMCObjectFileInfo(tm.getTargetTriple(), tm.isPositionIndependent(),
+                            ctx, tm.getCodeModel() == llvm::CodeModel::Large);
+#else
+  mofi.InitMCObjectFileInfo(tm.getTargetTriple(), tm.isPositionIndependent(),
+                            tm.getCodeModel(), ctx);
+#endif
+
+  auto disasm = unique(target.createMCDisassembler(*sti, ctx));
+  if (nullptr == disasm) {
+    return;
+  }
+
+  SymTable symTable(ctx);
+  disasm->setSymbolizer(llvm::make_unique<Symbolizer>(
+      ctx, llvm::make_unique<llvm::MCRelocationInfo>(ctx), symTable));
+
+  auto mcia = unique(target.createMCInstrAnalysis(mii));
+  if (nullptr == mcia) {
+    return;
+  }
+
+  auto mip = unique(
+      target.createMCInstPrinter(tm.getTargetTriple(), 0, *mai, *mii, *mri));
+  if (nullptr == mip) {
+    return;
+  }
+
+  auto mce = unique(target.createMCCodeEmitter(*mii, *mri, ctx));
+  if (nullptr == mce) {
+    return;
+  }
+
+  llvm::MCTargetOptions opts;
+  auto mab = unique(target.createMCAsmBackend(
+      *mri, tm.getTargetTriple().getTriple(), tm.getTargetCPU(), opts));
+  if (nullptr == mab) {
+    return;
+  }
+
+  // Streamer takes ownership of mip mce mab
+  auto asmStreamer = unique(target.createAsmStreamer(
+      ctx, llvm::make_unique<llvm::formatted_raw_ostream>(os), false, true,
+      mip.release(), mce.release(), mab.release(), false));
+  if (nullptr == asmStreamer) {
+    return;
+  }
+
+  asmStreamer->InitSections(false);
+
+  for (auto symbol : object.symbols()) {
+    auto name = llvm::cantFail(symbol.getName());
+    auto secIt = llvm::cantFail(symbol.getSection());
+    if (object.section_end() != secIt) {
+      auto sec = *secIt;
+      llvm::StringRef data;
+      sec.getContents(data);
+      llvm::ArrayRef<uint8_t> buff(
+          reinterpret_cast<const uint8_t *>(data.data()), data.size());
+      if (llvm::object::SymbolRef::ST_Function ==
+          llvm::cantFail(symbol.getType())) {
+        symTable.reset();
+        symTable.addLabel(0, 0, name);
+        for (auto reloc : sec.relocations()) {
+          auto symIt = reloc.getSymbol();
+          if (object.symbol_end() != symIt) {
+            auto sym = *symIt;
+            symTable.addExternalSymbolRel(reloc.getOffset(),
+                                          llvm::cantFail(sym.getName()));
+          }
+        }
+
+        printFunction(*disasm, *mcia, buff, symTable, *sti, *asmStreamer);
+        asmStreamer->EmitRawText("");
+      }
+    }
+  }
+}
+#else
+void disassemble(const llvm::TargetMachine & /*tm*/,
+                 const llvm::object::ObjectFile &object,
+                 llvm::raw_ostream &os) {
+  os << "Asm output not supported";
+  os.flush();
+}
+#endif

--- a/runtime/jit-rt/cpp-so/disassembler.h
+++ b/runtime/jit-rt/cpp-so/disassembler.h
@@ -1,0 +1,28 @@
+//===-- disassembler.h - jit support ----------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the Boost Software License. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Jit disassembler - allow to disassemble in-memory object files
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DISASSEMBLER_H
+#define DISASSEMBLER_H
+
+namespace llvm {
+namespace object {
+class ObjectFile;
+}
+class TargetMachine;
+class raw_ostream;
+}
+
+void disassemble(const llvm::TargetMachine &tm,
+                 const llvm::object::ObjectFile &object, llvm::raw_ostream &os);
+
+#endif // DISASSEMBLER_H

--- a/tests/dynamiccompile/asm_output.d
+++ b/tests/dynamiccompile/asm_output.d
@@ -1,0 +1,33 @@
+
+// REQUIRES: atleast_llvm500
+// RUN: %ldc -enable-dynamic-compile -run %s
+
+import std.array;
+import std.string;
+import ldc.attributes;
+import ldc.dynamic_compile;
+
+__gshared int value = 32;
+
+@dynamicCompile int foo()
+{
+  return value;
+}
+
+void main(string[] args)
+{
+  auto dump = appender!string();
+  CompilerSettings settings;
+  settings.dumpHandler = (DumpStage stage, in char[] str)
+  {
+    if (DumpStage.FinalAsm == stage)
+    {
+      dump.put(str);
+    }
+  };
+  compileDynamicCode(settings);
+
+  // Check function and variables names in asm
+  assert(-1 != indexOf(dump.data, foo.mangleof));
+  assert(-1 != indexOf(dump.data, value.mangleof));
+}

--- a/tests/dynamiccompile/dump_handler.d
+++ b/tests/dynamiccompile/dump_handler.d
@@ -9,9 +9,28 @@ import ldc.dynamic_compile;
   return 5;
 }
 
+@dynamicCompile int bar(int i = 5)
+{
+  if(i > 0)
+  {
+    return bar(i - 1) + 1;
+  }
+  return 1;
+}
+
+@dynamicCompile int baz()
+{
+  int i = 0;
+  foreach(j;1..4)
+  {
+    i += j * j;
+  }
+  return i;
+}
+
 void main(string[] args)
 {
-  bool dumpHandlerCalled[4] = false;
+  bool[4] dumpHandlerCalled = false;
   bool progressHandlerCalled = false;
   CompilerSettings settings;
 
@@ -25,10 +44,11 @@ void main(string[] args)
   };
   compileDynamicCode(settings);
   assert(5 == foo());
+  assert(6 == bar());
+  assert(14 == baz());
   assert(dumpHandlerCalled[DumpStage.OriginalModule]);
   assert(dumpHandlerCalled[DumpStage.MergedModule]);
   assert(dumpHandlerCalled[DumpStage.OptimizedModule]);
-  // asm dump is disabled for now
-  //assert(dumpHandlerCalled[DumpStage.FinalAsm]);
+  assert(dumpHandlerCalled[DumpStage.FinalAsm]);
   assert(progressHandlerCalled);
 }


### PR DESCRIPTION
Debug asm output was disabled previously because`addPassesToEmitFile` asm output was different from actual jit asm. This is attempt to disassemble jit binary instead.