### PR TITLE
Predefine version D_HardFloat instead of D_SoftFloat for -float-abi=softfp

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -345,7 +345,7 @@ llvm::TargetMachine *
 createTargetMachine(const std::string targetTriple, const std::string arch,
                     std::string cpu, const std::string featuresString,
                     const ExplicitBitness::Type bitness,
-                    FloatABI::Type floatABI,
+                    FloatABI::Type &floatABI,
 #if LDC_LLVM_VER >= 309
                     llvm::Optional<llvm::Reloc::Model> relocModel,
 #else
@@ -468,20 +468,19 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     targetOptions.MCOptions.DwarfVersion = 3;
 #endif
 
-  auto ldcFloatABI = floatABI;
-  if (ldcFloatABI == FloatABI::Default) {
+  if (floatABI == FloatABI::Default) {
     switch (triple.getArch()) {
     default: // X86, ...
-      ldcFloatABI = FloatABI::Hard;
+      floatABI = FloatABI::Hard;
       break;
     case llvm::Triple::arm:
     case llvm::Triple::thumb:
-      ldcFloatABI = getARMFloatABI(triple, getLLVMArchSuffixForARM(cpu));
+      floatABI = getARMFloatABI(triple, getLLVMArchSuffixForARM(cpu));
       break;
     }
   }
 
-  switch (ldcFloatABI) {
+  switch (floatABI) {
   default:
     llvm_unreachable("Floating point ABI type unknown.");
   case FloatABI::Soft:

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -50,13 +50,14 @@ ComputeBackend::Type getComputeTargetType(llvm::Module*);
 /**
  * Creates an LLVM TargetMachine suitable for the given (usually command-line)
  * parameters and the host platform defaults.
+ * Also finalizes floatABI if it's set to FloatABI::Default.
  *
  * Does not depend on any global state.
 */
 llvm::TargetMachine *
 createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
                     std::string featuresString, ExplicitBitness::Type bitness,
-                    FloatABI::Type floatABI,
+                    FloatABI::Type &floatABI,
 #if LDC_LLVM_VER >= 309
                     llvm::Optional<llvm::Reloc::Model> relocModel,
 #else

--- a/gen/dcompute/targetCUDA.cpp
+++ b/gen/dcompute/targetCUDA.cpp
@@ -35,10 +35,11 @@ public:
     const bool is64 = global.params.is64bit;
     auto tripleString = is64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda";
 
+    auto floatABI = ::FloatABI::Hard;
     targetMachine = createTargetMachine(
         tripleString, is64 ? "nvptx64" : "nvptx",
         "sm_" + ldc::to_string(tversion / 10), {},
-        is64 ? ExplicitBitness::M64 : ExplicitBitness::M32, ::FloatABI::Hard,
+        is64 ? ExplicitBitness::M64 : ExplicitBitness::M32, floatABI,
         llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(), false);
 
     _ir = new IRState("dcomputeTargetCUDA", ctx);

--- a/tests/driver/float_abi.d
+++ b/tests/driver/float_abi.d
@@ -1,0 +1,35 @@
+// REQUIRES: target_ARM
+
+// RUN: %ldc -c -o- %s -mtriple=armv7-linux-android -float-abi=soft   -d-version=SOFT
+// RUN: %ldc -c -o- %s -mtriple=armv7-linux-android -float-abi=softfp -d-version=SOFTFP
+// RUN: %ldc -c -o- %s -mtriple=armv7-linux-gnueabihf                 -d-version=HARD
+
+version (SOFT)
+{
+    version (ARM_SoftFloat) {} else static assert(0);
+    version (ARM_SoftFP) static assert(0);
+    version (ARM_HardFloat) static assert(0);
+
+    version (D_SoftFloat) {} else static assert(0);
+    version (D_HardFloat) static assert(0);
+}
+else version (SOFTFP)
+{
+    version (ARM_SoftFloat) static assert(0);
+    version (ARM_SoftFP) {} else static assert(0);
+    version (ARM_HardFloat) static assert(0);
+
+    version (D_SoftFloat) static assert(0);
+    version (D_HardFloat) {} else static assert(0);
+}
+else version (HARD)
+{
+    version (ARM_SoftFloat) static assert(0);
+    version (ARM_SoftFP) static assert(0);
+    version (ARM_HardFloat) {} else static assert(0);
+
+    version (D_SoftFloat) static assert(0);
+    version (D_HardFloat) {} else static assert(0);
+}
+else
+    static assert(0);


### PR DESCRIPTION
Matching the `D_HardFloat` [semantics](https://dlang.org/spec/version.html#predefined-versions):
> The target hardware has a floating point unit