### PR TITLE
Travis OSX: Downgrade to xcode v9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,11 @@ matrix:
       d: dmd
       env: LLVM_VERSION=3.7.1 OPTS="-DTEST_COVERAGE=ON"
     - os: osx
+      osx_image: xcode9.2
       d: ldc-beta
       env: LLVM_VERSION=6.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON
     - os: osx
+      osx_image: xcode9.2
       d: dmd
       env: LLVM_VERSION=4.0.0 OPTS="-DBUILD_SHARED_LIBS=ON"
 #  allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ matrix:
   include:
     - os: linux
       d: ldc
-      env: LLVM_VERSION=6.0.0
+      env: LLVM_VERSION=6.0.1
     - os: linux
       d: ldc-beta
-      env: LLVM_VERSION=5.0.1 OPTS="-DLIB_SUFFIX=64"
+      env: LLVM_VERSION=5.0.2 OPTS="-DLIB_SUFFIX=64"
     - os: linux
       d: ldc
       env: LLVM_VERSION=4.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
@@ -35,9 +35,9 @@ matrix:
 
 cache:
   directories:
+    - llvm-6.0.1
     - llvm-spirv-6.0.0
-    - llvm-6.0.0
-    - llvm-5.0.1
+    - llvm-5.0.2
     - llvm-4.0.1
     - llvm-4.0.0
     - llvm-3.9.1

--- a/dmd/root/rmem.h
+++ b/dmd/root/rmem.h
@@ -17,7 +17,7 @@
      * than D's 'uint'
      */
     typedef unsigned d_size_t;
-#elif __APPLE__ && __LP64__ && LDC_HOST_DigitalMars && LDC_HOST_FE_VER >= 2079
+#elif __APPLE__ && __LP64__ && LDC_HOST_DigitalMars && LDC_HOST_FE_VER >= 2079 && LDC_HOST_FE_VER <= 2081
     typedef unsigned long long d_size_t;
 #else
     typedef size_t d_size_t;


### PR DESCRIPTION
With August, they changed the default OSX image from xcode v8.3 to v9.4.1, and that's apparently when the druntime-test-shared failure was introduced for Travis OSX:

```
Testing finalize
/Users/travis/build/ldc-developers/ldc/runtime/druntime-test-shared/finalize
Illegal instruction: 4
```

CircleCI OSX is using xcode v9.2 without issues.