### PR TITLE
Remove ldc.profile.getData(string) to remove profile-rt Phobos dependency

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -329,8 +329,6 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
   }
 
   // Link with profile-rt library when generating an instrumented binary.
-  // profile-rt uses Phobos (MD5 hashing) and therefore must be passed on the
-  // commandline before Phobos.
   if (global.params.genInstrProf) {
 #if LDC_LLVM_VER >= 308
     if (global.params.targetTriple->isOSLinux()) {

--- a/runtime/profile-rt/d/ldc/profile.d
+++ b/runtime/profile-rt/d/ldc/profile.d
@@ -135,21 +135,24 @@ void resetCounts(alias F)()
 }
 
 /**
- * Get profile data struct for a given (mangled) function name.
+ * Get profile data struct for a given function.
  *
  * Params:
- *  funcname = Mangled function name.
+ *  F = The function to get the profile data of.
  * Returns:
- *  Pointer to the profile data for ($D funcname), or null if no profile data
- *  was found for ($D funcname).
+ *  Pointer to the profile data for ($D F), or null if no profile data was found
+ *  for ($D F).
  */
-const(ProfileData)* getData(string funcname)
+const(ProfileData)* getData(alias F)()
+    // TODO: add constraint on F
 {
+    enum mangledName = F.mangleof;
+
     version(HASHED_FUNC_NAMES)
     {
         import std.digest.md;
         import std.bitmanip;
-        auto md5hash = md5Of(funcname);
+        auto md5hash = md5Of(mangledName);
         auto nameref = peek!(ulong, Endian.littleEndian)(md5hash[0..8]);
     }
 
@@ -164,27 +167,11 @@ const(ProfileData)* getData(string funcname)
         }
         else
         {
-            if (funcname == (*data).Name[0..(*data).NameSize])
+            if (mangledName == (*data).Name[0..(*data).NameSize])
                 return data;
         }
     }
     return null;
-}
-
-/**
- * Get profile data struct for a given function.
- *
- * Params:
- *  F = The function to get the profile data of.
- * Returns:
- *  Pointer to the profile data for ($D F), or null if no profile data was found
- *  for ($D F).
- */
-const(ProfileData)* getData(alias F)()
-    // TODO: add constraint on F
-{
-    enum mangledName = F.mangleof;
-    return getData(mangledName);
 }
 
 /**

--- a/tests/PGO/profile_rt_calls.d
+++ b/tests/PGO/profile_rt_calls.d
@@ -15,8 +15,6 @@ bool notinstrumented(bool a, bool b) {
 }
 
 extern(C) void getdataprofile() {
-    assert( getData("unknown function") == null );
-    assert( getData("getdataprofile") != null );
     assert( getData!foo != null );
     assert( getData!fooC != null );
     assert( getData!fooCpp != null );


### PR DESCRIPTION
I think the extra functionality added into profile-rt (compared with LLVM's profile-rt) is of very little value, and perhaps not worth making our own version of compiler-rt's profile-rt. We could kill all that, and just use LLVM's profile-rt, but for now, I just want to remove the Phobos dependency in non-templated code.
Wit this PR only the templated code in ldc.profile depends on Phobos, so it's possible to link with profile-rt without requiring Phobos.