### PR TITLE
Fix attributes.d test for PPC.

### DIFF
--- a/tests/codegen/attributes.d
+++ b/tests/codegen/attributes.d
@@ -26,7 +26,7 @@ import ldc.attributes;
 //---------------------------------------------------------------------
 
 
-// CHECK-LABEL: define i32 @_Dmain
+// CHECK-LABEL: define{{.*}} i32 @_Dmain
 void main() {
   sectionedfoo();
 }


### PR DESCRIPTION
On PPC, the i32 ABI is `signext i32`.

Cherry pick from #2635 