### PR TITLE
Fix hidden overloaded virtual function 'RootObject::print' warning (NFC)

### DIFF
--- a/dmd/template.h
+++ b/dmd/template.h
@@ -150,6 +150,7 @@ public:
 
     virtual TemplateParameter *syntaxCopy() = 0;
     virtual bool declareParameter(Scope *sc) = 0;
+    using RootObject::print; // LDC: suppresses hidden overloaded virtual function 'RootObject::print' warning
     virtual void print(RootObject *oarg, RootObject *oded) = 0;
     virtual RootObject *specialization() = 0;
     virtual RootObject *defaultArg(Loc instLoc, Scope *sc) = 0;


### PR DESCRIPTION
Upstream, the print method has been removed already, so this is a temporary fix for LDC 1.12 only.