### PR TITLE
MSVC: Fix `extended ptr` semantics in DMD-style inline asm

### DIFF
--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2558,12 +2558,7 @@ struct AsmProcessor {
         type_suffix = 'l';
         break;
       case Extended_Ptr:
-        // MS C runtime: real = 64-bit double
-        if (global.params.targetTriple->isWindowsMSVCEnvironment()) {
-          type_suffix = 'l';
-        } else {
-          type_suffix = 't';
-        }
+        type_suffix = 't';
         break;
       default:
         return false;
@@ -3195,7 +3190,8 @@ struct AsmProcessor {
           // Tfloat64
           TY ty = v->type->toBasetype()->ty;
           operand->dataSizeHint =
-              ty == Tfloat80 || ty == Timaginary80
+              (ty == Tfloat80 || ty == Timaginary80) &&
+                      !global.params.targetTriple->isWindowsMSVCEnvironment()
                   ? Extended_Ptr
                   : static_cast<PtrType>(v->type->size(Loc()));
         }
@@ -3616,7 +3612,9 @@ struct AsmProcessor {
     case TOKfloat64:
       return Double_Ptr;
     case TOKfloat80:
-      return Extended_Ptr;
+      return global.params.targetTriple->isWindowsMSVCEnvironment()
+                 ? Double_Ptr
+                 : Extended_Ptr;
     case TOKidentifier:
       for (int i = 0; i < N_PtrNames; i++) {
         if (tok->ident == ptrTypeIdentTable[i]) {

--- a/tests/codegen/dmd_inline_asm_fp_types.d
+++ b/tests/codegen/dmd_inline_asm_fp_types.d
@@ -1,0 +1,40 @@
+// REQUIRES: target_X86
+
+// RUN: %ldc -output-s -mtriple=x86_64-windows-msvc -of=%t_msvc.s %s
+// RUN: FileCheck --check-prefix=COMMON --check-prefix=MSVC %s < %t_msvc.s
+// RUN: %ldc -output-s -mtriple=x86_64-linux-gnu -of=%t_linux.s %s
+// RUN: FileCheck --check-prefix=COMMON --check-prefix=LINUX %s < %t_linux.s
+
+// COMMON: _D23dmd_inline_asm_fp_types3fooFfdeZv
+void foo(float a, double b, real c)
+{
+    asm
+    {
+        // COMMON: flds
+        fld a;
+        // COMMON-NEXT: fldl
+        fld b;
+        // MSVC-NEXT: fldl
+        // LINUX-NEXT: fldt
+        fld c;
+        ret;
+    }
+}
+
+// COMMON: _D23dmd_inline_asm_fp_types3barFPvZv
+void bar(void* ptr)
+{
+    asm
+    {
+        // COMMON: flds
+        fld float ptr [ptr];
+        // COMMON-NEXT: fldl
+        fld double ptr [ptr];
+        // MSVC-NEXT: fldl
+        // LINUX-NEXT: fldt
+        fld real ptr [ptr];
+        // COMMON-NEXT: fldt
+        fld extended ptr [ptr];
+        ret;
+    }
+}


### PR DESCRIPTION
Don't map `Extended_Ptr` to `Double_Ptr` for MSVC targets with 64-bit reals.
Instead, map reals to `Double_Ptr` directly, thereby still allowing to work with 80-bit extended precision values via `extended ptr`.