### PR TITLE
WIP: Fix addFuncEntryCall lit test run by forwarding CXX variable

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -57,6 +57,10 @@ env_cc = os.environ.get('CC', '')
 if env_cc:
     config.environment['CC'] = env_cc
 
+env_cxx = os.environ.get('CXX', '')
+if env_cxx:
+    config.environment['CXX'] = env_cxx
+
 # Define available features so that we can disable tests depending on LLVM version
 config.available_features.add("llvm%d" % config.llvm_version)
 # LLVM version history: 3.8, 3.9, 4.0, 5.0, ...


### PR DESCRIPTION
Running the lit tests while building ldc 1.8.0-beta1 package with the Nix package manager on Mac OSX results in:

```
797: $ "make" "-f" "/private/tmp/nix-build-ldcBuild-1.8.0-beta1.drv-0/ldc-1.8.0-beta1-src/tests/plugins/addFuncEntryCall/Makefile"
797: # command output:
797: g++ -O3 -I/nix/store/r383pjg0ck57kl3z2afmy9pqkyllxj60-llvm-5.0.1/include -stdlib=libc++ -fPIC -fvisibility-inlines-hidden -std=c++11 -pedantic -O3 -DNDEBUG -fno-exceptions -DLLVM_BUILD_GLOBAL_ISEL -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti -fpic -Wl,-flat_namespace -Wl,-undefined,suppress -shared /private/tmp/nix-build-ldcBuild-1.8.0-beta1.drv-0/ldc-1.8.0-beta1-src/tests/plugins/addFuncEntryCall/addFuncEntryCallPass.cpp -o addFuncEntryCallPass.so
797: 
797: # command stderr:
797: make: g++: Command not found
797: make: *** [/private/tmp/nix-build-ldcBuild-1.8.0-beta1.drv-0/ldc-1.8.0-beta1-src/tests/plugins/addFuncEntryCall/Makefile:23: addFuncEntryCallPass] Error 127
797: 
797: error: command failed with exit status: 2
```
