### PR TITLE
Ship with LTO default libs on Linux & macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,9 +169,9 @@ commonSteps: &commonSteps
           # TODO: enable for OSX too; linker currently crashing with:
           #       Assertion failed: (WasErased && "Expected to drop a reference")
           if [ "$CI_OS" = "linux" ]; then
-            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_thin -flto=thin -defaultlib=phobos2-ldc-bc,druntime-ldc-bc
+            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_thin -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
             ./hello_thin
-            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_full -flto=full -defaultlib=phobos2-ldc-bc,druntime-ldc-bc
+            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_full -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
             ./hello_full
           fi
     - run:
@@ -257,7 +257,7 @@ jobs:
       - CI_OS: linux
       - LLVM_VERSION: 6.0.0
       - HOST_LDC_VERSION: 1.8.0
-      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_BC_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
       - DUB_VERSION: v1.7.2
   build-osx:
     <<: *commonSteps
@@ -270,7 +270,7 @@ jobs:
       - LLVM_VERSION: 6.0.0
       - HOST_LDC_VERSION: 1.8.0
       - BOOTSTRAP_CMAKE_FLAGS: "-DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
-      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_BC_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
       - DUB_VERSION: v1.7.2
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,13 +155,25 @@ commonSteps: &commonSteps
           cd ..
           altLibSuffix="32"
           if [ "$CI_OS" = "osx" ]; then
-              altLibSuffix=""
+            altLibSuffix=""
           fi
           echo 'void main() { import std.stdio; writeln("Hello world, ", size_t.sizeof * 8, " bits"); }' > hello.d
           $LDC_INSTALL_DIR/bin/ldc2 hello.d -m64 -of=hello64 -link-defaultlib-shared -L-Wl,-rpath,$LDC_INSTALL_DIR/lib
-          $LDC_INSTALL_DIR/bin/ldc2 hello.d -m32 -of=hello32 -link-defaultlib-shared -L-Wl,-rpath,$LDC_INSTALL_DIR/lib$altLibSuffix
           ./hello64
+          $LDC_INSTALL_DIR/bin/ldc2 hello.d -m32 -of=hello32 -link-defaultlib-shared -L-Wl,-rpath,$LDC_INSTALL_DIR/lib$altLibSuffix
           ./hello32
+    - run:
+        name: Hello world integration test with LTO
+        command: |
+          cd ..
+          # TODO: enable for OSX too; linker currently crashing with:
+          #       Assertion failed: (WasErased && "Expected to drop a reference")
+          if [ "$CI_OS" = "linux" ]; then
+            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_thin -flto=thin -defaultlib=phobos2-ldc-bc,druntime-ldc-bc
+            ./hello_thin
+            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_full -flto=full -defaultlib=phobos2-ldc-bc,druntime-ldc-bc
+            ./hello_full
+          fi
     - run:
         name: Build dub
         command: |
@@ -245,7 +257,7 @@ jobs:
       - CI_OS: linux
       - LLVM_VERSION: 6.0.0
       - HOST_LDC_VERSION: 1.8.0
-      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_BC_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
       - DUB_VERSION: v1.7.2
   build-osx:
     <<: *commonSteps
@@ -258,7 +270,7 @@ jobs:
       - LLVM_VERSION: 6.0.0
       - HOST_LDC_VERSION: 1.8.0
       - BOOTSTRAP_CMAKE_FLAGS: "-DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
-      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_BC_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
       - DUB_VERSION: v1.7.2
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,14 +166,10 @@ commonSteps: &commonSteps
         name: Hello world integration test with LTO
         command: |
           cd ..
-          # TODO: enable for OSX too; linker currently crashing with:
-          #       Assertion failed: (WasErased && "Expected to drop a reference")
-          if [ "$CI_OS" = "linux" ]; then
-            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_thin -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
-            ./hello_thin
-            $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_full -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
-            ./hello_full
-          fi
+          $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_thin -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
+          ./hello_thin
+          $LDC_INSTALL_DIR/bin/ldc2 hello.d -of=hello_full -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
+          ./hello_full
     - run:
         name: Build dub
         command: |

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -343,9 +343,12 @@ void writeModule(llvm::Module *m, const char *filename) {
   };
 
   // write LLVM bitcode
