### PR TITLE
Link the druntime and Phobos test-runners with LDC.

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -445,8 +445,10 @@ endmacro()
 # using LDC as archiver. LDC handles (cross-)archiving internally via LLVM
 # and supports LTO objects.
 set(CMAKE_D_CREATE_STATIC_LIBRARY "${LDC_EXE_FULL} -lib -of=<TARGET> <OBJECTS>")
+set(CMAKE_D_LINK_EXECUTABLE "${LDC_EXE_FULL} -of=<TARGET> <LINK_FLAGS> <OBJECTS>")
 foreach(f ${D_FLAGS})
     append("\"${f}\"" CMAKE_D_CREATE_STATIC_LIBRARY)
+    append("\"${f}\"" CMAKE_D_LINK_EXECUTABLE)
 endforeach()
 
 # Sets the common properties for all library targets.
@@ -763,29 +765,26 @@ macro(append_testrunner_linkflags libname path_suffix is_shared output_flags)
         else()
             # the MS linker supports /WHOLEARCHIVE since VS 2015 Update 2
             string(REPLACE "/" "\\" tested_lib_winpath ${tested_lib_path})
-            append("/WHOLEARCHIVE:${tested_lib_winpath}" ${output_flags})
+            append("-L/WHOLEARCHIVE:${tested_lib_winpath}" ${output_flags})
             append("libcmt.lib libvcruntime.lib" ${output_flags})
         endif()
     else()
         if("${is_shared}" STREQUAL "ON")
-            append("-Wl,-rpath,${tested_lib_path}" ${output_flags})
+            append("-L-Wl,-rpath,${tested_lib_path}" ${output_flags})
             if("${TARGET_SYSTEM}" MATCHES "APPLE")
                 set(tested_lib_path "${tested_lib_path}/lib${libname}.dylib")
                 append("${tested_lib_path}" ${output_flags})
             else()
                 set(tested_lib_path "${tested_lib_path}/lib${libname}.so")
-                append("-Wl,--no-as-needed,${tested_lib_path},--as-needed" ${output_flags})
+                append("-L-Wl,--no-as-needed,${tested_lib_path},--as-needed" ${output_flags})
             endif()
         else()
             set(tested_lib_path "${tested_lib_path}/lib${libname}.a")
             if("${TARGET_SYSTEM}" MATCHES "APPLE")
-                append("-Wl,-force_load,${tested_lib_path}" ${output_flags})
+                append("-L-Wl,-force_load,${tested_lib_path}" ${output_flags})
             else()
-                append("-Wl,--whole-archive,${tested_lib_path},--no-whole-archive" ${output_flags})
+                append("-L-Wl,--whole-archive,${tested_lib_path},--no-whole-archive" ${output_flags})
             endif()
-            foreach(l ${C_SYSTEM_LIBS})
-                append("-l${l}" ${output_flags})
-            endforeach()
         endif()
     endif()
 endmacro()
@@ -811,6 +810,9 @@ function(build_test_runners name_suffix path_suffix d_flags c_flags linkflags is
     )
     add_custom_target(test_runner${target_suffix} DEPENDS ${test_runner_o})
 
+    # Use LDC to link the test runners
+    set(test_runner_linker_language D)
+
     set(druntime_name druntime-test-runner${target_suffix})
     add_executable(${druntime_name} EXCLUDE_FROM_ALL ${PROJECT_BINARY_DIR}/dummy.c)
     set(full_linkflags "${test_runner_o} ${linkflags}")
@@ -820,6 +822,7 @@ function(build_test_runners name_suffix path_suffix d_flags c_flags linkflags is
         COMPILE_FLAGS   ${c_flags}
         LINK_FLAGS      ${full_linkflags}
         LINK_DEPENDS    "${test_runner_o};${tested_lib_path}"
+        LINKER_LANGUAGE ${test_runner_linker_language}
     )
     add_test(build-${druntime_name} "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${druntime_name})
     set(_GLOBAL_TESTRUNNERS "${_GLOBAL_TESTRUNNERS};${druntime_name}" CACHE INTERNAL "")
@@ -835,6 +838,7 @@ function(build_test_runners name_suffix path_suffix d_flags c_flags linkflags is
             COMPILE_FLAGS   ${c_flags}
             LINK_FLAGS      ${full_linkflags}
             LINK_DEPENDS    "${test_runner_o};${tested_lib_path}"
+            LINKER_LANGUAGE ${test_runner_linker_language}
         )
         add_test(build-${phobos_name} "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${phobos_name})
         set(_GLOBAL_TESTRUNNERS "${_GLOBAL_TESTRUNNERS};${phobos_name}" CACHE INTERNAL "")

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -794,7 +794,7 @@ file(WRITE ${PROJECT_BINARY_DIR}/dummy.c "")
 
 # Generates targets for a pair of druntime/Phobos test runners.
 # The build targets are also appended to the _GLOBAL_TESTRUNNERS list.
-function(build_test_runners name_suffix path_suffix d_flags c_flags linkflags is_shared)
+function(build_test_runners name_suffix path_suffix d_flags c_flags ld_linkflags is_shared)
     set(target_suffix)
     get_target_suffix("${name_suffix}" "${path_suffix}" target_suffix)
 
@@ -812,6 +812,11 @@ function(build_test_runners name_suffix path_suffix d_flags c_flags linkflags is
 
     # Use LDC to link the test runners
     set(test_runner_linker_language D)
+    # Prefix ld_linkflags with "-L" so they pass through LDC
+    set(linkflags "")
+    foreach(f ${ld_linkflags})
+        append("-L${f}" ${linkflags})
+    endforeach()
 
     set(druntime_name druntime-test-runner${target_suffix})
     add_executable(${druntime_name} EXCLUDE_FROM_ALL ${PROJECT_BINARY_DIR}/dummy.c)


### PR DESCRIPTION
This is needed for example when building with -fsanitize=address. Linking with LDC is needed in that case such that the correct ASan runtime library is linked in (and rpath is set correctly for it). It is similar for `-flto`.

It's a bit of a hack, but works on my machine. Let's see what the CI systems say.


My testcase:
```
ldc-build-runtime --dFlags='-fsanitize=address;-fsanitize-blacklist=/Users/johan/ldc/ldc2-1.7.0-beta1-osx-x86_64/asan_blacklist.txt' BUILD_SHARED_LIBS=OFF --testrunners
```
 Adding `-fsanitize=address` to the `--linkerFlags` doesn't work, because then the wrong version of address sanitizer runtime is used (the one provided by my system's clang is different from the ldc2-1.7.0 compiler)
