### PR TITLE
PGO: Make profile-rt a template-only module.

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -633,9 +633,8 @@ macro(build_all_runtime_variants d_flags c_flags ld_flags path_suffix outlist_ta
     build_runtime_variants("${d_flags}" "${c_flags}" "${ld_flags}" "${path_suffix}" ${outlist_targets})
 
     # static profile-rt
-    build_profile_runtime("${d_flags};${D_FLAGS};${D_FLAGS_RELEASE}" "${c_flags}" "${ld_flags}" "" "${path_suffix}" ${outlist_targets})
+    build_profile_runtime("${c_flags}" "${ld_flags}" "" "${path_suffix}" ${outlist_targets})
     get_target_suffix("" "${path_suffix}" target_suffix)
-    set_common_library_properties(ldc-profile-rt${target_suffix} OFF)
 endmacro()
 
 

--- a/runtime/profile-rt/DefineBuildProfileRT.cmake
+++ b/runtime/profile-rt/DefineBuildProfileRT.cmake
@@ -1,7 +1,5 @@
 # Add LLVM Profile runtime for PGO
 
-file(GLOB LDC_PROFRT_D ${PROFILERT_DIR}/d/ldc/*.d)
-
 # Choose the correct subfolder depending on the LLVM version
 set(PROFILERT_LIBSRC_DIR "${PROFILERT_DIR}/profile-rt-${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}")
 file(GLOB LDC_PROFRT_C ${PROFILERT_LIBSRC_DIR}/*.c)
@@ -72,29 +70,12 @@ if(COMPILER_RT_TARGET_HAS_UNAME)
     set(PROFRT_EXTRA_FLAGS "${PROFRT_EXTRA_FLAGS} -DCOMPILER_RT_HAS_UNAME=1")
 endif()
 
-# Sets up the targets for building the D-source profile-rt object files,
-# appending the names of the (bitcode) files to link into the library to
-# outlist_o (outlist_bc).
-macro(compile_profilert_D d_flags lib_suffix path_suffix all_at_once outlist_o outlist_bc)
-    get_target_suffix("${lib_suffix}" "${path_suffix}" target_suffix)
-    dc("${LDC_PROFRT_D}"
-       "${PROFILERT_DIR}/d"
-       "${d_flags}"
-       "${PROJECT_BINARY_DIR}/objects${target_suffix}"
-       "${all_at_once}"
-       ${outlist_o}
-       ${outlist_bc}
-    )
-endmacro()
-
-macro(build_profile_runtime d_flags c_flags ld_flags lib_suffix path_suffix outlist_targets)
+macro(build_profile_runtime c_flags ld_flags lib_suffix path_suffix outlist_targets)
     set(output_path ${CMAKE_BINARY_DIR}/lib${path_suffix})
 
-    set(profilert_d_o "")
-    set(profilert_d_bc "")
-    compile_profilert_D("${d_flags};-relocation-model=pic" "${lib_suffix}" "${path_suffix}" "${COMPILE_ALL_D_FILES_AT_ONCE}" profilert_d_o profilert_d_bc)
+    get_target_suffix("${lib_suffix}" "${path_suffix}" target_suffix)
 
-    add_library(ldc-profile-rt${target_suffix} STATIC ${profilert_d_o} ${LDC_PROFRT_C} ${LDC_PROFRT_CXX})
+    add_library(ldc-profile-rt${target_suffix} STATIC ${LDC_PROFRT_C} ${LDC_PROFRT_CXX})
     set_target_properties(
         ldc-profile-rt${target_suffix} PROPERTIES
         OUTPUT_NAME                 ldc-profile-rt${lib_suffix}
@@ -111,4 +92,4 @@ macro(build_profile_runtime d_flags c_flags ld_flags lib_suffix path_suffix outl
 endmacro()
 
 # Install D interface files to profile-rt.
-install(DIRECTORY ${PROFILERT_DIR}/d/ldc DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.d")
+install(DIRECTORY ${PROFILERT_DIR}/d/ldc DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.di")

--- a/runtime/profile-rt/d/ldc/profile.di
+++ b/runtime/profile-rt/d/ldc/profile.di
@@ -3,11 +3,16 @@
  * instrumented programs (compiled with -fprofile-instr-generate).
  * It provides an interface to the profile-rt runtime library.
  *
- * Note that this only works for instrumented binaries.
+ * The functions in this module only work for PGO-instrumented binaries.
  *
- * Copyright: Authors 2016-2016
- * License: University of Illinois Open Source License and MIT License. See LDC's LICENSE for details.
- * Authors:   Johan B C Engelen
+ * This module is template-only, and is not compiled nor linked into druntime.
+ * This way, LDC does not need its own profile-rt library and LDC can directly
+ * use compiler-rt's profile runtime library.
+ *
+ * Copyright: Authors 2016-2018
+ * License: University of Illinois Open Source License and MIT License.
+ *          See LDC's LICENSE for details.
+ * Authors: LDC Team
  */
 module ldc.profile;
 
@@ -101,7 +106,6 @@ extern(C++) struct ProfileData {
 }
 
 // Symbols provided by profile-rt lib
-private {
 extern(C) {
     alias uint64_t = ulong;
     alias __llvm_profile_data = ProfileData;
@@ -115,16 +119,14 @@ extern(C) {
     void __llvm_profile_reset_counters();
     uint64_t __llvm_profile_get_magic();
     uint64_t __llvm_profile_get_version();
-}}
+}
 
 /**
  * Reset all profiling information of the whole program.
  * This can be used for example to remove transient start-up behavior from the
  * profile.
  */
-void resetAll() {
-    __llvm_profile_reset_counters();
-}
+alias resetAll = __llvm_profile_reset_counters;
 
 /**
  * Reset profile counter values for a function.


### PR DESCRIPTION
This removes all D code from the profile-rt runtime library. The ldc.profile module is no longer compiled and linked into profile-rt. We can now directly use compiler-rt's profile library. But that will happen in another patch.