### PR TITLE
Adapt to using SPIR-V support as an external library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,15 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       d: ldc-beta
-      env: LLVM_VERSION=6.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON
+      env: LLVM_VERSION=8.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF" LLVM_SPIRV_AVAILABLE=ON
 
 cache:
   directories:
     - llvm-7.0.1
     - llvm-7.0.0
     - llvm-6.0.1
-    - llvm-spirv-6.0.0
+    - llvm-spirv-8.0.0
+    - llvm-spirv
     - llvm-5.0.2
     - llvm-4.0.1
     - llvm-3.9.1
@@ -54,7 +55,12 @@ before_install:
   -
     if [ ! -e "$LLVM_ROOT_DIR/bin/llvm-config" ]; then
       if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then
-        wget -O llvm.tar.bz2 https://github.com/thewilsonator/llvm/releases/download/pre-intrinsics/LLVM-6.0.0-Darwin.tar.bz2;
+        wget -O llvm.tar.bz2 https://github.com/thewilsonator/llvm/releases/download/pre-intrinsics/LLVM-8.0.0svn-Darwin.tar.bz2;
+        wget -O llvm-spirv.tar.bz2 https://github.com/thewilsonator/SPIRV-LLVM-Translator/releases/download/v8.0.0-a1/SPIRV-LLVM-Translator-a1.tar.bz2;
+        mkdir -p llvm-spirv;
+        tar -xf llvm-spirv.tar.bz2 --strip 1 -C `pwd`/llvm-spirv;
+        rm llvm-spirv.tar.bz2;
+        export PKG_CONFIG_PATH=`pwd`/llvm-spirv/lib/pkgconfig;
       else
         if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
           if [ "${LLVM_VERSION}" = "4.0.1" ]; then
@@ -70,6 +76,9 @@ before_install:
       mkdir -p $LLVM_ROOT_DIR;
       tar -xf llvm.tar.* --strip 1 -C $LLVM_ROOT_DIR;
       rm llvm.tar.*;
+      if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then
+      	cp -f llvm-spirv/bin/llvm-spirv $LLVM_ROOT_DIR/bin/;
+      fi
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
     export LLVM_ROOT_DIR="$PWD/llvm-$LLVM_VERSION";
     if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then
     	export LLVM_ROOT_DIR="$PWD/llvm-spirv-$LLVM_VERSION";
