### PR TITLE
[ltsmaster] Backport LLVM 7 adaptations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,26 @@ commonSteps: &commonSteps
     - run:
         name: Run DMD testsuite
         when: always
-        command: cd ../ninja-ldc && DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R dmd-testsuite
+        command: |
+          cd ../ninja-ldc
+          if [ "$CI_OS" = "linux" ]; then
+            # runnable/{sdtor,variadic} fail, see https://github.com/ldc-developers/ldc/pull/2825#issuecomment-415527889
+            rm ../project/tests/d2/dmd-testsuite/runnable/{sdtor,variadic}.d
+          fi
+          DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R dmd-testsuite
+          cd ..
     - run:
         name: Run stdlib unittests
         when: always
-        command: cd ../ninja-ldc && ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
+        command: |
+          cd ../ninja-ldc
+          if [ "$CI_OS" = "osx" ]; then
+            # 32-bit std.process unittests fail; exclude for now
+            ctest -j3 --output-on-failure -E "std\.process.*-32|dmd-testsuite|lit-tests"
+          else
+            ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
+          fi
+          cd ..
     - run:
         name: Install LDC
         command: |
@@ -118,15 +133,6 @@ commonSteps: &commonSteps
           fi
           ./build.sh
           cp bin/dub $LDC_INSTALL_DIR/bin
-          cd ..
-    - run:
-        name: Build dlang tools
-        command: |
-          cd ..
-          git clone --recursive https://github.com/dlang/tools.git
-          cd tools
-          make -f posix.mak install DMD=$LDC_INSTALL_DIR/bin/ldmd2 INSTALL_DIR=$PWD
-          cp bin/{rdmd,ddemangle,dustmite} $LDC_INSTALL_DIR/bin
           cd ..
     - run:
         name: Pack installation dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,68 +1,214 @@
