### PR TITLE
Remove checking of fuzz testcase characters

### DIFF
--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -42,6 +42,3 @@ extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)
 
     return 0;
 }
-
-// The test unit should start with "FUZ"
-// CHECK: FUZ

--- a/tests/sanitizers/fuzz_basic.d
+++ b/tests/sanitizers/fuzz_basic.d
@@ -9,13 +9,13 @@
 // RUN: cat %t.out
 // RUN: FileCheck %s < %t.out
 
-// CHECK: ERROR: libFuzzer: deadly signal
-
 void FuzzMe(const(ubyte*) data, size_t size)
 {
     if ((size >= 3) && data[0] == 'F' && data[1] == 'U' && data[2] == 'Z')
     {
+// CHECK: fuzz_basic.d([[@LINE+1]]): Assertion failure
         assert(false);
+// CHECK: ERROR: libFuzzer: deadly signal
     }
 }
 
@@ -36,6 +36,3 @@ extern (C) int LLVMFuzzerTestOneInput(const(ubyte*) data, size_t size)
     FuzzMe(data, size);
     return 0;
 }
-
-// The test unit should start with "FUZ"
-// CHECK: FUZ


### PR DESCRIPTION
..., because they are not output when the reproducing testcase is too long (> 256 chars).

This should fix the spurious failures https://github.com/ldc-developers/ldc/pull/2556#issuecomment-363888571