### PR TITLE
Fix issue #2865

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -817,17 +817,21 @@ public:
     }
     assert(isaPointer(baseValue));
 
-    llvm::Value *offsetValue;
+    llvm::Value *offsetValue = nullptr;
 
     if (e->offset == 0) {
       offsetValue = baseValue;
     } else {
-      uint64_t elemSize = gDataLayout->getTypeAllocSize(
-          baseValue->getType()->getContainedType(0));
-      if (e->offset % elemSize == 0) {
-        // We can turn this into a "nice" GEP.
-        offsetValue = DtoGEPi1(baseValue, e->offset / elemSize);
-      } else {
+      LLType *elemType = baseValue->getType()->getContainedType(0);
+      if (elemType->isSized()) {
+        uint64_t elemSize = gDataLayout->getTypeAllocSize(elemType);
+        if (e->offset % elemSize == 0) {
+          // We can turn this into a "nice" GEP.
+          offsetValue = DtoGEPi1(baseValue, e->offset / elemSize);
+        }
+      }
+
+      if (!offsetValue) {
         // Offset isn't a multiple of base type size, just cast to i8* and
         // apply the byte offset.
         offsetValue =

--- a/tests/codegen/gh2865.d
+++ b/tests/codegen/gh2865.d
@@ -1,0 +1,8 @@
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+void foo()
+{
+    // CHECK: %1 = getelementptr {{.*}}_D6gh28653fooFZv{{.*}} to i8*), i32 -10
+    // CHECK-NEXT: %2 = ptrtoint i8* %1 to i{{32|64}}
+    auto addr = (cast(size_t) &foo) - 10;
+}

--- a/tests/compilable/gh2865.d
+++ b/tests/compilable/gh2865.d
@@ -1,6 +1,0 @@
-// RUN: %ldc -c %s
-
-void foo()
-{
-    auto addr = (cast(size_t) &foo) - 10;
-}

--- a/tests/compilable/gh2865.d
+++ b/tests/compilable/gh2865.d
@@ -1,0 +1,6 @@
+// RUN: %ldc -c %s
+
+void foo()
+{
+    auto addr = (cast(size_t) &foo) - 10;
+}


### PR DESCRIPTION
Functions, labels etc. aren't sized; respect that when coming across a `SymOffExp` (and checking whether we can elide a pointer cast to `i8*` for the GEP).