### PR TITLE
Fix array_equals_memcmp_dyn test.

### DIFF
--- a/tests/codegen/array_equals_memcmp_dyn.d
+++ b/tests/codegen/array_equals_memcmp_dyn.d
@@ -22,10 +22,17 @@ bool static_dynamic(bool[4] a, bool[] b)
 // ASM-LABEL: inv_dynamic_dynamic{{.*}}:
 bool inv_dynamic_dynamic(bool[] a, bool[] b)
 {
-    // LLVM: call i32 @memcmp(
+    // The front-end turns this into a call to druntime template function `object.__equals!(bool, bool).__equals(bool[], bool[])`
+    // After optimization (inlining), it should boil down to a length check and a call to memcmp.
+    // ASM: memcmp
     return a != b;
 }
 
+// LLVM-LABEL: define{{.*}} @_D6object{{.*}}equals{{.*}}
+// ASM-LABEL: _D6object{{.*}}equals{{.*}}:
+
+// LLVM-LABEL: define{{.*}} @_Dmain
+// ASM-LABEL: _Dmain:
 void main()
 {
     assert( static_dynamic([true, false, true, false], [true, false, true, false]));

--- a/tests/codegen/array_equals_memcmp_dyn.d
+++ b/tests/codegen/array_equals_memcmp_dyn.d
@@ -28,7 +28,7 @@ bool inv_dynamic_dynamic(bool[] a, bool[] b)
     return a != b;
 }
 
-// LLVM-LABEL: define{{.*}} @_D6object{{.*}}equals{{.*}}
+// LLVM-LABEL: define{{.*}} @{{.*}}_D6object{{.*}}equals{{.*}}
 // ASM-LABEL: _D6object{{.*}}equals{{.*}}:
 
 // LLVM-LABEL: define{{.*}} @_Dmain


### PR DESCRIPTION
The frontend now does most of the dyn-dyn comparison optimization (turning it into a druntime template function call).

Caused a failure on PPC: http://buildbot.ldc-developers.org/builders/powerosl_builder/builds/1080/steps/check/logs/stdio