### PR TITLE
druntime: Work around core.cpuid regression with LLVM 6 on Win32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
       DUB_VERSION:                 v1.9.0
     - APPVEYOR_JOB_ARCH:           x86
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      LLVM_VERSION:                5.0.1
+      LLVM_VERSION:                6.0.1-2
       HOST_LDC_VERSION:            1.10.0
       DUB_VERSION:                 v1.9.0
 


### PR DESCRIPTION
I.e., #2629.