### PR TITLE
Emit ModuleInfos as COMDATs again

### DIFF
--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -308,5 +308,6 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
   // Create a global symbol with the above initialiser.
   LLGlobalVariable *moduleInfoSym = getIrModule(m)->moduleInfoSymbol();
   b.finalize(moduleInfoSym);
+  setLinkage({LLGlobalValue::ExternalLinkage, supportsCOMDAT()}, moduleInfoSym);
   return moduleInfoSym;
 }


### PR DESCRIPTION
Reverts this functional change introduced by ldc-developers/ldc@3f38f971. I overlooked this because
`setLinkage({<linkage>, false}, <symbol>)` does NOT clear the COMDAT if previously set.