### PR TITLE
[ltsmaster] backport betterC and OS-specific assert functions

### DIFF
--- a/dmd2/globals.h
+++ b/dmd2/globals.h
@@ -128,6 +128,7 @@ struct Param
     bool addMain; // LDC_FIXME: Implement.
     bool allInst; // LDC_FIXME: Implement.
     unsigned nestedTmpl; // maximum nested template instantiations
+    bool betterC;       // be a "better C" compiler; no dependency on D runtime
 #else
     bool pic;           // generate position-independent-code for shared libs
     bool color;         // use ANSI colors in console output
@@ -136,7 +137,6 @@ struct Param
     bool nofloat;       // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;      // rather than error on them
     bool enforcePropertySyntax;
-    bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
 #endif

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -408,6 +408,11 @@ cl::opt<bool, true>
              cl::desc("implement http://wiki.dlang.org/DIP25 (experimental)"),
              cl::location(global.params.useDIP25));
 
+cl::opt<bool, true> betterC(
+    "betterC",
+    cl::desc("omit generating some runtime information and helper functions"),
+    cl::location(global.params.betterC));
+
 cl::opt<unsigned char, true, CoverageParser> coverageAnalysis(
     "cov", cl::desc("Compile-in code coverage analysis\n(use -cov=n for n% "
                     "minimum required coverage)"),

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -159,6 +159,7 @@ Usage:\n\
   files.d        D source files\n\
   @cmdfile       read arguments from cmdfile\n\
   -allinst       generate code for all template instantiations\n\
+  -betterC       omit generating some runtime information and helper functions\n\
   -c             do not link\n\
   -color[=on|off]   force colored console output on or off\n\
   -conf=path     use config file at path\n\

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -459,12 +459,10 @@ static void parseCommandLine(int argc, char **argv, Strings &sourceFiles,
   }
 
   if (noDefaultLib) {
-    deprecation(
-        Loc(),
-        "-nodefaultlib is deprecated, as "
-        "-defaultlib/-debuglib now override the existing list instead of "
-        "appending to it. Please use the latter instead.");
-  } else {
+    deprecation(Loc(), "-nodefaultlib is deprecated, as -defaultlib/-debuglib "
+                       "now override the existing list instead of appending to "
+                       "it. Please use the latter instead.");
+  } else if (!global.params.betterC) {
     // Parse comma-separated default library list.
     std::stringstream libNames(linkDebugLib ? debugLib : defaultLib);
     while (libNames.good()) {

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -858,6 +858,10 @@ static void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("D_NoBoundsChecks");
   }
 
+  if (global.params.betterC) {
+    VersionCondition::addPredefinedGlobalIdent("D_BetterC");
+  }
+
   registerPredefinedTargetVersions();
 
   // Pass sanitizer arguments to linker. Requires clang.

--- a/gen/aa.cpp
+++ b/gen/aa.cpp
@@ -12,6 +12,7 @@
 #include "declaration.h"
 #include "module.h"
 #include "mtype.h"
+#include "gen/arrays.h"
 #include "gen/dvalue.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
@@ -91,14 +92,7 @@ DValue *DtoAAIndex(Loc &loc, Type *type, DValue *aa, DValue *key, bool lvalue) {
 
     gIR->scope() = IRScope(failbb);
 
-    llvm::Function *errorfn =
-        getRuntimeFunction(loc, gIR->module, "_d_arraybounds");
-    gIR->CreateCallOrInvoke(
-        errorfn, DtoModuleFileName(gIR->func()->decl->getModule(), loc),
-        DtoConstUint(loc.linnum));
-
-    // the function does not return
-    gIR->ir->CreateUnreachable();
+    DtoBoundsCheckFailCall(gIR, loc);
 
     // if ok, proceed in okbb
     gIR->scope() = IRScope(okbb);

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -280,6 +280,14 @@ void DtoCAssert(Module *M, Loc &loc, LLValue *msg) {
     args.push_back(file);
     args.push_back(line);
     args.push_back(msg);
+  } else if (global.params.targetTriple.isOSSolaris()) {
+    const auto irFunc = gIR->func();
+    const auto funcName =
+        (irFunc && irFunc->decl) ? irFunc->decl->toPrettyChars() : "";
+    args.push_back(msg);
+    args.push_back(file);
+    args.push_back(line);
+    args.push_back(DtoConstCString(funcName));
   } else if (global.params.targetTriple.getEnvironment() ==
              llvm::Triple::Android) {
     args.push_back(file);

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -280,6 +280,11 @@ void DtoCAssert(Module *M, Loc &loc, LLValue *msg) {
     args.push_back(file);
     args.push_back(line);
     args.push_back(msg);
+  } else if (global.params.targetTriple.getEnvironment() ==
+             llvm::Triple::Android) {
+    args.push_back(file);
+    args.push_back(line);
+    args.push_back(msg);
   } else {
     args.push_back(msg);
     args.push_back(file);

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -56,9 +56,10 @@ LLValue *DtoAllocaDump(LLValue *val, LLType *asType, int alignment = 0,
 
 // assertion generator
 void DtoAssert(Module *M, Loc &loc, DValue *msg);
+void DtoCAssert(Module *M, Loc &loc, LLValue *msg);
 
 // returns module file name
-LLValue *DtoModuleFileName(Module *M, const Loc &loc);
+LLConstant *DtoModuleFileName(Module *M, const Loc &loc);
 
 /// emits goto to LabelStatement with the target identifier
 void DtoGoto(Loc &loc, LabelDsymbol *target);

--- a/gen/module.cpp
+++ b/gen/module.cpp
@@ -743,8 +743,8 @@ void codegenModule(IRState *irs, Module *m, bool emitFullModuleInfo) {
   }
 
   // Skip emission of all the additional module metadata if requested by the
-  // user.
-  if (!m->noModuleInfo) {
+  // user or the betterC switch is on.
+  if (!global.params.betterC && !m->noModuleInfo) {
     // generate ModuleInfo
     genModuleInfo(m, emitFullModuleInfo);
 

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -178,6 +178,13 @@ llvm::GlobalVariable *getRuntimeGlobal(Loc &loc, llvm::Module &target,
                            g->getLinkage(), nullptr, g->getName());
 }
 
+// C assert function:
+// OSX:     void __assert_rtn(const char *func, const char *file, unsigned line,
+//                            const char *msg)
+// Android: void __assert(const char *file, int line, const char *msg)
+// MSVC:    void  _assert(const char *msg, const char *file, unsigned line)
+// else:    void __assert(const char *msg, const char *file, unsigned line)
+
 static const char *getCAssertFunctionName() {
   if (global.params.targetTriple.isOSDarwin()) {
     return "__assert_rtn";
@@ -185,6 +192,19 @@ static const char *getCAssertFunctionName() {
     return "_assert";
   }
   return "__assert";
+}
+
+static std::vector<Type *> getCAssertFunctionParamTypes() {
+  const auto voidPtr = Type::tvoidptr;
+  const auto uint = Type::tuns32;
+
+  if (global.params.targetTriple.isOSDarwin()) {
+    return {voidPtr, voidPtr, uint, voidPtr};
+  }
+  if (global.params.targetTriple.getEnvironment() == llvm::Triple::Android) {
+    return {voidPtr, uint, voidPtr};
+  }
+  return {voidPtr, voidPtr, uint};
 }
 
 llvm::Function *getCAssertFunction(const Loc &loc, llvm::Module &target) {
@@ -360,16 +380,10 @@ static void buildRuntimeModule() {
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  // C assert function:
-  // OSX:  void __assert_rtn(const char *func, const char *file, unsigned line,
-  //                         const char *msg)
-  // else: void [_]_assert(const char *msg, const char *file, unsigned line)
-  createFwdDecl(
-      LINKc, Type::tvoid, {getCAssertFunctionName()},
-      global.params.targetTriple->isOSDarwin()
-          ? llvm::ArrayRef<Type *>({voidPtrTy, voidPtrTy, uintTy, voidPtrTy})
-          : llvm::ArrayRef<Type *>({voidPtrTy, voidPtrTy, uintTy}),
-      {}, Attr_Cold_NoReturn);
+  // C assert function
+  createFwdDecl(LINKc, Type::tvoid, {getCAssertFunctionName()},
+                getCAssertFunctionParamTypes(), {},
+                Attr_Cold_NoReturn);
 
   // void _d_assert(string file, uint line)
   // void _d_arraybounds(string file, uint line)

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -183,6 +183,8 @@ llvm::GlobalVariable *getRuntimeGlobal(Loc &loc, llvm::Module &target,
 //                            const char *msg)
 // Android: void __assert(const char *file, int line, const char *msg)
 // MSVC:    void  _assert(const char *msg, const char *file, unsigned line)
+// Solaris: void __assert_c99(const char *assertion, const char *filename, int line_num,
+//                            const char *funcname);
 // else:    void __assert(const char *msg, const char *file, unsigned line)
 
 static const char *getCAssertFunctionName() {
@@ -190,6 +192,8 @@ static const char *getCAssertFunctionName() {
     return "__assert_rtn";
   } else if (global.params.targetTriple.isWindowsMSVCEnvironment()) {
     return "_assert";
+  } else if (global.params.targetTriple.isOSSolaris()) {
+    return "__assert_c99";
   }
   return "__assert";
 }
@@ -198,7 +202,7 @@ static std::vector<Type *> getCAssertFunctionParamTypes() {
   const auto voidPtr = Type::tvoidptr;
   const auto uint = Type::tuns32;
 
-  if (global.params.targetTriple.isOSDarwin()) {
+  if (global.params.targetTriple.isOSDarwin() || global.params.targetTriple.isOSSolaris()) {
     return {voidPtr, voidPtr, uint, voidPtr};
   }
   if (global.params.targetTriple.getEnvironment() == llvm::Triple::Android) {

--- a/gen/runtime.h
+++ b/gen/runtime.h
@@ -31,5 +31,6 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
 
 llvm::GlobalVariable *
 getRuntimeGlobal(const Loc &loc, llvm::Module &target, const char *name);
+llvm::Function *getCAssertFunction(const Loc &loc, llvm::Module &target);
 
 #endif // LDC_GEN_RUNTIME_H

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -1506,11 +1506,17 @@ public:
                            stmt->loc.toChars());
     LOG_SCOPE;
 
+    Module *const module = irs->func()->decl->getModule();
+
+    if (global.params.betterC) {
+      DtoCAssert(module, stmt->loc, DtoConstCString("no switch default"));
+      return;
+    }
+
     llvm::Function *fn =
         getRuntimeFunction(stmt->loc, irs->module, "_d_switch_error");
 
-    LLValue *moduleInfoSymbol =
-        getIrModule(irs->func()->decl->getModule())->moduleInfoSymbol();
+    LLValue *moduleInfoSymbol = getIrModule(module)->moduleInfoSymbol();
     LLType *moduleInfoType = DtoType(Module::moduleinfo->type);
 
     LLCallSite call = irs->CreateCallOrInvoke(

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1889,8 +1889,16 @@ public:
      * msg is not evaluated at all. So should use toElemDtor()
      * instead of toElem().
      */
-    DtoAssert(p->func()->decl->getModule(), e->loc,
-              e->msg ? toElemDtor(e->msg) : nullptr);
+    DValue *const msg = e->msg ? toElemDtor(e->msg) : nullptr;
+    Module *const module = p->func()->decl->getModule();
+    if (global.params.betterC) {
+      const auto cMsg =
+          msg ? DtoArrayPtr(msg) // assuming `msg` is null-terminated, like DMD
+              : DtoConstCString(e->e1->toChars());
+      DtoCAssert(module, e->e1->loc, cMsg);
+    } else {
+      DtoAssert(module, e->loc, msg);
+    }
 
     // passed:
     p->scope() = IRScope(passedbb);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2347,6 +2347,17 @@ public:
                          e->type->toChars());
     LOG_SCOPE;
 
+    if (global.params.betterC) {
+      error(
+          e->loc,
+          "array concatenation of expression `%s` requires the GC which is not "
+          "available with -betterC",
+          e->toChars());
+      result =
+          new DSliceValue(e->type, llvm::UndefValue::get(DtoType(e->type)), llvm::UndefValue::get(DtoType(e->type)));
+      return;
+    }
+
     result = DtoCatArrays(e->loc, e->type, e->e1, e->e2);
   }
 

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -93,6 +93,7 @@ LLConstantInt *DtoConstInt(int i);
 LLConstantInt *DtoConstUbyte(unsigned char i);
 LLConstant *DtoConstFP(Type *t, longdouble value);
 
+LLConstant *DtoConstCString(const char *);
 LLConstant *DtoConstString(const char *);
 LLConstant *DtoConstBool(bool);
 

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -737,8 +737,8 @@ void TypeInfoDeclaration_codegen(TypeInfoDeclaration *decl, IRState *p) {
 
   emitTypeMetadata(decl);
 
-  // this is a declaration of a builtin __initZ var
-  if (builtinTypeInfo(decl->tinfo)) {
+  // check if the definition can be elided
+  if (global.params.betterC || builtinTypeInfo(decl->tinfo)) {
     return;
   }
 

--- a/tests/codegen/betterC_typeinfo.d
+++ b/tests/codegen/betterC_typeinfo.d
@@ -1,22 +1,13 @@
 // Make sure the file can be compiled and linked successfully with -betterC.
 // Also test that druntime and Phobos aren't in the linker command line.
 // RUN: %ldc -betterC %s -v > %t.log
-// RUN: FileCheck %s --check-prefix=WITHOUT_TI < %t.log
-// WITHOUT_TI-NOT: druntime-ldc
-// WITHOUT_TI-NOT: phobos2-ldc
-
-// With version=WITH_TI, make sure the file can be compiled with -betterC...
-// RUN: %ldc -betterC -d-version=WITH_TI -c -of=%t%obj %s
-// ... but not linked due to the undefined TypeInfo.
-// RUN: not %ldc -betterC %t%obj > %t.fail 2>&1
-// RUN: FileCheck %s --check-prefix=WITH_TI < %t.fail
-// WITH_TI: _D37TypeInfo_S16betterC_typeinfo8MyStruct6__initZ
+// RUN: FileCheck %s < %t.log
+// CHECK-NOT: druntime-ldc
+// CHECK-NOT: phobos2-ldc
 
 struct MyStruct { int a; }
 
 extern (C) void main()
 {
     auto s = MyStruct();
-    version (WITH_TI)
-        auto ti = typeid(MyStruct);
 }

--- a/tests/codegen/betterC_typeinfo.d
+++ b/tests/codegen/betterC_typeinfo.d
@@ -1,0 +1,22 @@
+// Make sure the file can be compiled and linked successfully with -betterC.
+// Also test that druntime and Phobos aren't in the linker command line.
+// RUN: %ldc -betterC %s -v > %t.log
+// RUN: FileCheck %s --check-prefix=WITHOUT_TI < %t.log
+// WITHOUT_TI-NOT: druntime-ldc
+// WITHOUT_TI-NOT: phobos2-ldc
+
+// With version=WITH_TI, make sure the file can be compiled with -betterC...
+// RUN: %ldc -betterC -d-version=WITH_TI -c -of=%t%obj %s
+// ... but not linked due to the undefined TypeInfo.
+// RUN: not %ldc -betterC %t%obj > %t.fail 2>&1
+// RUN: FileCheck %s --check-prefix=WITH_TI < %t.fail
+// WITH_TI: _D37TypeInfo_S16betterC_typeinfo8MyStruct6__initZ
+
+struct MyStruct { int a; }
+
+extern (C) void main()
+{
+    auto s = MyStruct();
+    version (WITH_TI)
+        auto ti = typeid(MyStruct);
+}

--- a/tests/linking/betterc.d
+++ b/tests/linking/betterc.d
@@ -1,0 +1,15 @@
+// RUN: %ldc -betterC -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -betterC -defaultlib= -run %s
+
+// CHECK-NOT: ModuleInfoZ
+// CHECK-NOT: ModuleRefZ
+// CHECK-NOT: call void @ldc.register_dso
+version (CRuntime_Microsoft) {
+    extern(C) int mainCRTStartup() {
+        return 0;
+    }
+}
+
+extern (C) int main() {
+    return 0;
+}


### PR DESCRIPTION
This is useful in ltsmaster when porting to new platforms, certainly would like to have it for the Android/AArch64 port. I simply ran `git log master --grep=betterC` and found 11 commits that referenced it. This pull contains 8 of them, the first couple coming from @kinke's `betterC` pull #2365, but leaving out subsequent commits 97514dd, 1b8a3b9, and 04cd029, as they didn't seem necessary. Let me know if any of them should be in; I also had to add 612c8a7 to get the refactored `getCAssertFunctionParamTypes()`.

A basic `betterC` test file worked fine, time to run this pull through the CI and I'll backport the other `betterC` tests in the dmd testsuite when this gets in.