### PR TITLE
fix issue 2422 - remove overzealous error check

### DIFF
--- a/ir/irtypeclass.cpp
+++ b/ir/irtypeclass.cpp
@@ -99,10 +99,6 @@ IrTypeClass *IrTypeClass::get(ClassDeclaration *cd) {
     builder.addTailPadding(cd->structsize);
   }
 
-  if (global.errors) {
-    fatal();
-  }
-
   // set struct body and copy GEP indices
   isaStruct(t->type)->setBody(builder.defaultTypes(), t->packed);
   t->varGEPIndices = builder.varGEPIndices();

--- a/tests/compilable/gh2422.d
+++ b/tests/compilable/gh2422.d
@@ -1,0 +1,5 @@
+// RUN: %ldc -c -I%S/inputs %s
+
+import gh2422a;
+
+void main() { auto aa = ["": new Empty]; }

--- a/tests/compilable/inputs/gh2422a.d
+++ b/tests/compilable/inputs/gh2422a.d
@@ -1,0 +1,1 @@
+class Empty { }


### PR DESCRIPTION
global.errors may be nonzero due to speculative error at this point!
ie. when trying to speculatively make a constant class expression