### PR TITLE
[WIP] Fix mangling of extern(C++) function with two `real` arguments.

### DIFF
--- a/dmd/cppmangle.d
+++ b/dmd/cppmangle.d
@@ -1198,8 +1198,17 @@ extern(C++):
             case Tfloat64:               c = 'd';       break;
 version (IN_LLVM)
 {
-            // there are special cases for D `real`, handled via Target.cppTypeMangle() in the default case
-            case Tfloat80:               goto default;
+            // There are special cases for D `real` that need to be handled via Target.cppTypeMangle().
+            // Don't go to the default case because it would incorrectly substitute subsequent `real` arguments.
+            case Tfloat80:
+                auto cptr = Target.cppTypeMangle(t);
+                if (cptr is null)
+                    return error(t);
+                // Goto default case if the mangling is longer than one character.
+                if (cptr[1] != 0)
+                    goto default;
+                c = cptr[0];
+                break;
 }
 else
 {

--- a/dmd/cppmanglewin.d
+++ b/dmd/cppmanglewin.d
@@ -178,7 +178,10 @@ public:
             case Tuns64:
             case Tint128:
             case Tuns128:
+version (IN_LLVM) {} else
+{
             case Tfloat80:
+}
             case Twchar:
                 if (checkTypeSaved(type))
                     return;
@@ -241,10 +244,19 @@ public:
             break;
             // unsigned int
         case Tfloat80:
+version (IN_LLVM)
+{
+            // unlike DMD, LDC uses 64-bit `real` for Windows/MSVC targets,
+            // corresponding to MSVC++ long double
+            buf.writeByte('O');        // Visual C++ long double
+}
+else
+{
             if (flags & IS_DMC)
                 buf.writestring("_Z"); // DigitalMars long double
             else
                 buf.writestring("_T"); // Intel long double
+}
             break;
         case Twchar:
             if (flags & IS_DMC)

--- a/tests/codegen/mangling_real_real.d
+++ b/tests/codegen/mangling_real_real.d
@@ -10,7 +10,7 @@ import core.stdc.config;
 
 // LINUX: define {{.*}}Z8withrealee
 // ANDROID: define {{.*}}Z8withrealgg
-// WINDOWS: define {{.*}}?withreal@@YAX_T0@Z
+// WINDOWS: define {{.*}}?withreal@@YAXOO@Z
 extern (C++) void withreal(real a, real b)
 {
 }

--- a/tests/codegen/mangling_real_real.d
+++ b/tests/codegen/mangling_real_real.d
@@ -1,0 +1,23 @@
+// Tests that repeated `real` return types are treated as built-in types in C++ mangling (no substitution).
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-linux   -c -output-ll -of=%t.ll         %s && FileCheck %s --check-prefix=LINUX   < %t.ll
+// RUN: %ldc -mtriple=x86_64-android -c -output-ll -of=%t.android.ll %s && FileCheck %s --check-prefix=ANDROID < %t.android.ll
+// RUN: %ldc -mtriple=x86_64-windows -c -output-ll -of=%t.windows.ll %s && FileCheck %s --check-prefix=WINDOWS < %t.windows.ll
+
+import core.stdc.config;
+
+// LINUX: define {{.*}}Z8withrealee
+// ANDROID: define {{.*}}Z8withrealgg
+// WINDOWS: define {{.*}}?withreal@@YAX_T0@Z
+extern (C++) void withreal(real a, real b)
+{
+}
+
+// LINUX: define {{.*}}Z15withclongdoubleee
+// ANDROID: define {{.*}}Z15withclongdoublegg
+// WINDOWS: define {{.*}}?withclongdouble@@YAXOO@Z
+extern (C++) void withclongdouble(c_long_double a, c_long_double b)
+{
+}


### PR DESCRIPTION
The only mangling I am not sure of is the Windows mangling of `extern (C++) void withreal(real a, real b)`. @kinke Can you confirm the check `WINDOWS: define {{.*}}?withreal@@YAX_T0@Z` makes sense? The online demangler I tested with cannot demangle it; but I don't know what exactly we want to be doing for `real` arguments on windows w.r.t. mangling.

To be safe for some future platform where `real` would be mangled by more than one character, I forward to the old default behavior (including type mangling substitution, such as is done for other types whose mangling consists of multiple characters like `cfloat`).

See also: https://forum.dlang.org/post/dsrjmpnavxqsjqmlvotf@forum.dlang.org