### PR TITLE
Enforce SimplifyDRuntimeCalls pass for -betterC

### DIFF
--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -151,7 +151,8 @@ static void addStripExternalsPass(const PassManagerBuilder &builder,
 
 static void addSimplifyDRuntimeCallsPass(const PassManagerBuilder &builder,
                                          PassManagerBase &pm) {
-  if (builder.OptLevel >= 2 && builder.SizeLevel == 0) {
+  if ((builder.OptLevel >= 2 && builder.SizeLevel == 0) ||
+      global.params.betterC) {
     addPass(pm, createSimplifyDRuntimeCalls());
   }
 }
@@ -311,6 +312,8 @@ static void addOptimizationPasses(legacy::PassManagerBase &mpm,
   if (!disableLangSpecificPasses) {
     if (!disableSimplifyDruntimeCalls) {
       builder.addExtension(PassManagerBuilder::EP_LoopOptimizerEnd,
+                           addSimplifyDRuntimeCallsPass);
+      builder.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0,
                            addSimplifyDRuntimeCallsPass);
     }
 

--- a/tests/linking/betterc.d
+++ b/tests/linking/betterc.d
@@ -1,15 +1,27 @@
 // RUN: %ldc -betterC -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 // RUN: %ldc -betterC -defaultlib= -run %s
 
+extern(C):
+
 // CHECK-NOT: ModuleInfoZ
 // CHECK-NOT: ModuleRefZ
 // CHECK-NOT: call void @ldc.register_dso
 version (CRuntime_Microsoft) {
-    extern(C) int mainCRTStartup() {
+    int mainCRTStartup() {
         return 0;
     }
 }
 
-extern (C) int main() {
+void gh2425()
+{
+    char[16] buf;
+    const str = "hello world";
+    const ln = str.length;
+    // _d_array_slice_copy() inlined by SimplifyDRuntimeCalls pass
+    buf[0..ln] = str[0..ln];
+}
+
+int main() {
+    gh2425();
     return 0;
 }


### PR DESCRIPTION
To reduce druntime dependencies. Fixes issue #2425.