### PR TITLE
[2.079] Win32: Add extra underscore for mangled names of D symbols

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2320,10 +2320,9 @@ struct AsmProcessor {
   static bool prependExtraUnderscore(LINK link) {
     return global.params.targetTriple->getOS() == llvm::Triple::MacOSX ||
            global.params.targetTriple->getOS() == llvm::Triple::Darwin ||
-           // Win32: C symbols only
+           // Win32: all symbols except for MSVC++ ones
            (global.params.targetTriple->isOSWindows() &&
-            global.params.targetTriple->isArch32Bit() && link != LINKcpp &&
-            link != LINKd && link != LINKdefault);
+            global.params.targetTriple->isArch32Bit() && link != LINKcpp);
   }
 
   void addOperand(const char *fmt, AsmArgType type, Expression *e,

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -184,18 +184,16 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
   }
   // Windows is different
   else if (isWin) {
-    // prepend extra underscore for Win32 C symbols
-    if (triple.isArch32Bit() && fd->linkage != LINKcpp &&
-        fd->linkage != LINKd && fd->linkage != LINKdefault) {
+    // mangled names starting with '?' (MSVC++ symbols) apparently need quoting
+    if (mangle[0] == '?') {
+      fullmangle += '"';
+      fullmangle += mangle;
+      fullmangle += '"';
+      mangle = fullmangle.c_str();
+    } else if (triple.isArch32Bit()) {
+      // prepend extra underscore for Windows x86
       fullmangle += '_';
       fullmangle += mangle;
-      mangle = fullmangle.c_str();
-    }
-    // leading ? apparently needs quoting
-    else if (mangle[0] == '?') {
-      fullmangle += '"';
-      fullmangle += mangle;
-      fullmangle += '"';
       mangle = fullmangle.c_str();
     }
 

--- a/tests/codegen/hashed_mangling.d
+++ b/tests/codegen/hashed_mangling.d
@@ -15,9 +15,9 @@ extern (C) int externCfunctions_are_not_hashed_externCfunctions_are_not_hashed_e
 
 auto s(T)(T t)
 {
-    // HASH90-DAG: define{{.*}} @{{(\"\\01)?}}_D3one3two5three__T1sTiZQfFNaNbNiNfiZSQBkQBjQBi__TQBfTiZQBlFiZ__T6ResultTiZQk
-    // HASH90-DAG: define{{.*}} @{{(\"\\01)?}}_D3one3two5three3L1633_182fab6f09ff014d9f4a578edf9609981sZ
-    // HASH90-DAG: define{{.*}} @{{(\"\\01)?}}_D3one3two5three3L2333_9b5306e5c42722cd2cb93ae6beb422346Result3fooZ
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three__T1sTiZQfFNaNbNiNfiZSQBkQBjQBi__TQBfTiZQBlFiZ__T6ResultTiZQk
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L1633_182fab6f09ff014d9f4a578edf9609981sZ
+    // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L2333_9b5306e5c42722cd2cb93ae6beb422346Result3fooZ
     struct Result(T)
     {
         void foo(){}
@@ -29,8 +29,8 @@ auto klass(T)(T t)
 {
     class Result(T)
     {
-        // HASH90-DAG: define{{.*}} @{{(\"\\01)?}}_D3one3two5three__T5klassTiZQjFiZ__T6ResultTiZQk3fooMFZv
-        // HASH90-DAG: define{{.*}} @{{(\"\\01)?}}_D3one3two5three3L3433_de737f3d65ae58efa925cffda52cd8da6Result3fooZ
+        // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three__T5klassTiZQjFiZ__T6ResultTiZQk3fooMFZv
+        // HASH90-DAG: define{{.*}} @{{(\"\\01_)?}}_D3one3two5three3L3433_de737f3d65ae58efa925cffda52cd8da6Result3fooZ
         void foo(){}
     }
     return new Result!int();


### PR DESCRIPTION
DMD 2.079 introduces this breaking ABI change. Just like on 32-bit OSX, the mangled names of D symbols now include the platform-specific underscore prefix.