### PR TITLE
Some ABI refactoring, incl. efficiency improvements for IndirectByvalRewrite

### DIFF
--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -47,12 +47,9 @@ struct AArch64TargetABI : TargetABI {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
       // non-HFA and messes up register selection
       if (isHFA((TypeStruct *)retTy, &fty.ret->ltype)) {
-        fty.ret->rewrite = &hfaToArray;
-        fty.ret->ltype = hfaToArray.type(fty.ret->type);
-      }
-      else {
-        fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type);
+        hfaToArray.applyTo(*fty.ret, fty.ret->ltype);
+      } else {
+        integerRewrite.applyTo(*fty.ret);
       }
     }
 
@@ -75,12 +72,9 @@ struct AArch64TargetABI : TargetABI {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
       // non-HFA and messes up register selection
       if (ty->ty == Tstruct && isHFA((TypeStruct *)ty, &arg.ltype)) {
-        arg.rewrite = &hfaToArray;
-        arg.ltype = hfaToArray.type(arg.type);
-      }
-      else {
-        arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type);
+        hfaToArray.applyTo(arg, arg.ltype);
+      } else {
+        compositeToArray64.applyTo(arg);
       }
     }
   }

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -41,7 +41,7 @@ struct AArch64TargetABI : TargetABI {
            (t->ty == Tstruct && t->size() > 16 && !isHFA((TypeStruct *)t));
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     Type *retTy = fty.ret->type->toBasetype();
     if (!fty.ret->byref && retTy->ty == Tstruct) {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
@@ -59,7 +59,8 @@ struct AArch64TargetABI : TargetABI {
     }
 
     // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+        fty.args.size() > 1) {
       fty.reverseParams = true;
     }
   }

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -57,12 +57,6 @@ struct AArch64TargetABI : TargetABI {
       if (!arg->byref)
         rewriteArgument(fty, *arg);
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -84,12 +84,6 @@ struct ArmTargetABI : TargetABI {
       if (!arg->byref)
         rewriteArgument(fty, *arg);
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -74,10 +74,9 @@ struct ArmTargetABI : TargetABI {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
       // non-HFA and messes up register selection
       if (isHFA((TypeStruct *)retTy, &fty.ret->ltype)) {
-        fty.ret->rewrite = &hfaToArray;
+        hfaToArray.applyTo(*fty.ret, fty.ret->ltype);
       } else {
-        fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type);
+        integerRewrite.applyTo(*fty.ret);
       }
     }
 
@@ -108,13 +107,11 @@ struct ArmTargetABI : TargetABI {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
       // non-HFA and messes up register selection
       if (isHFA((TypeStruct *)ty, &arg.ltype)) {
-        arg.rewrite = &hfaToArray;
+        hfaToArray.applyTo(arg, arg.ltype);
       } else if (DtoAlignment(ty) <= 4) {
-        arg.rewrite = &compositeToArray32;
-        arg.ltype = compositeToArray32.type(arg.type);
+        compositeToArray32.applyTo(arg);
       } else {
-        arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type);
+        compositeToArray64.applyTo(arg);
       }
     }
   }

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -68,7 +68,7 @@ struct ArmTargetABI : TargetABI {
     // problem is better understood.
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     Type *retTy = fty.ret->type->toBasetype();
     if (!fty.ret->byref && retTy->ty == Tstruct) {
       // Rewrite HFAs only because union HFAs are turned into IR types that are
@@ -86,7 +86,8 @@ struct ArmTargetABI : TargetABI {
     }
 
     // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+        fty.args.size() > 1) {
       fty.reverseParams = true;
     }
   }

