### PR TITLE
Travis: Don't build with coverage instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: LLVM_VERSION=4.0.0 OPTS="-DLIB_SUFFIX=64"
     - os: linux
       d: dmd
-      env: LLVM_VERSION=3.9.1 OPTS="-DTEST_COVERAGE=ON"
+      env: LLVM_VERSION=3.9.1
     - os: osx
       osx_image: xcode9.2
       d: dmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,20 +103,14 @@ script:
   - ctest --output-on-failure -R "ldc2-unittest"
   # Run LIT testsuite
   - ctest -V -R "lit-tests"
-  # Run DMD testsuite
+  # Run DMD testsuite (release only, i.e., no dmd-testsuite-debug, to reduce time-outs)
   - |
     # The -lowmem tests don't work with an ltsmaster host compiler
     if [[ "$($DC --version | head -n 1)" == *0.17.* ]]; then
       rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d
       rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
     fi
-    # The Mac boxes are too slow and time out after 50 mins most of the time.
-    # So skip dmd-testsuite (release), only run dmd-testsuite-debug.
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite-debug"
-    else
-      DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite"
-    fi
+    DMD_TESTSUITE_MAKE_ARGS=-j3 ctest -V -R "dmd-testsuite" -E "-debug$"
   # Run defaultlib unittests & druntime stand-alone tests
   - ctest -j3 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
 


### PR DESCRIPTION
That job is frequently timing out. The implicit `-O0` for LDC's C++ parts (excl. LLVM) certainly don't help, and the coverage data hasn't been used for years (issue #1751).