### PR TITLE
Optionally enable GC for front-end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ script:
     # The -lowmem tests don't work with an ltsmaster host compiler.
     if [[ "$(${DC} --version | head -n 1)" == *0.17.* ]]; then
       rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d;
+      rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d;
     fi
   - DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
   # Run defaultlib unittests & druntime stand-alone tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,11 +117,15 @@ script:
   # Run LIT testsuite.
   - ctest -V -R "lit-tests"
   # Run DMD testsuite.
-  # Optimized runnable/testconst.d crashes (in _aaInX) with shared libs on Linux -
-  # only for Travis apparently.
-  -
+  - |
+    # Optimized runnable/testconst.d crashes (in _aaInX) with shared libs on Linux -
+    # only for Travis apparently.
     if [ "${TRAVIS_OS_NAME}" = "linux" ] && [[ "${OPTS}" == *-DBUILD_SHARED_LIBS?ON* ]]; then
       rm tests/d2/dmd-testsuite/runnable/testconst.d;
+    fi
+    # The -lowmem tests don't work with an ltsmaster host compiler.
+    if [[ "$(${DC} --version | head -n 1)" == *0.17.* ]]; then
+      rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d;
     fi
   - DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
   # Run defaultlib unittests & druntime stand-alone tests.

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -465,6 +465,12 @@ else
         return result;
     }
 
+    if (params.mixinFile)
+    {
+        params.mixinOut = cast(OutBuffer*)calloc(1, OutBuffer.sizeof);
+        atexit(&flushMixins); // see comment for flushMixins
+    }
+    scope(exit) flushMixins();
     global.path = buildPath(params.imppath);
     global.filePath = buildPath(params.fileImppath);
 
@@ -1475,8 +1481,8 @@ private void setTargetCPU(ref Param params)
 /**************************************
  * we want to write the mixin expansion file also on error, but there
  * are too many ways to terminate dmd (e.g. fatal() which calls exit(EXIT_FAILURE)),
- * so we cant use scope(exit) ...
- * so we do it with atexit(&flushMixins);
+ * so we can't rely on scope(exit) ... in tryMain() actually being executed
+ * so we add atexit(&flushMixins); for those fatal exits (with the GC still valid)
  */
 extern(C) void flushMixins()
 {
@@ -1488,6 +1494,8 @@ extern(C) void flushMixins()
     OutBuffer* ob = global.params.mixinOut;
     f.setbuffer(cast(void*)ob.data, ob.offset);
     f.write();
+
+    global.params.mixinOut = null;
 }
 
 version (IN_LLVM)
@@ -1929,11 +1937,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             auto tmp = p + 6 + 1;
             if (!tmp[0])
                 goto Lnoarg;
-            // The following are usedin atexit, so we can't rely on main's argv...
             params.mixinFile = mem.xstrdup(tmp);
-            // ... or the GC's memory being valid.
-            params.mixinOut = cast(OutBuffer*)calloc(1, OutBuffer.sizeof);
-            atexit(&flushMixins);
         }
         else if (arg == "-g") // https://dlang.org/dmd.html#switch-g
             params.symdebug = 1;

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -802,6 +802,22 @@ version (IN_LLVM) {} else
     }
 version (IN_LLVM)
 {
+    import core.memory : GC;
+
+    static if (__traits(compiles, GC.stats))
+    {
+        if (global.params.verbose)
+        {
+            static int toMB(ulong size) { return cast(int) (size / 1048576.0 + 0.5); }
+
+            const stats = GC.stats;
+            const used = toMB(stats.usedSize);
+            const free = toMB(stats.freeSize);
+            const total = toMB(stats.usedSize + stats.freeSize);
+            message("GC stats  %dM used, %dM free, %dM total", used, free, total);
+        }
+    }
+
     codegenModules(modules);
 }
 else

