### PR TITLE
[ltsmaster] Update Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
     - os: linux
-      env: LLVM_VERSION=5.0.0
+      env: LLVM_VERSION=5.0.1
     - os: linux
       env: LLVM_VERSION=4.0.1
     - os: linux
@@ -14,6 +14,8 @@ matrix:
       env: LLVM_VERSION=3.8.1 OPTS="-DBUILD_SHARED_LIBS=OFF"
     - os: linux
       env: LLVM_VERSION=3.7.1 OPTS="-DMULTILIB=ON"
+    - os: linux
+      env: LLVM_VERSION=3.6.2
     - os: osx
       env: LLVM_VERSION=4.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF"
   allow_failures:
@@ -21,12 +23,13 @@ matrix:
 
 cache:
   directories:
-    - llvm-5.0.0
+    - llvm-5.0.1
     - llvm-4.0.1
     - llvm-4.0.0
     - llvm-3.9.1
     - llvm-3.8.1
     - llvm-3.7.1
+    - llvm-3.6.2
 addons:
   apt:
     sources:


### PR DESCRIPTION
Update to LLVM 5.0.1 and add LLVM 3.6.2 (which is still supported
on ltsmaster).