### PR TITLE
dmd-testsuite: Pass LDC config flags as REQUIRED_ARGS (not part of DFLAGS)

### DIFF
--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -26,20 +26,20 @@ else()
     set(gdb_flags "OFF")
 endif()
 
-function(add_testsuite config_name dflags gdbflags model)
+function(add_testsuite config_name required_flags gdbflags model)
     set(name dmd-testsuite${config_name})
     set(outdir ${CMAKE_BINARY_DIR}/${name})
 
     add_test(NAME clean-${name}
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir})
 
-    set(all_dflags "-conf=${PROJECT_BINARY_DIR}/bin/${LDC_EXE}.conf ${dflags} ${gdb_dflags}")
-
-    # The DFLAGS environment variable read by LDMD is used because the DMD
-    # testsuite build system provides no way to run the test cases with a
-    # given set of flags without trying all combinations of them.
+    set(dflags "-conf=${PROJECT_BINARY_DIR}/bin/${LDC_EXE}.conf ${gdb_dflags}")
     add_test(NAME ${name}
-        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL} DFLAGS=${all_dflags} MODEL=${model} GDB_FLAGS=${gdbflags} quick
+        COMMAND make -k -C ${PROJECT_SOURCE_DIR}/tests/d2/dmd-testsuite
+                     RESULTS_DIR=${outdir} DMD=${LDMD_EXE_FULL}
+                     REQUIRED_ARGS=${required_flags} DFLAGS=${dflags}
+                     MODEL=${model} GDB_FLAGS=${gdbflags}
+                     quick
     )
     set_tests_properties(${name} PROPERTIES DEPENDS clean-${name})
 endfunction()


### PR DESCRIPTION
For less verbose output (hide DFLAGS again) and better upstreamability of the d_do_test patch filtering out redundant permute args.