### PR TITLE
Jit api versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,7 @@ if(LDC_DYNAMIC_COMPILE STREQUAL "AUTO")
         set(LDC_DYNAMIC_COMPILE True)
         message(STATUS "Building LDC with dynamic compilation support")
         add_definitions(-DLDC_DYNAMIC_COMPILE)
+        add_definitions(-DLDC_DYNAMIC_COMPILE_API_VERSION=1)
     endif()
 endif()
 

--- a/runtime/jit-rt/cpp-so/context.h
+++ b/runtime/jit-rt/cpp-so/context.h
@@ -23,6 +23,16 @@ enum class DumpStage : int {
   FinalAsm = 3
 };
 
+enum {
+    ApiVersion = LDC_DYNAMIC_COMPILE_API_VERSION
+};
+
+#define MAKE_JIT_API_CALL_IMPL(prefix, version) prefix##version
+#define MAKE_JIT_API_CALL(prefix, version) \
+  MAKE_JIT_API_CALL_IMPL(prefix, version)
+#define JIT_API_ENTRYPOINT MAKE_JIT_API_CALL(rtCompileProcessImplSo, \
+  LDC_DYNAMIC_COMPILE_API_VERSION)
+
 typedef void (*InterruptPointHandlerT)(void *, const char *action,
                                        const char *object);
 typedef void (*FatalHandlerT)(void *, const char *reason);

--- a/runtime/jit-rt/cpp/compile.cpp
+++ b/runtime/jit-rt/cpp/compile.cpp
@@ -16,6 +16,12 @@
 
 struct Context;
 
+#define MAKE_JIT_API_CALL_IMPL(prefix, version) prefix##version
+#define MAKE_JIT_API_CALL(prefix, version) \
+  MAKE_JIT_API_CALL_IMPL(prefix, version)
+#define JIT_API_ENTRYPOINT MAKE_JIT_API_CALL(rtCompileProcessImplSo, \
+  LDC_DYNAMIC_COMPILE_API_VERSION)
+
 extern "C" {
 
 // Silence missing-variable-declaration clang warning
@@ -25,11 +31,11 @@ const void *dynamiccompile_modules_head = nullptr;
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-    extern void rtCompileProcessImplSo(const void *modlist_head,
-                                       const Context *context,
-                                       std::size_t contextSize);
+extern void JIT_API_ENTRYPOINT(const void *modlist_head,
+                                   const Context *context,
+                                   std::size_t contextSize);
 
 void rtCompileProcessImpl(const Context *context, std::size_t contextSize) {
-  rtCompileProcessImplSo(dynamiccompile_modules_head, context, contextSize);
+  JIT_API_ENTRYPOINT(dynamiccompile_modules_head, context, contextSize);
 }
 }


### PR DESCRIPTION
It is expected dynamic compile api will be stable enough to be able to update jit shared library to newer version without recompiling application (e.g. to take advantage of new instructions or new compiler optimizations). But if we really need to break backward compatibility we should increase api version, so application can detect this.

There are two checks:
* Append api version to jit dll entrypoint name to cause undefined reference error if api version changed.
* Add api version to module jit description struct and check it before compilation

It is possible to support multiple api version by manually providing functions with older api versions and doing conversion for descriptions structs, but for now just abort.