### PR TITLE
Fix FPelim from LLVM8

### DIFF
--- a/driver/cl_options-llvm.cpp
+++ b/driver/cl_options-llvm.cpp
@@ -37,7 +37,7 @@ Optional<CodeModel::Model> getCodeModel() { return ::getCodeModel(); }
 CodeModel::Model getCodeModel() { return ::CMModel; }
 #endif
 
-#if LDC_LLVM_VER >= 900
+#if LDC_LLVM_VER >= 800
 llvm::Optional<llvm::FramePointer::FP> framePointerUsage() {
   if (::FramePointerUsage.getNumOccurrences() == 0)
     return llvm::None;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -469,7 +469,7 @@ void applyTargetMachineAttributes(llvm::Function &func,
   func.addFnAttr("no-infs-fp-math", TO.NoInfsFPMath ? "true" : "false");
   func.addFnAttr("no-nans-fp-math", TO.NoNaNsFPMath ? "true" : "false");
 
-#if LDC_LLVM_VER >= 900
+#if LDC_LLVM_VER >= 800
   switch (whichFramePointersToEmit()) {
     case llvm::FramePointer::None:
       func.addFnAttr("no-frame-pointer-elim", "false");

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -126,7 +126,7 @@ bool willCrossModuleInline() {
   return enableCrossModuleInlining == llvm::cl::BOU_TRUE;
 }
 
-#if LDC_LLVM_VER >= 900
+#if LDC_LLVM_VER >= 800
 llvm::FramePointer::FP whichFramePointersToEmit() {
   auto option = opts::framePointerUsage();
   if (option)

--- a/gen/optimizer.h
+++ b/gen/optimizer.h
@@ -34,7 +34,7 @@ bool willInline();
 
 bool willCrossModuleInline();
 
-#if LDC_LLVM_VER >= 900
+#if LDC_LLVM_VER >= 800
 llvm::FramePointer::FP whichFramePointersToEmit();
 #else
 bool willEliminateFramePointer();


### PR DESCRIPTION
It was apparently removed in LLVM8 not LLVM9

see https://github.com/llvm-mirror/llvm/blob/release_80/include/llvm/CodeGen/CommandFlags.inc