### PR TITLE
Add the `CRuntime_UClibc` version identifier

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -832,7 +832,7 @@ void registerPredefinedTargetVersions() {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
 #endif
     } else if (triple.getEnvironmentName() == "uclibc") {
-        VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
+      VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
     } else {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Glibc");
     }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -831,6 +831,8 @@ void registerPredefinedTargetVersions() {
     } else if (triple.isMusl()) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
 #endif
+    } else if (triple.getEnvironmentName() == "uclibc") {
+        VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
     } else {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Glibc");
     }


### PR DESCRIPTION
Enable the `uclibc` in triple, example usage  `arm-linux-uclibc`.

Unfortunately `uclibc` is not supported in the LLVM predefined identifiers, a patch was proposed a while ago but was not accepted, so I used the string version form the triple. I reckon this should be OK for most people using this (a rather small group :) )