### PR TITLE
Add coverage sanitizer options and include them all in the cache hash.

### DIFF
--- a/driver/cl_options_sanitizers.cpp
+++ b/driver/cl_options_sanitizers.cpp
@@ -109,8 +109,16 @@ void parseFSanitizeCoverageParameter(llvm::StringRef name,
     opts.TracePCGuard = true;
   }
 #if LDC_LLVM_VER >= 500
+  else if (name == "inline-8bit-counters") {
+    opts.Inline8bitCounters = true;
+  }
   else if (name == "no-prune") {
     opts.NoPrune = true;
+  }
+#endif
+#if LDC_LLVM_VER >= 600
+  else if (name == "pc-table") {
+    opts.PCTable = true;
   }
 #endif
   else {
@@ -182,18 +190,8 @@ void outputSanitizerSettings(llvm::raw_ostream &hash_os) {
   hash_os << SanitizerBits(enabledSanitizers);
 
 #ifdef ENABLE_COVERAGE_SANITIZER
-  hash_os << sanitizerCoverageOptions.CoverageType;
-  hash_os << sanitizerCoverageOptions.IndirectCalls;
-  hash_os << sanitizerCoverageOptions.TraceBB;
-  hash_os << sanitizerCoverageOptions.TraceCmp;
-  hash_os << sanitizerCoverageOptions.TraceDiv;
-  hash_os << sanitizerCoverageOptions.TraceGep;
-  hash_os << sanitizerCoverageOptions.Use8bitCounters;
-  hash_os << sanitizerCoverageOptions.TracePC;
-  hash_os << sanitizerCoverageOptions.TracePCGuard;
-#if LDC_LLVM_VER >= 500
-  hash_os << sanitizerCoverageOptions.NoPrune;
-#endif
+  hash_os.write(reinterpret_cast<char *>(&sanitizerCoverageOptions),
+                sizeof(sanitizerCoverageOptions));
 #endif
 }
 

--- a/tests/linking/ir2obj_caching_flags2.d
+++ b/tests/linking/ir2obj_caching_flags2.d
@@ -1,0 +1,24 @@
+// Test that certain cmdline flags result in different cache objects, even though the LLVM IR may be the same.
+// Test a few fsanitize-coverage options.
+
+// REQUIRES: atleast_llvm500
+
+// Note that the NO_HIT tests should change the default setting of the tested flag.
+
+// Create and then empty the cache for correct testing when running the test multiple times.
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir
+// RUN: %prunecache -f %t-dir --max-bytes=1
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -g                                 -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -fsanitize-coverage=trace-pc-guard -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -fsanitize-coverage=8bit-counters  -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -fsanitize-coverage=trace-cmp      -vv | FileCheck --check-prefix=NO_HIT %s
+// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -g                                 -vv | FileCheck --check-prefix=MUST_HIT %s
+// The last test is a MUST_HIT test (hits with the first compile invocation), to make sure that the cache wasn't pruned somehow which could effectively disable some NO_HIT tests.
+
+// MUST_HIT: Cache object found!
+// NO_HIT: Cache object not found.
+
+// Could hit is used for cases where we could have a cache hit, but currently we don't: a "TODO" item.
+// COULD_HIT: Cache object
+
+void main() {}


### PR DESCRIPTION
The important change is writing the full SanitizerCoverageOptions struct to the hash outputstream, such that options added (or removed) in the future are automatically included in the hash.