### PR TITLE
druntime: Fix rt.backtrace.dwarf

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -462,12 +462,6 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
   if (targetOptions.MCOptions.ABIName.empty())
     targetOptions.MCOptions.ABIName = getABI(triple);
 
-#if LDC_LLVM_VER >= 600
-  // druntime isn't ready for Dwarf v4+ debuginfos (e.g., in rt.backtrace.dwarf).
-  if (targetOptions.MCOptions.DwarfVersion == 0)
-    targetOptions.MCOptions.DwarfVersion = 3;
-#endif
-
   if (floatABI == FloatABI::Default) {
     switch (triple.getArch()) {
     default: // X86, ...


### PR DESCRIPTION
* Add support for 64-bit DWARF.
* Add support for DWARF v4.
* Fix alignment issues on non-x86 architectures (DWARF data is packed).
* Fix backtrace on Ubuntu 18.04 (DSO-relative DWARF addresses vs. absolute addresses returned by `backtrace()`) => probably fixes https://issues.dlang.org/show_bug.cgi?id=18068.

Testing here how `codegen/exception_stack_trace.d` looks like with Ubuntu 14.04; should go upstream when finished.