### PR TITLE
[ltsmaster] AArch64: Structs should not be passed with byval attribute

### DIFF
--- a/gen/abi.h
+++ b/gen/abi.h
@@ -152,8 +152,10 @@ struct TargetABI {
   /***** Static Helpers *****/
 
   /// Check if struct 't' is a Homogeneous Floating-point Aggregate (HFA)
-  /// consisting of up to 4 of same floating point type.  If so, optionally
-  /// produce the rewriteType: an array of that floating point type
+  /// consisting of up to `maxFloats` fields of same floating point type.
+  ///
+  /// If so, optionally produce the rewriteType: an array of that floating
+  /// point type.
   static bool isHFA(TypeStruct *t, llvm::Type **rewriteType = nullptr, const int maxFloats = 4);
 
 protected:


### PR DESCRIPTION
This is the code from issue #2150. Greatly improves the ABI.