### PR TITLE
Replace predefined versions WebAssembly{32,64} by general WebAssembly

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -742,10 +742,8 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
     break;
   case llvm::Triple::wasm32:
-    VersionCondition::addPredefinedGlobalIdent("WebAssembly32");
-    break;
   case llvm::Triple::wasm64:
-    VersionCondition::addPredefinedGlobalIdent("WebAssembly64");
+    VersionCondition::addPredefinedGlobalIdent("WebAssembly");
     break;
   default:
     warning(Loc(), "unknown target CPU architecture: %s",


### PR DESCRIPTION
As that (+ `D_LP64` for wasm64) is what DMD does, according to Petar (https://github.com/ldc-developers/ldc/issues/2144#issuecomment-335181401).