-  if (global.params.output_bc || (doLTO && outputObj)) {
-    std::string bcpath =
-        (doLTO && outputObj) ? filename : replaceExtensionWith(global.bc_ext);
+  const bool emitBitcodeAsObjectFile =
+      doLTO && outputObj && !global.params.output_bc;
+  if (global.params.output_bc || emitBitcodeAsObjectFile) {
+    std::string bcpath = emitBitcodeAsObjectFile
+                             ? filename
+                             : replaceExtensionWith(global.bc_ext);
     Logger::println("Writing LLVM bitcode to: %s\n", bcpath.c_str());
     std::error_code errinfo;
     llvm::raw_fd_ostream bos(bcpath.c_str(), errinfo, llvm::sys::fs::F_None);
@@ -436,7 +439,7 @@ void writeModule(llvm::Module *m, const char *filename) {
     }
   }
 
-  if (outputObj && !doLTO) {
+  if (outputObj && !emitBitcodeAsObjectFile) {
     writeObjectFile(m, filename);
     if (useIR2ObjCache) {
       cache::cacheObjectFile(filename, moduleHash);

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -368,7 +368,7 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
         endif()
 
         set(output_o  ${output_basedir}/${output_root}${CMAKE_C_OUTPUT_EXTENSION})
-        set(output_bc ${output_basedir}/${output_root}.bc)
+        set(output_bc ${output_basedir}/${output_root}.bc${CMAKE_C_OUTPUT_EXTENSION})
         list(APPEND ${outlist_o} ${output_o})
         if(BUILD_BC_LIBS)
             list(APPEND ${outlist_bc} ${output_bc})
@@ -378,13 +378,16 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
             list(APPEND relative_src_files ${relative_src_file})
         else()
             set(outfiles ${output_o})
+            set(renameCommand "")
             if(BUILD_BC_LIBS)
+                set(renameCommand mv ${output_basedir}/${output_root}.bc ${output_bc})
                 list(APPEND outfiles ${output_bc})
             endif()
 
             add_custom_command(
                 OUTPUT  ${outfiles}
                 COMMAND ${LDC_EXE_FULL} ${dc_flags} -of=${output_o} ${relative_src_file}
+                COMMAND ${renameCommand}
                 WORKING_DIRECTORY ${src_basedir}
                 DEPENDS ${f} ${dc_deps}
             )
@@ -392,9 +395,15 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
     endforeach()
 
     if(${all_at_once})
+        set(renameCommand "")
+        if(BUILD_BC_LIBS)
+            set(renameCommand find ${output_basedir} -iname '*.bc' -exec mv '{}' '{}${CMAKE_C_OUTPUT_EXTENSION}' "\\\\;")
+        endif()
+
         add_custom_command(
             OUTPUT  ${${outlist_o}} ${${outlist_bc}}
             COMMAND ${LDC_EXE_FULL} ${dc_flags} -od=${output_basedir} -op ${relative_src_files}
+            COMMAND ${renameCommand}
             WORKING_DIRECTORY ${src_basedir}
             DEPENDS ${src_files} ${dc_deps}
         )
@@ -453,12 +462,18 @@ foreach(f ${D_FLAGS})
 endforeach()
 
 # Sets the common properties for all library targets.
-function(set_common_library_properties target is_shared)
+function(set_common_library_properties target name output_dir c_flags ld_flags is_shared)
     set_target_properties(${target} PROPERTIES
-        VERSION ${DMDFE_VERSION}
-        SOVERSION ${DMDFE_PATCH_VERSION}
-        LINKER_LANGUAGE C
-        MACOSX_RPATH ON
+        OUTPUT_NAME                 ${name}
+        ARCHIVE_OUTPUT_DIRECTORY    ${output_dir}
+        LIBRARY_OUTPUT_DIRECTORY    ${output_dir}
+        RUNTIME_OUTPUT_DIRECTORY    ${output_dir}
+        COMPILE_FLAGS               "${c_flags}"
+        LINK_FLAGS                  "${ld_flags}"
+        VERSION                     ${DMDFE_VERSION}
+        SOVERSION                   ${DMDFE_PATCH_VERSION}
+        LINKER_LANGUAGE             C
+        MACOSX_RPATH                ON
     )
     if(RT_ARCHIVE_WITH_LDC AND NOT is_shared)
         set_target_properties(${target} PROPERTIES LINKER_LANGUAGE D)
@@ -488,16 +503,10 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
     get_target_suffix("${lib_suffix}" "${path_suffix}" target_suffix)
     add_library(druntime-ldc${target_suffix} ${library_type}
         ${druntime_o} ${DRUNTIME_C} ${DRUNTIME_ASM})
-    set_target_properties(
-        druntime-ldc${target_suffix} PROPERTIES
-        OUTPUT_NAME                 druntime-ldc${lib_suffix}
-        ARCHIVE_OUTPUT_DIRECTORY    ${output_path}
-        LIBRARY_OUTPUT_DIRECTORY    ${output_path}
-        RUNTIME_OUTPUT_DIRECTORY    ${output_path}
-        COMPILE_FLAGS               "${c_flags}"
-        LINK_FLAGS                  "${ld_flags}"
+    set_common_library_properties(druntime-ldc${target_suffix}
+        druntime-ldc${lib_suffix} ${output_path}
+        "${c_flags}" "${ld_flags}" ${is_shared}
     )
-    set_common_library_properties(druntime-ldc${target_suffix} "${is_shared}")
 
     # When building a shared library, we need to link in all the default
     # libraries otherwise implicitly added by LDC to make it loadable from
@@ -511,16 +520,10 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
     if(PHOBOS2_DIR)
         add_library(phobos2-ldc${target_suffix} ${library_type}
             ${phobos2_o} ${PHOBOS2_C})
-        set_target_properties(
-            phobos2-ldc${target_suffix} PROPERTIES
-            OUTPUT_NAME                 phobos2-ldc${lib_suffix}
-            ARCHIVE_OUTPUT_DIRECTORY    ${output_path}
-            LIBRARY_OUTPUT_DIRECTORY    ${output_path}
-            RUNTIME_OUTPUT_DIRECTORY    ${output_path}
-            COMPILE_FLAGS               "${c_flags}"
-            LINK_FLAGS                  "${ld_flags}"
+        set_common_library_properties(phobos2-ldc${target_suffix}
+            phobos2-ldc${lib_suffix} ${output_path}
+            "${c_flags}" "${ld_flags}" ${is_shared}
         )
-        set_common_library_properties(phobos2-ldc${target_suffix} "${is_shared}")
 
         if("${is_shared}" STREQUAL "ON")
             # Make sure to link shared unittest-Phobos against shared NON-unittest-druntime
@@ -530,34 +533,27 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
                 druntime-ldc${target_suffix_without_unittest} ${C_SYSTEM_LIBS})
         endif()
 
-        list(APPEND ${outlist_targets} "phobos2-ldc${target_suffix}")
+        list(APPEND ${outlist_targets} phobos2-ldc${target_suffix})
     endif()
 
     if(BUILD_BC_LIBS AND "${is_shared}" STREQUAL "OFF" AND NOT "${lib_suffix}" MATCHES "-unittest")
-        find_program(LLVM_AR_EXE llvm-ar
-            HINTS ${LLVM_ROOT_DIR}/bin
-            DOC "path to llvm-ar tool"
-        )
-        if(NOT LLVM_AR_EXE)
-            message(SEND_ERROR "llvm-ar not found")
-        endif()
-
-        set(bclibs
-            ${output_path}/libdruntime-ldc${lib_suffix}-bc.a
-            ${output_path}/libphobos2-ldc${lib_suffix}-bc.a
-        )
-        add_custom_command(
-            OUTPUT ${bclibs}
-            COMMAND ${LLVM_AR_EXE} rs libdruntime-ldc${lib_suffix}-bc.a ${druntime_bc}
-            COMMAND ${LLVM_AR_EXE} rs libphobos2-ldc${lib_suffix}-bc.a ${phobos2_bc}
-            WORKING_DIRECTORY ${output_path}
-            DEPENDS
-                ${druntime_bc}
-                ${phobos2_bc}
-            VERBATIM
+        add_library(druntime-ldc-bc${target_suffix} STATIC
+            ${druntime_bc} ${DRUNTIME_C} ${DRUNTIME_ASM})
+        set_common_library_properties(druntime-ldc-bc${target_suffix}
+            druntime-ldc-bc${lib_suffix} ${output_path}
+            "${c_flags}" "${ld_flags}" OFF
         )
 
-        add_custom_target(bitcode-libraries${target_suffix} ALL DEPENDS ${bclibs})
+        add_library(phobos2-ldc-bc${target_suffix} STATIC
+            ${phobos2_bc} ${PHOBOS2_C})
+        set_common_library_properties(phobos2-ldc-bc${target_suffix}
+            phobos2-ldc-bc${lib_suffix} ${output_path}
+            "${c_flags}" "${ld_flags}" OFF
+        )
+
+        add_custom_target(bitcode-libraries${target_suffix} ALL
+            DEPENDS druntime-ldc-bc${target_suffix} phobos2-ldc-bc${target_suffix}
+        )
     endif()
 endmacro()
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -658,6 +658,10 @@ if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
         list(APPEND libs_to_install druntime-ldc.a druntime-ldc-debug.a
                                     phobos2-ldc.a  phobos2-ldc-debug.a
         )
+        # Only install the release versions of the (static-only) bitcode libraries.
+        if(BUILD_BC_LIBS)
+            list(APPEND libs_to_install druntime-ldc-bc.a phobos2-ldc-bc.a)
+        endif()
     endif()
     if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
         set(suffix ${SHARED_LIB_SUFFIX}.dylib)
@@ -709,6 +713,11 @@ else()
     # don't add multilib targets to libs_to_install
     if(MULTILIB)
         build_runtime_variants("-m${MULTILIB_SUFFIX}" "-m${MULTILIB_SUFFIX} ${RT_CFLAGS}" "-m${MULTILIB_SUFFIX} ${LD_FLAGS}" "${MULTILIB_SUFFIX}" dummy)
+    endif()
+
+    # Only install the release versions of the (static-only) bitcode libraries.
+    if(BUILD_BC_LIBS)
+        list(APPEND libs_to_install druntime-ldc-bc phobos2-ldc-bc)
     endif()
 
     foreach(libname ${libs_to_install})

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -533,7 +533,7 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
         list(APPEND ${outlist_targets} "phobos2-ldc${target_suffix}")
     endif()
 
-    if(BUILD_BC_LIBS)
+    if(BUILD_BC_LIBS AND "${is_shared}" STREQUAL "OFF" AND NOT "${lib_suffix}" MATCHES "-unittest")
         find_program(LLVM_AR_EXE llvm-ar
             HINTS ${LLVM_ROOT_DIR}/bin
             DOC "path to llvm-ar tool"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 set(DMDFE_VERSION         ${D_VERSION}.${DMDFE_MINOR_VERSION}.${DMDFE_PATCH_VERSION})
 
 set(MULTILIB              OFF                                 CACHE BOOL   "Build both 32/64 bit runtime libraries")
-set(BUILD_BC_LIBS         OFF                                 CACHE BOOL   "Build the runtime as LLVM bitcode libraries")
+set(BUILD_LTO_LIBS        OFF                                 CACHE BOOL   "Also build the runtime as LLVM bitcode libraries for LTO")
 set(INCLUDE_INSTALL_DIR   ${CMAKE_INSTALL_PREFIX}/include/d   CACHE PATH   "Path to install D modules to")
 set(BUILD_SHARED_LIBS     AUTO                                CACHE STRING "Whether to build the runtime as a shared library (ON|OFF|BOTH)")
 set(D_FLAGS               -w                                  CACHE STRING "Runtime D compiler flags, separated by ';'")
@@ -346,7 +346,7 @@ endforeach()
 # The paths of the output files are appended to outlist_o and outlist_bc, respectively.
 macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outlist_bc)
     set(dc_flags -c --output-o ${d_flags})
-    if(BUILD_BC_LIBS)
+    if(BUILD_LTO_LIBS)
         list(APPEND dc_flags --output-bc)
     endif()
 
@@ -370,7 +370,7 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
         set(output_o  ${output_basedir}/${output_root}${CMAKE_C_OUTPUT_EXTENSION})
         set(output_bc ${output_basedir}/${output_root}.bc${CMAKE_C_OUTPUT_EXTENSION})
         list(APPEND ${outlist_o} ${output_o})
-        if(BUILD_BC_LIBS)
+        if(BUILD_LTO_LIBS)
             list(APPEND ${outlist_bc} ${output_bc})
         endif()
 
@@ -379,7 +379,7 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
         else()
             set(outfiles ${output_o})
             set(renameCommand "")
-            if(BUILD_BC_LIBS)
+            if(BUILD_LTO_LIBS)
                 set(renameCommand mv ${output_basedir}/${output_root}.bc ${output_bc})
                 list(APPEND outfiles ${output_bc})
             endif()
@@ -396,7 +396,7 @@ macro(dc src_files src_basedir d_flags output_basedir all_at_once outlist_o outl
 
     if(${all_at_once})
         set(renameCommand "")
-        if(BUILD_BC_LIBS)
+        if(BUILD_LTO_LIBS)
             set(renameCommand find ${output_basedir} -iname '*.bc' -exec mv '{}' '{}${CMAKE_C_OUTPUT_EXTENSION}' "\\\\;")
         endif()
 
@@ -536,23 +536,19 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
         list(APPEND ${outlist_targets} phobos2-ldc${target_suffix})
     endif()
 
-    if(BUILD_BC_LIBS AND "${is_shared}" STREQUAL "OFF" AND NOT "${lib_suffix}" MATCHES "-unittest")
-        add_library(druntime-ldc-bc${target_suffix} STATIC
+    if(BUILD_LTO_LIBS AND "${is_shared}" STREQUAL "OFF" AND NOT "${lib_suffix}" MATCHES "-unittest")
+        add_library(druntime-ldc-lto${target_suffix} STATIC
             ${druntime_bc} ${DRUNTIME_C} ${DRUNTIME_ASM})
-        set_common_library_properties(druntime-ldc-bc${target_suffix}
-            druntime-ldc-bc${lib_suffix} ${output_path}
+        set_common_library_properties(druntime-ldc-lto${target_suffix}
+            druntime-ldc-lto${lib_suffix} ${output_path}
             "${c_flags}" "${ld_flags}" OFF
         )
 
-        add_library(phobos2-ldc-bc${target_suffix} STATIC
+        add_library(phobos2-ldc-lto${target_suffix} STATIC
             ${phobos2_bc} ${PHOBOS2_C})
-        set_common_library_properties(phobos2-ldc-bc${target_suffix}
-            phobos2-ldc-bc${lib_suffix} ${output_path}
+        set_common_library_properties(phobos2-ldc-lto${target_suffix}
+            phobos2-ldc-lto${lib_suffix} ${output_path}
             "${c_flags}" "${ld_flags}" OFF
-        )
-
-        add_custom_target(bitcode-libraries${target_suffix} ALL
-            DEPENDS druntime-ldc-bc${target_suffix} phobos2-ldc-bc${target_suffix}
         )
     endif()
 endmacro()
@@ -659,8 +655,8 @@ if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
                                     phobos2-ldc.a  phobos2-ldc-debug.a
         )
         # Only install the release versions of the (static-only) bitcode libraries.
-        if(BUILD_BC_LIBS)
-            list(APPEND libs_to_install druntime-ldc-bc.a phobos2-ldc-bc.a)
+        if(BUILD_LTO_LIBS)
+            list(APPEND libs_to_install druntime-ldc-lto.a phobos2-ldc-lto.a)
         endif()
     endif()
     if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
@@ -716,8 +712,8 @@ else()
     endif()
 
     # Only install the release versions of the (static-only) bitcode libraries.
-    if(BUILD_BC_LIBS)
-        list(APPEND libs_to_install druntime-ldc-bc phobos2-ldc-bc)
+    if(BUILD_LTO_LIBS)
+        list(APPEND libs_to_install druntime-ldc-lto phobos2-ldc-lto)
     endif()
 
     foreach(libname ${libs_to_install})

--- a/runtime/jit-rt/DefineBuildJitRT.cmake
+++ b/runtime/jit-rt/DefineBuildJitRT.cmake
@@ -58,16 +58,12 @@ if(LDC_DYNAMIC_COMPILE)
         set(output_path ${CMAKE_BINARY_DIR}/lib${path_suffix})
 
         add_library(ldc-jit-rt-so${target_suffix} SHARED ${LDC_JITRT_SO_CXX} ${LDC_JITRT_SO_H})
-        set_target_properties(
-            ldc-jit-rt-so${target_suffix} PROPERTIES
-            OUTPUT_NAME                 ldc-jit
-            ARCHIVE_OUTPUT_DIRECTORY    ${output_path}
-            LIBRARY_OUTPUT_DIRECTORY    ${output_path}
-            RUNTIME_OUTPUT_DIRECTORY    ${output_path}
-            COMPILE_FLAGS               "${c_flags} ${LDC_CXXFLAGS} ${LLVM_CXXFLAGS} ${JITRT_EXTRA_FLAGS}"
-            LINK_FLAGS                  "${ld_flags} ${JITRT_EXTRA_LDFLAGS}"
+        set_common_library_properties(ldc-jit-rt-so${target_suffix}
+            ldc-jit ${output_path}
+            "${c_flags} ${LDC_CXXFLAGS} ${LLVM_CXXFLAGS} ${JITRT_EXTRA_FLAGS}"
+            "${ld_flags} ${JITRT_EXTRA_LDFLAGS}"
+            ON
         )
-        set_common_library_properties(ldc-jit-rt-so${target_suffix} ON)
 
         target_link_libraries(ldc-jit-rt-so${target_suffix} ${JITRT_LLVM_LIBS})
 
@@ -76,16 +72,12 @@ if(LDC_DYNAMIC_COMPILE)
         compile_jit_rt_D("-enable-dynamic-compile;${d_flags}" "" "${path_suffix}" "${COMPILE_ALL_D_FILES_AT_ONCE}" jitrt_d_o jitrt_d_bc)
 
         add_library(ldc-jit-rt${target_suffix} STATIC ${jitrt_d_o} ${LDC_JITRT_CXX} ${LDC_JITRT_H})
-        set_target_properties(
-            ldc-jit-rt${target_suffix} PROPERTIES
-            OUTPUT_NAME                 ldc-jit-rt
-            ARCHIVE_OUTPUT_DIRECTORY    ${output_path}
-            LIBRARY_OUTPUT_DIRECTORY    ${output_path}
-            RUNTIME_OUTPUT_DIRECTORY    ${output_path}
-            COMPILE_FLAGS               "${c_flags} ${JITRT_EXTRA_FLAGS}"
-            LINK_FLAGS                  "${ld_flags} ${JITRT_EXTRA_LDFLAGS}"
+        set_common_library_properties(ldc-jit-rt${target_suffix}
+            ldc-jit-rt ${output_path}
+            "${c_flags} ${JITRT_EXTRA_FLAGS}"
+            "${ld_flags} ${JITRT_EXTRA_LDFLAGS}"
+            OFF
         )
-        set_common_library_properties(ldc-jit-rt${target_suffix} OFF)
 
         target_link_libraries(ldc-jit-rt${target_suffix} ldc-jit-rt-so${target_suffix})
 


### PR DESCRIPTION
This allows additional bitcode libs to be generated simultaneously with the normal druntime/Phobos libs (i.e., single compilation) by including something like `-DBUILD_LTO_LIBS=ON -DD_FLAGS="-w;-flto=thin"` in the CMake command line (additional D_FLAGS entry here to include the ThinLTO module summaries in the bitcode files; not needed for FullLTO).

This then allows linking against the LTO default libs via `ldc2 -flto=<thin|full> ... -defaultlib=phobos2-ldc-lto,druntime-ldc-lto`; unfortunately, I couldn't test this yet, as my LLVM 6 Linux build has a 0-byte LLVMgold.so...