--- a/dmd/root/filename.d
+++ b/dmd/root/filename.d
@@ -710,16 +710,16 @@ nothrow:
                     // exists and name is *really* a "child" of path
                     if (exists(cname) && strncmp(cpath, cname, strlen(cpath)) == 0)
                     {
-                        .free(cast(void*)cpath);
+                        mem.xfree(cast(void*)cpath);
                         const(char)* p = mem.xstrdup(cname);
-                        .free(cast(void*)cname);
+                        mem.xfree(cast(void*)cname);
                         return p;
                     }
                 cont:
                     if (cpath)
-                        .free(cast(void*)cpath);
+                        mem.xfree(cast(void*)cpath);
                     if (cname)
-                        .free(cast(void*)cname);
+                        mem.xfree(cast(void*)cname);
                 }
             }
             return null;

--- a/dmd/root/rmem.d
+++ b/dmd/root/rmem.d
@@ -12,236 +12,288 @@
 
 module dmd.root.rmem;
 
+import core.stdc.stdlib;
+import core.stdc.stdio;
 import core.stdc.string;
+
+version = GC;
 
 version (GC)
 {
     import core.memory : GC;
 
-    extern (C++) struct Mem
-    {
-        static char* xstrdup(const(char)* p) nothrow
-        {
-            return p[0 .. strlen(p) + 1].dup.ptr;
-        }
-
-        static void xfree(void* p) nothrow
-        {
-            return GC.free(p);
-        }
-
-        static void* xmalloc(size_t n) nothrow
-        {
-            return GC.malloc(n);
-        }
-
-        static void* xcalloc(size_t size, size_t n) nothrow
-        {
-            return GC.calloc(size * n);
-        }
-
-        static void* xrealloc(void* p, size_t size) nothrow
-        {
-            return GC.realloc(p, size);
-        }
-
-        static void error() nothrow
-        {
-            import core.stdc.stdlib : exit, EXIT_FAILURE;
-            import core.stdc.stdio : printf;
-
-            printf("Error: out of memory\n");
-            exit(EXIT_FAILURE);
-        }
-    }
-
-    extern (C) void* allocmemory(size_t m_size) nothrow
-    {
-        return GC.malloc(m_size);
-    }
-
-    extern (C++) const __gshared Mem mem;
+    enum isGCAvailable = true;
 }
 else
