### PR TITLE
No context ptr for nested non-extern(D) functions

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1813,11 +1813,11 @@ FuncDeclaration *getParentFunc(Dsymbol *sym) {
     return nullptr;
   }
 
-  // Static functions and function (not delegate) literals don't allow
-  // access to a parent context, even if they are nested.
+  // Static/non-extern(D) functions and function (not delegate) literals don't
+  // allow access to a parent context, even if they are nested.
   if (FuncDeclaration *fd = sym->isFuncDeclaration()) {
     bool certainlyNewRoot =
-        fd->isStatic() ||
+        fd->isStatic() || fd->linkage != LINKd ||
         (fd->isFuncLiteralDeclaration() &&
          static_cast<FuncLiteralDeclaration *>(fd)->tok == TOKfunction);
     if (certainlyNewRoot) {

--- a/tests/compilable/gh2808.d
+++ b/tests/compilable/gh2808.d
@@ -1,0 +1,12 @@
+// RUN: %ldc -c %s
+
+void foo()
+{
+    extern(C) void DoubleArrayToAnyArray(void* arg0)
+    {
+        auto dg = () => { auto r = arg0; };
+    }
+    auto local = 123;
+    auto arg = () { return local; }();
+    DoubleArrayToAnyArray(null);
+}


### PR DESCRIPTION
Fixes issue #2808.