### PR TITLE
Set proper calling convention and attributes to jit thunk call

### DIFF
--- a/gen/dynamiccompile.cpp
+++ b/gen/dynamiccompile.cpp
@@ -710,6 +710,8 @@ void createThunkFunc(llvm::Module &module, const llvm::Function *src,
     args.push_back(&arg);
   }
   auto ret = builder.CreateCall(thunkPtr, args);
+  ret->setCallingConv(src->getCallingConv());
+  ret->setAttributes(src->getAttributes());
   if (dst->getReturnType()->isVoidTy()) {
     builder.CreateRetVoid();
   } else {

--- a/tests/dynamiccompile/simple.d
+++ b/tests/dynamiccompile/simple.d
@@ -28,6 +28,11 @@ static assert(false, "LDC_DynamicCompilation is not defined");
   writeln("baz");
 }
 
+@dynamicCompile int bzz(int a, int b)
+{
+  return a + b;
+}
+
 void main(string[] args)
 {
   void run(CompilerSettings settings)
@@ -38,6 +43,7 @@ void main(string[] args)
     baz();
     int function() fptr = &bar;
     assert(12 == fptr());
+    assert(15 == bzz(7, 8));
   }
 
   foreach(i;0..4)


### PR DESCRIPTION
For some reason, this broke things only on win32.