+    enum isGCAvailable = false;
+
+extern (C++) struct Mem
 {
-    import core.stdc.stdlib;
-    import core.stdc.stdio;
-
-    extern (C++) struct Mem
+    static char* xstrdup(const(char)* s) nothrow
     {
-        static char* xstrdup(const(char)* s) nothrow
-        {
-            if (s)
-            {
-                auto p = .strdup(s);
-                if (p)
-                    return p;
-                error();
-            }
+        if (!s)
             return null;
-        }
 
-        static void xfree(void* p) nothrow
+        version (GC)
+            if (isGCEnabled)
+                return s[0 .. strlen(s) + 1].dup.ptr;
+
+        auto p = .strdup(s);
+        if (!p)
+            error();
+        return p;
+    }
+
+    static void xfree(void* p) nothrow
+    {
+        if (!p)
+            return;
+
+        version (GC)
+            if (isGCEnabled)
+                return GC.free(p);
+
+        .free(p);
+    }
+
+    static void* xmalloc(size_t size) nothrow
+    {
+        if (!size)
+            return null;
+
+        version (GC)
+            if (isGCEnabled)
+                return GC.malloc(size);
+
+        auto p = .malloc(size);
+        if (!p)
+            error();
+        return p;
+    }
+
+    static void* xcalloc(size_t size, size_t n) nothrow
+    {
+        const totalSize = size * n;
+        if (!totalSize)
+            return null;
+
+        version (GC)
+            if (isGCEnabled)
+                return GC.calloc(totalSize);
+
+        auto p = .calloc(size, n);
+        if (!p)
+            error();
+        return p;
+    }
+
+    static void* xrealloc(void* p, size_t size) nothrow
+    {
+        version (GC)
+            if (isGCEnabled)
+                return GC.realloc(p, size);
+
+        if (!size)
         {
             if (p)
                 .free(p);
+            return null;
         }
 
-        static void* xmalloc(size_t size) nothrow
+        if (!p)
         {
-            if (!size)
-                return null;
-
-            auto p = .malloc(size);
+            p = .malloc(size);
             if (!p)
                 error();
             return p;
         }
 
-        static void* xcalloc(size_t size, size_t n) nothrow
-        {
-            if (!size || !n)
-                return null;
-
-            auto p = .calloc(size, n);
-            if (!p)
-                error();
-            return p;
-        }
-
-        static void* xrealloc(void* p, size_t size) nothrow
-        {
-            if (!size)
-            {
-                if (p)
-                    .free(p);
-                return null;
-            }
-
-            if (!p)
-            {
-                p = .malloc(size);
-                if (!p)
-                    error();
-                return p;
-            }
-
-            p = .realloc(p, size);
-            if (!p)
-                error();
-            return p;
-        }
-
-        static void error() nothrow
-        {
-            printf("Error: out of memory\n");
-            exit(EXIT_FAILURE);
-        }
+        p = .realloc(p, size);
+        if (!p)
+            error();
+        return p;
     }
 
-    extern (C++) const __gshared Mem mem;
-
-    enum CHUNK_SIZE = (256 * 4096 - 64);
-
-    __gshared size_t heapleft = 0;
-    __gshared void* heapp;
-
-    extern (C) void* allocmemory(size_t m_size) nothrow
+    static void error() nothrow
     {
-        // 16 byte alignment is better (and sometimes needed) for doubles
-        m_size = (m_size + 15) & ~15;
-
-        // The layout of the code is selected so the most common case is straight through
-        if (m_size <= heapleft)
-        {
-        L1:
-            heapleft -= m_size;
-            auto p = heapp;
-            heapp = cast(void*)(cast(char*)heapp + m_size);
-            return p;
-        }
-
-        if (m_size > CHUNK_SIZE)
-        {
-            auto p = malloc(m_size);
-            if (p)
-            {
-                return p;
-            }
-            printf("Error: out of memory\n");
-            exit(EXIT_FAILURE);
-        }
-
-        heapleft = CHUNK_SIZE;
-        heapp = malloc(CHUNK_SIZE);
-        if (!heapp)
-        {
-            printf("Error: out of memory\n");
-            exit(EXIT_FAILURE);
-        }
-        goto L1;
+        printf("Error: out of memory\n");
+        exit(EXIT_FAILURE);
     }
 
-    version (DigitalMars)
+    version (GC)
     {
-        enum OVERRIDE_MEMALLOC = true;
-    }
-    else version (LDC)
-    {
-        // Memory allocation functions gained weak linkage when the @weak attribute was introduced.
-        import ldc.attributes;
-        enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
-    }
-    else
-    {
-        enum OVERRIDE_MEMALLOC = false;
-    }
+        __gshared bool isGCEnabled = true;
 
-    static if (OVERRIDE_MEMALLOC)
-    {
-        extern (C) void* _d_allocmemory(size_t m_size) nothrow
+        static void disableGC()
         {
-            return allocmemory(m_size);
+            isGCEnabled = false;
         }
 
-        extern (C) Object _d_newclass(const ClassInfo ci) nothrow
+        static void addRange(const(void)* p, size_t size) nothrow
         {
-            auto p = allocmemory(ci.initializer.length);
-            p[0 .. ci.initializer.length] = cast(void[])ci.initializer[];
-            return cast(Object)p;
+            if (isGCEnabled)
+                GC.addRange(p, size);
         }
 
-        version (LDC)
+        static void removeRange(const(void)* p) nothrow
         {
-            extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
-            {
-                return cast(Object)allocmemory(ci.initializer.length);
-            }
-        }
-
-        extern (C) void* _d_newitemT(TypeInfo ti) nothrow
-        {
-            auto p = allocmemory(ti.tsize);
-            (cast(ubyte*)p)[0 .. ti.initializer.length] = 0;
-            return p;
-        }
-
-        extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
-        {
-            auto p = allocmemory(ti.tsize);
-            p[0 .. ti.initializer.length] = ti.initializer[];
-            return p;
-        }
-
-        // TypeInfo.initializer for compilers older than 2.070
-        static if(!__traits(hasMember, TypeInfo, "initializer"))
-        private const(void[]) initializer(T : TypeInfo)(const T t)
-        nothrow pure @safe @nogc
-        {
-            return t.init;
+            if (isGCEnabled)
+                GC.removeRange(p);
         }
     }
 }
