### PR TITLE
Config file: Adapt wasm section to lib-dirs

### DIFF
--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -36,9 +36,7 @@ default:
 "^wasm(32|64)-":
 {
     switches = [
-        "-defaultlib=druntime-ldc",@WASM_DEFAULT_LDC_SWITCHES@
+        "-defaultlib=",@WASM_DEFAULT_LDC_SWITCHES@
     ];
-    post-switches = [
-        "-I@RUNTIME_DIR@/src",
-    ];
+    lib-dirs = [];
 };

--- a/ldc2_install.conf.in
+++ b/ldc2_install.conf.in
@@ -36,10 +36,7 @@ default:
 "^wasm(32|64)-":
 {
     switches = [
-        "-defaultlib=phobos2-ldc,druntime-ldc",@WASM_DEFAULT_LDC_SWITCHES@
+        "-defaultlib=",@WASM_DEFAULT_LDC_SWITCHES@
     ];
-    post-switches = [
-        "-I@INCLUDE_INSTALL_DIR@/ldc",
-        "-I@INCLUDE_INSTALL_DIR@",
-    ];
+    lib-dirs = [];
 };

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -37,10 +37,7 @@ default:
 "^wasm(32|64)-":
 {
     switches = [
-        "-defaultlib=phobos2-ldc,druntime-ldc",@WASM_DEFAULT_LDC_SWITCHES@
+        "-defaultlib=",@WASM_DEFAULT_LDC_SWITCHES@
     ];
-    post-switches = [
-        "-I@RUNTIME_DIR@/src",
-        "-I@PHOBOS2_DIR@",
-    ];
+    lib-dirs = [];
 };


### PR DESCRIPTION
And clear `-defaultlib` explicitly, as there's no druntime/Phobos for linking. The linker will thus complain about missing symbols instead of not finding the lib files when trying to link without `-betterC`, which should give a better overview of what's actually required.