### PR TITLE
Windows: Map `export` to DLL storage classes for data too

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -896,13 +896,11 @@ void DtoResolveVariable(VarDeclaration *vd) {
     // as well).
     gvar->setAlignment(DtoAlignment(vd));
 
-    /* TODO: set DLL storage class when `export` is fixed (an attribute)
+    // Windows: initialize DLL storage class with `dllimport` for `export`ed
+    // symbols
     if (global.params.isWindows && vd->isExport()) {
-      auto c = vd->isImportedSymbol() ? LLGlobalValue::DLLImportStorageClass
-                                      : LLGlobalValue::DLLExportStorageClass;
-      gvar->setDLLStorageClass(c);
+      gvar->setDLLStorageClass(LLGlobalValue::DLLImportStorageClass);
     }
-    */
 
     applyVarDeclUDAs(vd, gvar);
     if (varIr->dynamicCompileConst) {

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -5,6 +5,12 @@
 
 export
 {
+    // CHECK-DAG: @{{.*}}exportedGlobal{{.*}} = dllexport
+    extern(C) __gshared void* exportedGlobal;
+
+    // CHECK-DAG: @{{.*}}importedGlobal{{.*}} = external dllimport
+    extern(C) extern __gshared void* importedGlobal;
+
     // CHECK-DAG: define dllexport {{.*}}_D6export11exportedFooFZv
     void exportedFoo() {}
 


### PR DESCRIPTION
Not just functions. Fixes issue #2437.