### PR TITLE
Remove obsolete LDC-specifc Port::stricmp()

### DIFF
--- a/dmd/root/port.d
+++ b/dmd/root/port.d
@@ -177,34 +177,6 @@ extern (C++) struct Port
         return (p[0] << 8) | p[1];
     }
 
-    version (IN_LLVM)
-    {
-        // LDC_FIXME: Move this into our C++ code, since only driver/gen is
-        // still using this.
-        static int stricmp(const(char)* s1, const(char)* s2)
-        {
-            int result = 0;
-            for (;;)
-            {
-                char c1 = *s1;
-                char c2 = *s2;
-
-                result = c1 - c2;
-                if (result)
-                {
-                    result = toupper(c1) - toupper(c2);
-                    if (result)
-                        break;
-                }
-                if (!c1)
-                    break;
-                s1++;
-                s2++;
-            }
-            return result;
-        }
-    }
-
     static void valcpy(void *dst, ulong val, size_t size)
     {
         switch (size)

--- a/dmd/root/port.h
+++ b/dmd/root/port.h
@@ -45,11 +45,6 @@ struct Port
     static unsigned readlongBE(void *buffer);
     static unsigned readwordLE(void *buffer);
     static unsigned readwordBE(void *buffer);
-
-#ifdef IN_LLVM
-    static int stricmp(const char *s1, const char *s2);
-#endif
-
     static void valcpy(void *dst, uint64_t val, size_t size);
 };
 


### PR DESCRIPTION
Btw, DMD v2.082.0 final has been tagged (unchanged from RC1, i.e., master is up-to-date).