+commonSteps: &commonSteps
+  steps:
+    # Each step starts in working dir `<root>/project` (containing the cloned LDC repo).
+    - run:
+        name: Install dependencies
+        command: |
+          cd ..
+          if [ "$CI_OS" = "linux" ]; then
+            export DEBIAN_FRONTEND=noninteractive
+            dpkg --add-architecture i386
+            apt-get -q update
+            apt-get -yq install software-properties-common
+            add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            apt-get -q update
+            apt-get -yq install curl git-core g++-6-multilib ninja-build gdb python-pip unzip zip libconfig-dev libcurl4-openssl-dev libcurl3:i386
+            echo "export CC=gcc-6" >> $BASH_ENV
+            echo "export CXX=g++-6" >> $BASH_ENV
+            # install CMake
+            curl -L -o cmake-x64.tar.gz https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz
+            mkdir cmake-x64
+            tar -xf cmake-x64.tar.gz --strip 1 -C cmake-x64
+            echo "export PATH=$PWD/cmake-x64/bin:$PATH" >> $BASH_ENV
+            # use ld.gold per default, so that LTO is tested
+            update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 99
+          else
+            # install libconfig
+            brew install libconfig
+            # install CMake
+            curl -L -o cmake-x64.tar.gz https://cmake.org/files/v3.10/cmake-3.10.0-Darwin-x86_64.tar.gz
+            mkdir cmake-x64
+            tar -xf cmake-x64.tar.gz --strip 3 -C cmake-x64
+            # install Ninja
+            curl -OL https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
+            mkdir ninja
+            tar -xf ninja-mac.zip -C ninja
+            echo "export PATH=$PWD/cmake-x64/bin:$PWD/ninja:$PATH" >> $BASH_ENV
+            # install Python pip
+            curl -OL https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py
+          fi
+          # install lit
+          pip install --user lit
+    - checkout
+    - run:
+        name: Install LDC-flavoured LLVM
+        command: |
+          cd ..
+          mkdir llvm-$LLVM_VERSION
+          assertsSuffix=""
+          if [ -z "$CIRCLE_TAG" ]; then
+            echo "Using LLVM with enabled assertions"
+            assertsSuffix="-withAsserts"
+          fi
+          curl -L -o llvm.tar.xz https://github.com/ldc-developers/llvm/releases/download/ldc-v$LLVM_VERSION/llvm-$LLVM_VERSION-$CI_OS-x86_64$assertsSuffix.tar.xz
+          tar -xf llvm.tar.xz --strip 1 -C llvm-$LLVM_VERSION
+          rm llvm.tar.xz
+    - run:
+        name: Checkout git submodules
+        command: git submodule update --init
+    - run:
+        name: Build LDC
+        command: |
+          cd ..
+          LDC_INSTALL_DIR=$PWD/ldc2-x64
+          mkdir ninja-ldc
+          cd ninja-ldc
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION -DCMAKE_INSTALL_PREFIX=$LDC_INSTALL_DIR -DINCLUDE_INSTALL_DIR=$LDC_INSTALL_DIR/import $EXTRA_CMAKE_FLAGS $CIRCLE_WORKING_DIRECTORY
+          ninja -j3
+          bin/ldc2 -version
+          cd ..
+    - run:
+        name: Build stdlib unittests
+        when: always
+        command: |
+          cd ../ninja-ldc
+          ninja -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest phobos2-ldc-unittest-debug-32 phobos2-ldc-unittest-32
+          ninja -j3 druntime-ldc-unittest-debug druntime-ldc-unittest druntime-ldc-unittest-debug-32 druntime-ldc-unittest-32
+          cd ..
+    - run:
+        name: Run LIT testsuite
+        when: always
+        command: cd ../ninja-ldc && ctest -V -R lit-tests
+    - run:
+        name: Run DMD testsuite
+        when: always
+        command: cd ../ninja-ldc && DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R dmd-testsuite
+    - run:
+        name: Run stdlib unittests
+        when: always
+        command: cd ../ninja-ldc && ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests"
+    - run:
+        name: Install LDC
+        command: |
+          cd ../ninja-ldc
+          ninja install
+          cd ..
+          LDC_INSTALL_DIR=$PWD/ldc2-x64
+          perl -pi -e s?$LDC_INSTALL_DIR/?%%ldcbinarypath%%/../?g $LDC_INSTALL_DIR/etc/ldc2.conf
+          cp project/LICENSE $LDC_INSTALL_DIR
+          git clone https://github.com/ldc-developers/ldc-scripts.git
+          cp ldc-scripts/ldc2-packaging/pkgfiles/README $LDC_INSTALL_DIR
+          # Now rename the installation dir to test portability.
+          NEW_LDC_INSTALL_DIR=$PWD/ldc2-install
+          mv $LDC_INSTALL_DIR $NEW_LDC_INSTALL_DIR
+          echo "export LDC_INSTALL_DIR=$NEW_LDC_INSTALL_DIR" >> $BASH_ENV
+    - run:
+        name: Build dub
+        command: |
+          cd ..
+          export DMD=$LDC_INSTALL_DIR/bin/ldmd2
+          git clone --recursive https://github.com/dlang/dub.git
+          cd dub
+          git checkout $DUB_VERSION
+          if [ -z "$CIRCLE_TAG" ]; then
+            # FIXME: dub is built with `-g -O`, which leads to issue #2361 with enabled
+            # assertions, at least on Linux. So strip `-g` for untagged builds.
+            perl -pi -e "s? -g -O ? -O ?g" build.sh
+          fi
+          ./build.sh
+          cp bin/dub $LDC_INSTALL_DIR/bin
+          cd ..
+    - run:
+        name: Build dlang tools
+        command: |
+          cd ..
+          git clone --recursive https://github.com/dlang/tools.git
+          cd tools
+          make -f posix.mak install DMD=$LDC_INSTALL_DIR/bin/ldmd2 INSTALL_DIR=$PWD
+          cp bin/{rdmd,ddemangle,dustmite} $LDC_INSTALL_DIR/bin
+          cd ..
+    - run:
+        name: Pack installation dir
+        command: |
+          cd ..
+          mkdir artifacts
+          if [ -z "$CIRCLE_TAG" ]; then
+            artifactBasename="ldc2-${CIRCLE_SHA1:0:8}-$CI_OS-x86_64-$(date "+%Y%m%d")"
+          else
+            artifactBasename="ldc2-${CIRCLE_TAG:1}-$CI_OS-x86_64"
+          fi
+          mv $LDC_INSTALL_DIR $artifactBasename
+          XZ_OPT=-9 tar -cJf artifacts/$artifactBasename.tar.xz $artifactBasename
+    - run:
+        name: Pack source dir
+        command: |
+          cd ..
+          if [ "$CI_OS" = "linux" ]; then
+            if [ -z "$CIRCLE_TAG" ]; then
+              artifactBasename="ldc-${CIRCLE_SHA1:0:8}-src"
+            else
+              artifactBasename="ldc-${CIRCLE_TAG:1}-src"
+            fi
+            GZIP=-9 tar -czf artifacts/$artifactBasename.tar.gz --exclude-vcs --transform=s/project/$artifactBasename/ project
+            tar -xf artifacts/$artifactBasename.tar.gz
+            zip -r -9 artifacts/$artifactBasename.zip $artifactBasename
+          fi
+    - store_artifacts:
+        path: ../artifacts
+    - run:
+        name: Deploy to GitHub release if tagged
+        command: |
+          cd ..
+          if [[ -n "$CIRCLE_TAG" ]]; then
+            if [ "$CI_OS" = "linux" ]; then
+              curl -L -o github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2
+            else
+              curl -L -o github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.7.2/darwin-amd64-github-release.tar.bz2
+            fi
+            tar -xf github-release.tar.bz2 --strip 3
+            cd artifacts
+            # Note: needs GITHUB_TOKEN environment variable
+            ../github-release upload --user ldc-developers --repo ldc --tag ${CIRCLE_TAG:-CI} --name "$(ls ldc2-*.tar.xz)" --file ldc2-*.tar.xz
+            if [[ -n "$CIRCLE_TAG" && "$CI_OS" = "linux" ]]; then
+              ../github-release upload --user ldc-developers --repo ldc --tag $CIRCLE_TAG --name "$(ls ldc-*-src.tar.gz)" --file ldc-*-src.tar.gz
+              ../github-release upload --user ldc-developers --repo ldc --tag $CIRCLE_TAG --name "$(ls ldc-*-src.zip)" --file ldc-*-src.zip
+            fi
+          fi
+
 version: 2
 jobs:
