### PR TITLE
Add some support for classes without TypeInfos

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -65,11 +65,6 @@ void DtoResolveClass(ClassDeclaration *cd) {
     getIrField(vd, true);
   }
 
-  // emit the interfaceInfosZ symbol if necessary
-  if (cd->vtblInterfaces && cd->vtblInterfaces->dim > 0) {
-    irAggr->getInterfaceArraySymbol(); // initializer is applied when it's built
-  }
-
   // interface only emit typeinfo and classinfo
   if (cd->isInterfaceDeclaration()) {
     irAggr->initializeInterface();

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -89,14 +89,13 @@ public:
       }
 
       // Emit TypeInfo.
-      DtoTypeInfoOf(decl->type, /*base=*/false);
-
-      // Declare __InterfaceZ.
-      IrAggr *ir = getIrAggr(decl);
-      llvm::GlobalVariable *interfaceZ = ir->getClassInfoSymbol();
-      // Only define if not speculative.
-      if (!isSpeculativeType(decl->type)) {
-        defineGlobal(interfaceZ, ir->getClassInfoInit(), decl);
+      if (global.params.useTypeInfo && Type::dtypeinfo) {
+        IrAggr *ir = getIrAggr(decl);
+        llvm::GlobalVariable *interfaceZ = ir->getClassInfoSymbol();
+        // Only define if not speculative.
+        if (!isSpeculativeType(decl->type)) {
+          defineGlobal(interfaceZ, ir->getClassInfoInit(), decl);
+        }
       }
     }
   }
@@ -196,9 +195,13 @@ public:
 
       ir->defineInterfaceVtbls();
 
-      llvm::GlobalVariable *classZ = ir->getClassInfoSymbol();
-      if (!isSpeculativeType(decl->type)) {
-        defineGlobal(classZ, ir->getClassInfoInit(), decl);
+      // Emit TypeInfo.
+      if (global.params.useTypeInfo && Type::dtypeinfo) {
+        llvm::GlobalVariable *classZ = ir->getClassInfoSymbol();
+        // Only define if not speculative.
+        if (!isSpeculativeType(decl->type)) {
+          defineGlobal(classZ, ir->getClassInfoInit(), decl);
+        }
       }
     }
   }

--- a/tests/baremetal/classes.d
+++ b/tests/baremetal/classes.d
@@ -1,0 +1,29 @@
+// Use classes with virtual functions.
+
+// -betterC for C assert.
+// RUN: %ldc -betterC %baremetal_args -run %s
+
+class A
+{
+    int x;
+    bool isB() { return false; }
+}
+
+class B : A
+{
+    override bool isB() { return true; }
+}
+
+__gshared A a = new A();
+__gshared B b = new B();
+
+extern(C) int main()
+{
+    A obj = a;
+    assert(!obj.isB());
+
+    obj = b;
+    assert(obj.isB());
+
+    return 0;
+}


### PR DESCRIPTION
For `-betterC` and/or a minimal `object.d` without TypeInfo:

* Skip TypeInfo emission for classes and interfaces.
* Emit null as first vtable member.

Makes dmd-testsuite's `{compilable,runnable}/minimal2.d` work.