### PR TITLE
#2687: ARMv7: dynamiccompile failures

### DIFF
--- a/tests/dynamiccompile/asm_output.d
+++ b/tests/dynamiccompile/asm_output.d
@@ -1,6 +1,7 @@
 
 // RUN: %ldc -enable-dynamic-compile -run %s
 
+import std.stdio;
 import std.array;
 import std.string;
 import ldc.attributes;
@@ -31,10 +32,15 @@ void main(string[] args)
   {
     if (DumpStage.FinalAsm == stage)
     {
+      write(str);
       dump.put(str);
     }
   };
+  writeln("===========================================");
   compileDynamicCode(settings);
+  writeln();
+  writeln("===========================================");
+  stdout.flush();
 
   // Check function and variables names in asm
   assert(1 == count(dump.data, foo.mangleof));

--- a/tests/dynamiccompile/throw.d
+++ b/tests/dynamiccompile/throw.d
@@ -4,7 +4,7 @@
 // XFAIL: Windows
 //
 // Also, some issue on Arm
-// XFAIL: target_ARM
+// XFAIL: host_ARM
 // RUN: %ldc -enable-dynamic-compile -run %s
 
 import std.exception;

--- a/tests/dynamiccompile/throw.d
+++ b/tests/dynamiccompile/throw.d
@@ -2,6 +2,9 @@
 // exceptions is broken on windows
 // win64 issue https://bugs.llvm.org//show_bug.cgi?id=24233
 // XFAIL: Windows
+//
+// Also, some issue on Arm
+// XFAIL: target_ARM
 // RUN: %ldc -enable-dynamic-compile -run %s
 
 import std.exception;


### PR DESCRIPTION
* Disable jit exceptions test on ARM (I don't have hardware, nor time to debug it right now)
* Dump actual asm output to stdout in `asm_output` test (lit will only display it if test fail, what I can see now from test failure, it should be at least partially correct)

@JohanEngelen 