### PR TITLE
[ltsmaster] Rename test suite llvm-ir-testsuite to lit-tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,11 +100,11 @@ script:
       ninja -j3 druntime-ldc-unittest-debug druntime-ldc-unittest;
     fi
   # Run LIT testsuite.
-  - ctest -V -R "llvm-ir-testsuite"
+  - ctest -V -R "lit-tests"
   # Run DMD testsuite.
   - DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
   # Link and run Phobos & druntime unittest runners.
-  - ctest -j3 --output-on-failure -E "dmd-testsuite|llvm-ir-testsuite"
+  - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
 
 notifications:
   email:

--- a/tests/ir/CMakeLists.txt
+++ b/tests/ir/CMakeLists.txt
@@ -6,7 +6,7 @@ set( TESTS_IR_DIR    ${CMAKE_CURRENT_SOURCE_DIR}           )
 configure_file(lit.site.cfg.in lit.site.cfg )
 configure_file(runlit.py       runlit.py    COPYONLY)
 
-add_test(NAME llvm-ir-testsuite
+add_test(NAME lit-tests
     COMMAND python runlit.py -v .
 )
 


### PR DESCRIPTION
This syncs the names with master.