### PR TITLE
Travis: Disable Linux LLVM 7.0.1 job (C++ compiler ABI mismatch?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ sudo: false
 
 matrix:
   include:
-    - os: linux
-      d: ldc
-      env: LLVM_VERSION=7.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
+    # FIXME: strange crashes, possibly due to C++ compiler mismatch
+    #- os: linux
+    #  d: ldc
+    #  env: LLVM_VERSION=7.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
     - os: linux
       d: ldc-beta
       env: LLVM_VERSION=6.0.1 OPTS="-DBUILD_SHARED_LIBS=OFF -DLIB_SUFFIX=64"


### PR DESCRIPTION
This only *appeared* to work, as long as the official prebuilt 7.0.1 archive wasn't available for download (I guess). The 'successful' [job](https://travis-ci.org/ldc-developers/ldc/jobs/471620842) in #2955 used a preinstalled LLVM 5.0.0 (`/usr/local/clang-5.0.0`).