### PR TITLE
jit: refactor valueparser

### DIFF
--- a/runtime/jit-rt/cpp-so/optimizer.cpp
+++ b/runtime/jit-rt/cpp-so/optimizer.cpp
@@ -159,7 +159,8 @@ void setRtCompileVar(const Context &context, llvm::Module &module,
   if (nullptr != var) {
     auto type = var->getType()->getElementType();
     auto initializer =
-        parseInitializer(context, module.getDataLayout(), type, init);
+        parseInitializer(module.getDataLayout(), *type, init,
+                         [&](const std::string &str) { fatal(context, str); });
     var->setConstant(true);
     var->setInitializer(initializer);
     var->setLinkage(llvm::GlobalValue::PrivateLinkage);

--- a/runtime/jit-rt/cpp-so/valueparser.cpp
+++ b/runtime/jit-rt/cpp-so/valueparser.cpp
@@ -21,96 +21,168 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
+
+void checkOverrideType(
+    llvm::Type &type, llvm::Constant &val,
+    const llvm::function_ref<void(const std::string &)> &errHandler) {
+  auto retType = val.getType();
+  if (retType != &type) {
+    std::string str;
+    llvm::raw_string_ostream ss(str);
+    ss << "Override type mismatch, expected \"";
+    type.print(ss);
+    ss << "\", got \"";
+    retType->print(ss);
+    ss << "\"";
+    ss.flush();
+    errHandler(str);
+  }
+}
+
 template <typename T>
-llvm::ConstantInt *getInt(llvm::LLVMContext &context, const void *data) {
+llvm::Constant *
+callOverride(const ParseInitializerOverride &override, llvm::Type &type,
+             const T &val,
+             const llvm::function_ref<void(const std::string &)> &errHandler) {
+  if (override) {
+    auto ptr = reinterpret_cast<const char *>(&val);
+    auto ret = (*override)(type, ptr, sizeof(val));
+    if (ret != nullptr) {
+      checkOverrideType(type, *ret, errHandler);
+    }
+    return ret;
+  }
+  return nullptr;
+}
+
+template <typename T>
+llvm::Constant *
+getInt(llvm::LLVMContext &context, const void *data, llvm::Type &type,
+       const llvm::function_ref<void(const std::string &)> &errHandler,
+       const ParseInitializerOverride &override) {
   assert(nullptr != data);
   const T val = *static_cast<const T *>(data);
+  if (auto ret = callOverride(override, type, val, errHandler)) {
+    return ret;
+  }
   return llvm::ConstantInt::get(context, llvm::APInt(sizeof(T) * 8, val, true));
 }
 
 template <typename T>
-llvm::ConstantFP *getFloat(llvm::LLVMContext &context, const void *data) {
+llvm::Constant *
+getFloat(llvm::LLVMContext &context, const void *data, llvm::Type &type,
+         const llvm::function_ref<void(const std::string &)> &errHandler,
+         const ParseInitializerOverride &override) {
   assert(nullptr != data);
   const T val = *static_cast<const T *>(data);
+  if (auto ret = callOverride(override, type, val, errHandler)) {
+    return ret;
+  }
   return llvm::ConstantFP::get(context, llvm::APFloat(val));
 }
 
-llvm::Constant *getPtr(llvm::LLVMContext &context, llvm::Type *targetType,
-                       const void *data) {
-  assert(nullptr != targetType);
+llvm::Constant *
+getPtr(llvm::LLVMContext &context, const void *data, llvm::Type &type,
+       const llvm::function_ref<void(const std::string &)> &errHandler,
+       const ParseInitializerOverride &override) {
   assert(nullptr != data);
   const auto val = *static_cast<const uintptr_t *>(data);
+  if (auto ret = callOverride(override, type, val, errHandler)) {
+    return ret;
+  }
   return llvm::ConstantExpr::getIntToPtr(
       llvm::ConstantInt::get(context, llvm::APInt(sizeof(val) * 8, val)),
-      targetType);
+      &type);
+}
+
+llvm::Constant *
+getStruct(const void *data, const llvm::DataLayout &dataLayout,
+          llvm::Type &type,
+          const llvm::function_ref<void(const std::string &)> &errHandler,
+          const ParseInitializerOverride &override) {
+  assert(nullptr != data);
+  if (override) {
+    auto size = dataLayout.getTypeStoreSize(&type);
+    auto ptr = static_cast<const char *>(data);
+    auto ret = (*override)(type, ptr, size);
+    if (ret != nullptr) {
+      checkOverrideType(type, *ret, errHandler);
+      return ret;
+    }
+  }
+  auto stype = llvm::cast<llvm::StructType>(&type);
+  auto slayout = dataLayout.getStructLayout(stype);
+  auto numElements = stype->getNumElements();
+  llvm::SmallVector<llvm::Constant *, 16> elements(numElements);
+  for (unsigned i = 0; i < numElements; ++i) {
+    const auto elemType = stype->getElementType(i);
+    const auto elemOffset = slayout->getElementOffset(i);
+    const auto elemPtr = static_cast<const char *>(data) + elemOffset;
+    elements[i] =
+        parseInitializer(dataLayout, *elemType, elemPtr, errHandler, override);
+  }
+  return llvm::ConstantStruct::get(stype, elements);
 }
 }
 
-llvm::Constant *parseInitializer(const Context &context,
-                                 const llvm::DataLayout &dataLayout,
-                                 llvm::Type *type, const void *data) {
-  assert(nullptr != type);
+llvm::Constant *
+parseInitializer(const llvm::DataLayout &dataLayout, llvm::Type &type,
+                 const void *data,
+                 llvm::function_ref<void(const std::string &)> errHandler,
+                 const ParseInitializerOverride &override) {
   assert(nullptr != data);
-  auto &llcontext = type->getContext();
-  if (type->isIntegerTy()) {
-    const auto width = type->getIntegerBitWidth();
+  auto &llcontext = type.getContext();
+  if (type.isIntegerTy()) {
+    const auto width = type.getIntegerBitWidth();
     switch (width) {
     case 8:
-      return getInt<uint8_t>(llcontext, data);
+      return getInt<uint8_t>(llcontext, data, type, errHandler, override);
     case 16:
-      return getInt<uint16_t>(llcontext, data);
+      return getInt<uint16_t>(llcontext, data, type, errHandler, override);
     case 32:
-      return getInt<uint32_t>(llcontext, data);
+      return getInt<uint32_t>(llcontext, data, type, errHandler, override);
     case 64:
-      return getInt<uint64_t>(llcontext, data);
+      return getInt<uint64_t>(llcontext, data, type, errHandler, override);
     default:
-      fatal(context,
-            std::string("Invalid int bit width: ") + std::to_string(width));
+      errHandler(std::string("Invalid int bit width: ") +
+                 std::to_string(width));
+      return nullptr;
     }
   }
-  if (type->isFloatingPointTy()) {
-    const auto width = type->getPrimitiveSizeInBits();
+  if (type.isFloatingPointTy()) {
+    const auto width = type.getPrimitiveSizeInBits();
     switch (width) {
     case 32:
-      return getFloat<float>(llcontext, data);
+      return getFloat<float>(llcontext, data, type, errHandler, override);
     case 64:
-      return getFloat<double>(llcontext, data);
+      return getFloat<double>(llcontext, data, type, errHandler, override);
     default:
-      fatal(context,
-            std::string("Invalid fp bit width: ") + std::to_string(width));
+      errHandler(std::string("Invalid fp bit width: ") + std::to_string(width));
+      return nullptr;
     }
   }
-  if (type->isPointerTy()) {
-    return getPtr(llcontext, type, data);
+  if (type.isPointerTy()) {
+    return getPtr(llcontext, data, type, errHandler, override);
   }
-  if (type->isStructTy()) {
-    auto stype = llvm::cast<llvm::StructType>(type);
-    auto slayout = dataLayout.getStructLayout(stype);
-    auto numElements = stype->getNumElements();
-    llvm::SmallVector<llvm::Constant *, 16> elements(numElements);
-    for (unsigned i = 0; i < numElements; ++i) {
-      const auto elemType = stype->getElementType(i);
-      const auto elemOffset = slayout->getElementOffset(i);
-      const auto elemPtr = static_cast<const char *>(data) + elemOffset;
-      elements[i] = parseInitializer(context, dataLayout, elemType, elemPtr);
-    }
-    return llvm::ConstantStruct::get(stype, elements);
+  if (type.isStructTy()) {
+    return getStruct(data, dataLayout, type, errHandler, override);
   }
-  if (type->isArrayTy()) {
-    auto elemType = type->getArrayElementType();
+  if (type.isArrayTy()) {
+    auto elemType = type.getArrayElementType();
     const auto step = dataLayout.getTypeAllocSize(elemType);
-    const auto numElements = type->getArrayNumElements();
+    const auto numElements = type.getArrayNumElements();
     llvm::SmallVector<llvm::Constant *, 16> elements(numElements);
     for (uint64_t i = 0; i < numElements; ++i) {
       const auto elemPtr = static_cast<const char *>(data) + step * i;
-      elements[i] = parseInitializer(context, dataLayout, elemType, elemPtr);
+      elements[i] = parseInitializer(dataLayout, *elemType, elemPtr, errHandler,
+                                     override);
     }
-    return llvm::ConstantArray::get(llvm::cast<llvm::ArrayType>(type),
+    return llvm::ConstantArray::get(llvm::cast<llvm::ArrayType>(&type),
                                     elements);
   }
   std::string tname;
   llvm::raw_string_ostream os(tname);
-  type->print(os, true);
-  fatal(context, std::string("Unhandled type: ") + os.str());
+  type.print(os, true);
+  errHandler(std::string("Unhandled type: ") + os.str());
   return nullptr;
 }

--- a/runtime/jit-rt/cpp-so/valueparser.h
+++ b/runtime/jit-rt/cpp-so/valueparser.h
@@ -16,16 +16,21 @@
 #ifndef VALUEPARSER_H
 #define VALUEPARSER_H
 
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/STLExtras.h"
+
 namespace llvm {
 class Constant;
 class Type;
 class DataLayout;
 }
 
-struct Context;
+using ParseInitializerOverride = llvm::Optional<
+    llvm::function_ref<llvm::Constant *(llvm::Type &, const void *, size_t)>>;
 
-llvm::Constant *parseInitializer(const Context &context,
-                                 const llvm::DataLayout &dataLayout,
-                                 llvm::Type *type, const void *data);
+llvm::Constant *parseInitializer(
+    const llvm::DataLayout &dataLayout, llvm::Type &type, const void *data,
+    llvm::function_ref<void(const std::string &)> errHandler,
+    const ParseInitializerOverride &override = ParseInitializerOverride{});
 
 #endif // VALUEPARSER_H


### PR DESCRIPTION
* remove dependency from `Context`, pass `errHandler` callback instead
* Optional `override` callback, to override initializer read from memory with some custom value (required by `bind` feature)