### PR TITLE
Try to test asm output in another way for more platform independence

### DIFF
--- a/tests/ir/asm_output.d
+++ b/tests/ir/asm_output.d
@@ -1,9 +1,10 @@
 // RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix LLVM < %t.ll
 // RUN: %ldc -c -output-s  -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
 
-int main() {
-    return 42;
-// Try to keep these very simple checks independent of architecture:
+// Try to keep these very simple checks independent of architecture.
+
+// ASM: D7example3fooFZi:
+int foo() {
 // LLVM:  ret i32 42
-// ASM:  {{(\$|#|.long )}}42
+    return 42;
 }

--- a/tests/ir/asm_output.d
+++ b/tests/ir/asm_output.d
@@ -3,8 +3,8 @@
 
 // Try to keep these very simple checks independent of architecture.
 
-// ASM: D7example3fooFZi:
-int foo() {
+// ASM: foofoofoofoo:
+extern(C) int foofoofoofoo() {
 // LLVM:  ret i32 42
     return 42;
 }


### PR DESCRIPTION
See failure on PPC: http://buildbot.ldc-developers.org/builders/powerosl_builder/builds/1081/steps/testlit/logs/stdio

To be cherry-picked onto `master` once merged.

@redstar 