### PR TITLE
Use IndirectByvalRewrite for non-POD args and extern(C++) on Posix

### DIFF
--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -32,10 +32,10 @@ struct AArch64TargetABI : TargetABI {
     if (!isPOD(rt))
       return true;
 
-    return passByVal(rt);
+    return passByVal(tf, rt);
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     t = t->toBasetype();
     return t->ty == Tsarray ||
            (t->ty == Tstruct && t->size() > 16 && !isHFA((TypeStruct *)t));

--- a/gen/abi-arm.cpp
+++ b/gen/abi-arm.cpp
@@ -42,7 +42,7 @@ struct ArmTargetABI : TargetABI {
              !isHFA((TypeStruct *)rt)));
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     // AAPCS does not use an indirect arg to pass aggregates, however
     // clang uses byval for types > 64-bytes, then llvm backend
     // converts back to non-byval.  Without this special handling the

--- a/gen/abi-mips64.cpp
+++ b/gen/abi-mips64.cpp
@@ -42,7 +42,7 @@ struct MIPS64TargetABI : TargetABI {
     return (rt->ty == Tstruct || rt->ty == Tsarray);
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     TY ty = t->toBasetype()->ty;
     return ty == Tstruct || ty == Tsarray;
   }

--- a/gen/abi-nvptx.cpp
+++ b/gen/abi-nvptx.cpp
@@ -24,7 +24,7 @@ struct NVPTXTargetABI : TargetABI {
     else
         return llvm::CallingConv::PTX_Device;
   }
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -49,7 +49,7 @@ struct PPCTargetABI : TargetABI {
     return rt->ty == Tsarray || rt->ty == Tstruct;
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     // On ppc, aggregates are always passed as an indirect value.
     // On ppc64, they are always passed by value. However, clang
     // used byval for type > 64 bytes.

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -38,10 +38,10 @@ struct PPC64LETargetABI : TargetABI {
     if (!isPOD(rt))
       return true;
 
-    return passByVal(rt);
+    return passByVal(tf, rt);
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     t = t->toBasetype();
     return t->ty == Tsarray || (t->ty == Tstruct && t->size() > 16 &&
                                 !isHFA((TypeStruct *)t, nullptr, 8));

--- a/gen/abi-spirv.cpp
+++ b/gen/abi-spirv.cpp
@@ -24,7 +24,7 @@ struct SPIRVTargetABI : TargetABI {
     else
       return llvm::CallingConv::SPIR_FUNC;
   }
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *t) override {
     t = t->toBasetype();
     return ((t->ty == Tsarray || t->ty == Tstruct) && t->size() > 64);
   }

--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -117,7 +117,7 @@ public:
     return passPointerToHiddenCopy(rt, /*isReturnValue=*/true, tf->linkage);
   }
 
-  bool passByVal(Type *t) override {
+  bool passByVal(TypeFunction *, Type *) override {
     // LLVM's byval attribute is not compatible with the Win64 ABI
     return false;
   }

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -310,7 +310,9 @@ struct UnknownTargetABI : TargetABI {
     return (rt->ty == Tstruct || rt->ty == Tsarray);
   }
 
-  bool passByVal(Type *t) override { return t->toBasetype()->ty == Tstruct; }
+  bool passByVal(TypeFunction *, Type *t) override {
+    return t->toBasetype()->ty == Tstruct;
+  }
 
   void rewriteFunctionType(IrFuncTy &) override {
     // why?
@@ -361,7 +363,7 @@ struct IntrinsicABI : TargetABI {
 
   bool returnInArg(TypeFunction *tf) override { return false; }
 
-  bool passByVal(Type *t) override { return false; }
+  bool passByVal(TypeFunction *, Type *t) override { return false; }
 
   bool reverseExplicitParams(TypeFunction *) override { return false; }
 

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -137,7 +137,7 @@ struct TargetABI {
   /// parameter.
   /// The LL caller needs to pass a pointer to the original argument (the memcpy
   /// source).
-  virtual bool passByVal(Type *t) = 0;
+  virtual bool passByVal(TypeFunction *tf, Type *t) = 0;
 
   /// Returns true if the 'this' argument is to be passed before the 'sret'
   /// argument.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -170,7 +170,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
       // ref/out
       attrs.addDereferenceable(loweredDType->size());
     } else {
-      if (abi->passByVal(loweredDType)) {
+      if (abi->passByVal(f, loweredDType)) {
         // LLVM ByVal parameters are pointers to a copy in the function
         // parameters stack. The caller needs to provide a pointer to the
         // original argument.

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -129,7 +129,7 @@ static void addExplicitArguments(std::vector<LLValue *> &args, AttrSet &attrs,
   std::vector<IrFuncTyArg *> optionalIrArgs;
   for (size_t i = formalDArgCount; i < explicitDArgCount; i++) {
     Type *argType = argexps[i]->type;
-    bool passByVal = gABI->passByVal(argType);
+    bool passByVal = gABI->passByVal(irFty.type, argType);
 
     AttrBuilder initialAttrs;
     if (passByVal) {


### PR DESCRIPTION
Fixing one aspect of issue #2702; not tackling the different destruction rules yet.