### PR TITLE
Extend LDC_inline_ir pragma

### DIFF
--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -42,14 +42,69 @@ void copyFnAttributes(llvm::Function *wannabe, llvm::Function *idol) {
   auto fnAttrSet = attrSet.getFnAttributes();
   wannabe->addAttributes(LLAttributeSet::FunctionIndex, fnAttrSet);
 }
-} // anonymous namespace
 
-namespace {
 std::string exprToString(StringExp *strexp) {
   assert(strexp != nullptr);
   assert(strexp->sz == 1);
   return std::string(strexp->toPtr(), strexp->numberOfCodeUnits());
 }
+} // anonymous namespace
+
+void DtoCheckInlineIRPragma(Identifier *ident, Dsymbol *s) {
+  assert(ident != nullptr);
+  assert(s != nullptr);
+  if (TemplateDeclaration *td = s->isTemplateDeclaration()) {
+    Dsymbol *member = td->onemember;
+    if (!member) {
+      error(s->loc, "the `%s` pragma template must have exactly one member",
+            ident->toChars());
+      fatal();
+    }
+    FuncDeclaration *fun = member->isFuncDeclaration();
+    if (!fun) {
+      error(
+          s->loc,
+          "the `%s` pragma template's member must be a function declaration",
+          ident->toChars());
+      fatal();
+    }
+    // The magic inlineIR template is one of
+    // pragma(LDC_inline_ir)
+    //   R inlineIR(string code, R, P...)(P);
+    // pragma(LDC_inline_ir)
+    //   R inlineIREx(string prefix, string code, string suffix, R, P...)(P);
+
+    TemplateParameters &params = *td->parameters;
+    bool valid_params =
+        (params.dim == 3 && params[1]->isTemplateTypeParameter() &&
+         params[2]->isTemplateTupleParameter()) ||
+        (params.dim == 5 && params[3]->isTemplateTypeParameter() &&
+         params[4]->isTemplateTupleParameter());
+
+    if (valid_params) {
+      TemplateValueParameter *p0 = params[0]->isTemplateValueParameter();
+      valid_params = valid_params && p0 && p0->valType == Type::tstring;
+      if (params.dim == 5) {
+        TemplateValueParameter *p1 = params[1]->isTemplateValueParameter();
+        valid_params = valid_params && p1 && p1->valType == Type::tstring;
+        TemplateValueParameter *p2 = params[2]->isTemplateValueParameter();
+        valid_params = valid_params && p2 && p2->valType == Type::tstring;
+      }
+    }
+
+    if (!valid_params) {
+      error(s->loc,
+            "the `%s` pragma template must have three "
+            "(string, type and type tuple) or "
+            "five (string, string, string, type and type tuple) parameters",
+            ident->toChars());
+      fatal();
+    }
+  } else {
+    error(s->loc, "the `%s` pragma is only allowed on template declarations",
+          ident->toChars());
+    fatal();
+  }
 }
 
 DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,

--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -76,19 +76,14 @@ void DtoCheckInlineIRPragma(Identifier *ident, Dsymbol *s) {
 
     TemplateParameters &params = *td->parameters;
     bool valid_params =
-        (params.dim == 3 && params[1]->isTemplateTypeParameter() &&
-         params[2]->isTemplateTupleParameter()) ||
-        (params.dim == 5 && params[3]->isTemplateTypeParameter() &&
-         params[4]->isTemplateTupleParameter());
+        (params.dim == 3 || params.dim == 5) &&
+        params[params.dim - 2]->isTemplateTypeParameter() &&
+        params[params.dim - 1]->isTemplateTupleParameter();
 
     if (valid_params) {
-      TemplateValueParameter *p0 = params[0]->isTemplateValueParameter();
-      valid_params = valid_params && p0 && p0->valType == Type::tstring;
-      if (params.dim == 5) {
-        TemplateValueParameter *p1 = params[1]->isTemplateValueParameter();
-        valid_params = valid_params && p1 && p1->valType == Type::tstring;
-        TemplateValueParameter *p2 = params[2]->isTemplateValueParameter();
-        valid_params = valid_params && p2 && p2->valType == Type::tstring;
+      for (d_size_t i = 0; i < (params.dim - 2); ++i) {
+        TemplateValueParameter *p0 = params[i]->isTemplateValueParameter();
+        valid_params = valid_params && p0 && p0->valType == Type::tstring;
       }
     }
 
@@ -151,7 +146,6 @@ DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
       prefix = exprToString(prefexp);
       code = exprToString(strexp);
       suffix = exprToString(suffexp);
-
     } else {
       Expression *a0 = isExpression(objs[0]);
       assert(a0);

--- a/gen/inlineir.h
+++ b/gen/inlineir.h
@@ -25,6 +25,10 @@ class Function;
 class Value;
 }
 
+/// Check LDC_inline_ir pragma declaration is valid
+/// Will call fatal() in case of errors
+void DtoCheckInlineIRPragma(Identifier *ident, Dsymbol *s);
+
 DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
                         Expressions *arguments,
                         llvm::Value *sretPointer = nullptr);

--- a/tests/codegen/inline_ir.d
+++ b/tests/codegen/inline_ir.d
@@ -1,0 +1,21 @@
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+pragma(LDC_inline_ir)
+    R inlineIREx(string prefix, string code, string suffix, R, P...)(P);
+
+alias inlineIREx!("", "store i32 %1, i32* %0, !nontemporal !0", "!0 = !{i32 1}", void, int*, int) nontemporalStore;
+alias inlineIREx!("!0 = !{i32 1}", "%i = load i32, i32* %0, !nontemporal !0\nret i32 %i", "", int, const int*) nontemporalLoad;
+
+int foo(const int* src)
+{
+  // CHECK: %{{.*}} = load i32, i32* {{.*}} !nontemporal ![[METADATA:[0-9]+]]
+  return nontemporalLoad(src);
+}
+
+void bar(int* dst, int val)
+{
+  // CHECK: store i32 {{.*}} !nontemporal ![[METADATA]]
+  nontemporalStore(dst, val);
+}
+
+// CHECK: ![[METADATA]] = !{i32 1}


### PR DESCRIPTION
Add extended version of  `LDC_inline_ir` pragma which allow to add arbitrary code before and after function.