### PR TITLE
Windows: Make LDC package fully self-sufficient (get rid of MSVC dependency)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -168,6 +168,20 @@ after_test:
         }
         # Now rename the installation dir to test portability.
         ren "$ldcInstallDir" ldc2-install
+  # Include MinGW-w64-based libs
+  - ps: |
+        cd c:\projects
+        $ldcInstallDir = 'c:\projects\ldc2-install'
+        mkdir mingw-w64-libs
+        cd mingw-w64-libs
+        appveyor DownloadFile "https://github.com/ldc-developers/mingw-w64-libs/releases/download/v6.0.0-rc.1/mingw-w64-libs-v6.0.0-rc.1.7z" -FileName mingw-w64-libs.7z
+        7z x mingw-w64-libs.7z > $null
+        If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {
+          cp -r lib64 "$ldcInstallDir\lib\mingw"
+        } Else {
+          cp -r lib32 "$ldcInstallDir\lib\mingw"
+        }
+        cd ..
   # Hello world integration test with LTO (x64 only)
   - ps: |
         If ($Env:APPVEYOR_JOB_ARCH -eq 'x64') {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ install:
           #echo 'Using LLVM with enabled assertions'
           #$assertsSuffix = '-withAsserts'
         }
-        appveyor DownloadFile "https://github.com/ldc-developers/llvm/releases/download/ldc-v$Env:LLVM_VERSION/llvm-$Env:LLVM_VERSION-windows-$Env:APPVEYOR_JOB_ARCH$assertsSuffix.7z" -FileName llvm.7z
+        appveyor DownloadFile "https://github.com/ldc-developers/llvm/releases/download/ldc-v$Env:LLVM_VERSION/llvm-$Env:LLVM_VERSION-windows-$Env:APPVEYOR_JOB_ARCH$assertsSuffix-clang.7z" -FileName llvm.7z
   - md llvm
   - cd llvm
   - 7z x ..\llvm.7z > nul
@@ -98,6 +98,8 @@ install:
   - set PATH=%CD%\llvm\bin;%CD%\ninja;%CD%\make;C:\Program Files\Git\usr\bin;%PATH%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%APPVEYOR_JOB_ARCH%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %APPVEYOR_JOB_ARCH%
+  # Let CMake configure 64-bit clang-cl for 32-bit code emission
+  - if "%APPVEYOR_JOB_ARCH%" == "x86" ( set "CFLAGS=-m32" && set "CXXFLAGS=-m32" && set "ASMFLAGS=-m32" )
   # Print environment info
   - set
   - msbuild /version
