### PR TITLE
Fix C++ header virtual function overrides

### DIFF
--- a/ddmd/aggregate.h
+++ b/ddmd/aggregate.h
@@ -191,7 +191,7 @@ public:
     void semantic(Scope *sc);
     void semanticTypeInfoMembers();
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
-    const char *kind();
+    const char *kind() const;
     void finalizeSize();
     bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
@@ -204,7 +204,7 @@ class UnionDeclaration : public StructDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
 
     UnionDeclaration *isUnionDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -303,7 +303,7 @@ public:
     virtual bool isCPPinterface() const;
     bool isAbstract();
     virtual int vtblOffset() const;
-    const char *kind();
+    const char *kind() const;
 
     void addLocalClass(ClassDeclarations *);
 
@@ -322,7 +322,7 @@ public:
     void semantic(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
     bool isBaseOf(BaseClass *bc, int *poffset);
-    const char *kind();
+    const char *kind() const;
     int vtblOffset() const;
     bool isCPPinterface() const;
     bool isCOMinterface() const;

--- a/ddmd/aliasthis.h
+++ b/ddmd/aliasthis.h
@@ -28,7 +28,7 @@ public:
     Identifier *ident;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     AliasThis *isAliasThis() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/ddmd/attrib.h
+++ b/ddmd/attrib.h
@@ -200,10 +200,10 @@ public:
     Dsymbols *cache;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    bool oneMember(Dsymbol *ps, Identifier *ident);
+    bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void addComment(const char *comment);
+    void addComment(const utf8_t *comment);
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     const char *kind() const;

--- a/ddmd/attrib.h
+++ b/ddmd/attrib.h
@@ -43,7 +43,7 @@ public:
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     void addComment(const utf8_t *comment);
-    const char *kind();
+    const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     bool hasPointers();
@@ -114,7 +114,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind();
+    const char *kind() const;
     const char *toPrettyChars(bool unused);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -145,7 +145,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     void setScope(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind();
+    const char *kind() const;
     AnonDeclaration *isAnonDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -187,7 +187,7 @@ public:
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -252,7 +252,7 @@ public:
     void setScope(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
     Expressions *getAttributes();
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/ddmd/declaration.h
+++ b/ddmd/declaration.h
@@ -133,7 +133,7 @@ public:
     int inuse;                  // used to detect cycles
     const char *mangleOverride;      // overridden symbol with pragma(mangle, "...")
 
-    const char *kind();
+    const char *kind() const;
     d_uns64 size(Loc loc);
     int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
 
@@ -182,7 +182,7 @@ public:
     TypeTuple *tupletype;       // !=NULL if this is a type tuple
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     Type *getType();
     Dsymbol *toAlias2();
     bool needThis();
@@ -208,7 +208,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void aliasSemantic(Scope *sc);
     bool overloadInsert(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
     Type *getType();
     Dsymbol *toAlias();
     Dsymbol *toAlias2();
@@ -227,7 +227,7 @@ public:
     Dsymbol *aliassym;
     bool hasOverloads;
 
-    const char *kind();
+    const char *kind() const;
     bool equals(RootObject *o);
     bool overloadInsert(Dsymbol *s);
 
@@ -270,7 +270,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind();
+    const char *kind() const;
     AggregateDeclaration *isThis();
     bool needThis();
     bool isExport();
@@ -651,7 +651,7 @@ public:
     virtual bool isFinalFunc();
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
-    const char *kind();
+    const char *kind() const;
     FuncDeclaration *isUnique();
     bool checkNestedReference(Scope *sc, Loc loc);
     bool needsClosure();
@@ -690,7 +690,7 @@ public:
     bool hasOverloads;
 
     FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
-    const char *kind();
+    const char *kind() const;
 
     FuncDeclaration *toAliasFunc();
     void accept(Visitor *v) { v->visit(this); }
@@ -715,7 +715,7 @@ public:
     void modifyReturns(Scope *sc, Type *tret);
 
     FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
-    const char *kind();
+    const char *kind() const;
     const char *toPrettyChars(bool QualifyTypes = false);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -724,7 +724,7 @@ class CtorDeclaration : public FuncDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
@@ -751,7 +751,7 @@ class DtorDeclaration : public FuncDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
@@ -847,7 +847,7 @@ public:
     int varargs;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();
@@ -863,7 +863,7 @@ public:
     Parameters *parameters;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     bool isDelete();
     bool isVirtual();
     bool addPreInvariant();

--- a/ddmd/dsymbol.h
+++ b/ddmd/dsymbol.h
@@ -218,7 +218,7 @@ public:
 
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
-    virtual const char *kind();
+    virtual const char *kind() const;
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual Dsymbol *toAlias2();
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);
@@ -329,7 +329,7 @@ public:
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     bool isforwardRef();
     static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
-    const char *kind();
+    const char *kind() const;
     FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
@@ -381,7 +381,7 @@ public:
 
     void push(Dsymbol *s);
     OverloadSet *isOverloadSet() { return this; }
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -395,7 +395,7 @@ class ForwardingScopeDsymbol : public ScopeDsymbol
     Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     void importScope(Dsymbol *s, Prot protection);
     void semantic(Scope *sc);
-    const char *kind();
+    const char *kind() const;
 
     ForwardingScopeDsymbol *isForwardingScopeDsymbol() { return this; }
 };

--- a/ddmd/enum.h
+++ b/ddmd/enum.h
@@ -54,7 +54,7 @@ public:
     void setScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Type *getType();
-    const char *kind();
+    const char *kind() const;
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool isDeprecated();                // is Dsymbol deprecated?
     Prot prot();
@@ -88,7 +88,7 @@ public:
     EnumDeclaration *ed;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
     Expression *getVarExp(Loc loc, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }

--- a/ddmd/import.h
+++ b/ddmd/import.h
@@ -47,7 +47,7 @@ public:
     AliasDeclarations aliasdecls; // corresponding AliasDeclarations for alias=name pairs
 
     void addAlias(Identifier *name, Identifier *alias);
-    const char *kind();
+    const char *kind() const;
     Prot prot();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);

--- a/ddmd/module.h
+++ b/ddmd/module.h
@@ -52,7 +52,7 @@ public:
     unsigned tag;       // auto incremented tag, used to mask package tree in scopes
     Module *mod;        // != NULL if isPkgMod == PKGmodule
 
-    const char *kind();
+    const char *kind() const;
 
     static DsymbolTable *resolve(Identifiers *packages, Dsymbol **pparent, Package **ppkg);
 
@@ -137,7 +137,7 @@ public:
 
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 
-    const char *kind();
+    const char *kind() const;
     File *setOutfile(const char *name, const char *dir, const char *arg, const char *ext);
     void setDocfile();
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.

--- a/ddmd/nspace.h
+++ b/ddmd/nspace.h
@@ -29,7 +29,7 @@ class Nspace : public ScopeDsymbol
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind();
+    const char *kind() const;
     Nspace *isNspace() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/ddmd/staticassert.h
+++ b/ddmd/staticassert.h
@@ -29,7 +29,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/ddmd/template.h
+++ b/ddmd/template.h
@@ -90,7 +90,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
 
     Prot prot();
@@ -312,7 +312,7 @@ public:
     static Objects *arraySyntaxCopy(Objects *objs);
     Dsymbol *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol
-    const char *kind();
+    const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *toChars();
     const char* toPrettyCharsHelper();
@@ -349,7 +349,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic2(Scope *sc);
-    const char *kind();
+    const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();

--- a/ddmd/version.h
+++ b/ddmd/version.h
@@ -27,7 +27,7 @@ public:
 
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -40,7 +40,7 @@ public:
 
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
A number of overrides were actually not overriding (instead hiding the virtual functions).
Fixed upstream in https://github.com/dlang/dmd/pull/7402 and https://github.com/dlang/dmd/pull/7401

Applying early because it can cause hard to find bugs and leads (thankfully) to a compiler warning flood.