### PR TITLE
[2.079] Call _Unwind_Resume() directly (except for ARM EABI)

### DIFF
--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -32,6 +32,8 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
 
 llvm::Function *getCAssertFunction(const Loc &loc, llvm::Module &target);
 
+llvm::Function *getUnwindResumeFunction(const Loc &loc, llvm::Module &target);
+
 void emitInstrumentationFnEnter(FuncDeclaration *decl);
 void emitInstrumentationFnLeave(FuncDeclaration *decl);
 

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -799,8 +799,7 @@ llvm::BasicBlock *TryCatchFinallyScopes::getOrCreateResumeUnwindBlock() {
     llvm::BasicBlock *oldBB = irs.scopebb();
     irs.scope() = IRScope(resumeUnwindBlock);
 
-    llvm::Function *resumeFn =
-        getRuntimeFunction(Loc(), irs.module, "_d_eh_resume_unwind");
+    llvm::Function *resumeFn = getUnwindResumeFunction(Loc(), irs.module);
     irs.ir->CreateCall(resumeFn, DtoLoad(getOrCreateEhPtrSlot()));
     irs.ir->CreateUnreachable();
 


### PR DESCRIPTION
This fixes the 32-bit std.file unittests on Linux with enabled optimizations.

The remaining LDC-specific ARM EABI wrapper (`_d_eh_resume_unwind()`) is implemented in assembly (ldc/eh_asm.S), preserving registers apparently.