### PR TITLE
Lit tests that use DMD-style asm should explicitly target a supporting target (X86)

### DIFF
--- a/tests/semantic/asm_datadefinition_diag.d
+++ b/tests/semantic/asm_datadefinition_diag.d
@@ -1,7 +1,9 @@
 // Tests diagnostics of using data definition directives in inline asm.
 // Note: this test should be removed once we _do_ support them.
 
-// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+// REQUIRES: target_X86
+
+// RUN: not %ldc -mtriple=x86_64-linux-gnu -c %s 2>&1 | FileCheck %s
 
 void foo()
 {

--- a/tests/semantic/dcompute.d
+++ b/tests/semantic/dcompute.d
@@ -81,9 +81,6 @@ void func()
     //CHECK-NOT: Error:
     scope(exit)
         func2();
-
-    //CHECK: dcompute.d([[@LINE+1]]): Error: asm not allowed in `@compute` code
-    asm {ret;}
 }
 
 void func1() {}

--- a/tests/semantic/dcompute_asm.d
+++ b/tests/semantic/dcompute_asm.d
@@ -1,0 +1,15 @@
+// Test that the "asm" statement is not allowed for DCompute code.
+
+// "asm" is only allowed for X86, so we must explicitly target X86 in this test.
+// REQUIRES: target_X86
+
+// RUN: not %ldc -mtriple=x86_64-linux-gnu -o- %s 2>&1 | FileCheck %s
+
+@compute(CompileFor.deviceOnly) module tests.semaintic.dcompute;
+import ldc.dcompute;
+
+void func()
+{
+    //CHECK: dcompute_asm.d([[@LINE+1]]): Error: asm not allowed in `@compute` code
+    asm {ret;}
+}


### PR DESCRIPTION
This should fix these tests for e.g. arm platforms, see failure on armv7 platform : http://buildbot.ldc-developers.org/builders/armv7neon_builder/builds/289/steps/testlit/logs/stdio
