### PR TITLE
Add __ir to ldc.llvmasm, to replace ldc.simd.inlineIR.

### DIFF
--- a/tests/codegen/inlineIR_math.d
+++ b/tests/codegen/inlineIR_math.d
@@ -1,4 +1,4 @@
-// Tests inlineIR + math optimizations
+// Tests inline IR + math optimizations
 
 // REQUIRES: target_X86
 
@@ -6,15 +6,14 @@
 // RUN: %ldc -mtriple=x86_64-linux-gnu -mattr=+fma -O3 -release -c -output-s -of=%t.s %s && FileCheck %s --check-prefix ASM < %t.s
 
 import ldc.attributes;
-pragma(LDC_inline_ir) R inlineIR(string s, R, P...)(P);
-
+import ldc.llvmasm;
 
 // Test that internal @inline.ir.*" functions for the inlined IR pieces are always inlined and are not present as a global symbol
 // LLVM-NOT: @inline.ir.
 // LLVM-NOT: alwaysinline
 
 
-// inlineIR should inherit the enclosing function attributes, thus preserving the enclosing function attributes after inlining.
+// __ir should inherit the enclosing function attributes, thus preserving the enclosing function attributes after inlining.
 // LLVM-LABEL: define{{.*}} @dot
 // LLVM-SAME: #[[UNSAFEFPMATH:[0-9]+]]
 // ASM-LABEL: dot:
@@ -26,9 +25,9 @@ extern (C) double dot(double[] a, double[] b)
 // ASM: vfmadd{{[123][123][123]}}pd
     foreach (size_t i; 0 .. a.length)
     {
-        s = inlineIR!(`%p = fmul fast double %0, %1
-                       %r = fadd fast double %p, %2
-                       ret double %r`, double)(a[i], b[i], s);
+        s = __ir!(`%p = fmul fast double %0, %1
+                   %r = fadd fast double %p, %2
+                   ret double %r`, double)(a[i], b[i], s);
     }
     return s;
 }
@@ -41,14 +40,14 @@ extern (C) double features(double[] a, double[] b)
     double s = 0;
     foreach (size_t i; 0 .. a.length)
     {
-        s = inlineIR!(`%p = fmul fast double %0, %1
-                       %r = fadd fast double %p, %2
-                       ret double %r`, double)(a[i], b[i], s);
+        s = __ir!(`%p = fmul fast double %0, %1
+                   %r = fadd fast double %p, %2
+                   ret double %r`, double)(a[i], b[i], s);
     }
     return s;
 }
 
-// Test that inlineIR works when calling function has special attributes defined for its parameters
+// Test that inline IR works when calling function has special attributes defined for its parameters
 // LLVM-LABEL: define{{.*}} @dot160
 // ASM-LABEL: dot160:
 extern (C) double dot160(double[160] a, double[160] b)
@@ -58,22 +57,22 @@ extern (C) double dot160(double[160] a, double[160] b)
 // ASM-NOT: vfmadd
     foreach (size_t i; 0 .. a.length)
     {
-        s = inlineIR!(`%p = fmul double %0, %1
-                       %r = fadd double %p, %2
-                       ret double %r`, double)(a[i], b[i], s);
+        s = __ir!(`%p = fmul double %0, %1
+                   %r = fadd double %p, %2
+                   ret double %r`, double)(a[i], b[i], s);
     }
     return s;
 }
 
-// Test inlineIR alias defined outside any function
-alias inlineIR!(`%p = fmul fast double %0, %1
-                 %r = fadd fast double %p, %2
-                 ret double %r`,
-                 double, double, double, double) muladdFast;
-alias inlineIR!(`%p = fmul double %0, %1
-                 %r = fadd double %p, %2
-                 ret double %r`,
-                 double, double, double, double) muladd;
+// Test inline IR alias defined outside any function
+alias __ir!(`%p = fmul fast double %0, %1
+             %r = fadd fast double %p, %2
+             ret double %r`,
+             double, double, double, double) muladdFast;
+alias __ir!(`%p = fmul double %0, %1
+             %r = fadd double %p, %2
+             ret double %r`,
+             double, double, double, double) muladd;
 
 // LLVM-LABEL: define{{.*}} @aliasInlineUnsafe
 // LLVM-SAME: #[[UNSAFEFPMATH]]

--- a/tests/codegen/inline_ir.d
+++ b/tests/codegen/inline_ir.d
@@ -1,10 +1,9 @@
 // RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
-pragma(LDC_inline_ir)
-    R inlineIREx(string prefix, string code, string suffix, R, P...)(P);
+import ldc.llvmasm;
 
-alias inlineIREx!("", "store i32 %1, i32* %0, !nontemporal !0", "!0 = !{i32 1}", void, int*, int) nontemporalStore;
-alias inlineIREx!("!0 = !{i32 1}", "%i = load i32, i32* %0, !nontemporal !0\nret i32 %i", "", int, const int*) nontemporalLoad;
+alias __irEx!("", "store i32 %1, i32* %0, !nontemporal !0", "!0 = !{i32 1}", void, int*, int) nontemporalStore;
+alias __irEx!("!0 = !{i32 1}", "%i = load i32, i32* %0, !nontemporal !0\nret i32 %i", "", int, const int*) nontemporalLoad;
 
 int foo(const int* src)
 {

--- a/tests/codegen/inputs/input_discard_valuename.d
+++ b/tests/codegen/inputs/input_discard_valuename.d
@@ -6,9 +6,9 @@ extern(C) void bar()
 }
 
 // Make sure we can use inline IR in non-textual IR compiles:
-pragma(LDC_inline_ir) R __ir(string s, R, P...)(P);
 double inlineIR(double a)
 {
+    import ldc.llvmasm: __ir;
     auto s = __ir!(`ret double %0`, double)(a);
     return s;
 }


### PR DESCRIPTION
Inline IR is more generally applicable than SIMD, so it is out-of-place in `ldc.simd`. Because it is so similar in functionality to `__asm` and LLVM IR is called LLVM assembly, I think `__ir` fits better and should be in `ldc.llvmasm`. I've also added `*_trusted` variants similar to `__asm_trusted`.
For backwards compatibility, `ldc.simd.inlineIR` is still there (forwards to `ldc.llvmasm.__ir_trusted`.