### PR TITLE
Omit CPU type from man page

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -112,7 +112,9 @@ void printVersion(llvm::raw_ostream &OS) {
 #endif
   OS << "  Default target: " << llvm::sys::getDefaultTargetTriple() << "\n";
   std::string CPU = llvm::sys::getHostCPUName();
-  if (CPU == "generic") {
+  if (CPU == "generic" || getenv("SOURCE_DATE_EPOCH")) {
+    // SOURCE_DATE_EPOCH indicates that a reproducible build is wanted
+    // so we omit build system CPU type from man page
     CPU = "(unknown)";
   }
   OS << "  Host CPU: " << CPU << "\n";

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -113,8 +113,9 @@ void printVersion(llvm::raw_ostream &OS) {
   OS << "  Default target: " << llvm::sys::getDefaultTargetTriple() << "\n";
   std::string CPU = llvm::sys::getHostCPUName();
   if (CPU == "generic" || getenv("SOURCE_DATE_EPOCH")) {
-    // SOURCE_DATE_EPOCH indicates that a reproducible build is wanted
-    // so we omit build system CPU type from man page
+    // Env variable SOURCE_DATE_EPOCH indicates that a reproducible build is
+    // wanted. Don't print the actual host CPU in such an environment to aid
+    // in man page generation etc.
     CPU = "(unknown)";
   }
   OS << "  Host CPU: " << CPU << "\n";


### PR DESCRIPTION
When a reproducible build is wanted,
we should not add the build CPU type to man pages like ldmd2.1

See https://reproducible-builds.org/ for why this is matters.

The specification for SOURCE_DATE_EPOCH is at
https://reproducible-builds.org/specs/source-date-epoch/
and everyone doing reproducible builds, sets it.