### PR TITLE
Pull in Musl's assert function for betterC mode.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -827,10 +827,8 @@ void registerPredefinedTargetVersions() {
     if (triple.getEnvironment() == llvm::Triple::Android) {
       VersionCondition::addPredefinedGlobalIdent("Android");
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
-#if LDC_LLVM_VER >= 309
-    } else if (triple.isMusl()) {
+    } else if (isMusl()) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
-#endif
     } else if (triple.getEnvironmentName() == "uclibc") {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
     } else {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -70,6 +70,14 @@ bool isTargetWindowsMSVC() {
   return global.params.targetTriple->isWindowsMSVCEnvironment();
 }
 
+bool isMusl() {
+#if LDC_LLVM_VER >= 309
+  return global.params.targetTriple->isMusl();
+#else
+  return false;
+#endif
+}
+
 /******************************************************************************
  * Global context
  ******************************************************************************/
@@ -311,7 +319,7 @@ void DtoCAssert(Module *M, Loc &loc, LLValue *msg) {
     args.push_back(file);
     args.push_back(line);
     args.push_back(msg);
-  } else if (global.params.targetTriple->isOSSolaris()) {
+  } else if (global.params.targetTriple->isOSSolaris() || isMusl()) {
     const auto irFunc = gIR->func();
     const auto funcName =
         (irFunc && irFunc->decl) ? irFunc->decl->toPrettyChars() : "";

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -27,6 +27,9 @@ struct IRState;
 // An arrayreference type with initializer_list support (C++11):
 template <class T> using ArrayParam = llvm::ArrayRef<T>;
 
+// Helper function because LLVM's isMusl wasn't around before 3.9.
+bool isMusl();
+
 llvm::LLVMContext& getGlobalContext();
 
 // dynamic memory helpers

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -167,6 +167,8 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
 // MSVC:    void  _assert(const char *msg, const char *file, unsigned line)
 // Solaris: void __assert_c99(const char *assertion, const char *filename, int line_num,
 //                            const char *funcname);
+// Musl:    void __assert_fail(const char *assertion, const char *filename, int line_num,
+//                             const char *funcname);
 // else:    void __assert(const char *msg, const char *file, unsigned line)
 
 static const char *getCAssertFunctionName() {
@@ -176,6 +178,8 @@ static const char *getCAssertFunctionName() {
     return "_assert";
   } else if (global.params.targetTriple->isOSSolaris()) {
     return "__assert_c99";
+  } else if (isMusl()) {
+    return "__assert_fail";
   }
   return "__assert";
 }
@@ -184,7 +188,8 @@ static std::vector<Type *> getCAssertFunctionParamTypes() {
   const auto voidPtr = Type::tvoidptr;
   const auto uint = Type::tuns32;
 
-  if (global.params.targetTriple->isOSDarwin() || global.params.targetTriple->isOSSolaris()) {
+  if (global.params.targetTriple->isOSDarwin() ||
+      global.params.targetTriple->isOSSolaris() || isMusl()) {
     return {voidPtr, voidPtr, uint, voidPtr};
   }
   if (global.params.targetTriple->getEnvironment() == llvm::Triple::Android) {


### PR DESCRIPTION
With this pull, only two tests fail from the dmd testsuite on Alpine/x64.  [This one asserts because of some stack trace issue](https://github.com/ldc-developers/dmd-testsuite/blob/ldc/runnable/test17559.d#L48), and [this 32-bit test fails out with a different error than expected](https://github.com/ldc-developers/dmd-testsuite/blob/ldc/fail_compilation/fail80_m32.d) because [this druntime module has not been ported to `X86` yet](https://github.com/ldc-developers/druntime/blob/ldc/src/core/sys/posix/sys/types.d#L642). Neither is a big deal, so unless @yshui wants to handle them, this patch should be enough for the 1.8 release.