-  build:
+  build-linux:
+    <<: *commonSteps
     docker:
-      - image: gcc
+      - image: ubuntu:14.04
     environment:
-      - LLVM_VERSION: 5.0.0
-    steps:
-      - checkout
-      - run:
-          name: Checkout git submodules
-          command: git submodule update --init
-      - run:
-          name: Install basic dependencies
-          command: |
-            apt update
-            apt install -y software-properties-common cmake ninja-build libconfig++8-dev gdb python-pip unzip
-            pip install --user lit
-            g++ --version
-            ld --version
-            cmake --version
-            ninja --version
-            gdb --version
-            python -c "import lit; lit.main();" --version | head -n 1
-      - restore_cache:
-          keys:
-            - llvm-5.0.0
-      - run:
-          name: Install LLVM 5.0.0
-          command: |
-            if [[ ! -d llvm-$LLVM_VERSION ]]; then
-              wget -O llvm-$LLVM_VERSION.tar.xz http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-linux-x86_64-ubuntu16.04.tar.xz
-              mkdir llvm-$LLVM_VERSION
-              tar -xpf llvm-$LLVM_VERSION.tar.xz --strip 1 -C llvm-$LLVM_VERSION
-            fi
-      - save_cache:
-          key: llvm-5.0.0
-          paths:
-            - llvm-5.0.0
-      - run:
-          name: Build LDC
-          command: |
-            mkdir build
-            cd build
-            cmake -G Ninja -DLLVM_ROOT_DIR=$PWD/../llvm-$LLVM_VERSION ..
-            ninja -j3
-            bin/ldc2 -version
-            cd ..
-      - run:
-          name: Build stdlib unittests
-          command: |
-            cd build
-            ninja -j2 phobos2-ldc-unittest-debug phobos2-ldc-unittest
-            ninja -j3 druntime-ldc-unittest-debug druntime-ldc-unittest
-            cd ..
-          when: always
-      - run:
-          name: Run LIT testsuite
-          command: cd build && ctest -V -R llvm-ir-testsuite
-          when: always
-      - run:
-          name: Run DMD testsuite
-          command: cd build && DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R dmd-testsuite
-          when: always
-      - run:
-          name: Run stdlib unittests
-          command: cd build && ctest -j3 --output-on-failure -E "dmd-testsuite|llvm-ir-testsuite"
-          when: always
+      - CI_OS: linux
+      - LLVM_VERSION: 6.0.1-3
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++"
+      - DUB_VERSION: v1.9.0
+  build-osx:
+    <<: *commonSteps
+    macos:
+      xcode: "9.2.0"
+    environment:
+      - CI_OS: osx
+      - MACOSX_DEPLOYMENT_TARGET: 10.8
+      - USE_LIBCPP: true
+      - LLVM_VERSION: 6.0.1-3
+      - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_FLAGS='-stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS=-lc++"
+      - DUB_VERSION: v1.9.0
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-linux:
+          # This is required to also trigger the job after pushing a tag.
+          filters:
+            tags:
+              only: /.*/
+      - build-osx:
+          filters:
+            tags:
+              only: /.*/

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -129,8 +129,19 @@ char *concat(const char *a, int b) {
  * Runs the given executable, returning its error code.
  */
 int execute(const std::string &exePath, const char **args) {
+#if LDC_LLVM_VER >= 700
+  std::vector<llvm::StringRef> argv;
+  for (auto pArg = args; *pArg; ++pArg) {
+    argv.push_back(*pArg);
+  }
+  auto envVars = llvm::None;
+#else
+  auto argv = args;
+  auto envVars = nullptr;
+#endif
+
   std::string errorMsg;
-  int rc = ls::ExecuteAndWait(exePath, args, nullptr,
+  int rc = ls::ExecuteAndWait(exePath, argv, envVars,
 #if LDC_LLVM_VER >= 600
                               {},
 #else

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -94,6 +94,9 @@ static void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
 #else
                                  fout,
 #endif
+#if LDC_LLVM_VER >= 700
+                                 nullptr, // DWO output file
+#endif
                                  fileType, codeGenOptLevel())) {
     llvm_unreachable("no support for asm output");
   }
@@ -376,7 +379,13 @@ void writeModule(llvm::Module *m, std::string filename) {
             ERRORINFO_STRING(errinfo));
       fatal();
     }
-    llvm::WriteBitcodeToFile(m, bos);
+    llvm::WriteBitcodeToFile(
+#if LDC_LLVM_VER >= 700
+        *m,
+#else
+        m,
+#endif
+        bos);
   }
 
   // write LLVM IR

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -17,6 +17,9 @@
 #include "gen/attributes.h"
 
 #define DEBUG_TYPE "dgc2stack"
