### PR TITLE
AArch64: Fix C++ mangling of va_list & apply ltsmaster's IndirectByvalRewrite fix

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -75,10 +75,10 @@ build:
     - ctest --output-on-failure -R ldc2-unittest
     # Run LIT testsuite
     - ctest -V -R lit-tests || true
-    # Run DMD testsuite
-    - DMD_TESTSUITE_MAKE_ARGS='-j16 -k' ctest -V -R dmd-testsuite || true
-    # Run druntime/Phobos unittests
-    - ctest -j16 --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" || true
+    # Run DMD testsuite (non-debug only for now)
+    - DMD_TESTSUITE_MAKE_ARGS='-j16 -k' ctest -V -R dmd-testsuite -E "-debug$" || true
+    # Run druntime/Phobos unittests (non-debug only for now)
+    - ctest -j16 --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests|-debug(-shared)?$" || true
 
 integrations:
   notifications:

--- a/shippable.yml
+++ b/shippable.yml
@@ -30,20 +30,33 @@ build:
     - git checkout -b _backup
     - git checkout ltsmaster
     - git submodule update
-    - mkdir build-bootstrap
-    - cd build-bootstrap
+    - mkdir build-ltsmaster
+    - cd build-ltsmaster
     - |
       cmake -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ROOT_DIR=$PWD/../llvm \
-        -DCMAKE_INSTALL_PREFIX=$PWD/../bootstrap \
+        -DCMAKE_INSTALL_PREFIX=$PWD/../ldc-ltsmaster \
         ..
     - ninja install
     - cd ..
-    - bootstrap/bin/ldc2 --version
-    # Build actual version
+    - ldc-ltsmaster/bin/ldc2 --version
+    # Build actual version, for another bootstrapping step
     - git checkout _backup
     - git submodule update
+    - mkdir build-bootstrap
+    - cd build-bootstrap
+    - |
+      cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DLLVM_ROOT_DIR=$PWD/../llvm \
+        -DCMAKE_INSTALL_PREFIX=$PWD/../ldc-bootstrap \
+        -DD_COMPILER=$PWD/../ldc-ltsmaster/bin/ldmd2 \
+        ..
+    - ninja install
+    - cd ..
+    - ldc-bootstrap/bin/ldc2 --version
+    # Build with itself
     - mkdir build
     - cd build
     - |
@@ -52,7 +65,7 @@ build:
         -DLLVM_ROOT_DIR=$PWD/../llvm \
         -DLDC_INSTALL_LTOPLUGIN=ON \
         -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
-        -DD_COMPILER=$PWD/../bootstrap/bin/ldmd2 \
+        -DD_COMPILER=$PWD/../ldc-bootstrap/bin/ldmd2 \
         ..
     - ninja
     - bin/ldc2 --version

--- a/shippable.yml
+++ b/shippable.yml
@@ -48,11 +48,21 @@ build:
     - cd build
     - |
       cmake -G Ninja \
-        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DLLVM_ROOT_DIR=$PWD/../llvm \
         -DLDC_INSTALL_LTOPLUGIN=ON \
         -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
         -DD_COMPILER=$PWD/../bootstrap/bin/ldmd2 \
         ..
-    - ninja ldc2
+    - ninja
     - bin/ldc2 --version
+    # Build druntime/Phobos unittest runners
+    - ninja -j16 all-test-runners
+    # Build and run LDC D unittests
+    - ctest --output-on-failure -R ldc2-unittest
+    # Run LIT testsuite
+    - ctest -V -R lit-tests || true
+    # Run druntime/Phobos unittests
+    - ctest -j16 --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" || true
+    # Run DMD testsuite
+    - DMD_TESTSUITE_MAKE_ARGS='-j16 -k' ctest -V -R dmd-testsuite || true

--- a/shippable.yml
+++ b/shippable.yml
@@ -75,7 +75,16 @@ build:
     - ctest --output-on-failure -R ldc2-unittest
     # Run LIT testsuite
     - ctest -V -R lit-tests || true
-    # Run druntime/Phobos unittests
-    - ctest -j16 --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" || true
     # Run DMD testsuite
     - DMD_TESTSUITE_MAKE_ARGS='-j16 -k' ctest -V -R dmd-testsuite || true
+    # Run druntime/Phobos unittests
+    - ctest -j16 --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" || true
+
+integrations:
+  notifications:
+    - integrationName: email
+      type: email
+      on_success: never
+      on_failure: never
+      on_cancel: never
+      on_pull_request: never


### PR DESCRIPTION
C++ va_list is mangled as `std::__va_list` struct. According to clang IR, it's special in the sense of not ever being passed by value.

Let's do the same and pass a pointer while at the same time mangling the function as taking the arg by value.