### PR TITLE
Fix context of some nested aggregates

### DIFF
--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -259,18 +259,8 @@ LLValue *DtoNestedContext(Loc &loc, Dsymbol *sym) {
     return llvm::ConstantPointerNull::get(getVoidPtrType());
   }
 
-  FuncDeclaration *frameToPass = nullptr;
-  if (AggregateDeclaration *ad = sym->isAggregateDeclaration()) {
-    // If sym is a nested struct or a nested class, pass the frame
-    // of the function where sym is declared.
-    frameToPass = ad->toParent()->isFuncDeclaration();
-  } else if (FuncDeclaration *symfd = sym->isFuncDeclaration()) {
-    // If sym is a nested function, and its parent context is different
-    // than the one we got, adjust it.
-    frameToPass = getParentFunc(symfd);
-  }
-
-  if (frameToPass) {
+  // The symbol may need a parent context of the current function.
+  if (FuncDeclaration *frameToPass = getParentFunc(sym)) {
     IF_LOG Logger::println("Parent frame is from %s", frameToPass->toChars());
     FuncDeclaration *ctxfd = irFunc.decl;
     IF_LOG Logger::println("Current function is %s", ctxfd->toChars());

--- a/tests/codegen/nested_gh2960.d
+++ b/tests/codegen/nested_gh2960.d
@@ -1,0 +1,36 @@
+// RUN: %ldc -run %s
+
+template listDir(alias handler)
+{
+    struct NestedStruct
+    {
+        void callHandler() { handler(); }
+    }
+
+    class NestedClass
+    {
+        void callHandler() { handler(); }
+    }
+
+    void nestedFunc() { handler(); }
+
+    void listDir()
+    {
+        int a = 123;
+        void foo() { assert(a == 123); }
+
+        // pass local listDir() frame as context
+        foo();
+
+        // pass parent context for sibling symbols:
+        NestedStruct().callHandler();
+        (new NestedClass).callHandler();
+        nestedFunc();
+    }
+}
+
+void main()
+{
+    int magic = 0xDEADBEEF;
+    listDir!(() { assert(magic == 0xDEADBEEF); })();
+}


### PR DESCRIPTION
The context for instances of aggregates *not* nested in the current function, but some parent. Fixes #2960.