### PR TITLE
Cache struct literal constants per compilation unit, not globally

### DIFF
--- a/dmd/expression.d
+++ b/dmd/expression.d
@@ -2933,10 +2933,6 @@ extern (C++) final class StructLiteralExp : Expression
         // now contain pointers to themselves. While in toElem, contains a pointer
         // to the memory used to build the literal for resolving such references.
         void* inProgressMemory; // llvm::Value*
-
-        // A global variable for taking the address of this struct literal constant,
-        // if it already exists. Used to resolve self-references.
-        void* globalVar; // llvm::Constant*
     }
 
     bool useStaticInit;     /// if this is true, use the StructDeclaration's init symbol

--- a/dmd/expression.h
+++ b/dmd/expression.h
@@ -361,10 +361,6 @@ public:
     // now contain pointers to themselves. While in toElem, contains a pointer
     // to the memory used to build the literal for resolving such references.
     llvm::Value* inProgressMemory;
-
-    // A global variable for taking the address of this struct literal constant,
-    // if it already exists. Used to resolve self-references.
-    llvm::Constant *globalVar;
 #endif
 
     bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol

--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -180,6 +180,17 @@ void IRState::replaceGlobals() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+LLConstant *IRState::getStructLiteralConstant(StructLiteralExp *sle) const {
+  return static_cast<LLConstant *>(structLiteralConstants.lookup(sle));
+}
+
+void IRState::setStructLiteralConstant(StructLiteralExp *sle,
+                                       LLConstant *constant) {
+  structLiteralConstants[sle] = constant;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 IRBuilder<> *IRBuilderHelper::operator->() {
   IRBuilder<> &b = state->scope().builder;
   assert(b.GetInsertBlock() != NULL);

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -114,7 +114,8 @@ private:
       globalsToReplace;
 
   // Cache of (possibly bitcast) global variables for taking the address of
-  // struct literal constants. Used to resolve self-references.
+  // struct literal constants. (Also) used to resolve self-references. Must be
+  // cached per IR module: https://github.com/ldc-developers/ldc/issues/2990
   // [The real key type is `StructLiteralExp *`; a fwd class declaration isn't
   // enough to use it directly.]
   llvm::DenseMap<void *, llvm::Constant *> structLiteralConstants;

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -413,10 +413,10 @@ public:
     if (e->e1->op == TOKstructliteral) {
       StructLiteralExp *se = static_cast<StructLiteralExp *>(e->e1);
 
-      if (se->globalVar) {
+      result = p->getStructLiteralConstant(se);
+      if (result) {
         IF_LOG Logger::cout()
-            << "Returning existing global: " << *se->globalVar << '\n';
-        result = se->globalVar;
+            << "Returning existing global: " << *result << '\n';
         return;
       }
 
@@ -425,11 +425,12 @@ public:
           llvm::GlobalValue::InternalLinkage, nullptr, ".structliteral");
       globalVar->setAlignment(DtoAlignment(se->type));
 
-      se->globalVar = globalVar;
+      p->setStructLiteralConstant(se, globalVar);
       llvm::Constant *constValue = toConstElem(se);
-      se->globalVar = p->setGlobalVarInitializer(globalVar, constValue);
+      constValue = p->setGlobalVarInitializer(globalVar, constValue);
+      p->setStructLiteralConstant(se, constValue);
 
-      result = se->globalVar;
+      result = constValue;
       return;
     }
 
@@ -579,14 +580,14 @@ public:
     DtoResolveClass(origClass);
     StructLiteralExp *value = e->value;
 
-    if (value->globalVar) {
-      IF_LOG Logger::cout()
-          << "Using existing global: " << *value->globalVar << '\n';
+    result = p->getStructLiteralConstant(value);
+    if (result) {
+      IF_LOG Logger::cout() << "Using existing global: " << *result << '\n';
     } else {
       auto globalVar = new llvm::GlobalVariable(
           p->module, origClass->type->ctype->isClass()->getMemoryLLType(),
           false, llvm::GlobalValue::InternalLinkage, nullptr, ".classref");
-      value->globalVar = globalVar;
+      p->setStructLiteralConstant(value, globalVar);
 
       std::map<VarDeclaration *, llvm::Constant *> varInits;
 
@@ -623,11 +624,11 @@ public:
 
       llvm::Constant *constValue =
           getIrAggr(origClass)->createInitializerConstant(varInits);
+      constValue = p->setGlobalVarInitializer(globalVar, constValue);
+      p->setStructLiteralConstant(value, constValue);
 
-      value->globalVar = p->setGlobalVarInitializer(globalVar, constValue);
+      result = constValue;
     }
-
-    result = value->globalVar;
 
     if (e->type->ty == Tclass) {
       ClassDeclaration *targetClass = static_cast<TypeClass *>(e->type)->sym;


### PR DESCRIPTION
Fixes #2990.

I don't have a reduced testcase.