### PR TITLE
Generalize defaultlibs cmdline help category to linking options

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -21,6 +21,8 @@ namespace opts {
 // This vector is filled by parseCommandLine in main.cpp.
 llvm::SmallVector<const char *, 32> allArguments;
 
+cl::OptionCategory linkingCategory("Linking options");
+
 /* Option parser that defaults to zero when no explicit number is given.
  * i.e.:  -cov    --> value = 0
  *        -cov=9  --> value = 9
@@ -272,12 +274,13 @@ cl::list<std::string> transitions(
 
 cl::list<std::string>
     linkerSwitches("L", cl::desc("Pass <linkerflag> to the linker"),
-                   cl::value_desc("linkerflag"), cl::Prefix);
+                   cl::value_desc("linkerflag"), cl::cat(linkingCategory),
+                   cl::Prefix);
 
 cl::list<std::string>
     ccSwitches("Xcc", cl::CommaSeparated,
                cl::desc("Pass <ccflag> to GCC/Clang for linking"),
-               cl::value_desc("ccflag"));
+               cl::value_desc("ccflag"), cl::cat(linkingCategory));
 
 cl::opt<std::string>
     moduleDeps("deps", cl::ValueOptional, cl::ZeroOrMore,
@@ -289,7 +292,8 @@ cl::opt<std::string>
 cl::opt<cl::boolOrDefault>
     staticFlag("static", llvm::cl::ZeroOrMore,
                llvm::cl::desc("Create a statically linked binary, including "
-                              "all system dependencies"));
+                              "all system dependencies"),
+               cl::cat(linkingCategory));
 
 cl::opt<bool> m32bits("m32", cl::desc("32 bit target"), cl::ZeroOrMore);
 
@@ -369,7 +373,8 @@ cl::opt<bool> linkonceTemplates(
 
 cl::opt<bool> disableLinkerStripDead(
     "disable-linker-strip-dead", cl::ZeroOrMore,
-    cl::desc("Do not try to remove unused symbols during linking"));
+    cl::desc("Do not try to remove unused symbols during linking"),
+    cl::cat(linkingCategory));
 
 // Math options
 bool fFastMath; // Storage for the dynamically created ffast-math option.

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -39,6 +39,8 @@ namespace cl = llvm::cl;
 /// config and response files.
 extern llvm::SmallVector<const char *, 32> allArguments;
 
+extern cl::OptionCategory linkingCategory;
+
 /* Mostly generated with the following command:
    egrep -e '^(cl::|#if|#e)' gen/cl_options.cpp \
     | sed -re 's/^(cl::.*)\(.*$/    extern \1;/'

--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -18,10 +18,11 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
-static llvm::cl::opt<std::string> mscrtlib(
-    "mscrtlib", llvm::cl::ZeroOrMore, llvm::cl::value_desc("name"),
-    llvm::cl::desc(
-        "MS C runtime library to link against (libcmt[d] / msvcrt[d])"));
+static llvm::cl::opt<std::string>
+    mscrtlib("mscrtlib", llvm::cl::ZeroOrMore,
+             llvm::cl::desc("MS C runtime library to link with"),
+             llvm::cl::value_desc("libcmt[d]|msvcrt[d]"),
+             llvm::cl::cat(opts::linkingCategory));
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -23,7 +23,8 @@
 #if LDC_WITH_LLD
 static llvm::cl::opt<bool>
     useInternalLinker("link-internally", llvm::cl::ZeroOrMore, llvm::cl::Hidden,
-                      llvm::cl::desc("Use internal LLD for linking"));
+                      llvm::cl::desc("Use internal LLD for linking"),
+                      llvm::cl::cat(opts::linkingCategory));
 #else
 constexpr bool useInternalLinker = false;
 #endif

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -97,34 +97,31 @@ static cl::list<std::string, StringsAdapter>
                 cl::value_desc("directory"), cl::location(impPathsStore),
                 cl::Prefix);
 
-static cl::OptionCategory
-    defaultLibsCategory("Libraries linked with by default");
-
 static cl::opt<std::string>
     defaultLib("defaultlib", cl::ZeroOrMore, cl::value_desc("lib1,lib2,..."),
                cl::desc("Default libraries to link with (overrides previous)"),
-               cl::cat(defaultLibsCategory));
+               cl::cat(linkingCategory));
 
 static cl::opt<std::string> debugLib(
     "debuglib", cl::ZeroOrMore, cl::Hidden, cl::value_desc("lib1,lib2,..."),
     cl::desc("Debug versions of default libraries (overrides previous). If the "
              "option is omitted, LDC will append -debug to the -defaultlib "
              "names when linking with -link-defaultlib-debug"),
-    cl::cat(defaultLibsCategory));
+    cl::cat(linkingCategory));
 
 static cl::opt<bool> linkDefaultLibDebug(
     "link-defaultlib-debug", cl::ZeroOrMore,
     cl::desc("Link with debug versions of default libraries"),
-    cl::cat(defaultLibsCategory));
+    cl::cat(linkingCategory));
 static cl::alias _linkDebugLib("link-debuglib", cl::Hidden,
                                cl::aliasopt(linkDefaultLibDebug),
                                cl::desc("Alias for -link-defaultlib-debug"),
-                               cl::cat(defaultLibsCategory));
+                               cl::cat(linkingCategory));
 
 static cl::opt<bool> linkDefaultLibShared(
     "link-defaultlib-shared", cl::ZeroOrMore,
     cl::desc("Link with shared versions of default libraries"),
-    cl::cat(defaultLibsCategory));
+    cl::cat(linkingCategory));
 
 // This function exits the program.
 void printVersion(llvm::raw_ostream &OS) {

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -9,6 +9,7 @@
 
 #include "driver/tool.h"
 #include "mars.h"
+#include "driver/cl_options.h"
 #include "driver/exe_path.h"
 #include "driver/targetmachine.h"
 #include "llvm/Support/ConvertUTF.h"
@@ -25,7 +26,8 @@
 namespace opts {
 llvm::cl::opt<std::string>
     linker("linker", llvm::cl::ZeroOrMore, llvm::cl::desc("Linker to use"),
-           llvm::cl::value_desc("lld-link|lld|gold|bfd|..."));
+           llvm::cl::value_desc("lld-link|lld|gold|bfd|..."),
+           llvm::cl::cat(opts::linkingCategory));
 }
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
-help:
```
Linking options:

  -L=<linkerflag>                           - Pass <linkerflag> to the linker
  -Xcc=<ccflag>                             - Pass <ccflag> to GCC/Clang for linking
  -defaultlib=<lib1,lib2,...>               - Default libraries to link with (overrides previous)
  -disable-linker-strip-dead                - Do not try to remove unused symbols during linking
  -link-defaultlib-debug                    - Link with debug versions of default libraries
  -link-defaultlib-shared                   - Link with shared versions of default libraries
  -linker=<lld-link|lld|gold|bfd|...>       - Linker to use
  -mscrtlib=<libcmt[d]|msvcrt[d]>           - MS C runtime library to link with
  -static                                   - Create a statically linked binary, including all system dependencies
```

-help-hidden:
```
  -L=<linkerflag>                           - Pass <linkerflag> to the linker
  -Xcc=<ccflag>                             - Pass <ccflag> to GCC/Clang for linking
  -debuglib=<lib1,lib2,...>                 - Debug versions of default libraries (overrides previous). If the option is omitted, LDC will append -debug to the -defaultlib names when linking with -link-defaultlib-debug
  -defaultlib=<lib1,lib2,...>               - Default libraries to link with (overrides previous)
  -disable-linker-strip-dead                - Do not try to remove unused symbols during linking
  -link-debuglib                            - Alias for -link-defaultlib-debug
  -link-defaultlib-debug                    - Link with debug versions of default libraries
  -link-defaultlib-shared                   - Link with shared versions of default libraries
  -link-internally                          - Use internal LLD for linking
  -linker=<lld-link|lld|gold|bfd|...>       - Linker to use
  -mscrtlib=<libcmt[d]|msvcrt[d]>           - MS C runtime library to link with
  -static                                   - Create a statically linked binary, including all system dependencies
```