### PR TITLE
Add the ldc.attributes.assumeUsed attribute corresponding to "attribute((used))” in GNU C

### DIFF
--- a/ddmd/id.d
+++ b/ddmd/id.d
@@ -442,6 +442,7 @@ immutable Msgtable[] msgtable =
     { "udaLLVMFastMathFlag", "llvmFastMathFlag" },
     { "udaSection", "section" },
     { "udaTarget", "target" },
+    { "udaAssumeUsed", "_assumeUsed" },
     { "udaWeak", "_weak" },
     { "udaCompute", "compute" },
     { "udaKernel", "_kernel" },

--- a/ddmd/id.h
+++ b/ddmd/id.h
@@ -58,6 +58,7 @@ public:
     static Identifier *udaSection;
     static Identifier *udaOptStrategy;
     static Identifier *udaTarget;
+    static Identifier *udaAssumeUsed;
     static Identifier *udaWeak;
     static Identifier *udaAllocSize;
     static Identifier *udaLLVMAttr;

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -1,5 +1,6 @@
 #include "gen/uda.h"
 
+#include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
 #include "aggregate.h"
@@ -346,6 +347,11 @@ void applyAttrTarget(StructLiteralExp *sle, llvm::Function *func, IrFunction *ir
   }
 }
 
+void applyAttrAssumeUsed(IRState &irs, StructLiteralExp *sle, llvm::Constant *symbol) {
+  checkStructElems(sle, {});
+  irs.usedArray.push_back(symbol);
+}
+
 } // anonymous namespace
 
 void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar) {
@@ -366,6 +372,8 @@ void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar) {
       sle->error(
           "Special attribute `ldc.attributes.%s` is only valid for functions",
           ident->toChars());
+    } else if (ident == Id::udaAssumeUsed) {
+      applyAttrAssumeUsed(*gIR, sle, gvar);
     } else if (ident == Id::udaWeak) {
       // @weak is applied elsewhere
     } else if (ident == Id::udaDynamicCompile) {
@@ -409,6 +417,8 @@ void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc) {
       applyAttrSection(sle, func);
     } else if (ident == Id::udaTarget) {
       applyAttrTarget(sle, func, irFunc);
+    } else if (ident == Id::udaAssumeUsed) {
+      applyAttrAssumeUsed(*gIR, sle, func);
     } else if (ident == Id::udaWeak || ident == Id::udaKernel) {
       // @weak and @kernel are applied elsewhere
     } else if (ident == Id::udaDynamicCompile) {

--- a/tests/codegen/attr_assumeused.d
+++ b/tests/codegen/attr_assumeused.d
@@ -1,0 +1,15 @@
+// Tests @assumeUsed attribute
+
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK: @llvm.used = appending global {{.*}} @some_function {{.*}} @some_variable
+
+static import ldc.attributes;
+
+extern (C): // For easier name mangling
+
+@(ldc.attributes.assumeUsed) void some_function()
+{
+}
+
+@(ldc.attributes.assumeUsed) int some_variable;


### PR DESCRIPTION
The attribute adds the symbol to `llvm.used`.

My use case: LTO is nicely aggressive in removing symbols, but some symbols at Weka are not supposed to be removed.