### PR TITLE
AppVeyor: Include extra copy of libcurl.dll in lib directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,7 @@ after_test:
         git clone https://github.com/ldc-developers/ldc-scripts.git
         cp ldc-scripts\ldc2-packaging\pkgfiles\README.txt "$ldcInstallDir"
         cp libcurl\ldc2\libcurl.dll "$ldcInstallDir\bin"
+        cp libcurl\ldc2\libcurl.dll "$ldcInstallDir\lib"
         cp libcurl\ldc2\curl.lib "$ldcInstallDir\lib"
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
           cp c:\projects\llvm\bin\lld-link.exe "$ldcInstallDir\bin"


### PR DESCRIPTION
ldc-jit.dll is already there. libcurl.dll was only copied to the bin dir, so that dub.exe, ldc-build-runtime.exe etc. work out of the box and user-built executables find it too if the LDC bin dir happens to be in PATH.

This leads to the multilib package now including a 32-bit libcurl.dll for the sake of completeness (in the lib32 dir).