### PR TITLE
Add mising MIPS32 global identifier

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -733,6 +733,7 @@ void registerPredefinedTargetVersions() {
   case llvm::Triple::mips:
   case llvm::Triple::mipsel:
     VersionCondition::addPredefinedGlobalIdent("MIPS");
+    VersionCondition::addPredefinedGlobalIdent("MIPS32");
     registerPredefinedFloatABI("MIPS_SoftFloat", "MIPS_HardFloat");
     registerMipsABI();
     break;


### PR DESCRIPTION
According to https://dlang.org/spec/version.html there is no `MIPS` global identifier, noticed that LDC was setting it but not setting the `MIPS32` one mentioned on the spec. When I did the `uClibc` port I used the spec, so obviously it didn't worked.
This patch adds it to the mips/mipsel architecture selection. 

Using this config `ldc2 -mtriple=mipsel-unknown-linux-uclibc -mcpu=mips32 -gcc=mipsel-openwrt-linux-uclibc-gcc  -release -Os -betterC` I tested a simple `hello world` in `betterC` variant on my shiny new `LinkIt Smart 7688 Duo`, it worked! pretty impressive 👍