### PR TITLE
CMake: Don't include the runtime CMake config if no stdlib source available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,6 @@ commonSteps: &commonSteps
           pip install --user lit
     - checkout
     - run:
-        name: Checkout git submodules
-        command: git submodule update --init
-    - run:
         name: Install LDC-flavoured LLVM
         command: |
           cd ..
@@ -76,9 +73,21 @@ commonSteps: &commonSteps
           HOST_LDMD=$PWD/ldc2-$HOST_LDC_VERSION/bin/ldmd2
           mkdir bootstrap
           cd bootstrap
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DBUILD_SHARED_LIBS=OFF -DD_COMPILER=$HOST_LDMD $BOOTSTRAP_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DD_COMPILER=$HOST_LDMD $BOOTSTRAP_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
           ninja -j3
           bin/ldc2 -version
+          cd ..
+    - run:
+        name: Checkout git submodules
+        command: git submodule update --init
+    - run:
+        name: Build bootstrap stdlib
+        command: |
+          cd ..
+          HOST_LDMD=$PWD/ldc2-$HOST_LDC_VERSION/bin/ldmd2
+          cd bootstrap
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DBUILD_SHARED_LIBS=OFF -DD_COMPILER=$HOST_LDMD $BOOTSTRAP_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
+          ninja -j3
           cd ..
     - run:
         name: Build LDC and stdlib unittest runners

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,13 +904,18 @@ add_test(NAME build-ldc2-unittest COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BIN
 add_test(NAME ldc2-unittest COMMAND ${LDC_UNITTEST_EXE_FULL} --version)
 set_tests_properties(ldc2-unittest PROPERTIES DEPENDS build-ldc2-unittest)
 
-add_subdirectory(runtime)
+if(EXISTS "${PROJECT_SOURCE_DIR}/runtime/druntime/src/object.d")
+    add_subdirectory(runtime)
+else()
+    message(STATUS "Runtime file runtime/druntime/src/object.d not found, will build ldc binaries but not the standard library.")
+endif()
 if(D_VERSION EQUAL 2)
     add_subdirectory(tests/d2)
 endif()
 add_subdirectory(tests)
 
 # ldc-build-runtime tool
+configure_file(${PROJECT_SOURCE_DIR}/runtime/ldc-build-runtime.d.in ${PROJECT_BINARY_DIR}/ldc-build-runtime.d @ONLY)
 set(LDC_BUILD_RUNTIME_EXE_FULL ${PROJECT_BINARY_DIR}/bin/ldc-build-runtime${CMAKE_EXECUTABLE_SUFFIX})
 build_d_executable(
     "${LDC_BUILD_RUNTIME_EXE_FULL}"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -274,7 +274,6 @@ if(LDC_EXE)
     endif()
     configure_file(${PROJECT_PARENT_DIR}/${CONFIG_NAME}.conf.in ${PROJECT_BINARY_DIR}/../bin/${LDC_EXE}.conf @ONLY)
     configure_file(${PROJECT_PARENT_DIR}/${LDC_EXE}_install.conf.in ${PROJECT_BINARY_DIR}/../bin/${LDC_EXE}_install.conf @ONLY)
-    configure_file(${PROJECT_SOURCE_DIR}/ldc-build-runtime.d.in ${PROJECT_BINARY_DIR}/../ldc-build-runtime.d @ONLY)
 endif()
 
 #


### PR DESCRIPTION
This should allow [removing this line from CI, ie downloading the stdlib for no reason and wasting bandwidth](https://github.com/dlang/ci/pull/228/files#diff-e6bd4021b60e04e45022336bda968fdeR206), and could make building ldc easier for `betterC` users.

Tested on linux/x64 with Make and Ninja from a ldc git checkout without the submodules and with the ~`ldc2`~`all` target, ~other targets like `ldc-build-runtime` won't work~.