### PR TITLE
Add lib files when linking for a static library

### DIFF
--- a/driver/archiver.cpp
+++ b/driver/archiver.cpp
@@ -325,7 +325,7 @@ int createStaticLibrary() {
   for (auto objfile : global.params.objfiles) {
     args.push_back(objfile);
   }
-  
+
   // user libs
   for (auto libfile : global.params.libfiles) {
     args.push_back(libfile);

--- a/driver/archiver.cpp
+++ b/driver/archiver.cpp
@@ -325,6 +325,11 @@ int createStaticLibrary() {
   for (auto objfile : global.params.objfiles) {
     args.push_back(objfile);
   }
+  
+  // user libs
+  for (auto libfile : global.params.libfiles) {
+    args.push_back(libfile);
+  }
 
   // .res/.def files for lib.exe
   if (isTargetMSVC) {


### PR DESCRIPTION
LDC currently silently ignores all passed lib files when linking for a static library, but dmd doesn't.
Current proposal makes LDC match DMD's behavior and link the libraries together.