### PR TITLE
CMake: Fix issue #2784 (build as Xcode project)

### DIFF
--- a/runtime/jit-rt/DefineBuildJitRT.cmake
+++ b/runtime/jit-rt/DefineBuildJitRT.cmake
@@ -67,6 +67,7 @@ if(LDC_DYNAMIC_COMPILE)
             "${ld_flags} ${JITRT_EXTRA_LDFLAGS}"
             ON
         )
+        set_target_properties(ldc-jit-rt-so${target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
 
         target_link_libraries(ldc-jit-rt-so${target_suffix} ${JITRT_LLVM_LIBS})
 


### PR DESCRIPTION
Purely speculative - use CXX instead of C as linker language for the jit-rt DLL.