### PR TITLE
Debug info improvements (for GDB): printing global and imported symbols, non-member and member function calls

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -11,6 +11,7 @@
 #include "declaration.h"
 #include "enum.h"
 #include "id.h"
+#include "import.h"
 #include "init.h"
 #include "nspace.h"
 #include "rmem.h"
@@ -46,6 +47,15 @@ public:
   void visit(Dsymbol *sym) override {
     IF_LOG Logger::println("Ignoring Dsymbol::codegen for %s",
                            sym->toPrettyChars());
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+
+  void visit(Import *im) override {
+    IF_LOG Logger::println("Import::codegen for %s", im->toPrettyChars());
+    LOG_SCOPE
+
+    irs->DBuilder.EmitImport(im);
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -917,7 +917,7 @@ ldc::DISubprogram ldc::DIBuilder::EmitSubProgram(FuncDeclaration *fd) {
     name = fd->toPrettyChars(true);
   } else {
     scope = GetSymbolScope(fd);
-    name = fd->toChars();
+    name = fd->isMain() ? fd->toPrettyChars(true) : fd->toChars();
   }
 
   const auto linkageName = irFunc->getLLVMFuncName();

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -82,19 +82,6 @@ bool ldc::DIBuilder::mustEmitLocationsDebugInfo() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// get the module the symbol is in, or - for template instances - the current
-// module
-Module *ldc::DIBuilder::getDefinedModule(Dsymbol *s) {
-  // templates are defined in current module
-  if (DtoIsTemplateInstance(s)) {
-    return IR->dmodule;
-  }
-  // otherwise use the symbol's module
-  return s->getModule();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 ldc::DIBuilder::DIBuilder(IRState *const IR)
     : IR(IR), DBuilder(IR->module), CUNode(nullptr),
       isTargetMSVCx64(global.params.targetTriple->isWindowsMSVCEnvironment() &&

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -506,11 +506,10 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type) {
   LLType *T = DtoType(ad->type);
   if (t->ty == Tclass)
     T = T->getPointerElementType();
-  IrTypeAggr *ir = ad->type->ctype->isAggr();
-  assert(ir);
+  IrAggr *irAggr = getIrAggr(ad, true);
 
-  if (static_cast<llvm::MDNode *>(ir->diCompositeType) != nullptr) {
-    return ir->diCompositeType;
+  if (static_cast<llvm::MDNode *>(irAggr->diCompositeType) != nullptr) {
+    return irAggr->diCompositeType;
   }
 
   const llvm::StringRef name = ad->ident->toChars();
@@ -534,7 +533,7 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type) {
   // set diCompositeType to handle recursive types properly
   unsigned tag = (t->ty == Tstruct) ? llvm::dwarf::DW_TAG_structure_type
                                     : llvm::dwarf::DW_TAG_class_type;
-  ir->diCompositeType = DBuilder.createReplaceableCompositeType(
+  irAggr->diCompositeType = DBuilder.createReplaceableCompositeType(
       tag, name, scope, file, linnum);
 
   if (!ad->isInterfaceDeclaration()) // plain interfaces don't have one
@@ -602,9 +601,9 @@ ldc::DIType ldc::DIBuilder::CreateCompositeType(Type *type) {
                                     uniqueIdent(t)); // UniqueIdentifier
   }
 
-  ir->diCompositeType = DBuilder.replaceTemporary(
-      llvm::TempDINode(ir->diCompositeType), static_cast<llvm::DIType *>(ret));
-  ir->diCompositeType = ret;
+  irAggr->diCompositeType = DBuilder.replaceTemporary(
+      llvm::TempDINode(irAggr->diCompositeType), static_cast<llvm::DIType *>(ret));
+  irAggr->diCompositeType = ret;
 
   return ret;
 }

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -155,6 +155,7 @@ public:
 private:
   llvm::LLVMContext &getContext();
   Module *getDefinedModule(Dsymbol *s);
+  DIScope GetSymbolScope(Dsymbol *s);
   DIScope GetCurrentScope();
   void Declare(const Loc &loc, llvm::Value *storage, ldc::DILocalVariable divar,
                ldc::DIExpression diexpr);

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -158,7 +158,6 @@ public:
 
 private:
   llvm::LLVMContext &getContext();
-  Module *getDefinedModule(Dsymbol *s);
   DIScope GetSymbolScope(Dsymbol *s);
   DIScope GetCurrentScope();
   void Declare(const Loc &loc, llvm::Value *storage, ldc::DILocalVariable divar,

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -10,6 +10,7 @@
 #ifndef LDC_GEN_DIBUILDER_H
 #define LDC_GEN_DIBUILDER_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/DataLayout.h"
@@ -45,6 +46,7 @@ namespace ldc {
 
 // Define some basic types
 typedef llvm::DIType *DIType;
+typedef llvm::DICompositeType *DICompositeType;
 typedef llvm::DIFile *DIFile;
 typedef llvm::DIGlobalVariable *DIGlobalVariable;
 typedef llvm::DILocalVariable *DILocalVariable;
@@ -63,6 +65,8 @@ class DIBuilder {
   DICompileUnit CUNode;
 
   const bool isTargetMSVCx64;
+
+  llvm::DenseMap<Declaration*, llvm::TypedTrackingMDRef<llvm::MDNode>> StaticDataMemberCache;
 
   DICompileUnit GetCU() {
     return CUNode;
@@ -163,6 +167,8 @@ private:
                 ldc::DIExpression diexpr);
   void AddFields(AggregateDeclaration *sd, ldc::DIFile file,
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);
+  void AddStaticMembers(AggregateDeclaration *sd, ldc::DIFile file,
+                 llvm::SmallVector<llvm::Metadata *, 16> &elems);
   DIFile CreateFile(Loc &loc);
   DIFile CreateFile();
   DIFile CreateFile(Dsymbol* decl);
@@ -172,7 +178,8 @@ private:
   DIType CreateVectorType(Type *type);
   DIType CreateComplexType(Type *type);
   DIType CreateMemberType(unsigned linnum, Type *type, DIFile file,
-                          const char *c_name, unsigned offset, Prot::Kind);
+                          const char *c_name, unsigned offset, Prot::Kind,
+                          bool isStatic = false, DIScope scope = nullptr);
   DIType CreateCompositeType(Type *type);
   DIType CreateArrayType(Type *type);
   DIType CreateSArrayType(Type *type);
@@ -181,6 +188,7 @@ private:
   DISubroutineType CreateEmptyFunctionType();
   DIType CreateDelegateType(Type *type);
   DIType CreateTypeDescription(Type *type);
+  DICompositeType CreateCompositeTypeDescription(Type *type);
 
   bool mustEmitFullDebugInfo();
   bool mustEmitLocationsDebugInfo();

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -64,6 +64,7 @@ class DIBuilder {
 
   DICompileUnit CUNode;
 
+  const bool isTargetMSVC;
   const bool isTargetMSVCx64;
 
   llvm::DenseMap<Declaration*, llvm::TypedTrackingMDRef<llvm::MDNode>> StaticDataMemberCache;

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -24,6 +24,7 @@ struct IRState;
 class ClassDeclaration;
 class Dsymbol;
 class FuncDeclaration;
+class Import;
 class Module;
 class Type;
 class VarDeclaration;
@@ -52,6 +53,7 @@ typedef llvm::DILexicalBlock *DILexicalBlock;
 typedef llvm::DIScope *DIScope;
 typedef llvm::DISubroutineType *DISubroutineType;
 typedef llvm::DISubprogram *DISubprogram;
+typedef llvm::DIModule *DIModule;
 typedef llvm::DICompileUnit *DICompileUnit;
 
 class DIBuilder {
@@ -74,6 +76,14 @@ public:
   /// \brief Emit the Dwarf compile_unit global for a Module m.
   /// \param m        Module to emit as compile unit.
   void EmitCompileUnit(Module *m);
+
+  /// \brief Emit the Dwarf module global for a Module m.
+  /// \param m        Module to emit (either as definition or declaration).
+  DIModule EmitModule(Module *m);
+
+  /// \brief Emit the Dwarf imported entity and module global for an Import im.
+  /// \param im        Import to emit.
+  void EmitImport(Import *im);
 
   /// \brief Emit the Dwarf subprogram global for a function declaration fd.
   /// \param fd       Function declaration to emit as subprogram.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1000,7 +1000,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   };
 
   // debug info
-  irFunc->diSubprogram = gIR->DBuilder.EmitSubProgram(fd);
+  gIR->DBuilder.EmitSubProgram(fd);
 
   IF_LOG Logger::println("Doing function body for: %s", fd->toChars());
   gIR->funcGenStates.emplace_back(new FuncGenState(*irFunc, *gIR));

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -656,6 +656,8 @@ void codegenModule(IRState *irs, Module *m) {
   assert(!gIR && "gIR not null, codegen already in progress?!");
   gIR = irs;
 
+  irs->DBuilder.EmitModule(m);
+
   initRuntime();
 
   // Skip pseudo-modules for coverage analysis

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "import.h"
 #include "init.h"
 #include "mars.h"
 #include "module.h"
@@ -1590,7 +1591,10 @@ public:
   //////////////////////////////////////////////////////////////////////////
 
   void visit(ImportStatement *stmt) override {
-    // Empty.
+    for (auto s: *stmt->imports) {
+      assert(s->isImport());
+      irs->DBuilder.EmitImport(static_cast<Import*>(s));
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/ir/iraggr.h
+++ b/ir/iraggr.h
@@ -46,6 +46,10 @@ struct IrAggr {
   /// Aggregate D type.
   Type *type = nullptr;
 
+  /// Composite type debug description. This is not only to cache, but also
+  /// used for resolving forward references.
+  llvm::DIType *diCompositeType = nullptr;
+
   //////////////////////////////////////////////////////////////////////////
 
   // Returns the static default initializer of a field.

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -409,6 +409,7 @@ void IrAggr::defineInterfaceVtbl(BaseClass *b, bool new_instance,
       gIR->funcGenStates.emplace_back(new FuncGenState(*thunkFunc, *gIR));
 
       // debug info
+      thunkFunc->diSubprogram = nullptr;
       thunkFunc->diSubprogram = gIR->DBuilder.EmitThunk(thunk, thunkFd);
 
       // create entry and end blocks

--- a/ir/irmodule.h
+++ b/ir/irmodule.h
@@ -22,6 +22,7 @@ class Module;
 namespace llvm {
 class GlobalVariable;
 class Function;
+class DIModule;
 }
 
 struct IrModule {
@@ -43,6 +44,8 @@ struct IrModule {
   GatesList sharedGates;
   FuncDeclList unitTests;
   llvm::Function *coverageCtor = nullptr;
+
+  llvm::DIModule *diModule = nullptr;
 
 private:
   llvm::GlobalVariable *moduleInfoVar = nullptr;

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -67,10 +67,6 @@ public:
   void getMemberLocation(VarDeclaration *var, unsigned &fieldIndex,
                          unsigned &byteOffset) const;
 
-  /// Composite type debug description. This is not only to cache, but also
-  /// used for resolving forward references.
-  llvm::DIType *diCompositeType = nullptr;
-
   /// true, if the LLVM struct type for the aggregate is declared as packed
   bool packed = false;
 

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -71,7 +71,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr :
-// CHECK-SAME: args_cdb::main::__lambda
+// CHECK-SAME: args_cdb.main.__lambda
 
 // CDB: ?? slice
 // CHECK: struct int[]
@@ -139,7 +139,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr :
-// CHECK-SAME: args_cdb::main::__lambda
+// CHECK-SAME: args_cdb.main.__lambda
 // CDB: ?? *fun
 // CHECK: <function> *
 // CDB: ?? *slice
@@ -205,7 +205,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr : {{0x[0-9a-f`]*}}
-// CHECK-SAME: args_cdb::main::__lambda
+// CHECK-SAME: args_cdb.main.__lambda
 // CDB: ?? *fun
 // CHECK: <function> * {{0x[0-9a-f`]*}}
 // CDB: ?? *slice

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -29,7 +29,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
     // arguments implicitly passed by reference aren't shown if unused
     float cim = c.im + fa[7] + dg() + small.val + large.a;
     return 1;
-// CHECK: !args_cdb.byValue
+// CHECK: !args_cdb::byValue
 // CDB: dv /t
 
 // CHECK: unsigned char ub = 0x01
@@ -50,10 +50,10 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // x86: unsigned char [16] fa
 // x86: float [4] f4 = float [4]
 // x86: double [4] d4 = double [4]
-// CHECK: args_cdb.Small small
-// x64: args_cdb.Large * large
-// x86: args_cdb.Large large
-// CHECK: struct object.TypeInfo_Class * ti = {{0x[0-9a-f`]*}}
+// CHECK: args_cdb::Small small
+// x64: args_cdb::Large * large
+// x86: args_cdb::Large large
+// CHECK: struct object::TypeInfo_Class * ti = {{0x[0-9a-f`]*}}
 // CHECK: void * np = {{0x[0`]*}}
 
 // params emitted as locals (listed after params) for Win64:
@@ -71,7 +71,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr :
-// CHECK-SAME: args_cdb.main.__lambda
+// CHECK-SAME: args_cdb::main::__lambda
 
 // CDB: ?? slice
 // CHECK: struct int[]
@@ -90,17 +90,17 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK: double 17
 
 // CDB: ?? small
-// CHECK: args_cdb.Small
+// CHECK: args_cdb::Small
 // x64-NEXT: val : 0x12
 // no-x86-NEXT: val : 0x12 (displays garbage)
 
 // CDB: ?? large
-// CHECK: args_cdb.Large
+// CHECK: args_cdb::Large
 // x64-NEXT: a : 0x13
 // no-x86-NEXT: a : 0x13 (displays garbage)
 
 // CDB: ?? ti
-// CHECK: object.TypeInfo_Class
+// CHECK: object::TypeInfo_Class
 // CHECK-NEXT: m_init : byte[]
 }
 
@@ -115,7 +115,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CDB: bp `args_cdb.d:115`
 // CDB: g
     return 3;
-// CHECK: !args_cdb.byPtr
+// CHECK: !args_cdb::byPtr
 // CDB: dv /t
 // CDB: ?? *ub
 // CHECK: unsigned char 0x01
@@ -139,7 +139,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr :
-// CHECK-SAME: args_cdb.main.__lambda
+// CHECK-SAME: args_cdb::main::__lambda
 // CDB: ?? *fun
 // CHECK: <function> *
 // CDB: ?? *slice
@@ -156,14 +156,14 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CDB: ?? (*d4)[2]
 // CHECK: double 17
 // CDB: ?? *small
-// CHECK: struct args_cdb.Small
+// CHECK: struct args_cdb::Small
 // CHECK-NEXT: val : 0x12
 // CDB: ?? *large
-// CHECK: struct args_cdb.Large
+// CHECK: struct args_cdb::Large
 // CHECK-NEXT: a : 0x13
 // CHECK-NEXT: b :
 // CDB: ?? *ti
-// CHECK: struct object.TypeInfo_Class
+// CHECK: struct object::TypeInfo_Class
 // CHECK-NEXT: m_init : byte[]
 // CDB: ?? *np
 // CHECK: void * {{0x[0`]*}}
@@ -179,7 +179,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 {
 // CDB: bp `args_cdb.d:180`
 // CDB: g
-// CHECK: !args_cdb.byRef
+// CHECK: !args_cdb::byRef
 
 // CDB: dv /t
 // cdb displays references as pointers
@@ -205,7 +205,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 // CHECK: int delegate()
 // CHECK-NEXT: context :
 // CHECK-NEXT: funcptr : {{0x[0-9a-f`]*}}
-// CHECK-SAME: args_cdb.main.__lambda
+// CHECK-SAME: args_cdb::main::__lambda
 // CDB: ?? *fun
 // CHECK: <function> * {{0x[0-9a-f`]*}}
 // CDB: ?? *slice
@@ -221,14 +221,14 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 // CDB: ?? (*d4)[2]
 // CHECK: double 17
 // CDB: ?? *small
-// CHECK: struct args_cdb.Small
+// CHECK: struct args_cdb::Small
 // CHECK-NEXT: val : 0x12
 // CDB: ?? *large
-// CHECK: struct args_cdb.Large
+// CHECK: struct args_cdb::Large
 // CHECK-NEXT: a : 0x13
 // CHECK-NEXT: b :
 // CDB: ?? *ti
-// CHECK: struct object.TypeInfo_Class * {{0x[0-9a-f`]*}}
+// CHECK: struct object::TypeInfo_Class * {{0x[0-9a-f`]*}}
 // CHECK-NEXT: m_init : byte[]
 // CDB: ?? *np
 // no-CHECK: void * {{0x[0`]*}} (not available)

--- a/tests/debuginfo/baseclass_cdb.d
+++ b/tests/debuginfo/baseclass_cdb.d
@@ -26,11 +26,11 @@ int main(string[] args)
 // CDB: bp `baseclass_cdb.d:28`
 // CDB: g
     return 0;
-// CHECK: !D main
+// CHECK: !baseclass_cdb::main
 
 // CDB: ?? dc
 // cdb doesn't show base class info, but lists their members
-// CHECK: baseclass_cdb.DerivedClass
+// CHECK: baseclass_cdb::DerivedClass
 // CHECK: baseMember{{ *: *3}}
 // verify baseMember is not listed twice
 // CHECK-NEXT: derivedMember{{ *: *7}}

--- a/tests/debuginfo/baseclass_cdb.d
+++ b/tests/debuginfo/baseclass_cdb.d
@@ -26,7 +26,7 @@ int main(string[] args)
 // CDB: bp `baseclass_cdb.d:28`
 // CDB: g
     return 0;
-// CHECK: !baseclass_cdb::main
+// CHECK: !baseclass_cdb::D main
 
 // CDB: ?? dc
 // cdb doesn't show base class info, but lists their members

--- a/tests/debuginfo/basictypes_cdb.d
+++ b/tests/debuginfo/basictypes_cdb.d
@@ -42,7 +42,7 @@ int basic_types()
 // CDB: ld basictypes_cdb*
 // CDB: bp `basictypes_cdb.d:41`
 // CDB: g
-// CHECK: !basictypes_cdb.basic_types
+// CHECK: !basictypes_cdb::basic_types
 
 // enable case sensitive symbol lookup
 // CDB: .symopt-1

--- a/tests/debuginfo/inputs/import_a.d
+++ b/tests/debuginfo/inputs/import_a.d
@@ -1,0 +1,12 @@
+module inputs.import_a;
+
+static __gshared int a_Glob = 4213;
+
+struct a_sA
+{
+    static char statChar = 'B';
+}
+
+void bar() {
+    a_sA.statChar = 'C';
+}

--- a/tests/debuginfo/inputs/import_b.d
+++ b/tests/debuginfo/inputs/import_b.d
@@ -1,0 +1,10 @@
+module inputs.import_b;
+
+static __gshared float b_Glob = 55.22;
+
+enum b_eA { aaa = 9, zzz = 12 }
+
+class b_cA {
+ int n;
+ static __gshared int staticVal = 52;
+}

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -24,7 +24,7 @@ void encloser(int arg0, int arg1)
     }
 }
 
-// CHECK-LABEL: !DISubprogram(name:{{.*}}"nested"
+// CHECK-LABEL: !DISubprogram(name:{{.*}}nested"
 // CHECK: !DILocalVariable{{.*}}nes_i
 // CHECK: !DILocalVariable{{.*}}arg1
 // CHECK-NOT: arg:

--- a/tests/debuginfo/nested.d
+++ b/tests/debuginfo/nested.d
@@ -24,7 +24,7 @@ void encloser(int arg0, int arg1)
     }
 }
 
-// CHECK-LABEL: !DISubprogram(name:{{.*}}"{{.*}}encloser.nested"
+// CHECK-LABEL: !DISubprogram(name:{{.*}}"nested"
 // CHECK: !DILocalVariable{{.*}}nes_i
 // CHECK: !DILocalVariable{{.*}}arg1
 // CHECK-NOT: arg:

--- a/tests/debuginfo/nested_gdb.d
+++ b/tests/debuginfo/nested_gdb.d
@@ -4,11 +4,14 @@
 // RUN: gdb %t --batch -x %t.gdb >%t.out 2>&1
 // RUN: FileCheck %s -check-prefix=CHECK < %t.out
 
+// GDB: b _Dmain
+// GDB: r
+
 void encloser(int arg0, ref int arg1)
 {
     int enc_n = 123;
-// GDB: b 10
-// GDB: r
+// GDB: b 13
+// GDB: c
 // GDB: p arg0
 // CHECK: $1 = 1
 // GDB: p arg1
@@ -20,7 +23,7 @@ void encloser(int arg0, ref int arg1)
     void nested(int nes_i)
     {
         int blub = arg0 + arg1 + enc_n;
-// GDB: b 23
+// GDB: b 26
 // GDB: c
 // GDB: p arg0
 // CHECK: $4 = 1
@@ -29,7 +32,7 @@ void encloser(int arg0, ref int arg1)
 // GDB: p enc_n
 // CHECK: $6 = 125
         arg0 = arg1 = enc_n = nes_i;
-// GDB: b 32
+// GDB: b 35
 // GDB: c
 // GDB: p arg0
 // CHECK: $7 = 456
@@ -40,7 +43,7 @@ void encloser(int arg0, ref int arg1)
     }
 
     nested(456);
-// GDB: b 43
+// GDB: b 46
 // GDB: c
 // GDB: p arg0
 // no-CHECK: $10 = 456 (`<optimized out>` for LLVM < 5.0)

--- a/tests/debuginfo/print_gdb.d
+++ b/tests/debuginfo/print_gdb.d
@@ -1,0 +1,135 @@
+// REQUIRES: atleast_gdb80
+// RUN: %ldc %_gdb_dflags -I%S -g -of=%t %s %S/inputs/import_a.d %S/inputs/import_b.d
+// RUN: sed -e "/^\\/\\/ GDB:/!d" -e "s,// GDB:,," %s >%t.gdb
+// RUN: env LANG=C gdb %t --batch -x %t.gdb >%t.out 2>&1
+// RUN: FileCheck %s -check-prefix=CHECK < %t.out
+module print_gdb;
+
+import inputs.import_a;
+
+__gshared int globVal = 987;
+
+enum eA { ABC = 2, ZYX }
+
+struct sA
+{
+    static int someVal = 246;
+}
+
+struct sB
+{
+    uint k = 9;
+    uint memberFunc(uint a) { return k*k+a; }
+
+    static staticFunc(uint b) { return b * 2; }
+}
+
+class cC
+{
+    char c = '0';
+    char classMemberFunc(byte a) { return cast(char)(cast(byte)c+a); }
+
+    static classStaticFunc(byte b) { return cast(char)(cast(byte)'a' + b); }
+
+    mixin mix;
+}
+
+struct templatedStruct(T)
+{
+    T z;
+    T pal(T m) { return z * m; }
+}
+
+mixin template mix()
+{
+    uint mixedVal = 5;
+}
+
+double foo(double plus)
+{
+    return 42.13 + plus;
+}
+
+void main()
+{
+// GDB: b _Dmain
+// GDB: r
+
+    uint n = 5;
+    n = globVal; // reference every global symbol in main() to have them emitted
+    n = sA.someVal;
+    n = cast(int) a_sA.statChar;
+
+    foo(242.0);
+    bar();
+
+    // BP
+// GDB: b 66
+// GDB: c
+// GDB: p globVal
+// CHECK: = 987
+// GDB: p sA.someVal
+// CHECK: = 246
+// GDB: p a_sA.statChar
+// CHECK: = 67 'C'
+// GDB: p foo(0.12)
+// CHECK: = 42.25
+
+    sB strB;
+    strB.k = 12;
+    strB.k = strB.memberFunc(2);
+    strB.k = strB.staticFunc(3); // k = 6
+
+    eA e = eA.ZYX;
+
+    import inputs.import_b;
+    b_Glob = 99.88;
+    inputs.import_b.b_cA.staticVal = 78;
+
+    // BP
+// GDB: b 89
+// GDB: c
+// GDB: p strB
+// GDB: p strB.memberFunc(4)
+// CHECK: = 40
+// GDB: p sB.staticFunc(44)
+// CHECK: = 88
+// GDB: whatis eA
+// CHECK: type = print_gdb.eA
+// GDB: whatis print_gdb.eA
+// CHECK: type = print_gdb.eA
+// GDB: p b_Glob
+// CHECK: = 99.8
+
+    cC clsC = new cC;
+    clsC.classMemberFunc(2);
+    cC.classStaticFunc(4);
+    clsC.mixedVal++;
+
+        // BP
+// GDB: b 109
+// GDB: c
+// GDB: p *clsC
+// GDB: p clsC.classMemberFunc(6)
+// CHECK: = 54 '6'
+// GDB: p clsC.classStaticFunc(4)
+// CHECK: = 101 'e'
+// GDB: p clsC.mixedVal
+// CHECK: = 6
+
+//     class cD { static int staticVal = 741; }
+    // FIXME: GDB doesn't support access to nested type declarations yet
+
+    templatedStruct!int tsI;
+    templatedStruct!float tsF;
+
+    // BP
+// GDB: b 126
+// GDB: c
+// GDB: whatis tsF
+// CHECK: type = print_gdb.templatedStruct
+}
+
+// GDB: c
+// GDB: q
+// CHECK: exited normally

--- a/tests/debuginfo/strings_cdb.d
+++ b/tests/debuginfo/strings_cdb.d
@@ -20,7 +20,7 @@ int main(string[] args)
 // CDB: bp `strings_cdb.d:22`
 // CDB: g
     return 0;
-// CHECK: !strings_cdb::main
+// CHECK: !strings_cdb::D main
 
 // CDB: dt string
 // CHECK: !string

--- a/tests/debuginfo/strings_cdb.d
+++ b/tests/debuginfo/strings_cdb.d
@@ -20,7 +20,7 @@ int main(string[] args)
 // CDB: bp `strings_cdb.d:22`
 // CDB: g
     return 0;
-// CHECK: !D main
+// CHECK: !strings_cdb::main
 
 // CDB: dt string
 // CHECK: !string

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -183,4 +183,7 @@ if lit.util.which('gdb', config.environment['PATH']):
         gdb_version = m.group(1)
         if LooseVersion(gdb_version) < LooseVersion('7.8'):
             gdb_dflags = '-dwarf-version=2'
+        elif LooseVersion(gdb_version) >= LooseVersion('8.0'):
+            config.available_features.add('atleast_gdb80')
+
     config.substitutions.append( ('%_gdb_dflags', gdb_dflags) )


### PR DESCRIPTION
These commits bring LDC closer to GDC's DWARF output and Clang's IR output (regarding static variables and `this` parameters), and enables access to global/imported symbols and function calls (previously only non-member function calls worked, but only with the mangled name):

https://github.com/ldc-developers/ldc/blob/3d9aebc6677474261cc086dc8ee0bc154ce78a65/tests/debuginfo/print_gdb.d

Until recently I wrongly assumed that GDB's D support was incomplete and that calling functions with `print` or `call` wasn't implemented, then I tried GDC and it worked perfectly, @ibuclaw did an awesome job.

I don't know how this PR affects PDB/CodeView output. Last year symbol names got fully qualified: https://github.com/ldc-developers/ldc/pull/2362/commits/6e7249c5744c768bab9332505d6f6d7963ce3cb9 but now symbols get attached to the proper `DIScope` entry (while previously they were attached to the compile unit), so it might still work as expected. Could a Windows user test the PR?