### PR TITLE
Set -O3 in array_equals_memcmp assembly test

### DIFF
--- a/tests/codegen/array_equals_memcmp.d
+++ b/tests/codegen/array_equals_memcmp.d
@@ -2,7 +2,7 @@
 // More importantly: test that memcmp is _not_ used when it is not valid.
 
 // RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s --check-prefix=LLVM < %t.ll
-// RUN: %ldc -c -output-s  -of=%t.s  %s && FileCheck %s --check-prefix=ASM  < %t.s
+// RUN: %ldc -O3 -c -output-s  -of=%t.s  %s && FileCheck %s --check-prefix=ASM  < %t.s
 // RUN: %ldc -O3 -run %s
 
 module mod;


### PR DESCRIPTION
`memcmp` on small memory ranges is not optimized-out on `-O0` for AArch64, so turn optimization on. This fixes the test on AArch64.