### PR TITLE
Small fix to fix compiler warning (gcc bug?)

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -149,7 +149,7 @@ class AssemblyAnnotator : public AssemblyAnnotationWriter {
   const llvm::DataLayout &DL;
 
 public:
-  AssemblyAnnotator(const llvm::DataLayout &dl) : DL{dl} {}
+  AssemblyAnnotator(const llvm::DataLayout &dl) : DL(dl) {}
 
   void emitFunctionAnnot(const Function *F,
                          formatted_raw_ostream &os) override {


### PR DESCRIPTION
On the ARM scaleway buildbot, I saw this warning:
```
/var/lib/buildbot/slaves/scaleway/armv7_builder/build/driver/toobj.cpp: In constructor ‘{anonymous}::AssemblyAnnotator::AssemblyAnnotator(const llvm::DataLayout&)’:
/var/lib/buildbot/slaves/scaleway/armv7_builder/build/driver/toobj.cpp:152:56: warning: a temporary bound to ‘{anonymous}::AssemblyAnnotator::DL’ only persists until the constructor exits [-Wextra]
   AssemblyAnnotator(const llvm::DataLayout &dl) : DL{dl} {}
```
http://buildbot.ldc-developers.org/builders/armv7_builder/builds/3087/steps/make/logs/stdio

Looks like this gcc bug: https://stackoverflow.com/questions/25561387/spurious-warning-about-binding-temporary-to-reference-member-in-constructor

So let's just use old-style initialization, and we should be good.