### PR TITLE
Expose host architecture for lit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,15 +13,19 @@ else()
 endif()
 
 function(get_host_arch var_name)
-    # HACK!
-    # LLVMConfig provide useful LLVM_NATIVE_ARCH variable which is not
-    # provided from our FindLLVM nor from llvm-config.
-    # Parsing LLVM_HOST_TARGET is not enough, because it may require
-    # additional normalization (e.g. x86, x86_64, amd64, i686 -> x86), which
-    # is already done in LLVM_NATIVE_ARCH
-    include("${LLVM_CMAKEDIR}/LLVMConfig.cmake")
-    include("${LLVM_CMAKEDIR}/LLVM-Config.cmake")
-    set(${var_name} ${LLVM_NATIVE_ARCH} PARENT_SCOPE)
+    if(LDC_LLVM_VER GREATER 308)
+        # HACK!
+        # LLVMConfig provide useful LLVM_NATIVE_ARCH variable which is not
+        # provided from our FindLLVM nor from llvm-config.
+        # Parsing LLVM_HOST_TARGET is not enough, because it may require
+        # additional normalization (e.g. x86, x86_64, amd64, i686 -> x86), which
+        # is already done in LLVM_NATIVE_ARCH
+        include("${LLVM_CMAKEDIR}/LLVMConfig.cmake")
+        include("${LLVM_CMAKEDIR}/LLVM-Config.cmake")
+        set(${var_name} ${LLVM_NATIVE_ARCH} PARENT_SCOPE)
+    else()
+        set(${var_name} "" PARENT_SCOPE)
+    endif()
 endfunction()
 
 get_host_arch(LDC_HOST_ARCH)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,21 @@ else()
     set( DEFAULT_TARGET_BITS 32 )
 endif()
 
+function(get_host_arch var_name)
+    # HACK!
+    # LLVMConfig provide useful LLVM_NATIVE_ARCH variable which is not
+    # provided from our FindLLVM nor from llvm-config.
+    # Parsing LLVM_HOST_TARGET is not enough, because it may require
+    # additional normalization (e.g. x86, x86_64, amd64, i686 -> x86), which
+    # is already done in LLVM_NATIVE_ARCH
+    include("${LLVM_CMAKEDIR}/LLVMConfig.cmake")
+    include("${LLVM_CMAKEDIR}/LLVM-Config.cmake")
+    set(${var_name} ${LLVM_NATIVE_ARCH} PARENT_SCOPE)
+endfunction()
+
+get_host_arch(LDC_HOST_ARCH)
+message(STATUS "LDC_HOST_ARCH: ${LDC_HOST_ARCH}")
+
 configure_file(lit.site.cfg.in lit.site.cfg )
 configure_file(runlit.py       runlit.py    COPYONLY)
 

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -88,6 +88,11 @@ if (platform.system() == 'Windows') and (config.default_target_bits == 32):
 if (platform.system() == 'Windows') and (config.default_target_bits == 64):
     config.available_features.add('Windows_x64')
 
+# Define available features based on host arch
+# Examples: 'host_X86', 'host_ARM', 'host_PowerPC', 'host_AArch64'
+if (config.ldc_host_arch != ''):
+    config.available_features.add('host_' + config.ldc_host_arch)
+
 # Add "LTO" feature if linker support and LTO plugin are available
 # (LTO is supported from LLVM 3.9)
 canDoLTO = False
@@ -172,5 +177,3 @@ if lit.util.which('gdb', config.environment['PATH']):
         if LooseVersion(gdb_version) < LooseVersion('7.8'):
             gdb_dflags = '-dwarf-version=2'
     config.substitutions.append( ('%_gdb_dflags', gdb_dflags) )
-
-config.available_features.add(config.ldc_host_arch)

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -24,6 +24,7 @@ config.with_PGO            = True
 config.dynamic_compile     = @LDC_DYNAMIC_COMPILE@
 config.plugins_supported   = "@LDC_ENABLE_PLUGINS@" == "ON"
 config.gnu_make_bin        = "@GNU_MAKE_BIN@"
+config.ldc_host_arch       = "@LDC_HOST_ARCH@"
 
 config.name = 'LDC'
 
@@ -171,3 +172,5 @@ if lit.util.which('gdb', config.environment['PATH']):
         if LooseVersion(gdb_version) < LooseVersion('7.8'):
             gdb_dflags = '-dwarf-version=2'
     config.substitutions.append( ('%_gdb_dflags', gdb_dflags) )
+
+config.available_features.add(config.ldc_host_arch)


### PR DESCRIPTION
Hack with manual LLVMConfig inclusion is already used in jit cmake so it shouldnt break more things.