### PR TITLE
Don't waste an alloca for the nested context argument

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1098,11 +1098,6 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     gIR->DBuilder.EmitLocalVariable(thismem, fd->vthis, nullptr, true);
   }
 
-  // give the 'nestArg' parameter (an lvalue) storage
-  if (irFty.arg_nest) {
-    irFunc->nestArg = DtoAllocaDump(irFunc->nestArg, 0, "nestedFrame");
-  }
-
   // define all explicit parameters
   if (fd->parameters)
     defineParameters(irFty, *fd->parameters);

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -75,9 +75,8 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     ctx = DtoLoad(DtoGEPi(val, 0, getVthisIdx(cd), ".vthis"));
     skipDIDeclaration = true;
   } else {
-    Logger::println("Regular nested function, loading context arg");
-
-    ctx = DtoLoad(irfunc->nestArg);
+    Logger::println("Regular nested function, using context arg");
+    ctx = irfunc->nestArg;
   }
 
   assert(ctx);
@@ -224,7 +223,7 @@ LLValue *DtoNestedContext(Loc &loc, Dsymbol *sym) {
     fromParent = false;
   } else if (irFunc.nestArg) {
     // otherwise, it may have gotten a context from the caller
-    val = DtoLoad(irFunc.nestArg);
+    val = irFunc.nestArg;
   } else if (irFunc.thisArg) {
     // or just have a this argument
     AggregateDeclaration *ad = irFunc.decl->isMember2();
@@ -456,8 +455,6 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
         } else {
           src = DtoLoad(DtoGEPi(thisval, 0, getVthisIdx(cd), ".vthis"));
         }
-      } else {
-        src = DtoLoad(src);
       }
       if (depth > 1) {
         src = DtoBitCast(src, getVoidPtrType());


### PR DESCRIPTION
And so get rid of all loads too; just use the untouched pointer ~~argument~~ parameter directly.