### PR TITLE
Travis: Upgrade to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-dist: trusty
+dist: xenial
 language: d
-sudo: false
+
+git:
+  depth: 50
 
 matrix:
   include:
@@ -16,7 +18,7 @@ matrix:
       env: LLVM_VERSION=5.0.2 OPTS="-DBUILD_SHARED_LIBS=ON -DLIB_SUFFIX=64"
     - os: linux
       d: ldc-0.17.6
-      env: LLVM_VERSION=4.0.1 OPTS="-DLIB_SUFFIX=64"
+      env: LLVM_VERSION=4.0.0 OPTS="-DLIB_SUFFIX=64"
     - os: linux
       d: dmd
       env: LLVM_VERSION=3.9.1 OPTS="-DTEST_COVERAGE=ON"
@@ -35,89 +37,87 @@ cache:
     - llvm-7.0.0
     - llvm-6.0.1
     - llvm-5.0.2
-    - llvm-4.0.1
+    - llvm-4.0.0
     - llvm-3.9.1
 
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-4.9
     - gdb
     - ninja-build
 
+# Download & extract prebuilt vanilla LLVM if not in cache
 before_install:
   - export LLVM_ROOT_DIR="$PWD/llvm-$LLVM_VERSION"
-  -
+  - |
     if [ ! -e "$LLVM_ROOT_DIR/bin/llvm-config" ]; then
-      if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-        if [ "${LLVM_VERSION}" = "4.0.1" ]; then
-          export LLVM_ARCH="x86_64-linux-gnu-debian8";
-        else
-          export LLVM_ARCH="x86_64-linux-gnu-ubuntu-14.04";
-        fi;
+      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        export LLVM_ARCH="x86_64-linux-gnu-ubuntu-16.04"
       else
-        export LLVM_ARCH="x86_64-apple-darwin";
-      fi;
-      wget -O llvm.tar.xz http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-${LLVM_ARCH}.tar.xz;
-      mkdir -p $LLVM_ROOT_DIR;
-      tar -xf llvm.tar.xz --strip 1 -C $LLVM_ROOT_DIR;
-      rm llvm.tar.xz;
+        export LLVM_ARCH="x86_64-apple-darwin"
+      fi
+      wget -O llvm.tar.xz http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-$LLVM_ARCH.tar.xz
+      mkdir -p $LLVM_ROOT_DIR
+      tar -xf llvm.tar.xz --strip 1 -C $LLVM_ROOT_DIR
+      rm llvm.tar.xz
     fi
 
 install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export CC="gcc-4.9"; export CXX="g++-4.9"; fi
-  -
-    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py;
-      sudo python get-pip.py;
-      wget -O ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-mac.zip;
-      mkdir ninja;
-      tar -xf ninja-mac.zip -C ninja;
-      export PATH="$PWD/ninja:$PATH";
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      # Install pip
+      wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py
+      sudo python get-pip.py
+      rm get-pip.py
+      # Download & extract Ninja & add to PATH
+      wget -O ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-mac.zip
+      mkdir ninja
+      tar -xf ninja-mac.zip -C ninja
+      rm ninja-mac.zip
+      export PATH="$PWD/ninja:$PATH"
     fi
+  # Install lit
   - pip install --user lit
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ld --version; gdb --version; fi
-  - cmake --version
-  - ninja --version
   - python -c "import lit; lit.main();" --version | head -n 1
-  - eval "${DC} --version"
 
 script:
-  # Invoke CMake to generate the Ninja build files.
-  - cmake -G Ninja -DLLVM_ROOT_DIR=$LLVM_ROOT_DIR -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON $OPTS .
-  # Build LDC, LDC D unittests and defaultlib unittest runners.
-  # [Some unittest modules eat large amounts of memory during compilation => -j2.]
-  - ninja -j2 all ldc2-unittest runtime/objects-unittest/std/algorithm/searching.o runtime/objects-unittest-debug/std/algorithm/searching.o runtime/objects-unittest/std/range/package.o runtime/objects-unittest-debug/std/range/package.o runtime/objects-unittest/std/regex/internal/tests.o runtime/objects-unittest-debug/std/regex/internal/tests.o
-  - ninja -j3 all-test-runners
-  # Output some environment info, plus make sure we only run the test suite
-  # if we could actually build the executable.
-  - bin/ldc2 -version || exit 1
-  # Run LDC D unittests.
-  - ctest --output-on-failure -R "ldc2-unittest"
-  # Run LIT testsuite.
-  - ctest -V -R "lit-tests"
-  # Run DMD testsuite.
+  - cmake --version
+  - ninja --version
   - |
-    # Optimized runnable/testconst.d crashes (in _aaInX) with shared libs on Linux -
-    # only for Travis apparently.
-    if [ "${TRAVIS_OS_NAME}" = "linux" ] && [[ "${OPTS}" == *-DBUILD_SHARED_LIBS?ON* ]]; then
-      rm tests/d2/dmd-testsuite/runnable/testconst.d;
+    cmake -G Ninja . \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_ROOT_DIR=$LLVM_ROOT_DIR \
+      -DLDC_INSTALL_LTOPLUGIN=ON \
+      -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
+      $OPTS
+  # Build LDC & LDC D unittests & defaultlib unittest runners
+  - |
+    numJobs=3
+    # The OSX VM has only 4 GB of memory (Linux: 7.5)
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      numJobs=2
     fi
-    # The -lowmem tests don't work with an ltsmaster host compiler.
-    if [[ "$(${DC} --version | head -n 1)" == *0.17.* ]]; then
-      rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d;
-      rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d;
+    ninja -j$numJobs all ldc2-unittest all-test-runners
+  - bin/ldc2 -version || exit 1
+  # Run LDC D unittests
+  - ctest --output-on-failure -R "ldc2-unittest"
+  # Run LIT testsuite
+  - ctest -V -R "lit-tests"
+  # Run DMD testsuite
+  - |
+    # The -lowmem tests don't work with an ltsmaster host compiler
+    if [[ "$($DC --version | head -n 1)" == *0.17.* ]]; then
+      rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d
+      rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
     fi
   - DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
-  # Run defaultlib unittests & druntime stand-alone tests.
+  # Run defaultlib unittests & druntime stand-alone tests
   - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
 
 after_success:
-  -
-    if [[ "${OPTS}" == *-DTEST_COVERAGE?ON* ]]; then
-      coveralls -e runtime -e tests -e vcbuild --gcov gcov-4.9 --gcov-options '\-lp' > /dev/null 2>&1;
+  - |
+    if [[ "$OPTS" == *-DTEST_COVERAGE?ON* ]]; then
+      coveralls -e runtime -e tests -e vcbuild --gcov gcov-4.9 --gcov-options '\-lp' > /dev/null 2>&1
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,13 @@ script:
       rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d
       rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
     fi
-  - DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
+    # The Mac boxes are too slow and time out after 50 mins most of the time.
+    # So skip dmd-testsuite (release), only run dmd-testsuite-debug.
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite-debug"
+    else
+      DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
+    fi
   # Run defaultlib unittests & druntime stand-alone tests
   - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
 


### PR DESCRIPTION
The prebuilt 1.15.0-beta1 package (built on Ubuntu 16.04) doesn't work on Ubuntu 14.04, e.g.:
```
/usr/bin/ld.gold: error: /home/travis/dlang/ldc-1.15.0-beta1/bin/../lib/libphobos2-ldc.a(deflate.c.o): unsupported reloc 42 against global symbol _length_code
```

Considering Trusty reaches EOL next month, upgrade to Xenial.