--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -173,22 +173,22 @@ struct IntegerRewrite : ABIRewrite {
 //////////////////////////////////////////////////////////////////////////////
 
 /**
- * Implements explicit ByVal semantics defined like this:
+ * Implements indirect high-level-by-value semantics defined like this:
  * Instead of passing a copy of the original argument directly to the callee,
  * the caller makes a bitcopy on its stack first and then passes a pointer to
  * that copy to the callee.
  * The pointer is passed as regular parameter and hence occupies either a
  * register or a function parameters stack slot.
  *
- * This differs from LLVM's ByVal attribute for pointer parameters.
- * The ByVal attribute instructs LLVM to pass the pointed-to argument directly
- * as a copy on the function parameters stack. In this case, there's no need to
- * pass an explicit pointer; the address is implicit.
+ * This differs from LLVM's byval attribute for pointer parameters.
+ * The byval attribute instructs LLVM to bitcopy the IR argument pointee onto
+ * the callee parameters stack. The callee's IR parameter is an implicit pointer
+ * to that private copy.
  */
-struct ExplicitByvalRewrite : ABIRewrite {
+struct IndirectByvalRewrite : ABIRewrite {
   const unsigned minAlignment;
 
-  explicit ExplicitByvalRewrite(unsigned minAlignment = 16)
+  explicit IndirectByvalRewrite(unsigned minAlignment = 16)
       : minAlignment(minAlignment) {}
 
   LLValue *put(DValue *v, bool) override {

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -57,12 +57,6 @@ struct MIPS64TargetABI : TargetABI {
         rewriteArgument(fty, *arg);
       }
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -47,7 +47,7 @@ struct MIPS64TargetABI : TargetABI {
     return ty == Tstruct || ty == Tsarray;
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     if (!fty.ret->byref) {
       rewriteArgument(fty, *fty.ret);
     }
@@ -59,7 +59,8 @@ struct MIPS64TargetABI : TargetABI {
     }
 
     // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+        fty.args.size() > 1) {
       fty.reverseParams = true;
     }
   }

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -28,6 +28,7 @@ struct NVPTXTargetABI : TargetABI {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }
+  bool reverseExplicitParams(TypeFunction *) override { return false; }
   void rewriteFunctionType(IrFuncTy &fty) override {
     for (auto arg : fty.args) {
       if (!arg->byref)

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -28,7 +28,7 @@ struct NVPTXTargetABI : TargetABI {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }
-  void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     for (auto arg : fty.args) {
       if (!arg->byref)
         rewriteArgument(fty, *arg);

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -41,10 +41,8 @@ struct NVPTXTargetABI : TargetABI {
     Type *ty = arg.type->toBasetype();
     llvm::Optional<DcomputePointer> ptr;
     if (ty->ty == Tstruct &&
-        (ptr = toDcomputePointer(static_cast<TypeStruct*>(ty)->sym)))
-    {
-        arg.rewrite = &pointerRewite;
-        arg.ltype = pointerRewite.type(arg.type);
+        (ptr = toDcomputePointer(static_cast<TypeStruct *>(ty)->sym))) {
+      pointerRewite.applyTo(arg);
     }
   }
   // There are no exceptions at all, so no need for unwind tables.

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -82,15 +82,12 @@ struct PPCTargetABI : TargetABI {
 
     if (ty->ty == Tstruct || ty->ty == Tsarray) {
       if (canRewriteAsInt(ty, Is64Bit)) {
-        arg.rewrite = &integerRewrite;
-        arg.ltype = integerRewrite.type(arg.type);
+        integerRewrite.applyTo(arg);
       } else {
         if (Is64Bit) {
-          arg.rewrite = &compositeToArray64;
-          arg.ltype = compositeToArray64.type(arg.type);
+          compositeToArray64.applyTo(arg);
         } else {
-          arg.rewrite = &compositeToArray32;
-          arg.ltype = compositeToArray32.type(arg.type);
+          compositeToArray32.applyTo(arg);
         }
       }
     } else if (ty->isintegral()) {

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -70,12 +70,6 @@ struct PPCTargetABI : TargetABI {
         rewriteArgument(fty, *arg);
       }
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -58,7 +58,7 @@ struct PPCTargetABI : TargetABI {
            (!Is64Bit || t->size() > 64);
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     // return value
     if (!fty.ret->byref) {
       rewriteArgument(fty, *fty.ret);
@@ -72,7 +72,8 @@ struct PPCTargetABI : TargetABI {
     }
 
     // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+        fty.args.size() > 1) {
       fty.reverseParams = true;
     }
   }

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -59,12 +59,6 @@ struct PPC64LETargetABI : TargetABI {
         rewriteArgument(fty, *arg);
       }
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -70,14 +70,11 @@ struct PPC64LETargetABI : TargetABI {
     Type *ty = arg.type->toBasetype();
     if (ty->ty == Tstruct || ty->ty == Tsarray) {
       if (ty->ty == Tstruct && isHFA((TypeStruct *)ty, &arg.ltype, 8)) {
-        arg.rewrite = &hfaToArray;
-        arg.ltype = hfaToArray.type(arg.type);
+        hfaToArray.applyTo(arg, arg.ltype);
       } else if (canRewriteAsInt(ty, true)) {
-        arg.rewrite = &integerRewrite;
-        arg.ltype = integerRewrite.type(arg.type);
+        integerRewrite.applyTo(arg);
       } else {
-        arg.rewrite = &compositeToArray64;
-        arg.ltype = compositeToArray64.type(arg.type);
+        compositeToArray64.applyTo(arg);
       }
     } else if (ty->isintegral()) {
       arg.attrs.add(ty->isunsigned() ? LLAttribute::ZExt : LLAttribute::SExt);

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -47,7 +47,7 @@ struct PPC64LETargetABI : TargetABI {
                                 !isHFA((TypeStruct *)t, nullptr, 8));
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     // return value
     if (!fty.ret->byref) {
       rewriteArgument(fty, *fty.ret);
@@ -61,7 +61,8 @@ struct PPC64LETargetABI : TargetABI {
     }
 
     // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+        fty.args.size() > 1) {
       fty.reverseParams = true;
     }
   }

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -28,6 +28,7 @@ struct SPIRVTargetABI : TargetABI {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }
+  bool reverseExplicitParams(TypeFunction *) override { return false; }
   void rewriteFunctionType(IrFuncTy &fty) override {
     for (auto arg : fty.args) {
       if (!arg->byref)

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -28,7 +28,7 @@ struct SPIRVTargetABI : TargetABI {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }
-  void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     for (auto arg : fty.args) {
       if (!arg->byref)
         rewriteArgument(fty, *arg);

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -41,10 +41,8 @@ struct SPIRVTargetABI : TargetABI {
     Type *ty = arg.type->toBasetype();
     llvm::Optional<DcomputePointer> ptr;
     if (ty->ty == Tstruct &&
-        (ptr = toDcomputePointer(static_cast<TypeStruct*>(ty)->sym)))
-    {
-      arg.rewrite = &pointerRewite;
-      arg.ltype = pointerRewite.type(arg.type);
+        (ptr = toDcomputePointer(static_cast<TypeStruct *>(ty)->sym))) {
+      pointerRewite.applyTo(arg);
     }
   }
   // There are no exceptions at all, so no need for unwind tables.

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -120,12 +120,6 @@ public:
         rewriteArgument(fty, *arg);
       }
     }
-
-    // extern(D): reverse parameter order for non variadics, for DMD-compliance
-    if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-        fty.args.size() > 1) {
-      fty.reverseParams = true;
-    }
   }
 
   void rewriteVarargs(IrFuncTy &fty,

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -34,7 +34,7 @@
 struct Win64TargetABI : TargetABI {
 private:
   const bool isMSVC;
-  ExplicitByvalRewrite byvalRewrite;
+  IndirectByvalRewrite byvalRewrite;
   IntegerRewrite integerRewrite;
 
   bool isX87(Type *t) const {

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -319,12 +319,6 @@ void X86_64TargetABI::rewriteFunctionType(IrFuncTy &fty) {
   Logger::println("x86-64 ABI: Transforming argument types");
   LOG_SCOPE;
 
-  // extern(D): reverse parameter order for non variadics, for DMD-compliance
-  if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
-      fty.args.size() > 1) {
-    fty.reverseParams = true;
-  }
-
   int begin = 0, end = fty.args.size(), step = 1;
   if (fty.reverseParams) {
     begin = end - 1;

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -222,7 +222,7 @@ struct X86_64TargetABI : TargetABI {
 
   bool passByVal(Type *t) override;
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override;
+  void rewriteFunctionType(IrFuncTy &fty) override;
   void rewriteVarargs(IrFuncTy &fty, std::vector<IrFuncTyArg *> &args) override;
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override;
   void rewriteArgument(IrFuncTyArg &arg, RegCount &regCount);
@@ -289,7 +289,7 @@ void X86_64TargetABI::rewriteArgument(IrFuncTyArg &arg, RegCount &regCount) {
   }
 }
 
-void X86_64TargetABI::rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) {
+void X86_64TargetABI::rewriteFunctionType(IrFuncTy &fty) {
   RegCount &regCount = getRegCount(fty);
   regCount = RegCount(); // initialize
 
@@ -320,7 +320,8 @@ void X86_64TargetABI::rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) {
   LOG_SCOPE;
 
   // extern(D): reverse parameter order for non variadics, for DMD-compliance
-  if (tf->linkage == LINKd && tf->varargs != 1 && fty.args.size() > 1) {
+  if (fty.type->linkage == LINKd && fty.type->varargs != 1 &&
+      fty.args.size() > 1) {
     fty.reverseParams = true;
   }
 

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -123,12 +123,12 @@ struct X86TargetABI : TargetABI {
     return DtoIsInMemoryOnly(t);
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
-    const bool externD = (tf->linkage == LINKd && tf->varargs != 1);
+  void rewriteFunctionType(IrFuncTy &fty) override {
+    const bool externD = (fty.type->linkage == LINKd && fty.type->varargs != 1);
 
     // return value:
     if (!fty.ret->byref) {
-      Type *rt = tf->next->toBasetype(); // for sret, rt == void
+      Type *rt = fty.type->next->toBasetype(); // for sret, rt == void
       if (isAggregate(rt) && !isMagicCppStruct(rt) && canRewriteAsInt(rt) &&
           // don't rewrite cfloat for extern(D)
           !(externD && rt->ty == Tcomplex32)) {

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -131,10 +131,8 @@ struct X86TargetABI : TargetABI {
       Type *rt = tf->next->toBasetype(); // for sret, rt == void
       if (isAggregate(rt) && !isMagicCppStruct(rt) && canRewriteAsInt(rt) &&
           // don't rewrite cfloat for extern(D)
-          !(externD && rt->ty == Tcomplex32) &&
-          !integerRewrite.isObsoleteFor(fty.ret->ltype)) {
-        fty.ret->rewrite = &integerRewrite;
-        fty.ret->ltype = integerRewrite.type(fty.ret->type);
+          !(externD && rt->ty == Tcomplex32)) {
+        integerRewrite.applyToIfNotObsolete(*fty.ret);
       }
     }
 
@@ -173,8 +171,7 @@ struct X86TargetABI : TargetABI {
         } else if (!lastTy->isfloating() && (sz == 1 || sz == 2 || sz == 4)) {
           // rewrite aggregates as integers to make inreg work
           if (lastTy->ty == Tstruct || lastTy->ty == Tsarray) {
-            last->rewrite = &integerRewrite;
-            last->ltype = integerRewrite.type(last->type);
+            integerRewrite.applyTo(*last);
             // undo byval semantics applied via passByVal() returning true
             last->byref = false;
             last->attrs.clear();

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -181,11 +181,6 @@ struct X86TargetABI : TargetABI {
       }
 
       // all other arguments are passed on the stack, don't rewrite
-
-      // reverse parameter order
-      if (fty.args.size() > 1) {
-        fty.reverseParams = true;
-      }
     }
 
     workaroundIssue1356(fty.args);

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -238,6 +238,14 @@ bool TargetABI::canRewriteAsInt(Type *t, bool include64bit) {
 
 //////////////////////////////////////////////////////////////////////////////
 
+bool TargetABI::reverseExplicitParams(TypeFunction *tf) {
+  // Required by druntime for extern(D), except for `, ...`-style variadics.
+  return tf->linkage == LINKd && tf->varargs != 1 &&
+         Parameter::dim(tf->parameters) > 1;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 void TargetABI::rewriteVarargs(IrFuncTy &fty,
                                std::vector<IrFuncTyArg *> &args) {
   for (auto arg : args) {
@@ -354,6 +362,8 @@ struct IntrinsicABI : TargetABI {
   bool returnInArg(TypeFunction *tf) override { return false; }
 
   bool passByVal(Type *t) override { return false; }
+
+  bool reverseExplicitParams(TypeFunction *) override { return false; }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
     Type *ty = arg.type->toBasetype();

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -304,7 +304,7 @@ struct UnknownTargetABI : TargetABI {
 
   bool passByVal(Type *t) override { return t->toBasetype()->ty == Tstruct; }
 
-  void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &) override {
     // why?
   }
 };
@@ -369,7 +369,7 @@ struct IntrinsicABI : TargetABI {
     }
   }
 
-  void rewriteFunctionType(TypeFunction *tf, IrFuncTy &fty) override {
+  void rewriteFunctionType(IrFuncTy &fty) override {
     if (!fty.arg_sret) {
       Type *rt = fty.ret->type->toBasetype();
       if (rt->ty == Tstruct) {

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -37,6 +37,13 @@ llvm::Value *ABIRewrite::getRVal(Type *dty, LLValue *v) {
 
 //////////////////////////////////////////////////////////////////////////////
 
+void ABIRewrite::applyTo(IrFuncTyArg &arg, LLType *finalLType) {
+  arg.rewrite = this;
+  arg.ltype = finalLType ? finalLType : this->type(arg.type);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 LLValue *ABIRewrite::getAddressOf(DValue *v) {
   if (v->isLVal())
     return DtoLVal(v);
@@ -358,8 +365,7 @@ struct IntrinsicABI : TargetABI {
     LLType *abiTy = DtoUnpaddedStructType(arg.type);
 
     if (abiTy && abiTy != arg.ltype) {
-      arg.ltype = abiTy;
-      arg.rewrite = &remove_padding;
+      remove_padding.applyTo(arg, abiTy);
     }
   }
 

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -143,6 +143,11 @@ struct TargetABI {
   /// argument.
   virtual bool passThisBeforeSret(TypeFunction *tf) { return false; }
 
+  /// Returns true if the explicit parameters order is to be reversed.
+  /// Defaults to true for non-variadic extern(D) functions as required by
+  /// druntime.
+  virtual bool reverseExplicitParams(TypeFunction *tf);
+
   /// Called to give ABI the chance to rewrite the types
   virtual void rewriteFunctionType(IrFuncTy &fty) = 0;
   virtual void rewriteVarargs(IrFuncTy &fty, std::vector<IrFuncTyArg *> &args);

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -42,7 +42,7 @@ struct ABIRewrite {
   virtual ~ABIRewrite() = default;
 
   /// Transforms the D argument to a suitable LL argument.
-  virtual llvm::Value *put(DValue *v, bool isModifiableLvalue) = 0;
+  virtual llvm::Value *put(DValue *v, bool isLValueExp, bool isLastArgExp) = 0;
 
   /// Transforms the LL parameter back and returns the address for the D
   /// parameter.

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -144,7 +144,7 @@ struct TargetABI {
   virtual bool passThisBeforeSret(TypeFunction *tf) { return false; }
 
   /// Called to give ABI the chance to rewrite the types
-  virtual void rewriteFunctionType(TypeFunction *t, IrFuncTy &fty) = 0;
+  virtual void rewriteFunctionType(IrFuncTy &fty) = 0;
   virtual void rewriteVarargs(IrFuncTy &fty, std::vector<IrFuncTyArg *> &args);
   virtual void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) {}
 

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -57,6 +57,10 @@ struct ABIRewrite {
   /// specified D type.
   virtual llvm::Type *type(Type *t) = 0;
 
+  /// Applies this rewrite to the specified argument, adapting it where
+  /// necessary.
+  virtual void applyTo(IrFuncTyArg &arg, llvm::Type *finalLType = nullptr);
+
 protected:
   /***** Static Helpers *****/
 

--- a/gen/dcompute/abi-rewrites.h
+++ b/gen/dcompute/abi-rewrites.h
@@ -31,7 +31,7 @@ struct DComputePointerRewrite : ABIRewrite {
     // TODO: Is this correct?
     return DtoAllocaDump(v, this->type(dty));
   }
-  LLValue *put(DValue *dv, bool) override {
+  LLValue *put(DValue *dv, bool, bool) override {
     LLValue *address = getAddressOf(dv);
     LLType *t = this->type(dv->type);
     return loadFromMemory(address, t);

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1066,7 +1066,7 @@ void ldc::DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
 
   const bool isRefOrOut = vd->isRef() || vd->isOut(); // incl. special-ref vars
 
-  // For MSVC x64 targets, declare params rewritten by ExplicitByvalRewrite as
+  // For MSVC x64 targets, declare params rewritten by IndirectByvalRewrite as
   // DI references, as if they were ref parameters.
   const bool isPassedExplicitlyByval =
       isTargetMSVCx64 && !isRefOrOut && isaArgument(ll) && addr.empty();

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -187,6 +187,8 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
     ++nextLLArgIdx;
   }
 
+  newIrFty.reverseParams = abi->reverseExplicitParams(f);
+
   // let the ABI rewrite the types as necessary
   abi->rewriteFunctionType(newIrFty);
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -77,7 +77,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
 
   // Do not modify irFty yet; this function may be called recursively if any
   // of the argument types refer to this type.
-  IrFuncTy newIrFty;
+  IrFuncTy newIrFty(f);
 
   // The index of the next argument on the LLVM level.
   unsigned nextLLArgIdx = 0;
@@ -188,7 +188,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
   }
 
   // let the ABI rewrite the types as necessary
-  abi->rewriteFunctionType(f, newIrFty);
+  abi->rewriteFunctionType(newIrFty);
 
   // Now we can modify irFty safely.
   irFty = std::move(newIrFty);

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -388,7 +388,7 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
     } else if (vd->isParameter() && (vd->storage_class & STClazy)) {
       // The LL type is a delegate (LL struct).
       // Depending on the used TargetABI, the LL parameter is either a struct or
-      // a pointer to a struct (`byval` attribute, ExplicitByvalRewrite).
+      // a pointer to a struct (`byval` attribute, IndirectByvalRewrite).
       t = getIrParameter(vd)->value->getType();
       if (t->isPointerTy())
         t = t->getPointerElementType();

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -174,13 +174,9 @@ static void addExplicitArguments(std::vector<LLValue *> &args, AttrSet &attrs,
     // evaluate argument expression
     DValue *const dval = DtoArgument(formalParam, argexp);
 
-    // check whether it is an lvalue which might be modified by later argument
-    // expressions
-    const bool isModifiableLvalue =
-        argexp->isLvalue() && dArgIndex != explicitDArgCount - 1;
-
     // load from lvalue/let TargetABI rewrite it/...
-    llvm::Value *llVal = irFty.putParam(*irArg, dval, isModifiableLvalue);
+    llvm::Value *llVal = irFty.putArg(*irArg, dval, argexp->isLvalue(),
+                                      dArgIndex == explicitDArgCount - 1);
 
     const size_t llArgIdx =
         implicitLLArgCount +

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2273,7 +2273,7 @@ public:
       initsym = DtoBitCast(initsym, DtoType(e->type->pointerTo()));
 
       if (!dstMem)
-        return new DLValue(e->type, initsym);
+        dstMem = DtoAlloca(e->type, ".structliteral");
 
       assert(dstMem->getType() == initsym->getType());
       DtoMemCpy(dstMem, initsym);

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -16,12 +16,15 @@
 #include "gen/tollvm.h"
 #include "ir/irdsymbol.h"
 
-IrFunction::IrFunction(FuncDeclaration *fd) : FMF(opts::defaultFMF) {
+IrFunction::IrFunction(FuncDeclaration *fd)
+    : FMF(opts::defaultFMF), irFty(nullptr /*set immediately below*/) {
   decl = fd;
 
   Type *t = fd->type->toBasetype();
   assert(t->ty == Tfunction);
   type = static_cast<TypeFunction *>(t);
+
+  irFty.type = type;
 }
 
 void IrFunction::setNeverInline() {

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -111,8 +111,8 @@ struct IrFuncTy {
   llvm::Value *getRetRVal(Type *dty, llvm::Value *val);
   llvm::Value *getRetLVal(Type *dty, llvm::Value *val);
 
-  llvm::Value *putParam(const IrFuncTyArg &arg, DValue *dval,
-                        bool isModifiableLvalue);
+  llvm::Value *putArg(const IrFuncTyArg &arg, DValue *dval, bool isLValueExp,
+                      bool isLastArgExp);
   llvm::Value *getParamLVal(Type *dty, size_t idx, llvm::Value *val);
 
   AttrSet getParamAttrs(bool passThisBeforeSret);

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -27,6 +27,7 @@
 
 class DValue;
 class Type;
+class TypeFunction;
 struct ABIRewrite;
 namespace llvm {
 class Type;
@@ -83,6 +84,9 @@ struct IrFuncTyArg {
 
 // represents a function type
 struct IrFuncTy {
+  // D type
+  TypeFunction *type;
+
   // The final LLVM type
   llvm::FunctionType *funcType = nullptr;
 
@@ -116,6 +120,8 @@ struct IrFuncTy {
   llvm::Value *getParamLVal(Type *dty, size_t idx, llvm::Value *val);
 
   AttrSet getParamAttrs(bool passThisBeforeSret);
+
+  IrFuncTy(TypeFunction *tf) : type(tf) {}
 };
 
 #endif

--- a/ir/irtypefunction.cpp
+++ b/ir/irtypefunction.cpp
@@ -23,8 +23,10 @@ IrTypeFunction *IrTypeFunction::get(Type *dt) {
   assert(!dt->ctype);
   assert(dt->ty == Tfunction);
 
-  IrFuncTy irFty;
-  llvm::Type *lt = DtoFunctionType(dt, irFty, nullptr, nullptr);
+  TypeFunction *tf = static_cast<TypeFunction *>(dt);
+
+  IrFuncTy irFty(tf);
+  llvm::Type *lt = DtoFunctionType(tf, irFty, nullptr, nullptr);
 
   // Could have already built the type as part of a struct forward reference,
   // just as for pointers and arrays.
@@ -44,9 +46,11 @@ IrTypeDelegate *IrTypeDelegate::get(Type *t) {
   assert(t->ty == Tdelegate);
   assert(t->nextOf()->ty == Tfunction);
 
-  IrFuncTy irFty;
+  TypeFunction *tf = static_cast<TypeFunction *>(t->nextOf());
+
+  IrFuncTy irFty(tf);
   llvm::Type *ltf =
-      DtoFunctionType(t->nextOf(), irFty, nullptr, Type::tvoid->pointerTo());
+      DtoFunctionType(tf, irFty, nullptr, Type::tvoid->pointerTo());
   llvm::Type *types[] = {getVoidPtrType(), getPtrToType(ltf)};
   LLStructType *lt = LLStructType::get(gIR->context(), types, false);
 

--- a/tests/codegen/indirect_byval_rewrite.d
+++ b/tests/codegen/indirect_byval_rewrite.d
@@ -1,0 +1,36 @@
+// Ensures efficient indirect by-value passing via IndirectByvalRewrite.
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-windows-msvc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+struct Big { size_t a, b; }
+struct WithPostblit { Big b; this(this) {} }
+
+Big makeBig() { return Big(123, 456); }
+
+void foo(Big, WithPostblit, Big, WithPostblit);
+
+// CHECK: define {{.*}}_D22indirect_byval_rewrite3bar
+void bar()
+{
+    // CHECK:      %bigLValue = alloca %indirect_byval_rewrite.Big
+    Big bigLValue;
+    // CHECK-NEXT: %withPostblitLValue = alloca %indirect_byval_rewrite.WithPostblit
+    WithPostblit withPostblitLValue;
+
+    // * 1st arg: bigLValue bitcopy, copied by IndirectByvalRewrite
+    // CHECK-NEXT: %.hidden_copy_for_IndirectByvalRewrite = alloca %indirect_byval_rewrite.Big
+    // * 2nd arg: temporary withPostblitLValue copy (copied by frontend, incl. postblit)
+    // CHECK-NEXT: %__copytmp{{[0-9]*}} = alloca %indirect_byval_rewrite.WithPostblit
+    // * 3rd arg: sret temporary filled by makeBig()
+    // CHECK-NEXT: %.sret_tmp = alloca %indirect_byval_rewrite.Big
+    // * 4th arg: WithPostblit() literal
+    // CHECK-NEXT: %.structliteral = alloca %indirect_byval_rewrite.WithPostblit
+    foo(bigLValue, withPostblitLValue, makeBig(), WithPostblit());
+
+    // no more allocas!
+    // CHECK-NOT: alloca
+
+    // CHECK: ret void
+}


### PR DESCRIPTION
Unoptimized old IR for the included lit-test:
```LL
define void @_D22indirect_byval_rewrite3barFZv() #0 comdat {
  %bigLValue = alloca %indirect_byval_rewrite.Big, align 8 ; [#uses = 2, size/byte = 16]
  %withPostblitLValue = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 2, size/byte = 16]
  %.ExplicitByvalRewrite_dump = alloca %indirect_byval_rewrite.Big, align 16 ; [#uses = 2, size/byte = 16]
  %__copytmp3 = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 3, size/byte = 16]
  %.ExplicitByvalRewrite_dump1 = alloca %indirect_byval_rewrite.WithPostblit, align 16 ; [#uses = 2, size/byte = 16]
  %.sret_tmp = alloca %indirect_byval_rewrite.Big, align 8 ; [#uses = 2, size/byte = 16]
  %.ExplicitByvalRewrite_dump2 = alloca %indirect_byval_rewrite.Big, align 16 ; [#uses = 2, size/byte = 16]
  %.structliteral = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 2, size/byte = 16]
  %.ExplicitByvalRewrite_dump3 = alloca %indirect_byval_rewrite.WithPostblit, align 16 ; [#uses = 2, size/byte = 16]
  %1 = bitcast %indirect_byval_rewrite.Big* %bigLValue to i8* ; [#uses = 1]
  call void @llvm.memset.p0i8.i64(i8* %1, i8 0, i64 16, i32 1, i1 false)
  %2 = bitcast %indirect_byval_rewrite.WithPostblit* %withPostblitLValue to i8* ; [#uses = 1]
  call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i32 1, i1 false)
  %3 = bitcast %indirect_byval_rewrite.Big* %.ExplicitByvalRewrite_dump to i8* ; [#uses = 1]
  %4 = bitcast %indirect_byval_rewrite.Big* %bigLValue to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %3, i8* %4, i64 16, i32 8, i1 false)
  %5 = bitcast %indirect_byval_rewrite.WithPostblit* %__copytmp3 to i8* ; [#uses = 1]
  %6 = bitcast %indirect_byval_rewrite.WithPostblit* %withPostblitLValue to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %5, i8* %6, i64 16, i32 1, i1 false)
  call void @_D22indirect_byval_rewrite12WithPostblit10__postblitMFZv(%indirect_byval_rewrite.WithPostblit* nonnull %__copytmp3) #0
  %7 = bitcast %indirect_byval_rewrite.WithPostblit* %.ExplicitByvalRewrite_dump1 to i8* ; [#uses = 1]
  %8 = bitcast %indirect_byval_rewrite.WithPostblit* %__copytmp3 to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %7, i8* %8, i64 16, i32 8, i1 false)
  call void @_D22indirect_byval_rewrite7makeBigFZSQBj3Big(%indirect_byval_rewrite.Big* noalias sret align 8 %.sret_tmp) #0
  %9 = bitcast %indirect_byval_rewrite.Big* %.ExplicitByvalRewrite_dump2 to i8* ; [#uses = 1]
  %10 = bitcast %indirect_byval_rewrite.Big* %.sret_tmp to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %9, i8* %10, i64 16, i32 8, i1 false)
  %11 = getelementptr inbounds %indirect_byval_rewrite.WithPostblit, %indirect_byval_rewrite.WithPostblit* %.structliteral, i32 0, i32 0 ; [#uses = 2, type = %indirect_byval_rewrite.Big*]
  %12 = getelementptr inbounds %indirect_byval_rewrite.Big, %indirect_byval_rewrite.Big* %11, i32 0, i32 0 ; [#uses = 1, type = i64*]
  store i64 0, i64* %12
  %13 = getelementptr inbounds %indirect_byval_rewrite.Big, %indirect_byval_rewrite.Big* %11, i32 0, i32 1 ; [#uses = 1, type = i64*]
  store i64 0, i64* %13
  %14 = bitcast %indirect_byval_rewrite.WithPostblit* %.ExplicitByvalRewrite_dump3 to i8* ; [#uses = 1]
  %15 = bitcast %indirect_byval_rewrite.WithPostblit* %.structliteral to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %14, i8* %15, i64 16, i32 8, i1 false)
  call void @_D22indirect_byval_rewrite3fooFSQBe3BigSQBm12WithPostblitQBaQvZv(%indirect_byval_rewrite.WithPostblit* noalias nocapture align 16 %.ExplicitByvalRewrite_dump3, %indirect_byval_rewrite.Big* noalias nocapture align 16 %.ExplicitByvalRewrite_dump2, %indirect_byval_rewrite.WithPostblit* noalias nocapture align 16 %.ExplicitByvalRewrite_dump1, %indirect_byval_rewrite.Big* noalias nocapture align 16 %.ExplicitByvalRewrite_dump) #2
  ret void
}
```

New (3 moves (alloca+memcpy) less):
```LL
define void @_D22indirect_byval_rewrite3barFZv() #0 comdat {
  %bigLValue = alloca %indirect_byval_rewrite.Big, align 8 ; [#uses = 2, size/byte = 16]
  %withPostblitLValue = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 2, size/byte = 16]
  %.hidden_copy_for_IndirectByvalRewrite = alloca %indirect_byval_rewrite.Big, align 8 ; [#uses = 2, size/byte = 16]
  %__copytmp3 = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 3, size/byte = 16]
  %.sret_tmp = alloca %indirect_byval_rewrite.Big, align 8 ; [#uses = 2, size/byte = 16]
  %.structliteral = alloca %indirect_byval_rewrite.WithPostblit, align 8 ; [#uses = 2, size/byte = 16]
  %1 = bitcast %indirect_byval_rewrite.Big* %bigLValue to i8* ; [#uses = 1]
  call void @llvm.memset.p0i8.i64(i8* %1, i8 0, i64 16, i32 1, i1 false)
  %2 = bitcast %indirect_byval_rewrite.WithPostblit* %withPostblitLValue to i8* ; [#uses = 1]
  call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i32 1, i1 false)
  %3 = bitcast %indirect_byval_rewrite.Big* %.hidden_copy_for_IndirectByvalRewrite to i8* ; [#uses = 1]
  %4 = bitcast %indirect_byval_rewrite.Big* %bigLValue to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %3, i8* %4, i64 16, i32 8, i1 false)
  %5 = bitcast %indirect_byval_rewrite.WithPostblit* %__copytmp3 to i8* ; [#uses = 1]
  %6 = bitcast %indirect_byval_rewrite.WithPostblit* %withPostblitLValue to i8* ; [#uses = 1]
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %5, i8* %6, i64 16, i32 1, i1 false)
  call void @_D22indirect_byval_rewrite12WithPostblit10__postblitMFZv(%indirect_byval_rewrite.WithPostblit* nonnull %__copytmp3) #0
  call void @_D22indirect_byval_rewrite7makeBigFZSQBj3Big(%indirect_byval_rewrite.Big* noalias sret align 8 %.sret_tmp) #0
  %7 = getelementptr inbounds %indirect_byval_rewrite.WithPostblit, %indirect_byval_rewrite.WithPostblit* %.structliteral, i32 0, i32 0 ; [#uses = 2, type = %indirect_byval_rewrite.Big*]
  %8 = getelementptr inbounds %indirect_byval_rewrite.Big, %indirect_byval_rewrite.Big* %7, i32 0, i32 0 ; [#uses = 1, type = i64*]
  store i64 0, i64* %8
  %9 = getelementptr inbounds %indirect_byval_rewrite.Big, %indirect_byval_rewrite.Big* %7, i32 0, i32 1 ; [#uses = 1, type = i64*]
  store i64 0, i64* %9
  call void @_D22indirect_byval_rewrite3fooFSQBe3BigSQBm12WithPostblitQBaQvZv(%indirect_byval_rewrite.WithPostblit* noalias nocapture align 8 %.structliteral, %indirect_byval_rewrite.Big* noalias nocapture align 8 %.sret_tmp, %indirect_byval_rewrite.WithPostblit* noalias nocapture align 8 %__copytmp3, %indirect_byval_rewrite.Big* noalias nocapture align 8 %.hidden_copy_for_IndirectByvalRewrite) #2
  ret void
}
```