### PR TITLE
[ltsmaster] Use doubledouble as real type on PPC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,10 +169,6 @@ if( CMAKE_COMPILER_IS_GNUCXX
     AND CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6.0" )
     append("-mminimal-toc" DMD_CXXFLAGS LDC_CXXFLAGS)
 endif()
-# Do not use doubledouble on ppc
-if( CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|powerpc")
-    append("-mlong-double-64" DMD_CXXFLAGS LDC_CXXFLAGS)
-endif()
 if(UNIX)
     append("-DPOSIX -DLDC_POSIX" DMD_CXXFLAGS)
     append("-DLDC_POSIX" LDC_CXXFLAGS)

--- a/dmd2/cppmangle.c
+++ b/dmd2/cppmangle.c
@@ -664,12 +664,7 @@ public:
             case Tint128:   c = 'n';        break;
             case Tuns128:   c = 'o';        break;
             case Tfloat64:  c = 'd';        break;
-#if IN_LLVM
-            // There is no platform which uses __float128 for real.
-            case Tfloat80:  c = 'e'; break;
-#else
             case Tfloat80:  c = (Target::realsize - Target::realpad == 16) ? 'g' : 'e'; break;
-#endif
             case Tbool:     c = 'b';        break;
             case Tchar:     c = 'c';        break;
             case Twchar:    c = 't';        break; // unsigned short

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -54,6 +54,8 @@ llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
                        || (a == llvm::Triple::arm64) || (a == llvm::Triple::arm64_be)
 #endif
     ;
+  bool const anyPPC = (a == llvm::Triple::ppc) || (a == llvm::Triple::ppc64)
+                    || (a == llvm::Triple::ppc64le);
 
   // only x86 has 80bit float - but no support with MS C Runtime!
   if (anyX86 && !global.params.targetTriple.isWindowsMSVCEnvironment()) {
@@ -62,6 +64,10 @@ llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
 
   if (anyAarch64) {
     return llvm::Type::getFP128Ty(ctx);
+  }
+
+  if (anyPPC) {
+    return llvm::Type::getPPC_FP128Ty(ctx);
   }
 
   return llvm::Type::getDoubleTy(ctx);


### PR DESCRIPTION
The PPC platform uses the special doubledouble type for real numbers.