### PR TITLE
Simplify DSO registration with druntime

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -524,8 +524,10 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
 void ArgsBuilder::addLinker() {
   if (!opts::linker.empty()) {
     args.push_back("-fuse-ld=" + opts::linker);
-  } else if (global.params.isLinux && opts::isUsingThinLTO()) {
-    // default to ld.gold for ThinLTO on Linux due to ld.bfd issues (see #2278)
+  } else if (global.params.isLinux) {
+    // Default to ld.gold on Linux due to ld.bfd issues with ThinLTO (see #2278)
+    // and older bfd versions stripping llvm.used symbols (e.g., ModuleInfo
+    // refs) with --gc-sections (see #2870).
     args.push_back("-fuse-ld=gold");
   }
 }

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -237,39 +237,21 @@ llvm::Function *buildGetTLSAnchor() {
 /// {c, d}tors to invoke _d_dso_registry.
 ///
 /// Pseudocode:
-/// void ldc.register_dso(bool isShutdown, void* minfoUsedPointer) {
-///   if (dsoInitialized == isShutdown) {
-///     dsoInitialized = !isShutdown;
-///     auto record = {1, dsoSlot, minfoBeg, minfoEnd[, getTlsAnchor],
-///       minfoUsedPointer};
-///     _d_dso_registry(cast(CompilerDSOData*)&record);
-///   }
+/// void ldc.register_dso() {
+///   auto record = {1, dsoSlot, minfoBeg, minfoEnd[, getTlsAnchor]};
+///   _d_dso_registry(cast(CompilerDSOData*)&record);
 /// }
 ///
 /// On Darwin platforms, the record contains an extra pointer to a function
 /// which returns the address of a TLS global.
-llvm::Function *buildRegisterDSO(RegistryStyle style,
-                                 llvm::Value *dsoInitialized,
-                                 llvm::Value *dsoSlot, llvm::Value *minfoBeg,
-                                 llvm::Value *minfoEnd) {
-  llvm::Type *argTypes[] = {llvm::Type::getInt1Ty(gIR->context()),
-                            llvm::Type::getInt8PtrTy(gIR->context())};
-  const auto fnType = llvm::FunctionType::get(
-      llvm::Type::getVoidTy(gIR->context()), argTypes, false);
+llvm::Function *buildRegisterDSO(RegistryStyle style, llvm::Value *dsoSlot,
+                                 llvm::Value *minfoBeg, llvm::Value *minfoEnd) {
+  const auto fnType =
+      llvm::FunctionType::get(llvm::Type::getVoidTy(gIR->context()), false);
   const auto fn =
       llvm::Function::Create(fnType, llvm::GlobalValue::LinkOnceODRLinkage,
                              "ldc.register_dso", &gIR->module);
   fn->setVisibility(llvm::GlobalValue::HiddenVisibility);
-  auto argIt = fn->arg_begin();
-  const auto isShutdown = &*argIt;
-  isShutdown->setName("isShutdown");
-  ++argIt;
-  const auto minfoUsedPointer = &*argIt;
-  minfoUsedPointer->setName("minfoUsedPointer");
-
-  // Never inline – the functions is only called on startup/shutdown, hence
-  // it isn't worth the increase in code size.
-  fn->addFnAttr(llvm::Attribute::NoInline);
 
   const auto dsoRegistry =
       getRuntimeFunction(Loc(), gIR->module, "_d_dso_registry");
@@ -280,22 +262,9 @@ llvm::Function *buildRegisterDSO(RegistryStyle style,
     getTlsAnchorPtr = buildGetTLSAnchor();
   }
 
-  const auto entryBB = llvm::BasicBlock::Create(gIR->context(), "", fn);
-  const auto initBB = llvm::BasicBlock::Create(gIR->context(), "init", fn);
-  const auto endBB = llvm::BasicBlock::Create(gIR->context(), "end", fn);
-
   {
-    IRBuilder<> b(entryBB);
-    const auto loadedFlag =
-        b.CreateTrunc(b.CreateLoad(dsoInitialized), b.getInt1Ty());
-    const auto condEval =
-        b.CreateICmp(llvm::ICmpInst::ICMP_EQ, loadedFlag, isShutdown);
-    b.CreateCondBr(condEval, initBB, endBB);
-  }
-  {
-    IRBuilder<> b(initBB);
-    const auto newFlag = b.CreateXor(isShutdown, b.getTrue());
-    b.CreateStore(b.CreateZExt(newFlag, b.getInt8Ty()), dsoInitialized);
+    const auto bb = llvm::BasicBlock::Create(gIR->context(), "", fn);
+    IRBuilder<> b(bb);
 
     llvm::Constant *version = DtoConstSize_t(1);
     llvm::SmallVector<llvm::Type *, 6> memberTypes;
@@ -306,7 +275,6 @@ llvm::Function *buildRegisterDSO(RegistryStyle style,
     if (style == RegistryStyle::sectionDarwin) {
       memberTypes.push_back(getTlsAnchorPtr->getType());
     }
-    memberTypes.push_back(minfoUsedPointer->getType());
     llvm::StructType *stype =
         llvm::StructType::get(gIR->context(), memberTypes, false);
     llvm::Value *record = b.CreateAlloca(stype);
@@ -319,13 +287,8 @@ llvm::Function *buildRegisterDSO(RegistryStyle style,
     if (style == RegistryStyle::sectionDarwin) {
       b.CreateStore(getTlsAnchorPtr, b.CreateStructGEP(stype, record, i++));
     }
-    b.CreateStore(minfoUsedPointer, b.CreateStructGEP(stype, record, i++));
 
     b.CreateCall(dsoRegistry, b.CreateBitCast(record, recordPtrTy));
-    b.CreateBr(endBB);
-  }
-  {
-    IRBuilder<> b(endBB);
     b.CreateRetVoid();
   }
 
@@ -386,7 +349,15 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
   minfoBeg->setVisibility(llvm::GlobalValue::HiddenVisibility);
   minfoEnd->setVisibility(llvm::GlobalValue::HiddenVisibility);
 
-  // Build the ctor to invoke _d_dso_registry.
+  // We want to have one global constructor and destructor per object (i.e.
+  // executable/shared library) that calls _d_dso_registry with the respective
+  // DSO record.
+  // To enable safe direct linking of D objects (e.g., "g++ dcode.o cppcode.o"),
+  // we emit a pair of llvm.global_{c,d}tors into each object file, both
+  // pointing to a common ldc.register_dso() function.
+  // These per-object-file pairs will be folded to a single one when linking the
+  // DSO, together with the ldc.dso_slot globals and associated
+  // ldc.register_dso() functions.
 
   // This is the DSO slot for use by the druntime implementation.
   auto dsoSlot = defineGlobal(Loc(), gIR->module, "ldc.dso_slot",
@@ -394,80 +365,11 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
                               llvm::GlobalValue::LinkOnceODRLinkage, false);
   dsoSlot->setVisibility(llvm::GlobalValue::HiddenVisibility);
 
-  // Okay, so the theory is easy: We want to have one global constructor and
-  // destructor per object (i.e. executable/shared library) that calls
-  // _d_dso_registry with the respective DSO record. However, there are a
-  // couple of issues that make this harder than necessary:
-  //
-  //  1) The natural way to implement the "one-per-image" part would be to
-  //     emit a weak reference to a weak function into a .ctors.<somename>
-  //     section (llvm.global_ctors doesn't support the necessary
-  //     functionality, so we'd use our knowledge of the linker script to work
-  //     around that). But as of LLVM 3.4, emitting a symbol both as weak and
-  //     into a custom section is not supported by the MC layer. Thus, we have
-  //     to use a normal ctor/dtor and manually ensure that we only perform
-  //     the call once. This is done by introducing ldc.dso_initialized.
-  //
-  //  2) To make sure the .minfo section isn't removed by the linker when
-  //     using --gc-sections, we need to keep a reference to it around in
-  //     _every_ object file (as --gc-sections works per object file). The
-  //     natural place for this is the ctor, where we just load a reference
-  //     on the stack after the DSO record (to ensure LLVM doesn't optimize
-  //     it out). However, this way, we need to have at least one ctor
-  //     instance per object file be pulled into the final executable. We
-  //     do this here by making the module mangle string part of its name,
-  //     even thoguht this is slightly wasteful on -singleobj builds.
-  //
-  // It might be a better idea to simply use a custom linker script (using
-  // INSERT AFTER… so as to still keep the default one) to avoid all these
-  // problems. This would mean that it is no longer safe to link D objects
-  // directly using e.g. "g++ dcode.o cppcode.o", though.
+  const auto registerDSO = buildRegisterDSO(style, dsoSlot, minfoBeg, minfoEnd);
 
-  auto dsoInitialized = defineGlobal(
-      Loc(), gIR->module, "ldc.dso_initialized",
-      llvm::ConstantInt::get(llvm::Type::getInt8Ty(gIR->context()), 0),
-      llvm::GlobalValue::LinkOnceODRLinkage, false);
-  dsoInitialized->setVisibility(llvm::GlobalValue::HiddenVisibility);
-
-  // There is no reason for this cast to void*, other than that removing it
-  // seems to trigger a bug in the llvm::Linker (at least on LLVM 3.4)
-  // causing it to not merge the %object.ModuleInfo types properly. This
-  // manifests itself in a type mismatch assertion being triggered on the
-  // minfoUsedPointer store in the ctor as soon as the optimizer runs.
-  llvm::Value *minfoRefPtr = DtoBitCast(thismref, getVoidPtrType());
-
-  const auto registerDSO =
-      buildRegisterDSO(style, dsoInitialized, dsoSlot, minfoBeg, minfoEnd);
-
-  std::string ctorName = "ldc.dso_ctor.";
-  ctorName += moduleMangle;
-  const auto dsoCtor = llvm::Function::Create(
-      llvm::FunctionType::get(llvm::Type::getVoidTy(gIR->context()), false),
-      llvm::GlobalValue::LinkOnceODRLinkage, ctorName, &gIR->module);
-  dsoCtor->setVisibility(llvm::GlobalValue::HiddenVisibility);
-  {
-    const auto bb = llvm::BasicBlock::Create(gIR->context(), "", dsoCtor);
-    IRBuilder<> b{bb};
-    LLValue *params[] = {b.getFalse(), minfoRefPtr};
-    b.CreateCall(registerDSO, params);
-    b.CreateRetVoid();
-  }
-  llvm::appendToGlobalCtors(gIR->module, dsoCtor, 65535);
-
-  std::string dtorName = "ldc.dso_dtor.";
-  dtorName += moduleMangle;
-  const auto dsoDtor = llvm::Function::Create(
-      llvm::FunctionType::get(llvm::Type::getVoidTy(gIR->context()), false),
-      llvm::GlobalValue::LinkOnceODRLinkage, dtorName, &gIR->module);
-  dsoDtor->setVisibility(llvm::GlobalValue::HiddenVisibility);
-  {
-    const auto bb = llvm::BasicBlock::Create(gIR->context(), "", dsoDtor);
-    IRBuilder<> b{bb};
-    LLValue *params[] = {b.getTrue(), minfoRefPtr};
-    b.CreateCall(registerDSO, params);
-    b.CreateRetVoid();
-  }
-  llvm::appendToGlobalDtors(gIR->module, dsoDtor, 65535);
+  // tie to ldc.dso_slot global (drop {c,d}tor if the global is discarded)
+  llvm::appendToGlobalCtors(gIR->module, registerDSO, 65535, dsoSlot);
+  llvm::appendToGlobalDtors(gIR->module, registerDSO, 65535, dsoSlot);
 }
 
 // Add module-private variables and functions for coverage analysis.

--- a/tests/codegen/llvm_used_1.d
+++ b/tests/codegen/llvm_used_1.d
@@ -8,8 +8,9 @@
 // RUN: %ldc -O3 %S/inputs/module_ctor.d -run %s | FileCheck --check-prefix=EXECUTE %s
 
 // There was a bug where llvm.used was emitted more than once, whose symptom was that suffixed versions would appear: e.g. `@llvm.used.3`.
+// Expect 4 llvm.used entries - 2 ModuleInfos refs + ldc.dso_{c,d}tor refs.
 // LLVM-NOT: @llvm.used.
-// LLVM: @llvm.used = appending global [2 x i8*]
+// LLVM: @llvm.used = appending global [4 x i8*]
 // LLVM-NOT: @llvm.used.
 
 // EXECUTE: ctor


### PR DESCRIPTION
* The explicit reference to the ModuleInfo should be obsolete, it's added to the `llvm.used` array.
* Only keep a single pair of `ldc.dso_{c,d}tor` per DSO (pointing to a common `ldc.register_dso()` function) instead of a pair per linked-in D object file. This simplifies `ldc.register_dso()` and allows to get rid of the explicit ctor/dtor functions and the `ldc.dso_initialized` global.