### PR TITLE
Azure CI: Make prebuilt Linux package usable on Ubuntu 14.04 again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,10 @@ jobs:
     vmImage: 'ubuntu-16.04'
   variables:
     CI_OS: linux
-    EXTRA_CMAKE_FLAGS: -DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON
+    # To improve portability of the generated binaries, link the C++ standard library statically.
+    # Also don't use relax relocations for the C(++) parts of the default libraries in order to
+    # support older user binutils (e.g., Ubuntu 14.04).
+    EXTRA_CMAKE_FLAGS: -DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DRT_CFLAGS=-Wa,-mrelax-relocations=no -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON
   steps:
     - template: .azure-pipelines/posix.yml
 


### PR DESCRIPTION
By instructing the C(++) compiler not to emit relax relocations for the default libs, so that older binutils can be used to link against them.

Resolves #3020.

[I'll verify manually whether it actually works.]