### PR TITLE
Fix cat-assign-element issue if rhs affects the lhs length

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -805,6 +805,8 @@ void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
 
   assert(array);
 
+  Type *arrayType = array->type->toBasetype();
+
   // Evaluate the expression to be appended first; it may affect the array.
   DValue *expVal = toElem(exp);
 
@@ -812,7 +814,7 @@ void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
   // potentially moved to a new block).
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, "_d_arrayappendcTX");
   gIR->CreateCallOrInvoke(
-      fn, DtoTypeInfoOf(array->type->toBasetype()),
+      fn, DtoTypeInfoOf(arrayType),
       DtoBitCast(DtoLVal(array), fn->getFunctionType()->getParamType(1)),
       DtoConstSize_t(1), ".appendedArray");
 
@@ -822,7 +824,7 @@ void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
   LLValue *lastIndex =
       gIR->ir->CreateSub(newLength, DtoConstSize_t(1), ".lastIndex");
   LLValue *lastElemPtr = DtoGEP1(ptr, lastIndex, true, ".lastElem");
-  DLValue lastElem(array->type->nextOf(), lastElemPtr);
+  DLValue lastElem(arrayType->nextOf(), lastElemPtr);
   DtoAssign(loc, &lastElem, expVal, TOKblit);
   callPostblit(loc, exp, lastElemPtr);
 }

--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -799,33 +799,32 @@ DSliceValue *DtoResizeDynArray(Loc &loc, Type *arrayType, DValue *array,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoCatAssignElement(Loc &loc, Type *arrayType, DValue *array,
-                         Expression *exp) {
+void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
   IF_LOG Logger::println("DtoCatAssignElement");
   LOG_SCOPE;
 
   assert(array);
 
-  LLValue *oldLength = DtoArrayLen(array);
-
-  // Do not move exp->toElem call after creating _d_arrayappendcTX,
-  // otherwise a ~= a[$-i] won't work correctly
+  // Evaluate the expression to be appended first; it may affect the array.
   DValue *expVal = toElem(exp);
 
+  // The druntime function extends the slice in-place (length += 1, ptr
+  // potentially moved to a new block).
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, "_d_arrayappendcTX");
-  LLValue *appendedArray =
-      gIR->CreateCallOrInvoke(
-             fn, DtoTypeInfoOf(arrayType),
-             DtoBitCast(DtoLVal(array), fn->getFunctionType()->getParamType(1)),
-             DtoConstSize_t(1), ".appendedArray")
-          .getInstruction();
-  appendedArray = DtoAggrPaint(appendedArray, DtoType(arrayType));
+  gIR->CreateCallOrInvoke(
+      fn, DtoTypeInfoOf(array->type->toBasetype()),
+      DtoBitCast(DtoLVal(array), fn->getFunctionType()->getParamType(1)),
+      DtoConstSize_t(1), ".appendedArray");
 
+  // Assign to the new last element.
+  LLValue *newLength = DtoArrayLen(array);
   LLValue *ptr = DtoArrayPtr(array);
-  ptr = DtoGEP1(ptr, oldLength, true, ".lastElem");
-  DLValue lastElem(arrayType->nextOf(), ptr);
+  LLValue *lastIndex =
+      gIR->ir->CreateSub(newLength, DtoConstSize_t(1), ".lastIndex");
+  LLValue *lastElemPtr = DtoGEP1(ptr, lastIndex, true, ".lastElem");
+  DLValue lastElem(array->type->nextOf(), lastElemPtr);
   DtoAssign(loc, &lastElem, expVal, TOKblit);
-  callPostblit(loc, exp, ptr);
+  callPostblit(loc, exp, lastElemPtr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/arrays.h
+++ b/gen/arrays.h
@@ -66,7 +66,7 @@ DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
 DSliceValue *DtoResizeDynArray(Loc &loc, Type *arrayType, DValue *array,
                                llvm::Value *newdim);
 
-void DtoCatAssignElement(Loc &loc, Type *type, DValue *arr, Expression *exp);
+void DtoCatAssignElement(Loc &loc, DValue *arr, Expression *exp);
 DSliceValue *DtoCatAssignArray(Loc &loc, DValue *arr, Expression *exp);
 DSliceValue *DtoCatArrays(Loc &loc, Type *type, Expression *e1, Expression *e2);
 DSliceValue *DtoAppendDCharToString(Loc &loc, DValue *arr, Expression *exp);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2126,7 +2126,7 @@ public:
       DtoStore(DtoRVal(slice), DtoLVal(result));
     } else {
       // append element
-      DtoCatAssignElement(e->loc, e1type, result, e->e2);
+      DtoCatAssignElement(e->loc, result, e->e2);
     }
   }
 

--- a/tests/codegen/array_catassign_gh2588.d
+++ b/tests/codegen/array_catassign_gh2588.d
@@ -1,0 +1,14 @@
+// RUN: %ldc -run %s
+
+int work(ref int[] array)
+{
+    array ~= 123;
+    return 456;
+}
+
+void main()
+{
+    int[] array;
+    array ~= work(array);
+    assert(array == [ 123, 456 ]);
+}


### PR DESCRIPTION
I.e., this fixes #2588.

To fix the index of the new array element to be assigned to, I went for decrementing the new length instead of saving the old length directly before the druntime call (i.e., after evaluating the rhs expression due to its potential side effects). The IR seems more intuitive to me this way - load both new length+ptr directly after the druntime call and then decrement the length by 1.