### PR TITLE
Fix attributes.d test for PPC.

### DIFF
--- a/tests/ir/attributes.d
+++ b/tests/ir/attributes.d
@@ -26,7 +26,7 @@ import ldc.attributes;
 //---------------------------------------------------------------------
 
 
-// CHECK-LABEL: define i32 @_Dmain
+// CHECK-LABEL: define{{.*}} i32 @_Dmain
 void main() {
   sectionedfoo();
 }


### PR DESCRIPTION
On PPC, the i32 ABI is `signext i32`.

See failure: http://buildbot.ldc-developers.org/builders/powerosl_builder/builds/1081/steps/testlit/logs/stdio

To be cherry-pick onto `master` once merged.

@redstar 