-    	export PKG_CONFIG_PATH=`pwd`/llvm-spirv/lib/pkgconfig;
+    	export PKG_CONFIG_PATH="$PWD/llvm-spirv/lib/pkgconfig";
     fi;
   -
     if [ ! -e "$LLVM_ROOT_DIR/bin/llvm-config" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,10 @@ addons:
 before_install:
   -
     export LLVM_ROOT_DIR="$PWD/llvm-$LLVM_VERSION";
-    if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then export LLVM_ROOT_DIR="$PWD/llvm-spirv-$LLVM_VERSION"; fi
+    if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then
+    	export LLVM_ROOT_DIR="$PWD/llvm-spirv-$LLVM_VERSION";
+    	export PKG_CONFIG_PATH=`pwd`/llvm-spirv/lib/pkgconfig;
+    fi;
   -
     if [ ! -e "$LLVM_ROOT_DIR/bin/llvm-config" ]; then
       if [ -n "${LLVM_SPIRV_AVAILABLE}" ]; then
@@ -60,7 +63,6 @@ before_install:
         mkdir -p llvm-spirv;
         tar -xf llvm-spirv.tar.bz2 --strip 1 -C `pwd`/llvm-spirv;
         rm llvm-spirv.tar.bz2;
-        export PKG_CONFIG_PATH=`pwd`/llvm-spirv/lib/pkgconfig;
       else
         if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
           if [ "${LLVM_VERSION}" = "4.0.1" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,31 @@ if (NOT D_COMPILER_DMD_COMPAT)
     message(FATAL_ERROR "We currently only support building using a D compiler with a DMD-compatible commandline interface. (try 'ldmd2' or 'gdmd')")
 endif()
 
+# SPIRV needs LLVMDemangle
+set(LLVM_MODULES all-targets analysis asmparser asmprinter bitreader bitwriter codegen core
+                 debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel
+                 instcombine ipa ipo instrumentation irreader libdriver linker lto mc
+                 mcdisassembler mcparser objcarcopts object option profiledata scalaropts
+                 selectiondag support tablegen target transformutils vectorize
+                 windowsmanifest)
+
+find_package(PkgConfig)
+if(MSVC)
+    # make use pkg-config uses -LC:\path\to\build\LLVMSPIRVLib.lib not -L-lLLVMSPIRVLib
+    set(PKG_CONFIG_EXECUTABLE "${PKG_CONFIG_EXECUTABLE} --msvc-syntax")
+endif()
+pkg_check_modules(LLVM_SPIRV LLVMSPIRVLib)
+if (LLVM_SPIRV_FOUND)
+    message(STATUS "Building with SPIR-V support")
+    add_definitions("-DLDC_LLVM_SUPPORTED_TARGET_SPIRV=1")
+    set(LLVM_MODULES "${LLVM_MODULES}" demangle)
+endif()
+
 #
 # Locate LLVM.
 #
 
-find_package(LLVM 3.9 REQUIRED
-    all-targets analysis asmparser asmprinter bitreader bitwriter codegen core
-    debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel
-    instcombine ipa ipo instrumentation irreader libdriver linker lto mc
-    mcdisassembler mcparser objcarcopts object option profiledata scalaropts
-    selectiondag support tablegen target transformutils vectorize
-    windowsmanifest ${EXTRA_LLVM_MODULES})
+find_package(LLVM 3.9 REQUIRED ${LLVM_MODULES} ${EXTRA_LLVM_MODULES})
 math(EXPR LDC_LLVM_VER ${LLVM_VERSION_MAJOR}*100+${LLVM_VERSION_MINOR})
 # Remove LLVMTableGen library from list of libraries
 string(REGEX MATCH "[^;]*LLVMTableGen[^;]*" LLVM_TABLEGEN_LIBRARY "${LLVM_LIBRARIES}")
@@ -42,6 +56,9 @@ foreach(LLVM_SUPPORTED_TARGET ${LLVM_TARGETS_TO_BUILD})
     add_definitions("-DLDC_LLVM_SUPPORTED_TARGET_${LLVM_SUPPORTED_TARGET}=1")
 endforeach()
 
+if (LLVM_SPIRV_FOUND)
+    set(LLVM_LIBRARIES ${LLVM_LIBRARIES} "-l${LLVM_SPIRV_LIBRARIES}")
+endif()
 #
 # Get info about used Linux distribution.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,18 @@ include(CheckDSourceCompiles)
 include(CheckLinkFlag)
 include(BuildDExecutable)
 
+# Helper function
+function(append value)
+    foreach(variable ${ARGN})
+        if(${variable} STREQUAL "")
+            set(${variable} "${value}" PARENT_SCOPE)
+        else()
+            set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
+        endif()
+    endforeach(variable)
+endfunction()
+
+
 # The script currently only supports the DMD-style commandline interface
 if (NOT D_COMPILER_DMD_COMPAT)
     message(FATAL_ERROR "We currently only support building using a D compiler with a DMD-compatible commandline interface. (try 'ldmd2' or 'gdmd')")
@@ -37,7 +49,6 @@ endif()
 pkg_check_modules(LLVM_SPIRV LLVMSPIRVLib)
 if (LLVM_SPIRV_FOUND)
     message(STATUS "Building with SPIR-V support")
-    add_definitions("-DLDC_LLVM_SUPPORTED_TARGET_SPIRV=1")
     set(LLVM_MODULES "${LLVM_MODULES}" demangle)
 endif()
 
@@ -57,23 +68,16 @@ foreach(LLVM_SUPPORTED_TARGET ${LLVM_TARGETS_TO_BUILD})
 endforeach()
 
 if (LLVM_SPIRV_FOUND)
-    set(LLVM_LIBRARIES ${LLVM_LIBRARIES} "-l${LLVM_SPIRV_LIBRARIES}")
+    add_definitions("-DLDC_LLVM_SUPPORTED_TARGET_SPIRV=1")
+    foreach(flag ${LLVM_SPIRV_LDFLAGS})
+        append("${flag}" LLVM_LDFLAGS)
+    endforeach(flag)
 endif()
 #
 # Get info about used Linux distribution.
 #
 include(GetLinuxDistribution)
 
-# Helper function
-function(append value)
-    foreach(variable ${ARGN})
-        if(${variable} STREQUAL "")
-            set(${variable} "${value}" PARENT_SCOPE)
-        else()
-            set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
-        endif()
-    endforeach(variable)
-endfunction()
 
 #
 # Main configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,18 +27,10 @@ function(append value)
     endforeach(variable)
 endfunction()
 
-
 # The script currently only supports the DMD-style commandline interface
 if (NOT D_COMPILER_DMD_COMPAT)
     message(FATAL_ERROR "We currently only support building using a D compiler with a DMD-compatible commandline interface. (try 'ldmd2' or 'gdmd')")
 endif()
-
-set(LLVM_MODULES all-targets analysis asmparser asmprinter bitreader bitwriter codegen core
-                 debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel
-                 instcombine ipa ipo instrumentation irreader libdriver linker lto mc
-                 mcdisassembler mcparser objcarcopts object option profiledata scalaropts
-                 selectiondag support tablegen target transformutils vectorize
-                 windowsmanifest)
 
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
@@ -51,7 +43,7 @@ if(PkgConfig_FOUND)
     if (LLVM_SPIRV_FOUND)
         message(STATUS "Building with SPIR-V support")
         # SPIRV needs LLVMDemangle
-        set(LLVM_MODULES "${LLVM_MODULES}" demangle)
+        set(EXTRA_LLVM_MODULES "${EXTRA_LLVM_MODULES}" demangle)
     endif()
 endif()
 
@@ -59,7 +51,13 @@ endif()
 # Locate LLVM.
 #
 
-find_package(LLVM 3.9 REQUIRED ${LLVM_MODULES} ${EXTRA_LLVM_MODULES})
+find_package(LLVM 3.9 REQUIRED
+    all-targets analysis asmparser asmprinter bitreader bitwriter codegen core
+    debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel
+    instcombine ipa ipo instrumentation irreader libdriver linker lto mc
+    mcdisassembler mcparser objcarcopts object option profiledata scalaropts
+    selectiondag support tablegen target transformutils vectorize
+    windowsmanifest ${EXTRA_LLVM_MODULES})
 math(EXPR LDC_LLVM_VER ${LLVM_VERSION_MAJOR}*100+${LLVM_VERSION_MINOR})
 # Remove LLVMTableGen library from list of libraries
 string(REGEX MATCH "[^;]*LLVMTableGen[^;]*" LLVM_TABLEGEN_LIBRARY "${LLVM_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ if (NOT D_COMPILER_DMD_COMPAT)
     message(FATAL_ERROR "We currently only support building using a D compiler with a DMD-compatible commandline interface. (try 'ldmd2' or 'gdmd')")
 endif()
 
-# SPIRV needs LLVMDemangle
 set(LLVM_MODULES all-targets analysis asmparser asmprinter bitreader bitwriter codegen core
                  debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb globalisel
                  instcombine ipa ipo instrumentation irreader libdriver linker lto mc
@@ -43,12 +42,14 @@ set(LLVM_MODULES all-targets analysis asmparser asmprinter bitreader bitwriter c
 
 find_package(PkgConfig)
 if(MSVC)
-    # make use pkg-config uses -LC:\path\to\build\LLVMSPIRVLib.lib not -L-lLLVMSPIRVLib
+    # make pkg-config use -LC:\path\to\build\LLVMSPIRVLib.lib not -L-lLLVMSPIRVLib
+    # for MSVC
     set(PKG_CONFIG_EXECUTABLE "${PKG_CONFIG_EXECUTABLE} --msvc-syntax")
 endif()
 pkg_check_modules(LLVM_SPIRV LLVMSPIRVLib)
 if (LLVM_SPIRV_FOUND)
     message(STATUS "Building with SPIR-V support")
+    # SPIRV needs LLVMDemangle
     set(LLVM_MODULES "${LLVM_MODULES}" demangle)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,16 +41,18 @@ set(LLVM_MODULES all-targets analysis asmparser asmprinter bitreader bitwriter c
                  windowsmanifest)
 
 find_package(PkgConfig)
-if(MSVC)
-    # make pkg-config use -LC:\path\to\build\LLVMSPIRVLib.lib not -L-lLLVMSPIRVLib
-    # for MSVC
-    set(PKG_CONFIG_EXECUTABLE "${PKG_CONFIG_EXECUTABLE} --msvc-syntax")
-endif()
-pkg_check_modules(LLVM_SPIRV LLVMSPIRVLib)
-if (LLVM_SPIRV_FOUND)
-    message(STATUS "Building with SPIR-V support")
-    # SPIRV needs LLVMDemangle
-    set(LLVM_MODULES "${LLVM_MODULES}" demangle)
+if(PkgConfig_FOUND)
+    if(MSVC)
+        # make pkg-config use -LC:\path\to\build\LLVMSPIRVLib.lib not -L-lLLVMSPIRVLib
+        # for MSVC
+        set(PKG_CONFIG_EXECUTABLE "${PKG_CONFIG_EXECUTABLE} --msvc-syntax")
+    endif()
+    pkg_check_modules(LLVM_SPIRV LLVMSPIRVLib)
+    if (LLVM_SPIRV_FOUND)
+        message(STATUS "Building with SPIR-V support")
+        # SPIRV needs LLVMDemangle
+        set(LLVM_MODULES "${LLVM_MODULES}" demangle)
+    endif()
 endif()
 
 #

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -31,9 +31,6 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/Path.h"
-#ifdef LDC_LLVM_SUPPORTED_TARGET_SPIRV
-#include "llvm/Support/SPIRV.h"
-#endif
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #if LDC_LLVM_VER >= 600
@@ -46,6 +43,11 @@
 #include <cstddef>
 #include <fstream>
 
+#ifdef LDC_LLVM_SUPPORTED_TARGET_SPIRV
+namespace llvm {
+    ModulePass *createSPIRVWriterPass(llvm::raw_ostream &Str);
+};
+#endif
 static llvm::cl::opt<bool>
     NoIntegratedAssembler("no-integrated-as", llvm::cl::ZeroOrMore,
                           llvm::cl::Hidden,
@@ -65,7 +67,7 @@ void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   ComputeBackend::Type cb = getComputeTargetType(&m);
 
   if (cb == ComputeBackend::SPIRV) {
-#ifdef LDC_LLVM_SUPPORTED_TARGET_SPIRV
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV
     IF_LOG Logger::println("running createSPIRVWriterPass()");
     llvm::createSPIRVWriterPass(out)->runOnModule(m);
     IF_LOG Logger::println("Success.");

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -46,8 +46,9 @@
 #ifdef LDC_LLVM_SUPPORTED_TARGET_SPIRV
 namespace llvm {
     ModulePass *createSPIRVWriterPass(llvm::raw_ostream &Str);
-};
+}
 #endif
+
 static llvm::cl::opt<bool>
     NoIntegratedAssembler("no-integrated-as", llvm::cl::ZeroOrMore,
                           llvm::cl::Hidden,

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -67,7 +67,7 @@ void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   ComputeBackend::Type cb = getComputeTargetType(&m);
 
   if (cb == ComputeBackend::SPIRV) {
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV
+#ifdef LDC_LLVM_SUPPORTED_TARGET_SPIRV
     IF_LOG Logger::println("running createSPIRVWriterPass()");
     llvm::createSPIRVWriterPass(out)->runOnModule(m);
     IF_LOG Logger::println("Success.");

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -444,6 +444,8 @@ void applyTargetMachineAttributes(llvm::Function &func,
 
   // TODO: implement commandline switches to change the default values.
   // TODO: (correctly) apply these for NVPTX (but not for SPIRV).
+  if (gIR->dcomputetarget && gIR->dcomputetarget->target == DComputeTarget::OpenCL)
+    return;
   if (!gIR->dcomputetarget) {
     // Target CPU capabilities
     func.addFnAttr("target-cpu", target.getTargetCPU());

--- a/tests/codegen/dcompute_cl_addrspaces.d
+++ b/tests/codegen/dcompute_cl_addrspaces.d
@@ -1,5 +1,4 @@
 // See GH issue #2709
-// XFAIL: target_SPIRV
 
 // REQUIRES: target_SPIRV
 // RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_ocl220_64.ll \

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -26,6 +26,7 @@ config.plugins_supported   = "@LDC_ENABLE_PLUGINS@" == "ON"
 config.gnu_make_bin        = "@GNU_MAKE_BIN@"
 config.ldc_host_arch       = "@LDC_HOST_ARCH@"
 config.ldc_with_lld        = "@LDC_WITH_LLD@" == "ON"
+config.spirv_enabled       = @LLVM_SPIRV_FOUND@ +0 # LLVM_SPIRV_FOUND is blank if not set
 
 config.name = 'LDC'
 
@@ -87,6 +88,9 @@ config.available_features.add(platform.system())
 # Examples: 'target_X86', 'target_ARM', 'target_PowerPC', 'target_AArch64'
 for t in config.llvm_targetsstr.split(';'):
     config.available_features.add('target_' + t)
+
+if config.spirv_enabled:
+    config.available_features.add('target_SPIRV')
 
 # Add specific features for Windows x86/x64 testing
 if (platform.system() == 'Windows') and (config.default_target_bits == 32):


### PR DESCRIPTION
For use with https://github.com/KhronosGroup/SPIRV-LLVM-Translator now that I finally managed to get around to wrangling CMake, after breaking my backend upgrading LLVM. 

I'll add a release for OSX soon for testing, but this is something we can potentially do for LDC releases when we ship with LLVM7.