### PR TITLE
Make the fuzz_asan.d test more robust.

### DIFF
--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -17,7 +17,7 @@ bool FuzzMe(ubyte* data, size_t dataSize)
     // CHECK-NEXT: READ of size 1
     // CHECK-NEXT: #0 {{.*}} in {{.*fuzz_asan6FuzzMe.*}} {{.*}}fuzz_asan.d:
     // FIXME, debug line info is wrong (Github issue #2090). Once fixed, add [[@LINE+1]]
-           data[3] == 'Z'; // :‑<
+           data[dataSize] == 'Z'; // :‑<
 }
 
 extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)


### PR DESCRIPTION
The test now passes for any input that starts with FUZ and is longer than 3 chars.

This hopefully fixes some spurious test failures, probably caused by the random input growing beyond length=4 too quickly and not finding the "FUZ*" crasher after that (within reasonable time).