### PR TITLE
Propagate well-known length of newly allocated arrays

### DIFF
--- a/tests/codegen/array_alloc_gh3041.d
+++ b/tests/codegen/array_alloc_gh3041.d
@@ -1,0 +1,11 @@
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK-LABEL: define{{.*}} @{{.*}}3foo
+void[] foo()
+{
+    // CHECK-NEXT: %.gc_mem = call {{.*}} @_d_newarrayT
+    // CHECK-NEXT: %.ptr = extractvalue {{.*}} %.gc_mem, 1
+    // CHECK-NEXT: %1 = insertvalue {{.*}} { i{{32|64}} 3, i8* undef }, i8* %.ptr, 1
+    // CHECK-NEXT: ret {{.*}} %1
+    return new void[3];
+}


### PR DESCRIPTION
For better optimizability, as the length information is lost when using the slice returned by the druntime hooks directly. Resolves #3041.