### PR TITLE
Fix C++ mangling of `real` for MSVC targets

### DIFF
--- a/dmd/cppmanglewin.d
+++ b/dmd/cppmanglewin.d
@@ -179,7 +179,10 @@ public:
             case Tuns64:
             case Tint128:
             case Tuns128:
+version (IN_LLVM) {} else
+{
             case Tfloat80:
+}
             case Twchar:
                 if (checkTypeSaved(type))
                     return;
@@ -242,10 +245,19 @@ public:
             break;
             // unsigned int
         case Tfloat80:
+version (IN_LLVM)
+{
+            // unlike DMD, LDC uses 64-bit `real` for Windows/MSVC targets,
+            // corresponding to MSVC++ long double
+            buf.writeByte('O');        // Visual C++ long double
+}
+else
+{
             if (flags & IS_DMC)
                 buf.writestring("_Z"); // DigitalMars long double
             else
                 buf.writestring("_T"); // Intel long double
+}
             break;
         case Twchar:
             if (flags & IS_DMC)

--- a/tests/codegen/mangling_real_real.d
+++ b/tests/codegen/mangling_real_real.d
@@ -1,0 +1,23 @@
+// Tests that repeated `real` return types are treated as built-in types in C++ mangling (no substitution).
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-linux   -c -output-ll -of=%t.ll         %s && FileCheck %s --check-prefix=LINUX   < %t.ll
+// RUN: %ldc -mtriple=x86_64-android -c -output-ll -of=%t.android.ll %s && FileCheck %s --check-prefix=ANDROID < %t.android.ll
+// RUN: %ldc -mtriple=x86_64-windows -c -output-ll -of=%t.windows.ll %s && FileCheck %s --check-prefix=WINDOWS < %t.windows.ll
+
+import core.stdc.config;
+
+// LINUX: define {{.*}}Z8withrealee
+// ANDROID: define {{.*}}Z8withrealgg
+// WINDOWS: define {{.*}}?withreal@@YAXOO@Z
+extern (C++) void withreal(real a, real b)
+{
+}
+
+// LINUX: define {{.*}}Z15withclongdoubleee
+// ANDROID: define {{.*}}Z15withclongdoublegg
+// WINDOWS: define {{.*}}?withclongdouble@@YAXOO@Z
+extern (C++) void withclongdouble(c_long_double a, c_long_double b)
+{
+}


### PR DESCRIPTION
Cherry-pick from #2953 (Posix mangling fix already in 2.084 upstream => master):

Mangle as native Visual C++ long double. DMD has to special-case, as it's using 80-bit extended precision.