### PR TITLE
Always use PIC on FreeBSD, just like on Linux

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -423,6 +423,10 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
       // these OSes.
       // On Android, PIC is default as well.
       relocModel = llvm::Reloc::PIC_;
+    } else if (triple.isOSFreeBSD()) {
+      // We default to PIC code to avoid linking issues on FreeBSD, especially
+      // on aarch64.
+      relocModel = llvm::Reloc::PIC_;
     } else {
       // ARM for other than Darwin or Android defaults to static
       switch (triple.getArch()) {


### PR DESCRIPTION
This fixes errors like

```
[…]
/usr/bin/ld: error: can't create dynamic relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol: _D4core5cpuid6_ssse3yb in reado
nly segment; recompile object files with -fPIC                                                                               
>>> defined in runtime/objects-shared/core/cpuid.o
>>> referenced by cpuid.d                                                                                                    
>>>               runtime/objects-shared/core/cpuid.o:(_D4core5cpuid5ssse3FNaNbNdNiNeZb)                                     

/usr/bin/ld: error: can't create dynamic relocation R_AARCH64_LDST8_ABS_LO12_NC against symbol: _D4core5cpuid6_ssse3yb in read
only segment; recompile object files with -fPIC
>>> defined in runtime/objects-shared/core/cpuid.o
>>> referenced by cpuid.d
>>>               runtime/objects-shared/core/cpuid.o:(_D4core5cpuid5ssse3FNaNbNdNiNeZb)                                     
                                                                                                                             
/usr/bin/ld: error: can't create dynamic relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol: _D4core5cpuid6_sse41yb in reado
nly segment; recompile object files with -fPIC                                                                               
>>> defined in runtime/objects-shared/core/cpuid.o                                                                           
>>> referenced by cpuid.d
>>>               runtime/objects-shared/core/cpuid.o:(_D4core5cpuid5sse41FNaNbNdNiNeZb)                                     

/usr/bin/ld: error: can't create dynamic relocation R_AARCH64_LDST8_ABS_LO12_NC against symbol: _D4core5cpuid6_sse41yb in read
only segment; recompile object files with -fPIC
>>> defined in runtime/objects-shared/core/cpuid.o
>>> referenced by cpuid.d
>>>               runtime/objects-shared/core/cpuid.o:(_D4core5cpuid5sse41FNaNbNdNiNeZb)
```

and allows ASLR on [HardenedBSD](https://hardenedbsd.org) (/ "coming soon" ASR on upstream FreeBSD) to do its thing