### PR TITLE
Account for front-end implicitly casting vector return values to static arrays

### DIFF
--- a/tests/compilable/gh2988.d
+++ b/tests/compilable/gh2988.d
@@ -1,6 +1,3 @@
-// Host needs float4 support.
-// REQUIRES: host_X86
-
 // RUN: %ldc -c %s
 
 import core.simd;

--- a/tests/compilable/gh2988.d
+++ b/tests/compilable/gh2988.d
@@ -1,0 +1,14 @@
+// Host needs float4 support.
+// REQUIRES: host_X86
+
+// RUN: %ldc -c %s
+
+import core.simd;
+
+float4 getVector() { return float4(1.0f); }
+
+void foo()
+{
+    // front-end implicitly casts from float4 to float[4]
+    float x = getVector()[0];
+}


### PR DESCRIPTION
Fixes #2988.