### PR TITLE
DCompute CUDA: Use the datalayout from the targetmachine created by LLVM

### DIFF
--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -36,9 +36,10 @@ void DComputeTarget::doCodeGen(Module *m) {
 void DComputeTarget::emit(Module *m) {
   // Reset the global ABI to the target's ABI. Necessary because we have
   // multiple ABI we are trying to target. Also reset gIR. These are both
-  // reused. Somewhat of a HACK.
+  // reused. MAJOR HACK.
   gABI = abi;
   gIR = _ir;
+  gTargetMachine = targetMachine;
   doCodeGen(m);
 }
 
@@ -52,7 +53,6 @@ void DComputeTarget::writeModule() {
 
   const char *path = FileName::combine(global.params.objdir, os.str().c_str());
 
-  setGTargetMachine();
   ::writeModule(&_ir->module, path);
 
   delete _ir;

--- a/gen/dcompute/target.h
+++ b/gen/dcompute/target.h
@@ -18,6 +18,7 @@
 namespace llvm {
 class Module;
 class Function;
+class TargetMachine;
 }
 
 class Module;
@@ -32,6 +33,7 @@ public:
   const char *short_name;
   const char *binSuffix;
   TargetABI *abi;
+  llvm::TargetMachine *targetMachine = nullptr;
   // The nominal address spaces in DCompute are Private = 0, Global = 1,
   // Shared = 2, Constant = 3, Generic = 4
   std::array<int, 5> mapping;
@@ -47,8 +49,6 @@ public:
   void doCodeGen(Module *m);
   void writeModule();
 
-  // HACK: Resets the gTargetMachine to one appropriate for this dcompute target
-  virtual void setGTargetMachine() = 0;
   virtual void addMetadata() = 0;
   virtual void addKernelMetadata(FuncDeclaration *df, llvm::Function *llf) = 0;
 };

--- a/gen/dcompute/targetOCL.cpp
+++ b/gen/dcompute/targetOCL.cpp
@@ -52,7 +52,6 @@ public:
                                                     : SPIR_DATALAYOUT32);
     _ir->dcomputetarget = this;
   }
-  void setGTargetMachine() override { gTargetMachine = nullptr; }
 
   // Adapted from clang
   void addMetadata() override {


### PR DESCRIPTION
Fixes CUDA dcompute compilation with LLVM 6.0.
Why do we have to set the datalayout to something explicit? This breaks every now and then when LLVM changes things, making our datalayout invalid. If there is no good reason for, then we should use LLVM's datalayout. It currently is a maintenance problem.

@thewilsonator The dcompute compilation is still a major hack. Let's work towards making it less so.
For example, LDC's code is referencing gDataLayout throughout the code base, which is invalid when generating dcompute code. We should remove the `gDataLayout` global var, and just use `gTargetMachine->getDataLayout` (or `gIR->module.getDataLayout()` when possible).