### PR TITLE
AppVeyor: Temporarily revert to previous VS 2017 image for x64 job

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@
 environment:
   matrix:
     - APPVEYOR_JOB_ARCH:           x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2017
       LLVM_VERSION:                6.0.0
       HOST_LDC_VERSION:            1.8.0
       DUB_VERSION:                 v1.8.1


### PR DESCRIPTION
To work around the `tests/driver/mscrtlib.d` failures, which are probably due to the new 'Spectre-mitigation' MS libs breaking the EH terminate hook in druntime.