### PR TITLE
MSVC: Port Rainer's upstream extern(C++) method ABI fixes

### DIFF
--- a/dmd/semantic3.d
+++ b/dmd/semantic3.d
@@ -602,7 +602,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                 }
 
-                if (!funcdecl.inferRetType && !Target.isReturnOnStack(f))
+                if (!funcdecl.inferRetType && !Target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
@@ -656,7 +656,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (funcdecl.storage_class & STC.auto_)
                         funcdecl.storage_class &= ~STC.auto_;
                 }
-                if (!Target.isReturnOnStack(f))
+                if (!Target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 if (funcdecl.fbody.isErrorStatement())

--- a/dmd/target.d
+++ b/dmd/target.d
@@ -21,6 +21,7 @@ import dmd.dmodule;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.expression;
+import dmd.func;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -653,18 +654,21 @@ struct Target
     }
 
     /**
+     * Determine return style of function - whether in registers or
+     * through a hidden pointer to the caller's stack.
      * Params:
      *   tf = function type to check
+     *   needsThis = true if the function type is for a non-static member function
      * Returns:
      *   true if return value from function is on the stack
      */
   version(IN_LLVM)
   {
-    extern (C++) static bool isReturnOnStack(TypeFunction tf);
+    extern (C++) static bool isReturnOnStack(TypeFunction tf, bool needsThis);
   }
   else
   {
-    extern (C++) static bool isReturnOnStack(TypeFunction tf)
+    extern (C++) static bool isReturnOnStack(TypeFunction tf, bool needsThis)
     {
         if (tf.isref)
         {
@@ -691,6 +695,8 @@ struct Target
                 StructDeclaration sd = (cast(TypeStruct)tns).sym;
                 if (sd.ident == Id.__c_long_double)
                     return false;
+                if (tf.linkage == LINK.cpp && needsThis)
+                    return true;
                 if (!sd.isPOD() || sz > 8)
                     return true;
                 if (sd.fields.dim == 0)
@@ -708,6 +714,8 @@ struct Target
                 StructDeclaration sd = (cast(TypeStruct)tb).sym;
                 if (sd.ident == Id.__c_long_double)
                     return false;
+                if (tf.linkage == LINK.cpp && needsThis)
+                    return true;
             }
         }
 

--- a/dmd/target.h
+++ b/dmd/target.h
@@ -99,7 +99,7 @@ struct Target
     static Type *cppParameterType(Parameter *p);
     static LINK systemLinkage();
     static TypeTuple *toArgTypes(Type *t);
-    static bool isReturnOnStack(TypeFunction *tf);
+    static bool isReturnOnStack(TypeFunction *tf, bool needsThis);
     static d_uns64 parameterSize(const Loc& loc, Type *t);
 };
 

--- a/dmd/traits.d
+++ b/dmd/traits.d
@@ -1074,7 +1074,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
 
