### PR TITLE
[trivial] LLVM7.0: update code to use new API for creating MemCpy intrinsic call.

### DIFF
--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -101,8 +101,13 @@ Value *LibCallOptimization::CastToCStr(Value *V, IRBuilder<> &B) {
 /// expects that the size has type 'intptr_t' and Dst/Src are pointers.
 Value *LibCallOptimization::EmitMemCpy(Value *Dst, Value *Src, Value *Len,
                                        unsigned Align, IRBuilder<> &B) {
+#if LDC_LLVM_VER >= 700
+  return B.CreateMemCpy(CastToCStr(Dst, B), Align, CastToCStr(Src, B), Align,
+                        Len, false);
+#else
   return B.CreateMemCpy(CastToCStr(Dst, B), CastToCStr(Src, B), Len, Align,
                         false);
+#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -343,7 +343,11 @@ void DtoMemCpy(LLValue *dst, LLValue *src, LLValue *nbytes, unsigned align) {
   dst = DtoBitCast(dst, VoidPtrTy);
   src = DtoBitCast(src, VoidPtrTy);
 
+#if LDC_LLVM_VER >= 700
+  gIR->ir->CreateMemCpy(dst, align, src, align, nbytes, false /*isVolatile*/);
+#else
   gIR->ir->CreateMemCpy(dst, src, nbytes, align, false /*isVolatile*/);
+#endif
 }
 
 void DtoMemCpy(LLValue *dst, LLValue *src, bool withPadding, unsigned align) {


### PR DESCRIPTION
http://lists.llvm.org/pipermail/llvm-dev/2018-January/120542.html