### PR TITLE
Fix bounds checking for 16-bit targets (Issue #2520)

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -1361,7 +1361,9 @@ void DtoIndexBoundsCheck(Loc &loc, DValue *arr, DValue *index) {
   }
 
   llvm::ICmpInst::Predicate cmpop = llvm::ICmpInst::ICMP_ULT;
-  llvm::Value *cond = gIR->ir->CreateICmp(cmpop, DtoRVal(index),
+  llvm::Value *cond = gIR->ir->CreateICmp(cmpop,
+                                          gIR->ir->CreateTrunc(DtoRVal(index),
+                                                               DtoSize_t()),
                                           DtoArrayLen(arr), "bounds.cmp");
 
   llvm::BasicBlock *okbb = gIR->insertBB("bounds.ok");

--- a/tests/compilable/bounds_16_bit.d
+++ b/tests/compilable/bounds_16_bit.d
@@ -1,0 +1,20 @@
+// REQUIRES: target_MSP430
+
+// RUN: %ldc -mtriple=msp430 -c -output-ll %s
+
+void test()
+{
+    int[1] array;
+
+    ushort i = 0;
+    auto value = array[i];
+
+    short j = 0;
+    value = array[j];
+
+    uint k = 0;
+    value = array[k];
+
+    int l = 0;
+    value = array[l];
+}


### PR DESCRIPTION
Fixes Issue #2520 

This undoes the automatic zero extension of the index value used in the array bounds checking (back to `size_t`, which will not be a 32-bit for 16-bit targets). That fixes an internal LDC error that occurs when compiling, with bounds checking on, code like this:

```
void test()
{
    int[1] array;
    ushort k = 0;
    auto value = array[k];
}
```
