### PR TITLE
OSX: Set install_name of merged dylibs (issue #2442)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,19 @@ commonSteps: &commonSteps
           cp ldc-scripts/ldc2-packaging/pkgfiles/README ldc2-x64
           cp -r ldc-scripts/ldc2-packaging/pkgfiles/dub ldc2-x64/etc
     - run:
+        name: Hello world integration test with shared libs
+        command: |
+          cd ..
+          altLibSuffix="32"
+          if [ "$CI_OS" = "osx" ]; then
+              altLibSuffix=""
+          fi
+          echo 'void main() { import std.stdio; writeln("Hello world, ", size_t.sizeof * 8, " bits"); }' > hello.d
+          ldc2-x64/bin/ldc2 hello.d -m64 -of=hello64 -link-defaultlib-shared -L-Wl,-rpath,$PWD/ldc2-x64/lib
+          ldc2-x64/bin/ldc2 hello.d -m32 -of=hello32 -link-defaultlib-shared -L-Wl,-rpath,$PWD/ldc2-x64/lib$altLibSuffix
+          ./hello64
+          ./hello32
+    - run:
         name: Build dub
         command: |
           cd ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,11 @@ commonSteps: &commonSteps
         name: Build LDC and stdlib unittest runners
         command: |
           cd ..
-          INSTALL_DIR=$PWD/ldc2-x64
+          LDC_INSTALL_DIR=$PWD/ldc2-x64
           HOST_LDMD=$PWD/bootstrap/bin/ldmd2
           mkdir ninja-ldc
           cd ninja-ldc
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DINCLUDE_INSTALL_DIR=$INSTALL_DIR/import -DD_COMPILER=$HOST_LDMD $EXTRA_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DCMAKE_INSTALL_PREFIX=$LDC_INSTALL_DIR -DINCLUDE_INSTALL_DIR=$LDC_INSTALL_DIR/import -DD_COMPILER=$HOST_LDMD $EXTRA_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
           # compiling the std.regex.internal.tests unittests eats large amounts of memory
           if [ "$CI_OS" = "linux" ]; then
             ninja -j2 all runtime/objects-unittest-debug/std/regex/internal/tests.o runtime/objects-unittest/std/regex/internal/tests.o runtime/objects-unittest-debug_32/std/regex/internal/tests.o runtime/objects-unittest_32/std/regex/internal/tests.o
@@ -139,11 +139,16 @@ commonSteps: &commonSteps
           cd ../ninja-ldc
           ninja install
           cd ..
-          perl -pi -e s?$PWD/ldc2-x64/?%%ldcbinarypath%%/../?g ldc2-x64/etc/ldc2.conf
-          cp project/LICENSE ldc2-x64
+          LDC_INSTALL_DIR=$PWD/ldc2-x64
+          perl -pi -e s?$LDC_INSTALL_DIR/?%%ldcbinarypath%%/../?g $LDC_INSTALL_DIR/etc/ldc2.conf
+          cp project/LICENSE $LDC_INSTALL_DIR
           git clone https://github.com/ldc-developers/ldc-scripts.git
-          cp ldc-scripts/ldc2-packaging/pkgfiles/README ldc2-x64
-          cp -r ldc-scripts/ldc2-packaging/pkgfiles/dub ldc2-x64/etc
+          cp ldc-scripts/ldc2-packaging/pkgfiles/README $LDC_INSTALL_DIR
+          cp -r ldc-scripts/ldc2-packaging/pkgfiles/dub $LDC_INSTALL_DIR/etc
+          # Now rename the installation dir to test portability.
+          NEW_LDC_INSTALL_DIR=$PWD/ldc2-install
+          mv $LDC_INSTALL_DIR $NEW_LDC_INSTALL_DIR
+          echo "export LDC_INSTALL_DIR=$NEW_LDC_INSTALL_DIR" >> $BASH_ENV
     - run:
         name: Hello world integration test with shared libs
         command: |
@@ -153,15 +158,14 @@ commonSteps: &commonSteps
               altLibSuffix=""
           fi
           echo 'void main() { import std.stdio; writeln("Hello world, ", size_t.sizeof * 8, " bits"); }' > hello.d
-          ldc2-x64/bin/ldc2 hello.d -m64 -of=hello64 -link-defaultlib-shared -L-Wl,-rpath,$PWD/ldc2-x64/lib
-          ldc2-x64/bin/ldc2 hello.d -m32 -of=hello32 -link-defaultlib-shared -L-Wl,-rpath,$PWD/ldc2-x64/lib$altLibSuffix
+          $LDC_INSTALL_DIR/bin/ldc2 hello.d -m64 -of=hello64 -link-defaultlib-shared -L-Wl,-rpath,$LDC_INSTALL_DIR/lib
+          $LDC_INSTALL_DIR/bin/ldc2 hello.d -m32 -of=hello32 -link-defaultlib-shared -L-Wl,-rpath,$LDC_INSTALL_DIR/lib$altLibSuffix
           ./hello64
           ./hello32
     - run:
         name: Build dub
         command: |
           cd ..
-          LDC_INSTALL_DIR=$PWD/ldc2-x64
           export DMD=$LDC_INSTALL_DIR/bin/ldmd2
           git clone --recursive https://github.com/dlang/dub.git
           cd dub
@@ -178,7 +182,6 @@ commonSteps: &commonSteps
         name: Build dlang tools
         command: |
           cd ..
-          LDC_INSTALL_DIR=$PWD/ldc2-x64
           git clone --recursive https://github.com/dlang/tools.git
           cd tools
           make -f posix.mak install DMD=$LDC_INSTALL_DIR/bin/ldmd2 INSTALL_DIR=$PWD
@@ -194,7 +197,7 @@ commonSteps: &commonSteps
           else
             artifactBasename="ldc2-${CIRCLE_TAG:1}-$CI_OS-x86_64"
           fi
-          mv ldc2-x64 $artifactBasename
+          mv $LDC_INSTALL_DIR $artifactBasename
           XZ_OPT=-9 tar -cJf artifacts/$artifactBasename.tar.xz $artifactBasename
     - run:
         name: Pack source dir

--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -6,11 +6,12 @@ default:
 {
     // default switches injected before all explicit command-line switches
     switches = [
-        "-I@RUNTIME_DIR@/src",@SHARED_LIBS_RPATH@
+        "-I@RUNTIME_DIR@/src",
+        "-I@JITRT_DIR@/d",@SHARED_LIBS_RPATH@
         "-defaultlib=druntime-ldc"@ADDITIONAL_DEFAULT_LDC_SWITCHES@
     ];
     // default switches appended after all explicit command-line switches
     post-switches = [
-        "-L-L@PROJECT_BINARY_DIR@/../lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@
+        "-L-L@CMAKE_BINARY_DIR@/lib@LIB_SUFFIX@",@MULTILIB_ADDITIONAL_PATH@
     ];
 };

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(runtime C)
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -454,6 +454,7 @@ function(set_common_library_properties target is_shared)
         VERSION ${DMDFE_VERSION}
         SOVERSION ${DMDFE_PATCH_VERSION}
         LINKER_LANGUAGE C
+        MACOSX_RPATH ON
     )
     if(RT_ARCHIVE_WITH_LDC AND NOT is_shared)
         set_target_properties(${target} PROPERTIES LINKER_LANGUAGE D)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -246,18 +246,18 @@ endif()
 # Add extra paths on Linux and disable linker arch mismatch warnings (like
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of
 # fat binaries. Other Posixen might need to be added here.