+#if LDC_LLVM_VER >= 700
+#define DEBUG LLVM_DEBUG
+#endif
 
 #include "Passes.h"
 

--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -15,6 +15,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "simplify-drtcalls"
+#if LDC_LLVM_VER >= 700
+#define DEBUG LLVM_DEBUG
+#endif
 
 #include "Passes.h"
 #include "llvm/Pass.h"
@@ -103,8 +106,13 @@ Value *LibCallOptimization::CastToCStr(Value *V, IRBuilder<> &B) {
 /// expects that the size has type 'intptr_t' and Dst/Src are pointers.
 Value *LibCallOptimization::EmitMemCpy(Value *Dst, Value *Src, Value *Len,
                                        unsigned Align, IRBuilder<> &B) {
+#if LDC_LLVM_VER >= 700
+  return B.CreateMemCpy(CastToCStr(Dst, B), Align, CastToCStr(Src, B), Align,
+                        Len, false);
+#else
   return B.CreateMemCpy(CastToCStr(Dst, B), CastToCStr(Src, B), Len, Align,
                         false);
+#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/gen/passes/StripExternals.cpp
+++ b/gen/passes/StripExternals.cpp
@@ -16,6 +16,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "strip-externals"
+#if LDC_LLVM_VER >= 700
+#define DEBUG LLVM_DEBUG
+#endif
 
 #include "Passes.h"
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -361,7 +361,11 @@ void DtoMemCpy(LLValue *dst, LLValue *src, LLValue *nbytes, unsigned align) {
   dst = DtoBitCast(dst, VoidPtrTy);
   src = DtoBitCast(src, VoidPtrTy);
 
+#if LDC_LLVM_VER >= 700
+  gIR->ir->CreateMemCpy(dst, align, src, align, nbytes, false /*isVolatile*/);
+#else
   gIR->ir->CreateMemCpy(dst, src, nbytes, align, false /*isVolatile*/);
+#endif
 }
 
 void DtoMemCpy(LLValue *dst, LLValue *src, bool withPadding, unsigned align) {

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BUILD_SHARED_LIBS     OFF                                       CACHE BOOL  
 set(D_FLAGS               -w                                        CACHE STRING  "Runtime build flags, separated by ;")
 set(D_FLAGS_DEBUG         -g;-link-debuglib                         CACHE STRING  "Runtime build flags (debug libraries), separated by ;")
 set(D_FLAGS_RELEASE       -O3;-release                              CACHE STRING  "Runtime build flags (release libraries), separated by ;")
+set(RT_CFLAGS             ""                                        CACHE STRING  "Runtime extra C compiler flags, separated by ' '")
 if(MSVC)
     set(LINK_WITH_MSVCRT  ON                                        CACHE BOOL    "Link with MSVCRT.lib (DLL) instead of LIBCMT.lib (static)")
 endif()
@@ -519,8 +520,6 @@ endmacro()
 #
 # Set up build targets.
 #
-
-set(RT_CFLAGS "")
 
 # This is a bit of a mess as we need to join the two libraries together on
 # OS X before installing them. After this has run, LIBS_TO_INSTALL contains

--- a/utils/not.cpp
+++ b/utils/not.cpp
@@ -43,12 +43,23 @@ int main(int argc, const char **argv) {
   }
 #endif
 
+#if LDC_LLVM_VER >= 700
+  std::vector<StringRef> Argv;
+  Argv.reserve(argc);
+  for (int i = 0; i < argc; ++i)
+    Argv.push_back(argv[i]);
+  auto Env = llvm::None;
+#else
+  auto Argv = argv;
+  auto Env = nullptr;
+#endif
+
   std::string ErrMsg;
 #if LDC_LLVM_VER <= 305
-  int Result = sys::ExecuteAndWait(Program, argv, nullptr, nullptr, 0, 0,
+  int Result = sys::ExecuteAndWait(Program, Argv, Env, nullptr, 0, 0,
                                    &ErrMsg);
 #else
-  int Result = sys::ExecuteAndWait(*Program, argv, nullptr,
+  int Result = sys::ExecuteAndWait(*Program, Argv, Env,
 #if LDC_LLVM_VER >= 600
                                    {},
 #else


### PR DESCRIPTION
Tested with current LLVM branch `release_70` on Ubuntu x86_64. Builds fine; default libs too except for an assertion when compiling druntime's `ldc.arrayinit` (not sure if that's related or simply untested by CI):
```
ldc2: /home/martin/llvm/include/llvm/Support/Casting.h:255: typename llvm::cast_retty<X, Y*>::ret_type llvm::cast(Y*) [with X = llvm::Function; Y = llvm::Constant; typename llvm::cast_retty<X, Y*>::ret_type = llvm::Function*]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
#8 0x00005597f2cb2c5a (bin/ldc2+0x215fc5a)
#9 0x00005597f2cba9b7 llvm::IRBuilderBase::CreateMemCpy(llvm::Value*, unsigned int, llvm::Value*, unsigned int, llvm::Value*, bool, llvm::MDNode*, llvm::MDNode*, llvm::MDNode*, llvm::MDNode*) (bin/ldc2+0x21679b7)
#10 0x00005597f13939b4 DtoMemCpy(llvm::Value*, llvm::Value*, llvm::Value*, unsigned int) /home/martin/ldc/gen/tollvm.cpp:369:0
#11 0x00005597f13ea30d DtoInitClass(TypeClass*, llvm::Value*) /home/martin/ldc/gen/classes.cpp:182:0
#12 0x00005597f13ea45f DtoNewClass(Loc&, TypeClass*, NewExp*) /home/martin/ldc/gen/classes.cpp:112:0
```