+
+extern (C++) const __gshared Mem mem;
+
+enum CHUNK_SIZE = (256 * 4096 - 64);
+
+__gshared size_t heapleft = 0;
+__gshared void* heapp;
+
+extern (C) void* allocmemory(size_t m_size) nothrow
+{
+    // 16 byte alignment is better (and sometimes needed) for doubles
+    m_size = (m_size + 15) & ~15;
+
+    // The layout of the code is selected so the most common case is straight through
+    if (m_size <= heapleft)
+    {
+    L1:
+        heapleft -= m_size;
+        auto p = heapp;
+        heapp = cast(void*)(cast(char*)heapp + m_size);
+        return p;
+    }
+
+    if (m_size > CHUNK_SIZE)
+    {
+        auto p = malloc(m_size);
+        if (p)
+        {
+            return p;
+        }
+        printf("Error: out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+
+    heapleft = CHUNK_SIZE;
+    heapp = malloc(CHUNK_SIZE);
+    if (!heapp)
+    {
+        printf("Error: out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+    goto L1;
+}
+
+version (DigitalMars)
+{
+    enum OVERRIDE_MEMALLOC = true;
+}
+else version (LDC)
+{
+    // Memory allocation functions gained weak linkage when the @weak attribute was introduced.
+    import ldc.attributes;
+    enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
+}
+else
+{
+    enum OVERRIDE_MEMALLOC = false;
+}
+
+static if (OVERRIDE_MEMALLOC)
+{
+    // Override the host druntime allocation functions in order to use the bump-
+    // pointer allocation scheme (`allocmemory()` above) if the GC is disabled.
+    // That scheme is faster and comes with less memory overhead than using a
+    // disabled GC alone.
+
+    extern (C) void* _d_allocmemory(size_t m_size) nothrow
+    {
+        version (GC)
+            if (mem.isGCEnabled)
+                return GC.malloc(m_size);
+
+        return allocmemory(m_size);
+    }
+
+    version (GC)
+    {
+        private void* allocClass(const ClassInfo ci) nothrow
+        {
+            alias BlkAttr = GC.BlkAttr;
+
+            assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
+
+            BlkAttr attr = BlkAttr.NONE;
+            if (ci.m_flags & TypeInfo_Class.ClassFlags.hasDtor
+                && !(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass))
+                attr |= BlkAttr.FINALIZE;
+            if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
+                attr |= BlkAttr.NO_SCAN;
+            return GC.malloc(ci.initializer.length, attr, ci);
+        }
+
+        extern (C) void* _d_newitemU(const TypeInfo ti) nothrow;
+    }
+
+    extern (C) Object _d_newclass(const ClassInfo ci) nothrow
+    {
+        const initializer = ci.initializer;
+
+        version (GC)
+            auto p = mem.isGCEnabled ? allocClass(ci) : allocmemory(initializer.length);
+        else
+            auto p = allocmemory(initializer.length);
+
+        memcpy(p, initializer.ptr, initializer.length);
+        return cast(Object) p;
+    }
+
+    version (LDC)
+    {
+        extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
+        {
+            version (GC)
+                if (mem.isGCEnabled)
+                    return cast(Object) allocClass(ci);
+
+            return cast(Object) allocmemory(ci.initializer.length);
+        }
+    }
+
+    extern (C) void* _d_newitemT(TypeInfo ti) nothrow
+    {
+        version (GC)
+            auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemory(ti.tsize);
+        else
+            auto p = allocmemory(ti.tsize);
+
+        memset(p, 0, ti.tsize);
+        return p;
+    }
+
+    extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
+    {
+        version (GC)
+            auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemory(ti.tsize);
+        else
+            auto p = allocmemory(ti.tsize);
+
+        const initializer = ti.initializer;
+        memcpy(p, initializer.ptr, initializer.length);
+        return p;
+    }
+
+    // TypeInfo.initializer for compilers older than 2.070
+    static if(!__traits(hasMember, TypeInfo, "initializer"))
+    private const(void[]) initializer(T : TypeInfo)(const T t)
+    nothrow pure @safe @nogc
+    {
+        return t.init;
+    }
+}
+
 /**
 Makes a null-terminated copy of the given string on newly allocated memory.
 The null-terminator won't be part of the returned string slice. It will be

--- a/dmd/root/rmem.h
+++ b/dmd/root/rmem.h
@@ -27,12 +27,19 @@ struct Mem
     Mem() { }
 
     static char *xstrdup(const char *s);
+    static void xfree(void *p);
     static void *xmalloc(d_size_t size);
     static void *xcalloc(d_size_t size, d_size_t n);
     static void *xrealloc(void *p, d_size_t size);
-    static void xfree(void *p);
-    static void *xmallocdup(void *o, d_size_t size);
     static void error();
+
+#if 1 // version (GC)
+    static bool isGCEnabled;
+
+    static void disableGC();
+    static void addRange(const void *p, d_size_t size);
+    static void removeRange(const void *p);
+#endif
 };
 
 extern Mem mem;

--- a/driver/configfile.cpp
+++ b/driver/configfile.cpp
@@ -38,8 +38,6 @@ static llvm::cl::opt<std::string>
     clConf("conf", llvm::cl::desc("Use configuration file <filename>"),
            llvm::cl::value_desc("filename"), llvm::cl::ZeroOrMore);
 
-ConfigFile ConfigFile::instance;
-
 #if _WIN32
 std::string getUserHomeDirectory() {
   char buff[MAX_PATH];

--- a/driver/configfile.d
+++ b/driver/configfile.d
@@ -99,6 +99,8 @@ unittest
 
 extern(C++) struct ConfigFile
 {
+    __gshared ConfigFile instance;
+
 private:
 
     // representation

--- a/driver/configfile.h
+++ b/driver/configfile.h
@@ -18,7 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include <string>
 
-class ConfigFile {
+struct ConfigFile {
 public:
   static ConfigFile instance;
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -919,6 +919,17 @@ int cppmain(int argc, char **argv) {
 
   exe_path::initialize(argv[0]);
 
+  // Filter out druntime options in the cmdline, e.g., to configure the GC.
+  std::vector<char *> filteredArgs;
+  filteredArgs.reserve(argc);
+  for (int i = 0; i < argc; ++i) {
+    if (strncmp(argv[i], "--DRT-", 6) != 0)
+      filteredArgs.push_back(argv[i]);
+  }
+
+  argc = static_cast<int>(filteredArgs.size());
+  argv = filteredArgs.data();
+
   global._init();
   global.version = ldc::dmd_version;
   global.ldc_version = ldc::ldc_version;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -80,7 +80,6 @@ void gendocfile(Module *m);
 
 // In dmd/mars.d
 void generateJson(Modules *modules);
-extern "C" void flushMixins();
 
 using namespace opts;
 
@@ -337,12 +336,6 @@ void parseCommandLine(int argc, char **argv, Strings &sourceFiles) {
       global.params.hdrdir || global.params.hdrname;
 
   opts::initFromPathString(global.params.mixinFile, mixinFile);
-  if (global.params.mixinFile) {
-    global.params.mixinOut = new OutBuffer;
-    // DMD uses atexit() too, so that the file is written when exiting via
-    // fatal() etc. too.
-    atexit(&flushMixins);
-  }
 
   if (moduleDeps.getNumOccurrences() != 0) {
     global.params.moduleDeps = new OutBuffer;

--- a/driver/main.d
+++ b/driver/main.d
@@ -13,23 +13,14 @@
 
 module driver.main;
 
-import dmd.globals;
-import dmd.root.file;
-import dmd.root.outbuffer;
-
 // In driver/main.cpp
 extern(C++) int cppmain(int argc, char **argv);
 
-/+ Having a main() in D-source solves a few issues with building/linking with
- + DMD on Windows, with the extra benefit of implicitly initializing the D runtime.
+/+ We use this manual D main for druntime initialization via a manual
+ + _d_run_main() call in the C main() in driver/main.cpp.
  +/
-int main()
+extern(C) int _Dmain(string[])
 {
-    // For now, even just the frontend does not work with GC enabled, so we need
-    // to disable it entirely.
-    import core.memory;
-    GC.disable();
-
     import core.runtime;
     auto args = Runtime.cArgs();
     return cppmain(args.argc, cast(char**)args.argv);

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -3095,6 +3095,8 @@ struct AsmProcessor {
       }
     }
 
+    mem.addRange(asmcode->args.data(), asmcode->args.size() * sizeof(AsmArg));
+
     asmcode->insnTemplate = insnTemplate.str();
     Logger::cout() << "insnTemplate = " << asmcode->insnTemplate << '\n';
     return true;

--- a/ir/irfuncty.cpp
+++ b/ir/irfuncty.cpp
@@ -20,7 +20,11 @@
 IrFuncTyArg::IrFuncTyArg(Type *t, bool bref, AttrBuilder a)
     : type(t),
       ltype(t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t)),
-      attrs(std::move(a)), byref(bref) {}
+      attrs(std::move(a)), byref(bref) {
+  mem.addRange(&type, sizeof(type));
+}
+
+IrFuncTyArg::~IrFuncTyArg() { mem.removeRange(&type); }
 
 bool IrFuncTyArg::isInReg() const { return attrs.contains(LLAttribute::InReg); }
 bool IrFuncTyArg::isSRet() const {

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -77,6 +77,9 @@ struct IrFuncTyArg {
    *               LLVM Type will be of DtoType(type->pointerTo()), instead
    *               of just DtoType(type) */
   IrFuncTyArg(Type *t, bool byref, AttrBuilder attrs = AttrBuilder());
+  IrFuncTyArg(const IrFuncTyArg &) = delete;
+
+  ~IrFuncTyArg();
 };
 
 // represents a function type


### PR DESCRIPTION
This isn't looking too bad, although druntime cannot be compiled yet:

Phobos all-at-once compilation, Win64:
```
GC: used bytes = 1707268112
GC: used bytes = 570342720 [after collection]
```

`std.string` unittests:
```
GC: used bytes = 1651332656
GC: used bytes = 361209920
```

`std.algorithm.iteration` unittests:
```
GC: used bytes = 1496288448
GC: used bytes = 644807264
```

`std.regex.internal.tests` unittests:
```
GC: used bytes = 2079689120
GC: used bytes = 292884624
```

It doesn't reduce the peak memory requirements (well, maybe a little bit if LLVM allocates significant amounts during codegen), but reduces the time that memory is claimed, which should especially pay off with `-O`, as much more time will be spent in the LLVM optimizer. This might enable the usage of more CPU cores when building on systems with limited memory, as it reduces the chance of overlapping LDC processes with fat memory requirements.