### PR TITLE
[2.079] Support minimal runtime

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -177,12 +177,6 @@ void emitLLVMUsedArray(IRState &irs) {
 namespace ldc {
 CodeGenerator::CodeGenerator(llvm::LLVMContext &context, bool singleObj)
     : context_(context), moduleCount_(0), singleObj_(singleObj), ir_(nullptr) {
-  if (!ClassDeclaration::object) {
-    error(Loc(), "declaration for class `Object` not found; druntime not "
-                 "configured properly");
-    fatal();
-  }
-
 #if LDC_LLVM_VER >= 309
   // Set the context to discard value names when not generating textual IR.
   if (!global.params.output_ll) {

--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -54,8 +54,9 @@ void addMscrtLibs(std::vector<std::string> &args,
 }
 
 void addLibIfFound(std::vector<std::string> &args, const llvm::Twine &name) {
-  if (llvm::sys::fs::exists(exe_path::prependLibDir(name)))
-    args.push_back(name.str());
+  std::string candidate = exe_path::prependLibDir(name);
+  if (llvm::sys::fs::exists(candidate))
+    args.push_back(std::move(candidate));
 }
 
 void addSanitizerLibs(std::vector<std::string> &args) {

--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -674,13 +674,6 @@ DSliceValue *DtoNewDynArray(Loc &loc, Type *arrayType, DValue *dim,
   IF_LOG Logger::println("DtoNewDynArray : %s", arrayType->toChars());
   LOG_SCOPE;
 
-  // typeinfo arg
-  LLValue *arrayTypeInfo = DtoTypeInfoOf(arrayType);
-
-  // dim arg
-  assert(DtoType(dim->type) == DtoSize_t());
-  LLValue *arrayLen = DtoRVal(dim);
-
   // get runtime function
   Type *eltType = arrayType->toBasetype()->nextOf();
   bool zeroInit = eltType->isZeroInit();
@@ -689,6 +682,13 @@ DSliceValue *DtoNewDynArray(Loc &loc, Type *arrayType, DValue *dim,
                            ? (zeroInit ? "_d_newarrayT" : "_d_newarrayiT")
                            : "_d_newarrayU";
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, fnname);
+
+  // typeinfo arg
+  LLValue *arrayTypeInfo = DtoTypeInfoOf(arrayType);
+
+  // dim arg
+  assert(DtoType(dim->type) == DtoSize_t());
+  LLValue *arrayLen = DtoRVal(dim);
 
   // call allocator
   LLValue *newArray =
@@ -704,9 +704,6 @@ DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
   IF_LOG Logger::println("DtoNewMulDimDynArray : %s", arrayType->toChars());
   LOG_SCOPE;
 
-  // typeinfo arg
-  LLValue *arrayTypeInfo = DtoTypeInfoOf(arrayType);
-
   // get value type
   Type *vtype = arrayType->toBasetype();
   for (size_t i = 0; i < ndims; ++i) {
@@ -717,6 +714,9 @@ DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
   const char *fnname =
       vtype->isZeroInit() ? "_d_newarraymTX" : "_d_newarraymiTX";
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, fnname);
+
+  // typeinfo arg
+  LLValue *arrayTypeInfo = DtoTypeInfoOf(arrayType);
 
   // Check if constant
   bool allDimsConst = true;

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -360,11 +360,11 @@ DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *_to) {
   // call:
   // Object _d_dynamic_cast(Object o, ClassInfo c)
 
-  resolveObjectAndClassInfoClasses();
-
   llvm::Function *func =
       getRuntimeFunction(loc, gIR->module, "_d_dynamic_cast");
   LLFunctionType *funcTy = func->getFunctionType();
+
+  resolveObjectAndClassInfoClasses();
 
   // Object o
   LLValue *obj = DtoRVal(val);
@@ -397,11 +397,11 @@ DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *_to) {
   // call:
   // Object _d_interface_cast(void* p, ClassInfo c)
 
-  resolveObjectAndClassInfoClasses();
-
   llvm::Function *func =
       getRuntimeFunction(loc, gIR->module, "_d_interface_cast");
   LLFunctionType *funcTy = func->getFunctionType();
+
+  resolveObjectAndClassInfoClasses();
 
   // void* p
   LLValue *ptr = DtoRVal(val);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -613,8 +613,8 @@ LLConstant *DtoDefineClassInfo(ClassDeclaration *cd) {
   assert(cd->type->ty == Tclass);
 
   IrAggr *ir = getIrAggr(cd);
-  getClassInfoType(); // check declaration in object.d
-  ClassDeclaration *cinfo = Type::typeinfoclass;
+  Type *const cinfoType = getClassInfoType(); // check declaration in object.d
+  ClassDeclaration *const cinfo = Type::typeinfoclass;
 
   if (cinfo->fields.dim != 12) {
     error(Loc(), "Unexpected number of fields in `object.ClassInfo`; "
@@ -623,7 +623,7 @@ LLConstant *DtoDefineClassInfo(ClassDeclaration *cd) {
   }
 
   // use the rtti builder
-  RTTIBuilder b(cinfo);
+  RTTIBuilder b(cinfoType);
 
   LLConstant *c;
 
@@ -664,7 +664,7 @@ LLConstant *DtoDefineClassInfo(ClassDeclaration *cd) {
   if (cd->baseClass && !cd->isInterfaceDeclaration()) {
     b.push_classinfo(cd->baseClass);
   } else {
-    b.push_null(cinfo->type);
+    b.push_null(cinfoType);
   }
 
   // destructor

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -141,7 +141,7 @@ public:
       setLinkage(decl, initGlobal);
 
       // emit typeinfo
-      if (global.params.useTypeInfo) {
+      if (global.params.useTypeInfo && Type::dtypeinfo) {
         DtoTypeInfoOf(decl->type, /*base=*/false);
       }
     }

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -138,7 +138,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
   if (isLLVMVariadic && f->linkage == LINKd) {
     // Add extra `_arguments` parameter for D-style variadic functions.
     newIrFty.arg_arguments =
-        new IrFuncTyArg(Type::dtypeinfo->type->arrayOf(), false);
+        new IrFuncTyArg(getTypeInfoType()->arrayOf(), false);
     ++nextLLArgIdx;
   }
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1286,7 +1286,7 @@ LLConstant *DtoTypeInfoOf(Type *type, bool base) {
   LLConstant *c = isaConstant(getIrGlobal(tidecl)->value);
   assert(c != NULL);
   if (base) {
-    return llvm::ConstantExpr::getBitCast(c, DtoType(Type::dtypeinfo->type));
+    return llvm::ConstantExpr::getBitCast(c, DtoType(getTypeInfoType()));
   }
   return c;
 }

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -194,8 +194,9 @@ llvm::Constant *buildLocalClasses(Module *m, size_t &count) {
 }
 
 llvm::GlobalVariable *genModuleInfo(Module *m) {
-  getModuleInfoType(); // check declaration in object.d
-  auto moduleInfoDecl = Module::moduleinfo;
+  // check declaration in object.d
+  const auto moduleInfoType = getModuleInfoType();
+  const auto moduleInfoDecl = Module::moduleinfo;
 
   // The "new-style" ModuleInfo records are variable-length, with the presence
   // of the various fields indicated by a certain flag bit. The base struct
@@ -261,7 +262,7 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
   }
 
   // Now, start building the initialiser for the ModuleInfo instance.
-  RTTIBuilder b(moduleInfoDecl);
+  RTTIBuilder b(moduleInfoType);
 
   b.push_uint(flags);
   b.push_uint(0); // index

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -154,7 +154,7 @@ llvm::Constant *buildImportedModules(Module *m, size_t &count) {
 
 /// Builds the (constant) data content for the localClasses[] array.
 llvm::Constant *buildLocalClasses(Module *m, size_t &count) {
-  const auto classinfoTy = Type::typeinfoclass->type->ctype->getLLType();
+  const auto classinfoTy = DtoType(Type::typeinfoclass->type);
 
   ClassDeclarations aclasses;
   for (auto s : *m->members) {

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -708,9 +708,11 @@ void codegenModule(IRState *irs, Module *m) {
     fatal();
   }
 
-  // Skip emission of all the additional module metadata if requested by the
-  // user or the betterC switch is on.
-  if (global.params.useModuleInfo && !m->noModuleInfo) {
+  // Skip emission of all the additional module metadata if:
+  // a) the -betterC switch is on,
+  // b) requested explicitly by the user via pragma(LDC_no_moduleinfo), or if
+  // c) there's no ModuleInfo declaration.
+  if (global.params.useModuleInfo && !m->noModuleInfo && Module::moduleinfo) {
     // generate ModuleInfo
     registerModuleInfo(m);
   }

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -350,7 +350,7 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
   // functions).
   const bool isFirst = !gIR->module.getGlobalVariable("ldc.dso_slot");
 
-  llvm::Type *const moduleInfoPtrTy = DtoPtrToType(Module::moduleinfo->type);
+  llvm::Type *const moduleInfoPtrTy = DtoPtrToType(getModuleInfoType());
   const auto sectionName =
       style == RegistryStyle::sectionMSVC
           ? ".minfo"

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -66,7 +66,7 @@ struct Analysis {
   CallGraph *CG;
   CallGraphNode *CGNode;
 
-  Type *getTypeFor(Value *typeinfo) const;
+  llvm::Type *getTypeFor(Value *typeinfo) const;
 };
 }
 
@@ -105,7 +105,7 @@ enum Type {
 
 class FunctionInfo {
 protected:
-  Type *Ty;
+  llvm::Type *Ty;
 
 public:
   ReturnType::Type ReturnType;
@@ -559,7 +559,7 @@ bool GarbageCollect2Stack::runOnFunction(Function &F) {
   return Changed;
 }
 
-Type *Analysis::getTypeFor(Value *typeinfo) const {
+llvm::Type *Analysis::getTypeFor(Value *typeinfo) const {
   GlobalVariable *ti_global =
       dyn_cast<GlobalVariable>(typeinfo->stripPointerCasts());
   if (!ti_global) {
@@ -826,7 +826,7 @@ bool isSafeToStackAllocate(BasicBlock::iterator Alloc, Value *V,
       // its return value and doesn't unwind (a readonly function can leak bits
       // by throwing an exception or not depending on the input value).
       if (CS.onlyReadsMemory() && CS.doesNotThrow() &&
-          I->getType() == Type::getVoidTy(I->getContext())) {
+          I->getType() == llvm::Type::getVoidTy(I->getContext())) {
         break;
       }
 

--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -173,7 +173,7 @@ struct LLVM_LIBRARY_VISIBILITY ArrayCastLenOpt : public LibCallOptimization {
                        IRBuilder<> &B) override {
     // Verify we have a reasonable prototype for _d_array_cast_len
     const FunctionType *FT = Callee->getFunctionType();
-    const Type *RetTy = FT->getReturnType();
+    const llvm::Type *RetTy = FT->getReturnType();
     if (Callee->arg_size() != 3 || !isa<IntegerType>(RetTy) ||
         FT->getParamType(0) != RetTy || FT->getParamType(1) != RetTy ||
         FT->getParamType(2) != RetTy) {
@@ -263,7 +263,7 @@ struct LLVM_LIBRARY_VISIBILITY ArraySliceCopyOpt : public LibCallOptimization {
                        IRBuilder<> &B) override {
     // Verify we have a reasonable prototype for _d_array_slice_copy
     const FunctionType *FT = Callee->getFunctionType();
-    const Type *VoidPtrTy = PointerType::getUnqual(B.getInt8Ty());
+    const llvm::Type *VoidPtrTy = PointerType::getUnqual(B.getInt8Ty());
     if (Callee->arg_size() != 4 || FT->getReturnType() != B.getVoidTy() ||
         FT->getParamType(0) != VoidPtrTy ||
         !isa<IntegerType>(FT->getParamType(1)) ||

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -20,18 +20,16 @@
 #include "ir/iraggr.h"
 #include "ir/irfunction.h"
 
-RTTIBuilder::RTTIBuilder(AggregateDeclaration *base_class) {
-  DtoResolveDsymbol(base_class);
+RTTIBuilder::RTTIBuilder(Type *baseType) {
+  const auto ad = isAggregate(baseType);
+  assert(ad && "not an aggregate type");
 
-  base = base_class;
-  basetype = static_cast<TypeClass *>(base->type);
+  DtoResolveDsymbol(ad);
 
-  baseir = getIrAggr(base);
-  assert(baseir && "no IrStruct for TypeInfo base class");
+  if (ad->isClassDeclaration()) {
+    const auto baseir = getIrAggr(ad);
+    assert(baseir && "no IrAggr for TypeInfo base class");
 
-  prevFieldEnd = 0;
-
-  if (base->isClassDeclaration()) {
     // just start with adding the vtbl
     push(baseir->getVtblSymbol());
     // and monitor

--- a/gen/rttibuilder.h
+++ b/gen/rttibuilder.h
@@ -18,33 +18,25 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Constant.h"
 
-class AggregateDeclaration;
 class ClassDeclaration;
 class Dsymbol;
 class FuncDeclaration;
-struct IrGlobal;
-struct IrAggr;
 class Type;
-class TypeClass;
 namespace llvm {
 class StructType;
 class GlobalVariable;
 }
 
 class RTTIBuilder {
-  AggregateDeclaration *base;
-  TypeClass *basetype;
-  IrAggr *baseir;
-
   /// The offset (in bytes) at which the previously pushed field ended.
-  uint64_t prevFieldEnd;
+  uint64_t prevFieldEnd = 0;
 
 public:
   // 15 is enough for any D2 ClassInfo including 64 bit pointer alignment
   // padding
   llvm::SmallVector<llvm::Constant *, 15> inits;
 
-  explicit RTTIBuilder(AggregateDeclaration *base_class);
+  explicit RTTIBuilder(Type *baseType);
 
   void push(llvm::Constant *C);
   void push_null(Type *T);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -138,14 +138,17 @@ private:
   const char *const name;
   Type *type = nullptr;
 
+  const char *getKind() { return "class"; }
+
 public:
   LazyType(Declaration *&decl, const char *name) : declRef(decl), name(name) {}
 
   Type *get() {
     if (!type) {
       if (!declRef || !declRef->type) {
-        Logger::println("Missing class declaration: %s\n", name);
-        error(Loc(), "Missing class declaration: `%s`", name);
+        const char *kind = getKind();
+        Logger::println("Missing %s declaration: %s\n", kind, name);
+        error(Loc(), "Missing %s declaration: `%s`", kind, name);
         errorSupplemental(Loc(),
                           "Please check that object.d is included and valid");
         fatal();
@@ -166,6 +169,7 @@ LazyClassType aaTypeInfoTy(Type::typeinfoassociativearray,
                            "TypeInfo_AssociativeArray");
 
 using LazyAggregateType = LazyType<AggregateDeclaration>;
+template <> const char *LazyAggregateType::getKind() { return "struct"; }
 LazyAggregateType moduleInfoTy(Module::moduleinfo, "ModuleInfo");
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -386,6 +390,16 @@ static const char *getUnwindResumeFunctionName() {
 llvm::Function *getUnwindResumeFunction(const Loc &loc, llvm::Module &target) {
   return getRuntimeFunction(loc, target, getUnwindResumeFunctionName());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+Type *getObjectType() { return objectTy.get(); }
+Type *getThrowableType() { return throwableTy.get(); }
+Type *getTypeInfoType() { return typeInfoTy.get(); }
+Type *getClassInfoType() { return classInfoTy.get(); }
+Type *getStructTypeInfoType() { return structTypeInfoTy.get(); }
+Type *getAaTypeInfoType() { return aaTypeInfoTy.get(); }
+Type *getModuleInfoType() { return moduleInfoTy.get(); }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -183,6 +183,8 @@ LazyClassType invariantTypeInfoTy(Type::typeinfoinvariant,
 LazyClassType sharedTypeInfoTy(Type::typeinfoshared, "TypeInfo_Shared");
 LazyClassType inoutTypeInfoTy(Type::typeinfowild, "TypeInfo_Inout");
 LazyClassType throwableTy(ClassDeclaration::throwable, "Throwable");
+LazyClassType cppTypeInfoPtrTy(ClassDeclaration::cpp_type_info_ptr,
+                               "__cpp_type_info_ptr");
 
 using LazyAggregateType = LazyType<AggregateDeclaration>;
 template <> const char *LazyAggregateType::getKind() { return "struct"; }
@@ -429,6 +431,7 @@ Type *getInvariantTypeInfoType() { return invariantTypeInfoTy.get(); }
 Type *getSharedTypeInfoType() { return sharedTypeInfoTy.get(); }
 Type *getInoutTypeInfoType() { return inoutTypeInfoTy.get(); }
 Type *getThrowableType() { return throwableTy.get(); }
+Type *getCppTypeInfoPtrType() { return cppTypeInfoPtrTy.get(); }
 Type *getModuleInfoType() { return moduleInfoTy.get(); }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -161,12 +161,28 @@ public:
 
 using LazyClassType = LazyType<ClassDeclaration>;
 LazyClassType objectTy(ClassDeclaration::object, "Object");
-LazyClassType throwableTy(ClassDeclaration::throwable, "Throwable");
 LazyClassType typeInfoTy(Type::dtypeinfo, "TypeInfo");
-LazyClassType classInfoTy(Type::typeinfoclass, "TypeInfo_Class");
-LazyClassType structTypeInfoTy(Type::typeinfostruct, "TypeInfo_Struct");
+LazyClassType enumTypeInfoTy(Type::typeinfoenum, "TypeInfo_Enum");
+LazyClassType pointerTypeInfoTy(Type::typeinfopointer, "TypeInfo_Pointer");
+LazyClassType arrayTypeInfoTy(Type::typeinfoarray, "TypeInfo_Array");
+LazyClassType staticArrayTypeInfoTy(Type::typeinfostaticarray,
+                                    "TypeInfo_StaticArray");
 LazyClassType aaTypeInfoTy(Type::typeinfoassociativearray,
                            "TypeInfo_AssociativeArray");
+LazyClassType vectorTypeInfoTy(Type::typeinfovector, "TypeInfo_Vector");
+LazyClassType functionTypeInfoTy(Type::typeinfofunction, "TypeInfo_Function");
+LazyClassType delegateTypeInfoTy(Type::typeinfodelegate, "TypeInfo_Delegate");
+LazyClassType classInfoTy(Type::typeinfoclass, "TypeInfo_Class");
+LazyClassType interfaceTypeInfoTy(Type::typeinfointerface,
+                                  "TypeInfo_Interface");
+LazyClassType structTypeInfoTy(Type::typeinfostruct, "TypeInfo_Struct");
+LazyClassType tupleTypeInfoTy(Type::typeinfotypelist, "TypeInfo_Tuple");
+LazyClassType constTypeInfoTy(Type::typeinfoconst, "TypeInfo_Const");
+LazyClassType invariantTypeInfoTy(Type::typeinfoinvariant,
+                                  "TypeInfo_Invariant");
+LazyClassType sharedTypeInfoTy(Type::typeinfoshared, "TypeInfo_Shared");
+LazyClassType inoutTypeInfoTy(Type::typeinfowild, "TypeInfo_Inout");
+LazyClassType throwableTy(ClassDeclaration::throwable, "Throwable");
 
 using LazyAggregateType = LazyType<AggregateDeclaration>;
 template <> const char *LazyAggregateType::getKind() { return "struct"; }
@@ -394,11 +410,24 @@ llvm::Function *getUnwindResumeFunction(const Loc &loc, llvm::Module &target) {
 ////////////////////////////////////////////////////////////////////////////////
 
 Type *getObjectType() { return objectTy.get(); }
-Type *getThrowableType() { return throwableTy.get(); }
 Type *getTypeInfoType() { return typeInfoTy.get(); }
+Type *getEnumTypeInfoType() { return enumTypeInfoTy.get(); }
+Type *getPointerTypeInfoType() { return pointerTypeInfoTy.get(); }
+Type *getArrayTypeInfoType() { return arrayTypeInfoTy.get(); }
+Type *getStaticArrayTypeInfoType() { return staticArrayTypeInfoTy.get(); }
+Type *getAssociativeArrayTypeInfoType() { return aaTypeInfoTy.get(); }
+Type *getVectorTypeInfoType() { return vectorTypeInfoTy.get(); }
+Type *getFunctionTypeInfoType() { return functionTypeInfoTy.get(); }
+Type *getDelegateTypeInfoType() { return delegateTypeInfoTy.get(); }
 Type *getClassInfoType() { return classInfoTy.get(); }
+Type *getInterfaceTypeInfoType() { return interfaceTypeInfoTy.get(); }
 Type *getStructTypeInfoType() { return structTypeInfoTy.get(); }
-Type *getAaTypeInfoType() { return aaTypeInfoTy.get(); }
+Type *getTupleTypeInfoType() { return tupleTypeInfoTy.get(); }
+Type *getConstTypeInfoType() { return constTypeInfoTy.get(); }
+Type *getInvariantTypeInfoType() { return invariantTypeInfoTy.get(); }
+Type *getSharedTypeInfoType() { return sharedTypeInfoTy.get(); }
+Type *getInoutTypeInfoType() { return inoutTypeInfoTy.get(); }
+Type *getThrowableType() { return throwableTy.get(); }
 Type *getModuleInfoType() { return moduleInfoTy.get(); }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -50,7 +50,8 @@ static llvm::cl::opt<bool> nogc(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Internal LLVM module containing runtime declarations (functions and globals)
+// Internal LLVM module containing already declared runtime functions and
+// globals.
 static llvm::Module *M = nullptr;
 
 static void buildRuntimeModule();
@@ -129,6 +130,165 @@ void freeRuntime() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+template <typename Declaration> struct LazyType {
+private:
+  Declaration *&declRef;
+  const char *const name;
+  Type *type = nullptr;
+
+public:
+  LazyType(Declaration *&decl, const char *name) : declRef(decl), name(name) {}
+
+  Type *get() {
+    if (!type) {
+      if (!declRef || !declRef->type) {
+        Logger::println("Missing class declaration: %s\n", name);
+        error(Loc(), "Missing class declaration: `%s`", name);
+        errorSupplemental(Loc(),
+                          "Please check that object.d is included and valid");
+        fatal();
+      }
+      type = declRef->type;
+    }
+    return type;
+  }
+};
+
+using LazyClassType = LazyType<ClassDeclaration>;
+LazyClassType objectTy(ClassDeclaration::object, "Object");
+LazyClassType throwableTy(ClassDeclaration::throwable, "Throwable");
+LazyClassType typeInfoTy(Type::dtypeinfo, "TypeInfo");
+LazyClassType classInfoTy(Type::typeinfoclass, "TypeInfo_Class");
+LazyClassType structTypeInfoTy(Type::typeinfostruct, "TypeInfo_Struct");
+LazyClassType aaTypeInfoTy(Type::typeinfoassociativearray,
+                           "TypeInfo_AssociativeArray");
+
+using LazyAggregateType = LazyType<AggregateDeclaration>;
+LazyAggregateType moduleInfoTy(Module::moduleinfo, "ModuleInfo");
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct PotentiallyLazyType {
+private:
+  enum class Kind {
+    normal,
+    lazyClass,
+    lazyAggregate,
+  };
+  Kind kind;
+  int numIndirections = 0;
+  void *ptr;
+
+public:
+  PotentiallyLazyType(Type *type) : kind(Kind::normal), ptr(type) {}
+  PotentiallyLazyType(LazyClassType &type)
+      : kind(Kind::lazyClass), ptr(&type) {}
+  PotentiallyLazyType(LazyAggregateType &type)
+      : kind(Kind::lazyAggregate), ptr(&type) {}
+
+  PotentiallyLazyType pointerTo() const {
+    auto copy = *this;
+    copy.numIndirections++;
+    return copy;
+  }
+
+  Type *get() const {
+    Type *ty;
+    if (kind == Kind::lazyClass) {
+      ty = static_cast<LazyClassType *>(ptr)->get();
+    } else if (kind == Kind::lazyAggregate) {
+      ty = static_cast<LazyAggregateType *>(ptr)->get();
+    } else {
+      ty = static_cast<Type *>(ptr);
+    }
+
+    for (int i = 0; i < numIndirections; ++i)
+      ty = ty->pointerTo();
+
+    return ty;
+  }
+};
+
+const auto moduleInfoPtrTy = PotentiallyLazyType(moduleInfoTy).pointerTo();
+const auto objectPtrTy = PotentiallyLazyType(objectTy).pointerTo();
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct LazyFunctionDeclarer {
+  LINK linkage;
+  PotentiallyLazyType returnType;
+  std::vector<llvm::StringRef> mangledFunctionNames;
+  std::vector<PotentiallyLazyType> paramTypes;
+  std::vector<StorageClass> paramsSTC;
+  AttrSet attributes;
+
+  void declare() {
+    Parameters *params = nullptr;
+    if (!paramTypes.empty()) {
+      params = new Parameters();
+      for (size_t i = 0, e = paramTypes.size(); i < e; ++i) {
+        StorageClass stc = paramsSTC.empty() ? 0 : paramsSTC[i];
+        params->push(Parameter::create(stc, paramTypes[i].get(), nullptr, nullptr));
+      }
+    }
+    int varargs = 0;
+    auto dty = TypeFunction::create(params, returnType.get(), varargs, linkage);
+
+    // the call to DtoType performs many actions such as rewriting the function
+    // type and storing it in dty
+    auto llfunctype = llvm::cast<llvm::FunctionType>(DtoType(dty));
+    assert(dty->ctype);
+    auto attrs =
+        dty->ctype->getIrFuncTy().getParamAttrs(gABI->passThisBeforeSret(dty));
+    attrs.merge(attributes);
+
+    for (auto fname : mangledFunctionNames) {
+      llvm::Function *fn = llvm::Function::Create(
+          llfunctype, llvm::GlobalValue::ExternalLinkage, fname, M);
+
+      fn->setAttributes(attrs);
+
+      // On x86_64, always set 'uwtable' for System V ABI compatibility.
+      // FIXME: Move to better place (abi-x86-64.cpp?)
+      // NOTE: There are several occurances if this line.
+      if (global.params.targetTriple->getArch() == llvm::Triple::x86_64) {
+        fn->addFnAttr(LLAttribute::UWTable);
+      }
+
+      fn->setCallingConv(gABI->callingConv(linkage, dty));
+    }
+  }
+};
+
+// Use a pointer in order to share one declarer (declaring multiple functions
+// of the same type under different names) for multiple function names.
+llvm::StringMap<LazyFunctionDeclarer *> lazyFunctionDeclarers;
+
+// Registers a runtime function forward declaration. The actual declaration of
+// the function (and involved types) is deferred to the first
+// getRuntimeFunction() call.
+void createFwdDecl(LINK linkage, PotentiallyLazyType returnType,
+                   std::vector<llvm::StringRef> mangledFunctionNames,
+                   std::vector<PotentiallyLazyType> paramTypes,
+                   std::vector<StorageClass> paramsSTC = {},
+                   AttrSet attributes = {}) {
+  const auto ptr = new LazyFunctionDeclarer{linkage,
+                                            returnType,
+                                            mangledFunctionNames,
+                                            std::move(paramTypes),
+                                            std::move(paramsSTC),
+                                            attributes};
+
+  for (auto name : mangledFunctionNames)
+    lazyFunctionDeclarers[name] = ptr;
+}
+
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
                                    const char *name) {
   checkForImplicitGCCall(loc, name);
@@ -138,8 +298,15 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
 
   LLFunction *fn = M->getFunction(name);
   if (!fn) {
-    error(loc, "Runtime function `%s` was not found", name);
-    fatal();
+    const auto it = lazyFunctionDeclarers.find(name);
+    if (it == lazyFunctionDeclarers.end()) {
+      error(loc, "Runtime function `%s` was not found", name);
+      fatal();
+    }
+    // declare it in the M runtime module
+    it->second->declare();
+    fn = M->getFunction(name);
+    assert(fn);
   }
   LLFunctionType *fnty = fn->getFunctionType();
 
@@ -184,7 +351,7 @@ static const char *getCAssertFunctionName() {
   return "__assert";
 }
 
-static std::vector<Type *> getCAssertFunctionParamTypes() {
+static std::vector<PotentiallyLazyType> getCAssertFunctionParamTypes() {
   const auto voidPtr = Type::tvoidptr;
   const auto uint = Type::tuns32;
 
@@ -249,59 +416,6 @@ static Type *rt_dg2() {
   return dg2_t;
 }
 
-template <typename DECL> static void ensureDecl(DECL *decl, const char *msg) {
-  if (!decl || !decl->type) {
-    Logger::println("Missing class declaration: %s\n", msg);
-    error(Loc(), "Missing class declaration: `%s`", msg);
-    errorSupplemental(Loc(),
-                      "Please check that object.d is included and valid");
-    fatal();
-  }
-}
-
-// Parameters fnames are assumed to be already mangled!
-static void createFwdDecl(LINK linkage, Type *returntype,
-                          ArrayParam<llvm::StringRef> fnames,
-                          ArrayParam<Type *> paramtypes,
-                          ArrayParam<StorageClass> paramsSTC = {},
-                          AttrSet attribset = AttrSet()) {
-
-  Parameters *params = nullptr;
-  if (!paramtypes.empty()) {
-    params = new Parameters();
-    for (size_t i = 0, e = paramtypes.size(); i < e; ++i) {
-      StorageClass stc = paramsSTC.empty() ? 0 : paramsSTC[i];
-      params->push(Parameter::create(stc, paramtypes[i], nullptr, nullptr));
-    }
-  }
-  int varargs = 0;
-  auto dty = TypeFunction::create(params, returntype, varargs, linkage);
-
-  // the call to DtoType performs many actions such as rewriting the function
-  // type and storing it in dty
-  auto llfunctype = llvm::cast<llvm::FunctionType>(DtoType(dty));
-  assert(dty->ctype);
-  auto attrs =
-      dty->ctype->getIrFuncTy().getParamAttrs(gABI->passThisBeforeSret(dty));
-  attrs.merge(attribset);
-
-  for (auto fname : fnames) {
-    llvm::Function *fn = llvm::Function::Create(
-        llfunctype, llvm::GlobalValue::ExternalLinkage, fname, M);
-
-    fn->setAttributes(attrs);
-
-    // On x86_64, always set 'uwtable' for System V ABI compatibility.
-    // FIXME: Move to better place (abi-x86-64.cpp?)
-    // NOTE: There are several occurances if this line.
-    if (global.params.targetTriple->getArch() == llvm::Triple::x86_64) {
-      fn->addFnAttr(LLAttribute::UWTable);
-    }
-
-    fn->setCallingConv(gABI->callingConv(linkage, dty));
-  }
-}
-
 static void buildRuntimeModule() {
   Logger::println("building runtime module");
   M = new llvm::Module("ldc internal runtime", gIR->context());
@@ -322,19 +436,6 @@ static void buildRuntimeModule() {
   Type *wstringTy = Type::twchar->arrayOf();
   Type *dstringTy = Type::tdchar->arrayOf();
 
-  // Ensure that the declarations exist before creating llvm types for them.
-  ensureDecl(ClassDeclaration::object, "Object");
-  ensureDecl(Type::typeinfoclass, "TypeInfo_Class");
-  ensureDecl(Type::dtypeinfo, "TypeInfo");
-  ensureDecl(Type::typeinfoassociativearray, "TypeInfo_AssociativeArray");
-  ensureDecl(Module::moduleinfo, "ModuleInfo");
-
-  Type *objectTy = ClassDeclaration::object->type;
-  Type *throwableTy = ClassDeclaration::throwable->type;
-  Type *classInfoTy = Type::typeinfoclass->type;
-  Type *typeInfoTy = Type::dtypeinfo->type;
-  Type *aaTypeInfoTy = Type::typeinfoassociativearray->type;
-  Type *moduleInfoPtrTy = Module::moduleinfo->type->pointerTo();
   // The AA type is a struct that only contains a ptr
   Type *aaTy = voidPtrTy;
 
@@ -477,7 +578,7 @@ static void buildRuntimeModule() {
 
   // void _d_delarray_t(void[]* p, const TypeInfo_Struct ti)
   createFwdDecl(LINKc, voidTy, {"_d_delarray_t"},
-                {voidArrayPtrTy, Type::typeinfostruct->type}, {0, STCconst});
+                {voidArrayPtrTy, structTypeInfoTy}, {0, STCconst});
 
   // void _d_delmemory(void** p)
   // void _d_delinterface(void** p)
@@ -488,11 +589,11 @@ static void buildRuntimeModule() {
   createFwdDecl(LINKc, voidTy, {"_d_callfinalizer"}, {voidPtrTy});
 
   // D2: void _d_delclass(Object* p)
-  createFwdDecl(LINKc, voidTy, {"_d_delclass"}, {objectTy->pointerTo()});
+  createFwdDecl(LINKc, voidTy, {"_d_delclass"}, {objectPtrTy});
 
   // void _d_delstruct(void** p, TypeInfo_Struct inf)
   createFwdDecl(LINKc, voidTy, {"_d_delstruct"},
-                {voidPtrTy->pointerTo(), Type::typeinfostruct->type});
+                {voidPtrTy->pointerTo(), structTypeInfoTy});
 
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
@@ -512,32 +613,28 @@ static void buildRuntimeModule() {
 // int _aApplyRcd1(in char[] aa, dg_t dg)
 #define STR_APPLY1(TY, a, b)                                                   \
   {                                                                            \
-    const std::string prefix = "_aApply";                                      \
-    std::string fname1 = prefix + (a) + '1', fname2 = prefix + (b) + '1',      \
-                fname3 = prefix + 'R' + (a) + '1',                             \
-                fname4 = prefix + 'R' + (b) + '1';                             \
+    const char *fname1 = "_aApply" #a "1", *fname2 = "_aApply" #b "1",         \
+               *fname3 = "_aApplyR" #a "1", *fname4 = "_aApplyR" #b "1";       \
     createFwdDecl(LINKc, sizeTy, {fname1, fname2, fname3, fname4},             \
                   {TY, rt_dg1()});                                             \
   }
-  STR_APPLY1(stringTy, "cw", "cd")
-  STR_APPLY1(wstringTy, "wc", "wd")
-  STR_APPLY1(dstringTy, "dc", "dw")
+  STR_APPLY1(stringTy, cw, cd)
+  STR_APPLY1(wstringTy, wc, wd)
+  STR_APPLY1(dstringTy, dc, dw)
 #undef STR_APPLY1
 
 // int _aApplycd2(in char[] aa, dg2_t dg)
 // int _aApplyRcd2(in char[] aa, dg2_t dg)
 #define STR_APPLY2(TY, a, b)                                                   \
   {                                                                            \
-    const std::string prefix = "_aApply";                                      \
-    std::string fname1 = prefix + (a) + '2', fname2 = prefix + (b) + '2',      \
-                fname3 = prefix + 'R' + (a) + '2',                             \
-                fname4 = prefix + 'R' + (b) + '2';                             \
+    const char *fname1 = "_aApply" #a "2", *fname2 = "_aApply" #b "2",         \
+               *fname3 = "_aApplyR" #a "2", *fname4 = "_aApplyR" #b "2";       \
     createFwdDecl(LINKc, sizeTy, {fname1, fname2, fname3, fname4},             \
                   {TY, rt_dg2()});                                             \
   }
-  STR_APPLY2(stringTy, "cw", "cd")
-  STR_APPLY2(wstringTy, "wc", "wd")
-  STR_APPLY2(dstringTy, "dc", "dw")
+  STR_APPLY2(stringTy, cw, cd)
+  STR_APPLY2(wstringTy, wc, wd)
+  STR_APPLY2(dstringTy, dc, dw)
 #undef STR_APPLY2
 
   //////////////////////////////////////////////////////////////////////////////
@@ -678,10 +775,11 @@ static void buildRuntimeModule() {
   //////////////////////////////////////////////////////////////////////////////
 
   // void invariant._d_invariant(Object o)
-  createFwdDecl(
-      LINKd, voidTy,
-      {getIRMangledFuncName("_D9invariant12_d_invariantFC6ObjectZv", LINKd)},
-      {objectTy});
+  {
+    static const std::string mangle =
+        getIRMangledFuncName("_D9invariant12_d_invariantFC6ObjectZv", LINKd);
+    createFwdDecl(LINKd, voidTy, {mangle}, {objectTy});
+  }
 
   // void _d_dso_registry(void* data)
   // (the argument is really a pointer to

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -22,6 +22,7 @@ class Module;
 
 struct Loc;
 class FuncDeclaration;
+class Type;
 
 // D runtime support helpers
 bool initRuntime();
@@ -36,5 +37,13 @@ llvm::Function *getUnwindResumeFunction(const Loc &loc, llvm::Module &target);
 
 void emitInstrumentationFnEnter(FuncDeclaration *decl);
 void emitInstrumentationFnLeave(FuncDeclaration *decl);
+
+Type *getObjectType();
+Type *getThrowableType();
+Type *getTypeInfoType();
+Type *getClassInfoType();
+Type *getStructTypeInfoType();
+Type *getAaTypeInfoType();
+Type *getModuleInfoType();
 
 #endif // LDC_GEN_RUNTIME_H

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -39,11 +39,24 @@ void emitInstrumentationFnEnter(FuncDeclaration *decl);
 void emitInstrumentationFnLeave(FuncDeclaration *decl);
 
 Type *getObjectType();
-Type *getThrowableType();
 Type *getTypeInfoType();
+Type *getEnumTypeInfoType();
+Type *getPointerTypeInfoType();
+Type *getArrayTypeInfoType();
+Type *getStaticArrayTypeInfoType();
+Type *getAssociativeArrayTypeInfoType();
+Type *getVectorTypeInfoType();
+Type *getFunctionTypeInfoType();
+Type *getDelegateTypeInfoType();
 Type *getClassInfoType();
+Type *getInterfaceTypeInfoType();
 Type *getStructTypeInfoType();
-Type *getAaTypeInfoType();
+Type *getTupleTypeInfoType();
+Type *getConstTypeInfoType();
+Type *getInvariantTypeInfoType();
+Type *getSharedTypeInfoType();
+Type *getInoutTypeInfoType();
+Type *getThrowableType();
 Type *getModuleInfoType();
 
 #endif // LDC_GEN_RUNTIME_H

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -57,6 +57,7 @@ Type *getInvariantTypeInfoType();
 Type *getSharedTypeInfoType();
 Type *getInoutTypeInfoType();
 Type *getThrowableType();
+Type *getCppTypeInfoPtrType();
 Type *getModuleInfoType();
 
 #endif // LDC_GEN_RUNTIME_H

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -1565,10 +1565,10 @@ public:
         getRuntimeFunction(stmt->loc, irs->module, "_d_switch_error");
 
     LLValue *moduleInfoSymbol = getIrModule(module)->moduleInfoSymbol();
-    LLType *moduleInfoType = DtoType(Module::moduleinfo->type);
+    LLType *moduleInfoPtrType = DtoPtrToType(getModuleInfoType());
 
     LLCallSite call = irs->CreateCallOrInvoke(
-        fn, DtoBitCast(moduleInfoSymbol, getPtrToType(moduleInfoType)),
+        fn, DtoBitCast(moduleInfoSymbol, moduleInfoPtrType),
         DtoConstUint(stmt->loc.linnum));
     call.setDoesNotReturn();
   }

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -238,7 +238,7 @@ static LLValue *getTypeinfoArrayArgumentForDVarArg(Expressions *argexps,
   const size_t numVariadicArgs = numArgExps - begin;
 
   // build type info array
-  LLType *typeinfotype = DtoType(Type::dtypeinfo->type);
+  LLType *typeinfotype = DtoType(getTypeInfoType());
   LLArrayType *typeinfoarraytype =
       LLArrayType::get(typeinfotype, numVariadicArgs);
 
@@ -261,7 +261,7 @@ static LLValue *getTypeinfoArrayArgumentForDVarArg(Expressions *argexps,
   LLConstant *pinits[] = {
       DtoConstSize_t(numVariadicArgs),
       llvm::ConstantExpr::getBitCast(typeinfomem, getPtrToType(typeinfotype))};
-  LLType *tiarrty = DtoType(Type::dtypeinfo->type->arrayOf());
+  LLType *tiarrty = DtoType(getTypeInfoType()->arrayOf());
   tiinits = LLConstantStruct::get(isaStruct(tiarrty),
                                   llvm::ArrayRef<LLConstant *>(pinits));
   LLValue *typeinfoarrayparam = new llvm::GlobalVariable(

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2442,7 +2442,7 @@ public:
       LLFunctionType *funcTy = func->getFunctionType();
       LLValue *aaTypeInfo =
           DtoBitCast(DtoTypeInfoOf(stripModifiers(aatype), /*base=*/false),
-                     DtoType(getAaTypeInfoType()));
+                     DtoType(getAssociativeArrayTypeInfoType()));
 
       LLConstant *idxs[2] = {DtoConstUint(0), DtoConstUint(0)};
 
@@ -2654,7 +2654,7 @@ public:
         // For interfaces, the first entry in the vtbl is actually a pointer
         // to an Interface instance, which has the type info as its first
         // member, so we have to add an extra layer of indirection.
-        resultType = Type::typeinfointerface->type;
+        resultType = getInterfaceTypeInfoType();
         typinf = DtoLoad(
             DtoBitCast(typinf, DtoType(resultType->pointerTo()->pointerTo())));
       } else {

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2442,7 +2442,7 @@ public:
       LLFunctionType *funcTy = func->getFunctionType();
       LLValue *aaTypeInfo =
           DtoBitCast(DtoTypeInfoOf(stripModifiers(aatype), /*base=*/false),
-                     DtoType(Type::typeinfoassociativearray->type));
+                     DtoType(getAaTypeInfoType()));
 
       LLConstant *idxs[2] = {DtoConstUint(0), DtoConstUint(0)};
 
@@ -2658,7 +2658,7 @@ public:
         typinf = DtoLoad(
             DtoBitCast(typinf, DtoType(resultType->pointerTo()->pointerTo())));
       } else {
-        resultType = Type::typeinfoclass->type;
+        resultType = getClassInfoType();
         typinf = DtoBitCast(typinf, DtoType(resultType->pointerTo()));
       }
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -658,8 +658,7 @@ LLStructType *DtoModuleReferenceType() {
   LLStructType *st = LLStructType::create(gIR->context(), "ModuleReference");
 
   // add members
-  LLType *types[] = {getPtrToType(st),
-                     DtoType(Module::moduleinfo->type->pointerTo())};
+  LLType *types[] = {getPtrToType(st), DtoPtrToType(getModuleInfoType())};
 
   // resolve type
   st->setBody(types);

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -247,7 +247,7 @@ void emitBeginCatchMSVC(IRState &irs, Catch *ctch,
   } else {
     // catch all
     typeDesc = LLConstant::getNullValue(getVoidPtrType());
-    clssInfo = LLConstant::getNullValue(DtoType(Type::typeinfoclass->type));
+    clssInfo = LLConstant::getNullValue(DtoType(getClassInfoType()));
   }
 
   // "catchpad within %switch [TypeDescriptor, 0, &caughtObject]" must be

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -174,11 +174,13 @@ void TryCatchScope::emitCatchBodies(IRState &irs, llvm::Value *ehPtrSlot) {
       mangleBuf.printf("%d%s", 18, "_cpp_type_info_ptr");
       const auto wrapperMangle = getIRMangledVarName(mangleBuf.peekString(), LINKd);
 
-      RTTIBuilder b(ClassDeclaration::cpp_type_info_ptr);
+      const auto cppTypeInfoPtrType = getCppTypeInfoPtrType();
+      RTTIBuilder b(cppTypeInfoPtrType);
       b.push(cpp_ti);
 
       auto wrapperType = llvm::cast<llvm::StructType>(
-          static_cast<IrTypeClass*>(ClassDeclaration::cpp_type_info_ptr->type->ctype)->getMemoryLLType());
+          static_cast<IrTypeClass *>(cppTypeInfoPtrType->ctype)
+              ->getMemoryLLType());
       auto wrapperInit = b.get_constant(wrapperType);
 
       ci = getOrCreateGlobal(

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -81,7 +81,7 @@ void TryCatchScope::emitCatchBodies(IRState &irs, llvm::Value *ehPtrSlot) {
     const bool isCPPclass = cd->isCPPclass();
 
     const auto enterCatchFn = getRuntimeFunction(
-        Loc(), irs.module,
+        c->loc, irs.module,
         isCPPclass ? "__cxa_begin_catch" : "_d_eh_enter_catch");
     const auto ptr = DtoLoad(ehPtrSlot);
     const auto throwableObj = irs.ir->CreateCall(enterCatchFn, ptr);
@@ -273,7 +273,7 @@ void emitBeginCatchMSVC(IRState &irs, Catch *ctch,
   irs.funcGen().pgo.emitCounterIncrement(ctch);
   if (!isCPPclass) {
     auto enterCatchFn =
-        getRuntimeFunction(Loc(), irs.module, "_d_eh_enter_catch");
+        getRuntimeFunction(ctch->loc, irs.module, "_d_eh_enter_catch");
     irs.CreateCallOrInvoke(enterCatchFn, DtoBitCast(exnObj, getVoidPtrType()),
                            clssInfo);
   }
@@ -320,7 +320,7 @@ void TryCatchScope::emitCatchBodiesMSVC(IRState &irs, llvm::Value *) {
   if (!irs.func()->hasLLVMPersonalityFn()) {
     const char *personality = "__CxxFrameHandler3";
     irs.func()->setLLVMPersonalityFn(
-        getRuntimeFunction(Loc(), irs.module, personality));
+        getRuntimeFunction(stmt->loc, irs.module, personality));
   }
 }
 

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -144,8 +144,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::dtypeinfo);
+    RTTIBuilder b(getTypeInfoType());
     b.finalize(gvar);
   }
 
@@ -156,8 +155,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getEnumTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoenum);
+    RTTIBuilder b(getEnumTypeInfoType());
 
     assert(decl->tinfo->ty == Tenum);
     TypeEnum *tc = static_cast<TypeEnum *>(decl->tinfo);
@@ -192,8 +190,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getPointerTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfopointer);
+    RTTIBuilder b(getPointerTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
     // finish
@@ -207,8 +204,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getArrayTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoarray);
+    RTTIBuilder b(getArrayTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
     // finish
@@ -225,8 +221,7 @@ public:
     assert(decl->tinfo->ty == Tsarray);
     TypeSArray *tc = static_cast<TypeSArray *>(decl->tinfo);
 
-    getStaticArrayTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfostaticarray);
+    RTTIBuilder b(getStaticArrayTypeInfoType());
 
     // value typeinfo
     b.push_typeinfo(tc->nextOf());
@@ -249,8 +244,7 @@ public:
     assert(decl->tinfo->ty == Taarray);
     TypeAArray *tc = static_cast<TypeAArray *>(decl->tinfo);
 
-    getAssociativeArrayTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoassociativearray);
+    RTTIBuilder b(getAssociativeArrayTypeInfoType());
 
     // value typeinfo
     b.push_typeinfo(tc->nextOf());
@@ -269,8 +263,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getFunctionTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfofunction);
+    RTTIBuilder b(getFunctionTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
     // string deco
@@ -289,8 +282,7 @@ public:
     assert(decl->tinfo->ty == Tdelegate);
     Type *ret_type = decl->tinfo->nextOf()->nextOf();
 
-    getDelegateTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfodelegate);
+    RTTIBuilder b(getDelegateTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(ret_type);
     // string deco
@@ -311,8 +303,9 @@ public:
     TypeStruct *tc = static_cast<TypeStruct *>(decl->tinfo);
     StructDeclaration *sd = tc->sym;
 
-    getStructTypeInfoType(); // check declaration in object.d
-    auto structTypeInfoDecl = Type::typeinfostruct;
+    // check declaration in object.d
+    const auto structTypeInfoType = getStructTypeInfoType();
+    const auto structTypeInfoDecl = Type::typeinfostruct;
 
     // On x86_64, class TypeInfo_Struct contains 2 additional fields
     // (m_arg1/m_arg2) which are used for the X86_64 System V ABI varargs
@@ -329,7 +322,7 @@ public:
       fatal();
     }
 
-    RTTIBuilder b(structTypeInfoDecl);
+    RTTIBuilder b(structTypeInfoType);
 
     // handle opaque structs
     if (!sd->members) {
@@ -492,8 +485,7 @@ public:
     TypeClass *tc = static_cast<TypeClass *>(decl->tinfo);
     DtoResolveClass(tc->sym);
 
-    getInterfaceTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfointerface);
+    RTTIBuilder b(getInterfaceTypeInfoType());
 
     // TypeInfo base
     b.push_classinfo(tc->sym);
@@ -527,8 +519,7 @@ public:
     LLArrayType *arrTy = LLArrayType::get(tiTy, dim);
     LLConstant *arrC = LLConstantArray::get(arrTy, arrInits);
 
-    getTupleTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfotypelist);
+    RTTIBuilder b(getTupleTypeInfoType());
 
     // push TypeInfo[]
     b.push_array(arrC, dim, getTypeInfoType(), nullptr);
@@ -544,8 +535,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getConstTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoconst);
+    RTTIBuilder b(getConstTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
     // finish
@@ -559,8 +549,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getInvariantTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoinvariant);
+    RTTIBuilder b(getInvariantTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
     // finish
@@ -574,8 +563,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getSharedTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfoshared);
+    RTTIBuilder b(getSharedTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->unSharedOf()));
     // finish
@@ -589,8 +577,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
-    getInoutTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfowild);
+    RTTIBuilder b(getInoutTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
     // finish
@@ -607,8 +594,7 @@ public:
     assert(decl->tinfo->ty == Tvector);
     TypeVector *tv = static_cast<TypeVector *>(decl->tinfo);
 
-    getVectorTypeInfoType(); // check declaration in object.d
-    RTTIBuilder b(Type::typeinfovector);
+    RTTIBuilder b(getVectorTypeInfoType());
     // TypeInfo base
     b.push_typeinfo(tv->basetype);
     // finish

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -156,6 +156,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getEnumTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoenum);
 
     assert(decl->tinfo->ty == Tenum);
@@ -191,6 +192,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getPointerTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfopointer);
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
@@ -205,6 +207,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getArrayTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoarray);
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
@@ -222,6 +225,7 @@ public:
     assert(decl->tinfo->ty == Tsarray);
     TypeSArray *tc = static_cast<TypeSArray *>(decl->tinfo);
 
+    getStaticArrayTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfostaticarray);
 
     // value typeinfo
@@ -245,7 +249,7 @@ public:
     assert(decl->tinfo->ty == Taarray);
     TypeAArray *tc = static_cast<TypeAArray *>(decl->tinfo);
 
-    getAaTypeInfoType(); // check declaration in object.d
+    getAssociativeArrayTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoassociativearray);
 
     // value typeinfo
@@ -265,6 +269,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getFunctionTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfofunction);
     // TypeInfo base
     b.push_typeinfo(decl->tinfo->nextOf());
@@ -284,6 +289,7 @@ public:
     assert(decl->tinfo->ty == Tdelegate);
     Type *ret_type = decl->tinfo->nextOf()->nextOf();
 
+    getDelegateTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfodelegate);
     // TypeInfo base
     b.push_typeinfo(ret_type);
@@ -486,6 +492,7 @@ public:
     TypeClass *tc = static_cast<TypeClass *>(decl->tinfo);
     DtoResolveClass(tc->sym);
 
+    getInterfaceTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfointerface);
 
     // TypeInfo base
@@ -520,6 +527,7 @@ public:
     LLArrayType *arrTy = LLArrayType::get(tiTy, dim);
     LLConstant *arrC = LLConstantArray::get(arrTy, arrInits);
 
+    getTupleTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfotypelist);
 
     // push TypeInfo[]
@@ -536,6 +544,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getConstTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoconst);
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
@@ -550,6 +559,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getInvariantTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoinvariant);
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
@@ -564,6 +574,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getSharedTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfoshared);
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->unSharedOf()));
@@ -578,6 +589,7 @@ public:
                            decl->toChars());
     LOG_SCOPE;
 
+    getInoutTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfowild);
     // TypeInfo base
     b.push_typeinfo(merge(decl->tinfo->mutableOf()));
@@ -595,6 +607,7 @@ public:
     assert(decl->tinfo->ty == Tvector);
     TypeVector *tv = static_cast<TypeVector *>(decl->tinfo);
 
+    getVectorTypeInfoType(); // check declaration in object.d
     RTTIBuilder b(Type::typeinfovector);
     // TypeInfo base
     b.push_typeinfo(tv->basetype);

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -657,8 +657,8 @@ void TypeInfoDeclaration_codegen(TypeInfoDeclaration *decl, IRState *p) {
   emitTypeMetadata(decl);
 
   // check if the definition can be elided
-  if (!global.params.useTypeInfo || isSpeculativeType(decl->tinfo) ||
-      builtinTypeInfo(decl->tinfo)) {
+  if (!global.params.useTypeInfo || !Type::dtypeinfo ||
+      isSpeculativeType(decl->tinfo) || builtinTypeInfo(decl->tinfo)) {
     return;
   }
 


### PR DESCRIPTION
Thereby deferring requirements wrt. object.d declarations (Object, Throwable, TypeInfo, TypeInfo_Class, TypeInfo_Struct...) and paving the way for a minimal druntime.

This also greatly reduces the `-vv` output for tiny code samples, e.g., reduced test cases.