### PR TITLE
Fix semantic/target_traits.d test on non-X86 platforms.

### DIFF
--- a/tests/semantic/target_traits.d
+++ b/tests/semantic/target_traits.d
@@ -2,9 +2,9 @@
 
 // REQUIRES: target_X86
 
-// RUN: %ldc -mcpu=haswell -d-version=CPU_HASWELL -c %s
-// RUN: %ldc -mcpu=pentium -mattr=+fma -d-version=ATTR_FMA -c %s
-// RUN: %ldc -mcpu=pentium -mattr=+fma,-sse -d-version=ATTR_FMA_MINUS_SSE -c %s
+// RUN: %ldc -mtriple=x86_64-apple-darwin -mcpu=haswell -d-version=CPU_HASWELL -c %s
+// RUN: %ldc -mtriple=x86_64-apple-darwin -mcpu=pentium -mattr=+fma -d-version=ATTR_FMA -c %s
+// RUN: %ldc -mtriple=x86_64-apple-darwin -mcpu=pentium -mattr=+fma,-sse -d-version=ATTR_FMA_MINUS_SSE -c %s
 
 // Important: LLVM's default CPU selection already enables some features (like sse3)
 


### PR DESCRIPTION
Explicit targeting of x86 was forgotten in this test.

See for a failure on PPC: http://buildbot.ldc-developers.org/builders/powerosl_builder/builds/1080/steps/testlit/logs/stdio