-if("${TARGET_SYSTEM}" MATCHES "Linux|FreeBSD")
-    if(MULTILIB)
-        set(MULTILIB_ADDITIONAL_PATH         "\n        \"-L-L${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
-        set(MULTILIB_ADDITIONAL_INSTALL_PATH "\n        \"-L-L${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
-    endif()
+if(MULTILIB AND NOT "${TARGET_SYSTEM}" MATCHES "APPLE")
+    set(MULTILIB_ADDITIONAL_PATH         "\n        \"-L-L${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
+    set(MULTILIB_ADDITIONAL_INSTALL_PATH "\n        \"-L-L${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX}\",\n        \"-L--no-warn-search-mismatch\",")
+endif()
 
-    if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
-        if(MULTILIB)
-            set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",")
-        else()
-            set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
-        endif()
+# Set the -rpath linker option when shared runtime libraries are built.
+# The installed config file doesn't use SHARED_LIBS_RPATH.
+if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
+    if(MULTILIB AND NOT "${TARGET_SYSTEM}" MATCHES "APPLE")
+        set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",")
+    else()
+        set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
     endif()
 endif()
 
@@ -673,14 +673,24 @@ if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
         add_custom_command(
             OUTPUT  ${final_path}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}
-            COMMAND "lipo"
-            ARGS    ${multi_path} ${host_path} -create -output ${final_path}
+            COMMAND lipo ${multi_path} ${host_path} -create -output ${final_path}
             DEPENDS ${libtargets}
         )
 
         set(target_name "")
+        set(lib_extension "")
         get_filename_component(target_name ${lib} NAME_WE)
+        get_filename_component(lib_extension ${lib} EXT)
+
         add_custom_target(${target_name} ALL DEPENDS ${final_path})
+
+        # For merged dylibs, set install_name to "@rpath/<filename>".
+        if(${lib_extension} STREQUAL ".dylib")
+            add_custom_command(
+                TARGET ${target_name} POST_BUILD
+                COMMAND install_name_tool -id "@rpath/lib${lib}" ${final_path}
+            )
+        endif()
 
         install(FILES       ${final_path}
                 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -255,9 +255,9 @@ endif()
 # The installed config file doesn't use SHARED_LIBS_RPATH.
 if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
     if(MULTILIB AND NOT "${TARGET_SYSTEM}" MATCHES "APPLE")
-        set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",")
+        set(SHARED_LIBS_RPATH "\n        \"-L-Wl,-rpath,${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",")
     else()
-        set(SHARED_LIBS_RPATH "\n        \"-L-rpath=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
+        set(SHARED_LIBS_RPATH "\n        \"-L-Wl,-rpath,${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}\",")
     endif()
 endif()
 


### PR DESCRIPTION
If I understand the CMake docs correctly, CMake >= 3 defaults to setting the install_name appropriately when installing a shared library target (e.g., for MULTILIB=OFF).

Once again, the 32/64-bit merging step for OSX libraries prevents this automatism, as the merged libs are custom targets, so do it manually in form of a post-build command.