@@ -113,13 +115,13 @@ build_script:
   # Build bootstrap LDC
   - md bootstrap
   - cd bootstrap
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=c:/projects/llvm ..\ldc
+  - cmake -G Ninja -DCMAKE_C_COMPILER:PATH=clang-cl.exe -DCMAKE_CXX_COMPILER:PATH=clang-cl.exe -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=c:/projects/llvm ..\ldc
   - ninja -j2 all
   - cd ..
   # Build LDC and stdlib unittest runners
   - md ninja-ldc
   - cd ninja-ldc
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release %EXTRA_CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX=c:\projects\ldc2-%APPVEYOR_JOB_ARCH% -DINCLUDE_INSTALL_DIR=c:/projects/ldc2-%APPVEYOR_JOB_ARCH%/import -DLLVM_ROOT_DIR=c:/projects/llvm -DD_COMPILER=c:\projects\bootstrap\bin\ldmd2.exe ..\ldc
+  - cmake -G Ninja -DCMAKE_C_COMPILER:PATH=clang-cl.exe -DCMAKE_CXX_COMPILER:PATH=clang-cl.exe -DCMAKE_BUILD_TYPE=Release %EXTRA_CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX=c:\projects\ldc2-%APPVEYOR_JOB_ARCH% -DINCLUDE_INSTALL_DIR=c:/projects/ldc2-%APPVEYOR_JOB_ARCH%/import -DLLVM_ROOT_DIR=c:/projects/llvm -DD_COMPILER=c:\projects\bootstrap\bin\ldmd2.exe ..\ldc
   - ninja -j2 all all-test-runners
 
 #---------------------------------#

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -182,11 +182,23 @@ bool linkAgainstSharedDefaultLibs() {
 
 //////////////////////////////////////////////////////////////////////////////
 
+bool useInternalToolchainForMSVC() {
+#ifndef _WIN32
+  return true;
+#else
+  return !getenv("VSINSTALLDIR") && !getenv("LDC_VSDIR");
+#endif
+}
+
 llvm::StringRef getMscrtLibName() {
   llvm::StringRef name = mscrtlib;
   if (name.empty()) {
-    // default to static release variant
-    name = linkFullyStatic() != llvm::cl::BOU_FALSE ? "libcmt" : "msvcrt";
+    if (useInternalToolchainForMSVC()) {
+      name = "vcruntime140";
+    } else {
+      // default to static release variant
+      name = linkFullyStatic() != llvm::cl::BOU_FALSE ? "libcmt" : "msvcrt";
+    }
   }
   return name;
 }

--- a/driver/linker.h
+++ b/driver/linker.h
@@ -40,6 +40,12 @@ llvm::cl::boolOrDefault linkFullyStatic();
 bool linkAgainstSharedDefaultLibs();
 
 /**
+ * Indicates whether the internal 'toolchain' (-link-internally and MinGW-w64
+ * libs) is to be used for MSVC targets.
+ */
+bool useInternalToolchainForMSVC();
+
+/**
  * Returns the name of the MS C runtime library to link with.
  */
 llvm::StringRef getMscrtLibName();

--- a/packaging/README.txt
+++ b/packaging/README.txt
@@ -1,24 +1,37 @@
-This is a prebuilt binary package for LDC, the LLVM-based D compiler.
+This is a standalone (DMD-style) binary package for LDC, the LLVM-based D
+compiler.
 
 No installation is required, simply use the executables in the 'bin' subfolder.
-Just make sure you have a Microsoft Visual C++ 2015 or 2017 installation, either
-via Visual Studio or via the stand-alone Visual C++ Build Tools, both freely
-available from Microsoft. LDC relies on the MS linker (unless using
-'-link-internally') and on the MSVCRT + WinSDK libraries.
 
 The compiler configuration file is etc\ldc2.conf and can be easily customized
 to your liking, e.g., adding implicit command-line options and setting up cross-
 compilation.
 
-The LDC package is portable and should be able to detect your (latest) Visual
-C++ installation automatically.
-By setting the LDC_VSDIR environment variable to an existing Visual Studio
-directory, you can instruct LDC to use a specific Visual C++ installation.
-If run in a 'VS Native/Cross Tools Command Prompt' (i.e., if the environment
-variable VSINSTALLDIR is set), LDC skips the Visual C++ detection. This saves
-about one second for each linking operation, but linking will be restricted to
-the selected target (=> no cross-linking support via '-m32' in a x64 command
-prompt).
+The LDC package is portable and ships with LLD, the LLVM linker, as well as
+WinSDK & Visual C++ runtime (import) libraries based on MinGW-w64. In order to
+run the generated binaries, a Visual C++ 2015 runtime installation is required
+(vcruntime140.dll, ucrtbase.dll etc.).
+
+In case you prefer an official Microsoft toolchain for linking (Visual C++ 2015
+or newer), e.g., to link with the static Microsoft libraries (and thus avoid the
+dependency on the Visual C++ runtime installation for your users), you have the
+following options:
+
+* Run LDC in a 'VS Native/Cross Tools Command Prompt' (LDC checks whether the
+  VSINSTALLDIR environment variable is set).
+  LDC assumes the environment variables are all set up appropriately.
+* Set the LDC_VSDIR environment variable to some Visual Studio/Visual C++ Build
+  Tools installation directory, e.g.,
+  'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'.
+  LDC will invoke a batch file provided by VS to set up the environment
+  variables for the selected 32/64-bit target platform, which adds an overhead
+  of about 1 second for each linking operation.
+  You can also set LDC_VSDIR to some non-existing dummy path; LDC will try to
+  auto-detect your latest Visual C++ installation in that case.
+* Set up the etc\ldc2.conf config file and specify the path to the linker
+  ('-linker=<path>', or use '-link-internally') as well as the directories
+  containing the MS libs ('-L/LIBPATH:<path1> -L/LIBPATH:<path2> ...'; check out
+  the LIB environment variable in a VS tools command prompt).
 
 For further information, including on how to report bugs, please refer to the
 LDC wiki: http://wiki.dlang.org/LDC.

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -63,6 +63,11 @@ env_cxx = os.environ.get('CXX', '')
 if env_cxx:
     config.environment['CXX'] = env_cxx
 
+if (platform.system() == 'Windows'):
+    config.environment['VSINSTALLDIR'] = os.environ['VSINSTALLDIR']
+    config.environment['PATH'] = os.environ['PATH']
+    config.environment['LIB'] = os.environ['LIB']
+
 # Define available features so that we can disable tests depending on LLVM version
 config.available_features.add("llvm%d" % config.llvm_version)
 # LLVM version history: 3.9, 4.0, 5.0, ...


### PR DESCRIPTION
When experimenting with the MinGW-w64 based libs, there was a problem (well, one of many!) - an undefined reference to function `_(_)chkstk`, emitted by LLVM for stack probing (e.g., after an `alloca`) and not provided by MinGW-w64.

Initially, I used the symbol exported by ntdll.dll; normal user apps aren't supposed to depend on that system DLL though, and it also led to duplicate symbols for 32-bit code.

After some digging, I found that LLVM's builtins compiler-rt library contains 2 implementations (1 MS-compatible, 1 for MinGW/Cygwin, both with different names than the MS one). Our library didn't contain it though, so I digged deeper.

I found the culprit in the builtins CMake script; when using an MSVC toolchain, the builtins lib on Windows only contains very few C files and none of the various ASM ones, because they use AT&T syntax.

So I decided to try building LLVM & compiler-rt with clang instead. That works fine, but I had to fix the CMake script, as the ASM files are excluded for MS-*compatible* toolchains, incl. clang. So I forked
compiler-rt to fix this and some more annoyances (CMake fixes only, no code changes).

When compiling LLVM with clang-cl (`cl.exe`-compatible wrapper), the LLVM C++ compile flags include some clang-specific ones, so building LDC with MSVC didn't work. While that can be fixed at some point (stripping the clang-specific ones), I decided to build LDC (and the C/C++/ASM files in our default libs) with clang too. That required some adaptations, as it started out with > 5k warnings (and crashes in druntime). ;)

So this commit switches to clang for compiling C/C++/ASM, but still uses Microsoft's linker.

---

Some of the required adaptations are already in master (https://github.com/ldc-developers/ldc/commit/7b7e0e927c0a9adfb90ea3bcb11eb5bb9ac0af86, https://github.com/ldc-developers/ldc/commit/c0d269d5d9ed9586f114fceb1fe52e5f2239e02b, https://github.com/ldc-developers/druntime/commit/b2c58c7fc4a14e7b83a46713eb9b2109ec3ec68a, https://github.com/ldc-developers/druntime/commit/9250b1cffe3557f04b40263cf0a49271061835c2, https://github.com/ldc-developers/druntime/commit/4afc0547278e4dae1941101f5d39f76374dce144). I appended them to the merge-2.083 PR in order to make sure everything still works with the regular MSVC toolchain.

The compiler-rt changes will be pushed as soon as this works.