### PR TITLE
Temporarily make fuzz_basic test more verbose to track down spurious failure

### DIFF
--- a/tests/sanitizers/fuzz_basic.d
+++ b/tests/sanitizers/fuzz_basic.d
@@ -2,9 +2,12 @@
 
 // REQUIRES: atleast_llvm500
 // REQUIRES: Fuzzer
+// UNSUPPORTED: Windows
 
 // RUN: %ldc -g -fsanitize=fuzzer %s -of=%t%exe
-// RUN: not %t%exe 2>&1 | FileCheck %s
+// RUN: not %t%exe 2> %t.out
+// RUN: cat %t.out
+// RUN: FileCheck %s < %t.out
 
 // CHECK: ERROR: libFuzzer: deadly signal
 


### PR DESCRIPTION
When the test fails, it shows the libfuzzer output, so we can see crash details.