-        bool value = Target.isReturnOnStack(tf);
+        bool value = Target.isReturnOnStack(tf, fd && fd.needThis());
         return new IntegerExp(e.loc, value, Type.tbool);
     }
     if (e.ident == Id.getFunctionVariadicStyle)

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -22,7 +22,7 @@ struct AArch64TargetABI : TargetABI {
   CompositeToArray64 compositeToArray64;
   IntegerRewrite integerRewrite;
 
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
     }

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -25,7 +25,7 @@ struct ArmTargetABI : TargetABI {
   CompositeToArray64 compositeToArray64;
   IntegerRewrite integerRewrite;
 
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     // AAPCS 5.4 wants composites > 4-bytes returned by arg except for
     // Homogeneous Aggregates of up-to 4 float types (6.1.2.1) - an HFA.
     // TODO: see if Tsarray should be candidate for HFA.

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -25,7 +25,7 @@ struct MIPS64TargetABI : TargetABI {
 
   explicit MIPS64TargetABI(const bool Is64Bit) : Is64Bit(Is64Bit) {}
 
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
     }

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -35,7 +35,7 @@ struct NVPTXTargetABI : TargetABI {
         rewriteArgument(fty, *arg);
     }
   }
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     return !tf->isref && DtoIsInMemoryOnly(tf->next);
   }
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -35,7 +35,7 @@ struct PPCTargetABI : TargetABI {
 
   explicit PPCTargetABI(const bool Is64Bit) : Is64Bit(Is64Bit) {}
 
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
     }

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -28,7 +28,7 @@ struct PPC64LETargetABI : TargetABI {
 
   explicit PPC64LETargetABI() : hfaToArray(8) {}
 
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
     }

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -35,7 +35,7 @@ struct SPIRVTargetABI : TargetABI {
         rewriteArgument(fty, *arg);
     }
   }
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     return !tf->isref && DtoIsInMemoryOnly(tf->next);
   }
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -219,7 +219,7 @@ struct X86_64TargetABI : TargetABI {
   ImplicitByvalRewrite byvalRewrite;
   IndirectByvalRewrite indirectByvalRewrite;
 
-  bool returnInArg(TypeFunction *tf) override;
+  bool returnInArg(TypeFunction *tf, bool needsThis) override;
 
   bool passByVal(TypeFunction *tf, Type *t) override;
 
@@ -248,7 +248,7 @@ private:
 // The public getter for abi.cpp
 TargetABI *getX86_64TargetABI() { return new X86_64TargetABI; }
 
-bool X86_64TargetABI::returnInArg(TypeFunction *tf) {
+bool X86_64TargetABI::returnInArg(TypeFunction *tf, bool) {
   if (tf->isref) {
     return false;
   }

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -297,7 +297,7 @@ const char *TargetABI::objcMsgSendFunc(Type *ret, IrFuncTy &fty) {
 
 // Some reasonable defaults for when we don't know what ABI to use.
 struct UnknownTargetABI : TargetABI {
-  bool returnInArg(TypeFunction *tf) override {
+  bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
     }
@@ -361,7 +361,7 @@ TargetABI *TargetABI::getTarget() {
 struct IntrinsicABI : TargetABI {
   RemoveStructPadding remove_padding;
 
-  bool returnInArg(TypeFunction *tf) override { return false; }
+  bool returnInArg(TypeFunction *, bool) override { return false; }
 
   bool passByVal(TypeFunction *, Type *t) override { return false; }
 

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -224,7 +224,7 @@ bool hasCtor(StructDeclaration *s) {
 }
 
 bool TargetABI::isPOD(Type *t, bool excludeStructsWithCtor) {
-  t = t->toBasetype();
+  t = t->baseElemOf();
   if (t->ty != Tstruct)
     return true;
   StructDeclaration *sd = static_cast<TypeStruct *>(t)->sym;

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -307,11 +307,11 @@ struct UnknownTargetABI : TargetABI {
     // of physical registers, which leads, depending on the target, to
     // either horrendous codegen or backend crashes.
     Type *rt = tf->next->toBasetype();
-    return (rt->ty == Tstruct || rt->ty == Tsarray);
+    return passByVal(tf, rt);
   }
 
   bool passByVal(TypeFunction *, Type *t) override {
-    return t->toBasetype()->ty == Tstruct;
+    return DtoIsInMemoryOnly(t);
   }
 
   void rewriteFunctionType(IrFuncTy &) override {

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -120,13 +120,15 @@ struct TargetABI {
   }
 
   /// Returns true if the D function uses sret (struct return).
+  /// `needsThis` is true if the function type is for a non-static member
+  /// function.
   ///
   /// A LL sret function doesn't really return a struct (in fact, it returns
   /// void); it merely just sets a struct which has been pre-allocated by the
   /// caller.
   /// The address is passed as additional function parameter using the StructRet
   /// attribute.
-  virtual bool returnInArg(TypeFunction *tf) = 0;
+  virtual bool returnInArg(TypeFunction *tf, bool needsThis) = 0;
 
   /// Returns true if the D type is passed using the LLVM ByVal attribute.
   ///

--- a/gen/functions.h
+++ b/gen/functions.h
@@ -28,10 +28,8 @@ class FunctionType;
 }
 
 llvm::FunctionType *DtoFunctionType(Type *t, IrFuncTy &irFty, Type *thistype,
-                                    Type *nesttype, bool isMain = false,
-                                    bool isCtor = false,
-                                    bool isIntrinsic = false,
-                                    bool hasSel = false);
+                                    Type *nesttype,
+                                    FuncDeclaration *fd = nullptr);
 llvm::FunctionType *DtoFunctionType(FuncDeclaration *fdecl);
 
 void DtoResolveFunction(FuncDeclaration *fdecl);

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -268,6 +268,6 @@ Expression *Target::paintAsType(Expression *e, Type *type) {
  */
 void Target::loadModule(Module *m) {}
 
-bool Target::isReturnOnStack(TypeFunction *tf) {
-  return gABI->returnInArg(tf);
+bool Target::isReturnOnStack(TypeFunction *tf, bool needsThis) {
+  return gABI->returnInArg(tf, needsThis);
 }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -44,7 +44,8 @@ bool DtoIsInMemoryOnly(Type *type) {
 bool DtoIsReturnInArg(CallExp *ce) {
   Type *t = ce->e1->type->toBasetype();
   if (t->ty == Tfunction && (!ce->f || !DtoIsIntrinsic(ce->f))) {
-    return gABI->returnInArg(static_cast<TypeFunction *>(t));
+    return gABI->returnInArg(static_cast<TypeFunction *>(t),
+                             ce->f && ce->f->needThis());
   }
   return false;
 }


### PR DESCRIPTION
MSVC++ methods apparently return *all* structs via sret, even small PODs, see https://issues.dlang.org/show_bug.cgi?id=18928 and #1935.

The problem is that the ABI code operates with `TypeFunction`, which contains no information about enclosing aggregate nor whether it's a static function declaration (a class member function, behaving like other regular functions).

~~The very hacky attempt here is adding a new bool `ismethod` to TypeFunction, setting it at parse-time to whether it's declared in a non-static scope and later checking if it's additionally an aggregate member during type-semantic (at which point the `static` storage class appears to be masked out), setting it back to false if it isn't. But I'm not familiar with this front-end code at all, so may/hopefully have missed a simpler/more robust solution.~~