### PR TITLE
Fix typo in dmd.expression apparently causing sporadic frontend crashes

### DIFF
--- a/dmd/expression.d
+++ b/dmd/expression.d
@@ -2129,7 +2129,7 @@ extern (C++) /* IN_LLVM abstract */ class Expression : RootObject
 
         if (v.type.ty == Tstruct)
         {
-            StructDeclaration sd = (cast(TypeStruct)type).sym;
+            StructDeclaration sd = (cast(TypeStruct)v.type).sym;
             if (sd.hasNoFields)
                 return false;
         }


### PR DESCRIPTION
These sporadic segfaults have been plaguing AppVeyor lately, especially when building dub. Upstream pull: https://github.com/dlang/dmd/pull/8294