### PR TITLE
Circle & AppVeyor: Upgrade to LDC-LLVM 6.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - image: ubuntu:14.04
     environment:
       - CI_OS: linux
-      - LLVM_VERSION: 6.0.0
+      - LLVM_VERSION: 6.0.1
       - HOST_LDC_VERSION: 1.10.0
       - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
       - DUB_VERSION: v1.9.0
@@ -275,7 +275,7 @@ jobs:
       - CI_OS: osx
       - MACOSX_DEPLOYMENT_TARGET: 10.8
       - USE_LIBCPP: true
-      - LLVM_VERSION: 6.0.0
+      - LLVM_VERSION: 6.0.1
       - HOST_LDC_VERSION: 1.10.0
       - BOOTSTRAP_CMAKE_FLAGS: "-DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
       - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DD_FLAGS='-w;-flto=thin' -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,13 +158,19 @@ if(MSVC)
     if(${LLVM_CXXFLAGS} MATCHES "(^| )/MDd?( |$)")
         message(FATAL_ERROR "LLVM must be built with CMake option LLVM_USE_CRT_<CMAKE_BUILD_TYPE>=MT[d]")
     endif()
+    set(llvm_ob_flag)
+    string(REGEX MATCH "/Ob[0-2]" llvm_ob_flag "${LLVM_CXXFLAGS}")
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
         string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        # CMake defaults to /W3, LLVM uses /W4 => MS compiler warns about cmdline mismatch.
+        # CMake defaults to /W3, LLVM uses /W4 => MS compiler warns about overridden option.
         # Simply replace with /W4.
         string(REGEX REPLACE "/W[0-3]" "/W4" ${flag_var} "${${flag_var}}")
+        # Some CMake configs default to /Ob1, LLVM uses /Ob2. Replace with LLVM's option.
+        if(NOT llvm_ob_flag STREQUAL "")
+            string(REGEX REPLACE "/Ob[0-2]" "${llvm_ob_flag}" ${flag_var} "${${flag_var}}")
+        endif()
     endforeach()
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   matrix:
     - APPVEYOR_JOB_ARCH:           x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      LLVM_VERSION:                6.0.0
+      LLVM_VERSION:                6.0.1
       HOST_LDC_VERSION:            1.10.0
       DUB_VERSION:                 v1.9.0
     - APPVEYOR_JOB_ARCH:           x86
@@ -140,13 +140,7 @@ test_script:
   - set DMD_TESTSUITE_MAKE_ARGS=-j2
   - ctest -V -R "dmd-testsuite"
   # Run stdlib unittests
-  - ps: |
-        If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
-          # Exclude std.random unittests with enabled optimizations.
-          ctest -j2 --output-on-failure -E 'dmd-testsuite|lit-tests|ldc2-unittest|^std\.random$'
-        } Else {
-          ctest -j2 --output-on-failure -E 'dmd-testsuite|lit-tests|ldc2-unittest'
-        }
+  - ctest -j2 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
 
 #---------------------------------#
 #     deployment configuration    #

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/CommandLine.h"
@@ -30,6 +31,20 @@
 #include "mars.h"
 #include "driver/cl_options.h"
 #include "gen/logger.h"
+
+#ifdef LDC_LLVM_SUPPORTS_MACHO_DWARF_LINE_AS_REGULAR_SECTION
+// LDC-LLVM >= 6.0.1:
+// On Mac, emit __debug_line section in __DWARF segment as regular (non-debug)
+// section, like DMD, to enable file/line infos in backtraces. See
+// https://github.com/dlang/dmd/commit/2bf7d0db29416eacbb01a91e6502140e354ee0ef.
+static llvm::cl::opt<bool, true> preserveDwarfLineSection(
+    "preserve-dwarf-line-section",
+    llvm::cl::desc("Mac: preserve DWARF line section during linking for "
+                   "file/line infos in backtraces. Defaults to true."),
+    llvm::cl::Hidden, llvm::cl::ZeroOrMore,
+    llvm::cl::location(ldc::emitMachODwarfLineAsRegularSection),
+    llvm::cl::init(true));
+#endif
 
 static const char *getABI(const llvm::Triple &triple) {
   llvm::StringRef ABIName(opts::mABI);


### PR DESCRIPTION
Incl. `__debug_line` Mach-O section hack.