### PR TITLE
Cherry-pick: Emit constructors as .init_array instead of .ctors when appropriate (#2883)

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -469,6 +469,23 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     break;
   }
 
+  // Taken from clang's lib/Driver/ToolChains/Gnu.cpp
+  if (triple.getArch() == llvm::Triple::aarch64 ||
+      triple.getArch() == llvm::Triple::aarch64_be ||
+      (triple.getOS() == llvm::Triple::FreeBSD &&
+       triple.getOSMajorVersion() >= 12) ||
+      triple.getOS() == llvm::Triple::NaCl ||
+      (triple.getVendor() == llvm::Triple::MipsTechnologies &&
+       !triple.hasEnvironment()) ||
+      triple.getOS() == llvm::Triple::Solaris
+#if LDC_LLVM_VER >= 400
+      || triple.getArch() == llvm::Triple::riscv32
+      || triple.getArch() == llvm::Triple::riscv64
+#endif
+      ) {
+    targetOptions.UseInitArray = true;
+  }
+
   // Right now, we only support linker-level dead code elimination on Linux
   // using the GNU toolchain (based on ld's --gc-sections flag). The Apple ld
   // on OS X supports a similar flag (-dead_strip) that doesn't require

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -469,23 +469,6 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     break;
   }
 
-  // Taken from clang's lib/Driver/ToolChains/Gnu.cpp
-  if (triple.getArch() == llvm::Triple::aarch64 ||
-      triple.getArch() == llvm::Triple::aarch64_be ||
-      (triple.getOS() == llvm::Triple::FreeBSD &&
-       triple.getOSMajorVersion() >= 12) ||
-      triple.getOS() == llvm::Triple::NaCl ||
-      (triple.getVendor() == llvm::Triple::MipsTechnologies &&
-       !triple.hasEnvironment()) ||
-      triple.getOS() == llvm::Triple::Solaris
-#if LDC_LLVM_VER >= 400
-      || triple.getArch() == llvm::Triple::riscv32
-      || triple.getArch() == llvm::Triple::riscv64
-#endif
-      ) {
-    targetOptions.UseInitArray = true;
-  }
-
   // Right now, we only support linker-level dead code elimination on Linux
   // using the GNU toolchain (based on ld's --gc-sections flag). The Apple ld
   // on OS X supports a similar flag (-dead_strip) that doesn't require

--- a/tests/codegen/ctor_initarray_gh2883.d
+++ b/tests/codegen/ctor_initarray_gh2883.d
@@ -1,0 +1,11 @@
+// REQUIRES: target_AArch64
+
+// RUN: %ldc -mtriple=aarch64-unknown-linux -output-s -of=%t.s %s
+// RUN: FileCheck %s < %t.s
+
+// CHECK-NOT: .ctors
+// CHECK-NOT: .dtors
+// CHECK: .section  .init_array
+// CHECK: .section  .fini_array
+
+// No code needed to generate asm for a module.


### PR DESCRIPTION
AArch64 only supports .init_array, for example. The reason this wasn't discovered
earlier is that BFD and gold linkers automatically convert .ctors to .init_array
as a performance optimization.

Cherry-pick from issue #2883