### PR TITLE
@weak on definitions should not result in extern_weak linkage on declarations

### DIFF
--- a/tests/codegen/attr_weak_external.d
+++ b/tests/codegen/attr_weak_external.d
@@ -1,0 +1,12 @@
+// Test that an imported @weak function does not result in an extern_weak reference.
+
+// RUN: %ldc -c -I%S -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import inputs.attr_weak_external_input: weak_definition_seven;
+
+void foo()
+{
+    auto a = &weak_definition_seven;
+}
+
+// CHECK-NOT: extern_weak

--- a/tests/codegen/attr_weak_lto.d
+++ b/tests/codegen/attr_weak_lto.d
@@ -1,0 +1,22 @@
+// Test importing a @weak function with LTO
+
+// REQUIRES: LTO
+
+// RUN: %ldc -c %S/inputs/attr_weak_external_input.d -of=%t.thin%obj -flto=thin
+// RUN: %ldc -I%S -of=%t.thin%exe -flto=thin %s %t.thin%obj
+// RUN: %t.thin%exe
+
+// RUN: %ldc -c %S/inputs/attr_weak_external_input.d -of=%t.full%obj -flto=full
+// RUN: %ldc -I%S -of=%t.full%exe -flto=full %s %t.full%obj
+// RUN: %t.full%exe
+
+import inputs.attr_weak_external_input: weak_definition_seven;
+
+// Forward declaration intentionally without `@weak`
+extern(C) int weak_definition_four();
+
+void main()
+{
+    assert(&weak_definition_four != null);
+    assert(&weak_definition_seven != null);
+}

--- a/tests/codegen/inputs/attr_weak_external_input.d
+++ b/tests/codegen/inputs/attr_weak_external_input.d
@@ -1,0 +1,9 @@
+import ldc.attributes;
+
+extern(C) @weak int weak_definition_four() {
+  return 4;
+}
+
+extern(C) @weak int weak_definition_seven() {
+  return 7;
+}


### PR DESCRIPTION
This is useful for optionally linking with libraries. (if not linked with the function, the function address is set to `null` by the linker).

I don't know whether it works on Windows. On macOS, it's somewhat problematic because it requires telling the linker to accept such undefined references. With ELF, it should work fine.
The difference between platforms make this less useful, but it is not much trouble to support the usecase.