### PR TITLE
Remove one use of gDataLayout.

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -146,7 +146,11 @@ class AssemblyAnnotator : public AssemblyAnnotationWriter {
     return "";
   }
 
+  const llvm::DataLayout &DL;
+
 public:
+  AssemblyAnnotator(const llvm::DataLayout &dl) : DL{dl} {}
+
   void emitFunctionAnnot(const Function *F,
                          formatted_raw_ostream &os) override {
     os << "; [#uses = " << F->getNumUses() << ']';
@@ -172,7 +176,7 @@ public:
         os << ", type = " << *val.getType();
       } else if (isa<AllocaInst>(&val)) {
         os << ", size/byte = "
-           << gDataLayout->getTypeAllocSize(val.getType()->getContainedType(0));
+           << DL.getTypeAllocSize(val.getType()->getContainedType(0));
       }
       os << ']';
     }
@@ -387,7 +391,7 @@ void writeModule(llvm::Module *m, const char *filename) {
             errinfo.message().c_str());
       fatal();
     }
-    AssemblyAnnotator annotator;
+    AssemblyAnnotator annotator(m->getDataLayout());
     m->print(aos, &annotator);
   }
 


### PR DESCRIPTION
Work towards removing the use of global vars, in this case gDataLayout. We have multiple different layouts when compiling both to object code and to dcompute target like CUDA.