### PR TITLE
Fix identity comparisons of complex numbers

### DIFF
--- a/gen/complex.cpp
+++ b/gen/complex.cpp
@@ -421,10 +421,8 @@ LLValue *DtoComplexEquals(Loc &loc, TOK op, DValue *lhs, DValue *rhs) {
   LLValue *b1 = DtoBinFloatsEquals(loc, lhs_re, rhs_re, op);
   LLValue *b2 = DtoBinFloatsEquals(loc, lhs_im, rhs_im, op);
 
-  if (op == TOKequal) {
-    return gIR->ir->CreateAnd(b1, b2);
-  }
-  return gIR->ir->CreateOr(b1, b2);
+  return (op == TOKequal || op == TOKidentity) ? gIR->ir->CreateAnd(b1, b2)
+                                               : gIR->ir->CreateOr(b1, b2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/codegen/complex_identity_gh2918.d
+++ b/tests/codegen/complex_identity_gh2918.d
@@ -1,0 +1,17 @@
+// RUN: %ldc -run %s
+
+void main()
+{
+    creal f1 = +0.0 + 0.0i;
+    creal f2 = +0.0 - 0.0i;
+    creal f3 = -0.0 + 0.0i;
+    creal f4 = +0.0 + 0.0i;
+    assert(f1 !is f2);
+    assert(f1 !is f3);
+    assert(f2 !is f3);
+    assert(f1 is f4);
+    assert(!(f1 is f2));
+    assert(!(f1 is f3));
+    assert(!(f2 is f3));
+    assert(!(f1 !is f4));
+}


### PR DESCRIPTION
Obviously *both* real and imaginary parts need to be identical.
Fixes #2918.