### PR TITLE
DSliceValue: Don't cache *extracted* length & ptr

### DIFF
--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -80,29 +80,26 @@ DConstValue::DConstValue(Type *t, LLConstant *con) : DRValue(t, con) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue::DSliceValue(Type *t, LLValue *pair) : DRValue(t, pair) {
+DSliceValue::DSliceValue(Type *t, LLValue *pair, LLValue *length, LLValue *ptr)
+    : DRValue(t, pair), length(length), ptr(ptr) {
   assert(t->toBasetype()->ty == Tarray);
   // v may be an addrspace qualified pointer so strip it before doing a pointer
   // equality check.
   assert(stripAddrSpaces(pair->getType()) == DtoType(t));
 }
 
+DSliceValue::DSliceValue(Type *t, LLValue *pair)
+    : DSliceValue(t, pair, nullptr, nullptr) {}
+
 DSliceValue::DSliceValue(Type *t, LLValue *length, LLValue *ptr)
-    : DSliceValue(t, DtoAggrPair(length, ptr)) {
-  cachedLength = length;
-  cachedPtr = ptr;
-}
+    : DSliceValue(t, DtoAggrPair(length, ptr), length, ptr) {}
 
 LLValue *DSliceValue::getLength() {
-  if (!cachedLength)
-    cachedLength = DtoExtractValue(val, 0, ".len");
-  return cachedLength;
+  return length ? length : DtoExtractValue(val, 0, ".len");
 }
 
 LLValue *DSliceValue::getPtr() {
-  if (!cachedPtr)
-    cachedPtr = DtoExtractValue(val, 1, ".ptr");
-  return cachedPtr;
+  return ptr ? ptr : DtoExtractValue(val, 1, ".ptr");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -117,8 +117,11 @@ public:
 
 /// Represents a D slice (dynamic array).
 class DSliceValue : public DRValue {
-  llvm::Value *cachedLength = nullptr;
-  llvm::Value *cachedPtr = nullptr;
+  llvm::Value *const length = nullptr;
+  llvm::Value *const ptr = nullptr;
+
+  DSliceValue(Type *t, llvm::Value *pair, llvm::Value *length,
+              llvm::Value *ptr);
 
 public:
   DSliceValue(Type *t, llvm::Value *pair);

--- a/tests/compilable/gh2996.d
+++ b/tests/compilable/gh2996.d
@@ -1,0 +1,20 @@
+// RUN: %ldc -c %s
+
+struct Table
+{
+    RCArray _elems;
+
+    void update(int x)
+    {
+        auto e = _elems[0 .. x][x == 0 ? x : $];
+    }
+}
+
+struct RCArray
+{
+    int[] _arr;
+
+    inout opSlice(size_t, size_t) { return _arr; }
+    const length() { return _arr.length; }
+    const opDollar() { return length; }
+}


### PR DESCRIPTION
As they may be extracted earlier in an unrelated basic block.
Fixes #2996.