### PR TITLE
Don't emit object.RTInfo(Impl) instantiations in dcompute modules

### DIFF
--- a/dmd/dsymbolsem.d
+++ b/dmd/dsymbolsem.d
@@ -2468,6 +2468,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (tempdecl.ident == Id.RTInfo)
                 Type.rtinfo = tempdecl;
+            version (IN_LLVM) if (tempdecl.ident == Id.RTInfoImpl)
+                Type.rtinfoImpl = tempdecl;
         }
 
         /* Remember Scope for later instantiations, but make

--- a/dmd/id.d
+++ b/dmd/id.d
@@ -490,6 +490,7 @@ immutable Msgtable[] msgtable =
     { "dcompute" },
     { "dcPointer", "Pointer" },
     { "dcReflect", "__dcompute_reflect" },
+    { "RTInfoImpl" },
 ];
 
 

--- a/dmd/mtype.d
+++ b/dmd/mtype.d
@@ -465,6 +465,7 @@ extern (C++) abstract class Type : RootObject
     extern (C++) __gshared ClassDeclaration typeinfowild;
 
     extern (C++) __gshared TemplateDeclaration rtinfo;
+    version (IN_LLVM) extern (C++) __gshared TemplateDeclaration rtinfoImpl;
 
     extern (C++) __gshared Type[TMAX] basic;
 

--- a/dmd/mtype.h
+++ b/dmd/mtype.h
@@ -231,6 +231,9 @@ public:
     static ClassDeclaration *typeinfowild;
 
     static TemplateDeclaration *rtinfo;
+#if IN_LLVM
+    static TemplateDeclaration *rtinfoImpl;
+#endif
 
     static Type *basic[TMAX];
 

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -386,6 +386,15 @@ public:
         Logger::println("Does not need codegen, skipping.");
         return;
       }
+
+      if (irs->dcomputetarget && (decl->tempdecl == Type::rtinfo ||
+                                  decl->tempdecl == Type::rtinfoImpl)) {
+        // Emitting object.RTInfo(Impl) template instantiations in dcompute
+        // modules would require dcompute support for global variables.
+        Logger::println("Skipping object.RTInfo(Impl) template instantiations "
+                        "in dcompute modules.");
+        return;
+      }
     }
 
     for (auto &m : *decl->members) {

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -231,11 +231,20 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     IF_LOG Logger::println("current function = %s", fd->toChars());
     currentFunction = fd;
   }
-    
+
   void visit(TemplateDeclaration*) override {
     // Don't try to analyse uninstansiated templates.
     stop = true;
   }
+
+  void visit(TemplateInstance *ti) override {
+    // object.RTInfo(Impl) template instantiations are skipped during codegen,
+    // as they contain unsupported global variables.
+    if (ti->tempdecl == Type::rtinfo || ti->tempdecl == Type::rtinfoImpl) {
+      stop = true;
+    }
+  }
+
   // Override the default assert(0) behavior of Visitor:
   void visit(Statement *) override {}   // do nothing
   void visit(Expression *) override {}  // do nothing

--- a/tests/codegen/dcompute_cl_addrspaces.d
+++ b/tests/codegen/dcompute_cl_addrspaces.d
@@ -1,7 +1,6 @@
 // See GH issue #2709
 
 // REQUIRES: target_SPIRV
-// REQUIRES: dcompute_RTInfo_fix
 // RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_ocl220_64.ll \
 // RUN: && %llvm-spirv -to-text addrspace_ocl220_64.spv && FileCheck %s --check-prefix=SPT < addrspace_ocl220_64.spt
 @compute(CompileFor.deviceOnly) module dcompute_cl_addrspaces;

--- a/tests/codegen/dcompute_cu_addrspaces.d
+++ b/tests/codegen/dcompute_cu_addrspaces.d
@@ -1,5 +1,4 @@
 // REQUIRES: target_NVPTX
-// REQUIRES: dcompute_RTInfo_fix
 // RUN: %ldc -c -mdcompute-targets=cuda-350 -m64 -mdcompute-file-prefix=addrspace -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_cuda350_64.ll && FileCheck %s --check-prefix=PTX < addrspace_cuda350_64.ptx
 @compute(CompileFor.deviceOnly) module dcompute_cu_addrspaces;
 import ldc.dcompute;

--- a/tests/compilable/dcompute.d
+++ b/tests/compilable/dcompute.d
@@ -5,7 +5,6 @@
 //  - typeid generated for hashing of struct (typeid(const(T))) is ignored and does not error
 
 // REQUIRES: target_NVPTX
-// REQUIRES: dcompute_RTInfo_fix
 // RUN: %ldc -mdcompute-targets=cuda-350 -g %s
 
 @compute(CompileFor.deviceOnly) module dcompute;


### PR DESCRIPTION
This is not a perfect solution, as other modules might be relying on an emission (template culling...), but should work in most cases (and otherwise probably yields a linker error).

It'd have been a shame to ship with a totally broken dcompute for the first official LDC packages able to emit OpenCL (v1.15), so I reluctantly took matters in my own hands.