### PR TITLE
[ltsmaster] Enable LLVM 3.5 build again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: LLVM_VERSION=3.7.1 OPTS="-DMULTILIB=ON"
     - os: linux
       env: LLVM_VERSION=3.6.2
+    - os: linux
+      env: LLVM_VERSION=3.5.2
     - os: osx
       env: LLVM_VERSION=4.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF"
   allow_failures:
@@ -33,6 +35,7 @@ cache:
     - llvm-3.8.1
     - llvm-3.7.1
     - llvm-3.6.2
+    - llvm-3.5.2
 addons:
   apt:
     sources:


### PR DESCRIPTION
We claim in the release notes that we support LLVM 3.5. Let's
check this.