### PR TITLE
[ltsmaster] Emit constructors as .init_array instead of .ctors when appropriate

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -587,6 +587,23 @@ llvm::TargetMachine *createTargetMachine(
     break;
   }
 
+  // Taken from clang's lib/Driver/ToolChains/Gnu.cpp
+  if (triple.getArch() == llvm::Triple::aarch64 ||
+      triple.getArch() == llvm::Triple::aarch64_be ||
+      (triple.getOS() == llvm::Triple::FreeBSD &&
+       triple.getOSMajorVersion() >= 12) ||
+      triple.getOS() == llvm::Triple::NaCl ||
+      (triple.getVendor() == llvm::Triple::MipsTechnologies &&
+       !triple.hasEnvironment()) ||
+      triple.getOS() == llvm::Triple::Solaris
+#if LDC_LLVM_VER >= 400
+      || triple.getArch() == llvm::Triple::riscv32
+      || triple.getArch() == llvm::Triple::riscv64
+#endif
+      ) {
+    targetOptions.UseInitArray = true;
+  }
+
   // Right now, we only support linker-level dead code elimination on Linux
   // using the GNU toolchain (based on ld's --gc-sections flag). The Apple ld
   // on OS X supports a similar flag (-dead_strip) that doesn't require


### PR DESCRIPTION
AArch64 only supports `.init_array`, for example. The reason this wasn't discovered earlier is that BFD and gold linkers automatically convert `.ctors` to `.init_array` as a performance optimization.

Based on clang code: https://github.com/llvm-mirror/clang/blob/5897428cd24e2deefbcc6f6744c0d7d233aa6747/lib/Driver/ToolChains/Gnu.cpp#L2598-L2620

https://github.com/ldc-developers/druntime/pull/146