### PR TITLE
[WIP] Jit obj cache api

### DIFF
--- a/runtime/jit-rt/DefineBuildJitRT.cmake
+++ b/runtime/jit-rt/DefineBuildJitRT.cmake
@@ -3,7 +3,9 @@ if(LDC_DYNAMIC_COMPILE)
 
     # Choose the correct subfolder depending on the LLVM version
     file(GLOB LDC_JITRT_CXX ${JITRT_DIR}/cpp/*.cpp)
+    file(GLOB LDC_JITRT_H ${JITRT_DIR}/cpp/*.h)
     file(GLOB LDC_JITRT_SO_CXX ${JITRT_DIR}/cpp-so/*.cpp)
+    file(GLOB LDC_JITRT_SO_H ${JITRT_DIR}/cpp-so/*.h)
 
     # Set compiler-dependent flags
     if(MSVC)
@@ -55,7 +57,7 @@ if(LDC_DYNAMIC_COMPILE)
         get_target_suffix("" "${path_suffix}" target_suffix)
         set(output_path ${CMAKE_BINARY_DIR}/lib${path_suffix})
 
-        add_library(ldc-jit-rt-so${target_suffix} SHARED ${LDC_JITRT_SO_CXX})
+        add_library(ldc-jit-rt-so${target_suffix} SHARED ${LDC_JITRT_SO_CXX} ${LDC_JITRT_SO_H})
         set_target_properties(
             ldc-jit-rt-so${target_suffix} PROPERTIES
             OUTPUT_NAME                 ldc-jit
@@ -73,7 +75,7 @@ if(LDC_DYNAMIC_COMPILE)
         set(jitrt_d_bc "")
         compile_jit_rt_D("-enable-dynamic-compile;${d_flags}" "" "${path_suffix}" "${COMPILE_ALL_D_FILES_AT_ONCE}" jitrt_d_o jitrt_d_bc)
 
-        add_library(ldc-jit-rt${target_suffix} STATIC ${jitrt_d_o} ${LDC_JITRT_CXX})
+        add_library(ldc-jit-rt${target_suffix} STATIC ${jitrt_d_o} ${LDC_JITRT_CXX} ${LDC_JITRT_H})
         set_target_properties(
             ldc-jit-rt${target_suffix} PROPERTIES
             OUTPUT_NAME                 ldc-jit-rt

--- a/runtime/jit-rt/cpp-so/compile.cpp
+++ b/runtime/jit-rt/cpp-so/compile.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 
 #include "callback_ostream.h"
 #include "context.h"
@@ -69,14 +70,14 @@ struct RtCompileVarList {
 };
 
 struct RtCompileModuleList {
-  RtCompileModuleList *next;
+  const RtCompileModuleList *next;
   const char *irData;
   int irDataSize;
-  RtCompileFuncList *funcList;
+  const RtCompileFuncList *funcList;
   int funcListSize;
-  RtCompileSymList *symList;
+  const RtCompileSymList *symList;
   int symListSize;
-  RtCompileVarList *varList;
+  const RtCompileVarList *varList;
   int varListSize;
   const char *irHash;
   int irHashSize;
@@ -281,8 +282,9 @@ void setRtCompileVars(const Context &context, llvm::Module &module,
   }
 }
 
-template <typename T> llvm::ArrayRef<T> toArray(T *ptr, size_t size) {
-  return llvm::ArrayRef<T>(ptr, size);
+template <typename T> auto toArray(T *ptr, size_t size)
+-> llvm::ArrayRef<typename std::remove_cv<T>::type> {
+  return llvm::ArrayRef<typename std::remove_cv<T>::type>(ptr, size);
 }
 
 void *resolveSymbol(llvm::JITSymbol &symbol) {

--- a/runtime/jit-rt/cpp-so/compile_layer.h
+++ b/runtime/jit-rt/cpp-so/compile_layer.h
@@ -1,0 +1,50 @@
+#ifndef COMPILE_LAYER_HPP
+#define COMPILE_LAYER_HPP
+
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+
+template<typename BaseLayerT>
+class CompilerLayer {
+public:
+
+  using Compiler = llvm::orc::SimpleCompiler;
+  using ModuleHandleT = typename BaseLayerT::ObjHandleT;
+
+  CompilerLayer(BaseLayerT &BaseLayer, llvm::TargetMachine& TM):
+    baseLayer(BaseLayer),
+    compiler(BaseLayer, Compiler(TM)) {}
+
+  llvm::Expected<ModuleHandleT> addModule(std::shared_ptr<llvm::Module> M,
+                                          std::shared_ptr<llvm::JITSymbolResolver> Resolver) {
+    return compiler.addModule(std::move(M), std::move(Resolver));
+  }
+
+  llvm::Expected<ModuleHandleT> addObject(
+      std::unique_ptr<llvm::MemoryBuffer> ObjBuffer,
+      std::shared_ptr<llvm::JITSymbolResolver> Resolver) {
+    auto Obj =
+        llvm::object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
+    if (!Obj) {
+      return Obj.takeError();
+    }
+    using CompileResult = llvm::object::OwningBinary<llvm::object::ObjectFile>;
+    return baseLayer.addObject(
+          std::make_shared<CompileResult>(std::move(*Obj), std::move(ObjBuffer)),
+          std::move(Resolver));
+  }
+
+  llvm::Error removeModule(ModuleHandleT H) {
+    return baseLayer.removeObject(H);
+  }
+
+  llvm::JITSymbol findSymbol(const std::string &Name,
+                             bool ExportedSymbolsOnly) {
+    return baseLayer.findSymbol(Name, ExportedSymbolsOnly);
+  }
+private:
+  BaseLayerT &baseLayer;
+  llvm::orc::IRCompileLayer<BaseLayerT, Compiler> compiler;
+};
+
+#endif // COMPILE_LAYER_HPP

--- a/runtime/jit-rt/cpp-so/context.h
+++ b/runtime/jit-rt/cpp-so/context.h
@@ -30,10 +30,12 @@ typedef void (*DumpHandlerT)(void *, DumpStage stage, const char *str,
                              std::size_t len);
 struct Slice
 {
-    void* data;
+    const void* data;
     std::size_t len;
 };
-typedef Slice (*LoadCacheHandlerT)(void *, const char *desc);
+typedef void (*LoadCacheSinkT)(void *, const Slice &slice);
+typedef void (*LoadCacheHandlerT)(void *, const char *desc, void *,
+                                  LoadCacheSinkT sink);
 typedef void (*SaveCacheHandlerT)(void *, const char *desc, const Slice &slice);
 
 struct Context final {

--- a/runtime/jit-rt/cpp-so/context.h
+++ b/runtime/jit-rt/cpp-so/context.h
@@ -49,7 +49,7 @@ struct Context final {
   void *dumpHandlerData = nullptr;
   LoadCacheHandlerT loadCacheHandler = nullptr;
   void *loadCacheHandlerData = nullptr;
-  LoadCacheHandlerT saveCacheHandler = nullptr;
+  SaveCacheHandlerT saveCacheHandler = nullptr;
   void *saveCacheHandlerData = nullptr;
 };
 

--- a/runtime/jit-rt/cpp-so/context.h
+++ b/runtime/jit-rt/cpp-so/context.h
@@ -28,6 +28,13 @@ typedef void (*InterruptPointHandlerT)(void *, const char *action,
 typedef void (*FatalHandlerT)(void *, const char *reason);
 typedef void (*DumpHandlerT)(void *, DumpStage stage, const char *str,
                              std::size_t len);
+struct Slice
+{
+    void* data;
+    std::size_t len;
+};
+typedef Slice (*LoadCacheHandlerT)(void *, const char *desc);
+typedef void (*SaveCacheHandlerT)(void *, const char *desc, const Slice &slice);
 
 struct Context final {
   unsigned optLevel = 0;
@@ -38,6 +45,10 @@ struct Context final {
   void *fatalHandlerData = nullptr;
   DumpHandlerT dumpHandler = nullptr;
   void *dumpHandlerData = nullptr;
+  LoadCacheHandlerT loadCacheHandler = nullptr;
+  void *loadCacheHandlerData = nullptr;
+  LoadCacheHandlerT saveCacheHandler = nullptr;
+  void *saveCacheHandlerData = nullptr;
 };
 
 #endif // CONTEXT_H

--- a/runtime/jit-rt/cpp-so/valueparser.h
+++ b/runtime/jit-rt/cpp-so/valueparser.h
@@ -20,9 +20,15 @@ namespace llvm {
 class Constant;
 class Type;
 class DataLayout;
+class SHA1;
 }
 
 struct Context;
+
+void getInitializerHash(const Context &context,
+                        const llvm::DataLayout &dataLayout,
+                        llvm::Type *type, const void *data,
+                        llvm::SHA1& hasher);
 
 llvm::Constant *parseInitializer(const Context &context,
                                  const llvm::DataLayout &dataLayout,

--- a/runtime/jit-rt/cpp/compile.cpp
+++ b/runtime/jit-rt/cpp/compile.cpp
@@ -19,9 +19,9 @@ struct Context;
 extern "C" {
 
 // Silence missing-variable-declaration clang warning
-extern void *dynamiccompile_modules_head;
+extern const void *dynamiccompile_modules_head;
 
-void *dynamiccompile_modules_head = nullptr;
+const void *dynamiccompile_modules_head = nullptr;
 #ifdef _WIN32
 __declspec(dllimport)
 #endif

--- a/tests/dynamiccompile/globals_hash.d
+++ b/tests/dynamiccompile/globals_hash.d
@@ -1,0 +1,33 @@
+
+// RUN: %ldc -enable-dynamic-compile -run %s
+
+import ldc.attributes;
+import ldc.dynamic_compile;
+
+@dynamicCompileConst __gshared int value = 0;
+
+@dynamicCompile int foo()
+{
+  return value;
+}
+
+void main(string[] args)
+{
+  CompilerSettings settings;
+  const(char)[][] ids;
+  settings.saveCache = (in char[] id, in void[] data)
+  {
+    assert(data.length != 0);
+    ids ~= id;
+  };
+  compileDynamicCode(settings);
+  value = 3;
+  compileDynamicCode(settings);
+  value = 5;
+  compileDynamicCode(settings);
+
+  assert(ids.length == 3);
+  assert(ids[0] != ids[1]);
+  assert(ids[0] != ids[2]);
+  assert(ids[1] != ids[2]);
+}

--- a/tests/dynamiccompile/globals_hash.d
+++ b/tests/dynamiccompile/globals_hash.d
@@ -14,11 +14,12 @@ import ldc.dynamic_compile;
 void main(string[] args)
 {
   CompilerSettings settings;
-  const(char)[][] ids;
+  string[] ids;
   settings.saveCache = (in char[] id, in void[] data)
   {
+    assert(id.length != 0);
     assert(data.length != 0);
-    ids ~= id;
+    ids ~= id.idup;
   };
   compileDynamicCode(settings);
   value = 3;

--- a/tests/dynamiccompile/obj_cache.d
+++ b/tests/dynamiccompile/obj_cache.d
@@ -1,0 +1,49 @@
+
+// RUN: %ldc -enable-dynamic-compile -run %s save %t
+// RUN: %ldc -enable-dynamic-compile -run %s load %t
+
+import ldc.attributes;
+import ldc.dynamic_compile;
+import std.file;
+
+@dynamicCompile int foo()
+{
+  return 42;
+}
+
+void main(string[] args)
+{
+  assert(args.length == 3);
+  auto prefix = args[2];
+  if (args[1] == "save")
+  {
+    CompilerSettings settings;
+    settings.saveCache = (in char[] id, in void[] data)
+    {
+      assert(id.length != 0);
+      assert(data.length != 0);
+      std.file.write(prefix ~ id, data);
+    };
+    compileDynamicCode(settings);
+    assert(foo() == 42);
+  }
+  else if (args[1] == "load")
+  {
+    CompilerSettings settings;
+    settings.loadCache = (in char[] id, in void delegate(in void[]) sink)
+    {
+      assert(id.length != 0);
+      assert(std.file.exists(prefix ~ id));
+      auto data = std.file.read(prefix ~ id);
+      assert(data.length != 0);
+      sink(data);
+    };
+    compileDynamicCode(settings);
+    assert(foo() == 42);
+  }
+  else
+  {
+    assert(false);
+  }
+  
+}


### PR DESCRIPTION
Added 2 additional callbacks to dynamic compilation api:
* `saveCache` - called after jit modules compiled to object code so user can save it
* `loadCache` - called before jit compilation, user can call provided `sink` delegate to provide object code, module loading, optimization and compilation skipped in this case.

Objects identified by unique string id which is generated from target triple, cpu name, cpu feature string, jit modules IR hash (computed during compilation) and current state of `@dynamicCompileConst` variables.