### PR TITLE
Clarify that error messages relate only to DMD-style asm.

### DIFF
--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -109,13 +109,13 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
   if (!(t.getArch() == llvm::Triple::x86 ||
         t.getArch() == llvm::Triple::x86_64)) {
     s->error(
-        "DMD-style inline asm is not supported for the \"%s\" architecture",
+        "the `asm` statement is not supported for the \"%s\" architecture, use `ldc.llvmasm.__asm` instead",
         t.getArchName().str().c_str());
     err = true;
   }
   if (!global.params.useInlineAsm) {
     s->error(
-        "DMD-style inline asm is not allowed when the -noasm switch is used");
+        "the `asm` statement is not allowed when the -noasm switch is used");
     err = true;
   }
   if (err) {

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -108,12 +108,14 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
   llvm::Triple const &t = *global.params.targetTriple;
   if (!(t.getArch() == llvm::Triple::x86 ||
         t.getArch() == llvm::Triple::x86_64)) {
-    s->error("inline asm is not supported for the \"%s\" architecture",
-             t.getArchName().str().c_str());
+    s->error(
+        "DMD-style inline asm is not supported for the \"%s\" architecture",
+        t.getArchName().str().c_str());
     err = true;
   }
   if (!global.params.useInlineAsm) {
-    s->error("inline asm is not allowed when the -noasm switch is used");
+    s->error(
+        "DMD-style inline asm is not allowed when the -noasm switch is used");
     err = true;
   }
   if (err) {

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -108,9 +108,9 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
   llvm::Triple const &t = *global.params.targetTriple;
   if (!(t.getArch() == llvm::Triple::x86 ||
         t.getArch() == llvm::Triple::x86_64)) {
-    s->error(
-        "the `asm` statement is not supported for the \"%s\" architecture, use `ldc.llvmasm.__asm` instead",
-        t.getArchName().str().c_str());
+    s->error("the `asm` statement is not supported for the \"%s\" "
+             "architecture, use `ldc.llvmasm.__asm` instead",
+             t.getArchName().str().c_str());
     err = true;
   }
   if (!global.params.useInlineAsm) {


### PR DESCRIPTION
Inspired by the initially surprising error message reported on ARM:
`......./semantic/asm_datadefinition_diag.d(10): Error: inline asm is not supported for the "armv7a" architecture`

Shall I enhance the first error message with a hint towards `ldc.llvmasm.__asm`?
`"DMD-style inline asm is not supported for the \"%s\" architecture. Instead, use ldc.llvmasm.__asm."