### PR TITLE
Explicitly pass triple to option initialization routine. [NFC]

### DIFF
--- a/driver/cl_options_instrumentation.cpp
+++ b/driver/cl_options_instrumentation.cpp
@@ -17,6 +17,7 @@
 
 #include "errors.h"
 #include "globals.h"
+#include "llvm/ADT/Triple.h"
 
 namespace {
 namespace cl = llvm::cl;
@@ -67,7 +68,7 @@ static cl::opt<bool> dmdFunctionTrace(
     "fdmd-trace-functions", cl::ZeroOrMore,
     cl::desc("DMD-style runtime performance profiling of generated code"));
 
-void initializeInstrumentationOptionsFromCmdline() {
+void initializeInstrumentationOptionsFromCmdline(const llvm::Triple &triple) {
   if (ASTPGOInstrGenFile.getNumOccurrences() > 0) {
     pgoMode = PGO_ASTBasedInstr;
     if (ASTPGOInstrGenFile.empty()) {
@@ -101,9 +102,7 @@ void initializeInstrumentationOptionsFromCmdline() {
   // There is a bug in (our use of?) LLVM where codegen errors with
   // PGO_IRBasedInstr for Windows targets. So disable IRBased PGO on Windows for
   // now.
-  assert(global.params.targetTriple);
-  if ((pgoMode == PGO_IRBasedInstr) &&
-      global.params.targetTriple->isOSWindows()) {
+  if ((pgoMode == PGO_IRBasedInstr) && triple.isOSWindows()) {
     error(Loc(),
           "'-fprofile-generate' is not yet supported for Windows targets.");
   }

--- a/driver/cl_options_instrumentation.h
+++ b/driver/cl_options_instrumentation.h
@@ -18,6 +18,10 @@
 
 #include "gen/cl_helpers.h"
 
+namespace llvm {
+class Triple;
+}
+
 namespace opts {
 namespace cl = llvm::cl;
 
@@ -26,7 +30,7 @@ extern cl::opt<bool> instrumentFunctions;
 /// This initializes the instrumentation options, and checks the validity of the
 /// commandline flags. targetTriple should be initialized before calling this.
 /// It should be called only once.
-void initializeInstrumentationOptionsFromCmdline();
+void initializeInstrumentationOptionsFromCmdline(const llvm::Triple &triple);
 
 enum PGOKind {
   PGO_None,

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1066,7 +1066,8 @@ int cppmain(int argc, char **argv) {
     global.lib_ext = "a";
   }
 
-  opts::initializeInstrumentationOptionsFromCmdline();
+  opts::initializeInstrumentationOptionsFromCmdline(
+      *global.params.targetTriple);
 
   Strings libmodules;
   return mars_mainBody(files, libmodules);


### PR DESCRIPTION
This removes the dependency on the global parameter / makes the dependency much more explicit.