### PR TITLE
Don't count the "skipping definition" warning as a real warning.

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -968,13 +968,13 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   llvm::Function *const func = irFunc->getLLVMFunc();
 
   if (!func->empty()) {
-    // Don't count this warning as a real warning (to not stop compilation with `-w`)
-    auto savedWarningCount = global.params.warnings;
+    // XXX: HACK Don't count this warning as a real warning (to not stop compilation with `-w`)
+    auto savedWarningCount = global.warnings;
     warning(fd->loc,
             "LDC INTERNAL: skipping definition of function `%s` due to "
             "previous definition for the same mangled name: %s",
             fd->toPrettyChars(), mangleExact(fd));
-    global.params.warnings = savedWarningCount;
+    global.warnings = savedWarningCount;
     return;
   }
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -968,10 +968,13 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   llvm::Function *const func = irFunc->getLLVMFunc();
 
   if (!func->empty()) {
+    // Don't count this warning as a real warning (to not stop compilation with `-w`)
+    auto savedWarningCount = global.params.warnings;
     warning(fd->loc,
-            "skipping definition of function `%s` due to previous definition "
-            "for the same mangled name: %s",
+            "LDC INTERNAL: skipping definition of function `%s` due to "
+            "previous definition for the same mangled name: %s",
             fd->toPrettyChars(), mangleExact(fd));
+    global.params.warnings = savedWarningCount;
     return;
   }
 


### PR DESCRIPTION
The warning currently stops compilation with `-w`, but because this is not a real warning that the user can fix, compilation should continue. I've also marked the warning as "LDC INTERNAL" for clarity.