### PR TITLE
Support generic ldc.attributes.llvmAttr UDAs for function parameters

### DIFF
--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -214,10 +214,12 @@ struct IndirectByvalRewrite : ABIRewrite {
 
     // the copy is treated as a local variable of the callee
     // hence add the NoAlias and NoCapture attributes
-    arg.attrs.clear()
-        .add(LLAttribute::NoAlias)
-        .add(LLAttribute::NoCapture)
-        .addAlignment(DtoAlignment(arg.type));
+    auto &attrs = arg.attrs;
+    attrs.clear();
+    attrs.addAttribute(LLAttribute::NoAlias);
+    attrs.addAttribute(LLAttribute::NoCapture);
+    if (auto alignment = DtoAlignment(arg.type))
+      attrs.addAlignmentAttr(alignment);
   }
 };
 

--- a/gen/abi-ppc.cpp
+++ b/gen/abi-ppc.cpp
@@ -86,7 +86,8 @@ struct PPCTargetABI : TargetABI {
         }
       }
     } else if (ty->isintegral()) {
-      arg.attrs.add(ty->isunsigned() ? LLAttribute::ZExt : LLAttribute::SExt);
+      arg.attrs.addAttribute(ty->isunsigned() ? LLAttribute::ZExt
+                                              : LLAttribute::SExt);
     }
   }
 };

--- a/gen/abi-ppc64le.cpp
+++ b/gen/abi-ppc64le.cpp
@@ -72,7 +72,8 @@ struct PPC64LETargetABI : TargetABI {
         compositeToArray64.applyTo(arg);
       }
     } else if (ty->isintegral()) {
-      arg.attrs.add(ty->isunsigned() ? LLAttribute::ZExt : LLAttribute::SExt);
+      arg.attrs.addAttribute(ty->isunsigned() ? LLAttribute::ZExt
+                                              : LLAttribute::SExt);
     }
   }
 };

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -212,7 +212,9 @@ struct ImplicitByvalRewrite : ABIRewrite {
 
   void applyTo(IrFuncTyArg &arg, LLType *finalLType = nullptr) override {
     ABIRewrite::applyTo(arg, finalLType);
-    arg.attrs.addByVal(DtoAlignment(arg.type));
+    arg.attrs.addAttribute(LLAttribute::ByVal);
+    if (auto alignment = DtoAlignment(arg.type))
+      arg.attrs.addAlignmentAttr(alignment);
   }
 };
 

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -156,15 +156,16 @@ struct X86TargetABI : TargetABI {
       // try an implicit argument...
       if (fty.arg_this) {
         Logger::println("Putting 'this' in register");
-        fty.arg_this->attrs.add(LLAttribute::InReg);
+        fty.arg_this->attrs.addAttribute(LLAttribute::InReg);
       } else if (fty.arg_nest) {
         Logger::println("Putting context ptr in register");
-        fty.arg_nest->attrs.add(LLAttribute::InReg);
+        fty.arg_nest->attrs.addAttribute(LLAttribute::InReg);
       } else if (IrFuncTyArg *sret = fty.arg_sret) {
         Logger::println("Putting sret ptr in register");
         // sret and inreg are incompatible, but the ABI requires the
         // sret parameter to be in EAX in this situation...
-        sret->attrs.remove(LLAttribute::StructRet).add(LLAttribute::InReg);
+        sret->attrs.removeAttribute(LLAttribute::StructRet);
+        sret->attrs.addAttribute(LLAttribute::InReg);
       }
 
       // ... otherwise try the last argument
@@ -181,7 +182,7 @@ struct X86TargetABI : TargetABI {
 
         if (last->byref && !last->isByVal()) {
           Logger::println("Putting last (byref) parameter in register");
-          last->attrs.add(LLAttribute::InReg);
+          last->attrs.addAttribute(LLAttribute::InReg);
         } else if (!lastTy->isfloating() && (sz == 1 || sz == 2 || sz == 4)) {
           // rewrite aggregates as integers to make inreg work
           if (lastTy->ty == Tstruct || lastTy->ty == Tsarray) {
@@ -190,7 +191,7 @@ struct X86TargetABI : TargetABI {
             last->byref = false;
             last->attrs.clear();
           }
-          last->attrs.add(LLAttribute::InReg);
+          last->attrs.addAttribute(LLAttribute::InReg);
         }
       }
 
@@ -242,7 +243,7 @@ struct X86TargetABI : TargetABI {
     if (isMSVC) {
       for (auto arg : args) {
         if (arg->isByVal())
-          arg->attrs.remove(LLAttribute::Alignment);
+          arg->attrs.removeAttribute(LLAttribute::Alignment);
       }
     }
   }

--- a/gen/attributes.cpp
+++ b/gen/attributes.cpp
@@ -10,57 +10,6 @@
 #include "gen/attributes.h"
 #include "gen/irstate.h"
 
-bool AttrBuilder::hasAttributes() const { return builder.hasAttributes(); }
-
-bool AttrBuilder::contains(LLAttribute attribute) const {
-  return builder.contains(attribute);
-}
-
-AttrBuilder &AttrBuilder::clear() {
-  builder.clear();
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::add(LLAttribute attribute) {
-  // never set 'None' explicitly
-  if (attribute) {
-    builder.addAttribute(attribute);
-  }
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::remove(LLAttribute attribute) {
-  // never remove 'None' explicitly
-  if (attribute) {
-    builder.removeAttribute(attribute);
-  }
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::merge(const AttrBuilder &other) {
-  builder.merge(other.builder);
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::addAlignment(unsigned alignment) {
-  builder.addAlignmentAttr(alignment);
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::addByVal(unsigned alignment) {
-  builder.addAttribute(LLAttribute::ByVal);
-  if (alignment != 0) {
-    builder.addAlignmentAttr(alignment);
-  }
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::addDereferenceable(unsigned size) {
-  builder.addDereferenceableAttr(size);
-  return *this;
-}
-
-
 AttrSet::AttrSet(const AttrSet &base, unsigned index, LLAttribute attribute)
     : set(base.set.addAttribute(gIR->context(), index, attribute)) {}
 
@@ -77,7 +26,7 @@ AttrSet::extractFunctionAndReturnAttributes(const llvm::Function *function) {
 #endif
 }
 
-AttrSet &AttrSet::add(unsigned index, const AttrBuilder &builder) {
+AttrSet &AttrSet::add(unsigned index, const llvm::AttrBuilder &builder) {
   if (builder.hasAttributes()) {
 #if LDC_LLVM_VER >= 500
     set = set.addAttributes(gIR->context(), index, builder);

--- a/gen/attributes.h
+++ b/gen/attributes.h
@@ -18,32 +18,10 @@ using LLAttribute = llvm::Attribute::AttrKind;
   using LLAttributeSet = llvm::AttributeSet;
 #endif
 
-class AttrBuilder {
-  llvm::AttrBuilder builder;
-
-public:
-  AttrBuilder() = default;
-
-  bool hasAttributes() const;
-  bool contains(LLAttribute attribute) const;
-
-  AttrBuilder &clear();
-  AttrBuilder &add(LLAttribute attribute);
-  AttrBuilder &remove(LLAttribute attribute);
-  AttrBuilder &merge(const AttrBuilder &other);
-
-  AttrBuilder &addAlignment(unsigned alignment);
-  AttrBuilder &addByVal(unsigned alignment);
-  AttrBuilder &addDereferenceable(unsigned size);
-
-  operator llvm::AttrBuilder &() { return builder; }
-  operator const llvm::AttrBuilder &() const { return builder; }
-};
-
 class AttrSet {
   LLAttributeSet set;
 
-  AttrSet &add(unsigned index, const AttrBuilder &builder);
+  AttrSet &add(unsigned index, const llvm::AttrBuilder &builder);
 
 public:
   AttrSet() = default;
@@ -59,13 +37,13 @@ public:
   static AttrSet
   extractFunctionAndReturnAttributes(const llvm::Function *function);
 
-  AttrSet &addToParam(unsigned paramIndex, const AttrBuilder &builder) {
+  AttrSet &addToParam(unsigned paramIndex, const llvm::AttrBuilder &builder) {
     return add(paramIndex + FirstArgIndex, builder);
   }
-  AttrSet &addToFunction(const AttrBuilder &builder) {
+  AttrSet &addToFunction(const llvm::AttrBuilder &builder) {
     return add(LLAttributeSet::FunctionIndex, builder);
   }
-  AttrSet &addToReturn(const AttrBuilder &builder) {
+  AttrSet &addToReturn(const llvm::AttrBuilder &builder) {
     return add(LLAttributeSet::ReturnIndex, builder);
   }
   AttrSet &merge(const AttrSet &other);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -603,6 +603,11 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   // add func to IRFunc
   irFunc->setLLVMFunc(func);
 
+  // First apply the TargetMachine attributes, such that they can be overridden
+  // by UDAs.
+  applyTargetMachineAttributes(*func, *gTargetMachine);
+  applyFuncDeclUDAs(fdecl, irFunc);
+
   // parameter attributes
   if (!DtoIsIntrinsic(fdecl)) {
     applyParamAttrsToLLFunc(f, getIrFunc(fdecl)->irFty, func);
@@ -610,11 +615,6 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
       func->addFnAttr(LLAttribute::NoRedZone);
     }
   }
-
-  // First apply the TargetMachine attributes, such that they can be overridden
-  // by UDAs.
-  applyTargetMachineAttributes(*func, *gTargetMachine);
-  applyFuncDeclUDAs(fdecl, irFunc);
 
   if(irFunc->isDynamicCompiled()) {
     declareDynamicCompiledFunction(gIR, irFunc);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -91,20 +91,21 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
   } else {
     Type *rt = f->next;
     const bool byref = f->isref && rt->toBasetype()->ty != Tvoid;
-    AttrBuilder attrs;
+    llvm::AttrBuilder attrs;
 
     if (abi->returnInArg(f, fd && fd->needThis())) {
       // sret return
-      newIrFty.arg_sret = new IrFuncTyArg(
-          rt, true,
-          AttrBuilder().add(LLAttribute::StructRet).add(LLAttribute::NoAlias));
+      llvm::AttrBuilder sretAttrs;
+      sretAttrs.addAttribute(LLAttribute::StructRet);
+      sretAttrs.addAttribute(LLAttribute::NoAlias);
       if (unsigned alignment = DtoAlignment(rt))
-        newIrFty.arg_sret->attrs.addAlignment(alignment);
+        sretAttrs.addAlignmentAttr(alignment);
+      newIrFty.arg_sret = new IrFuncTyArg(rt, true, sretAttrs);
       rt = Type::tvoid;
       ++nextLLArgIdx;
     } else {
       // sext/zext return
-      attrs.add(DtoShouldExtend(byref ? rt->pointerTo() : rt));
+      DtoAddExtendAttr(byref ? rt->pointerTo() : rt, attrs);
     }
     newIrFty.ret = new IrFuncTyArg(rt, byref, attrs);
   }
@@ -112,18 +113,18 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
 
   if (thistype) {
     // Add the this pointer for member functions
-    AttrBuilder attrs;
-    attrs.add(LLAttribute::NonNull);
+    llvm::AttrBuilder attrs;
+    attrs.addAttribute(LLAttribute::NonNull);
     if (fd && fd->isCtorDeclaration()) {
-      attrs.add(LLAttribute::Returned);
+      attrs.addAttribute(LLAttribute::Returned);
     }
     newIrFty.arg_this =
         new IrFuncTyArg(thistype, thistype->toBasetype()->ty == Tstruct, attrs);
     ++nextLLArgIdx;
   } else if (nesttype) {
     // Add the context pointer for nested functions
-    AttrBuilder attrs;
-    attrs.add(LLAttribute::NonNull);
+    llvm::AttrBuilder attrs;
+    attrs.addAttribute(LLAttribute::NonNull);
     newIrFty.arg_nest = new IrFuncTyArg(nesttype, false, attrs);
     ++nextLLArgIdx;
   }
@@ -169,7 +170,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
     bool passPointer = arg->storageClass & (STCref | STCout);
 
     Type *loweredDType = arg->type;
-    AttrBuilder attrs;
+    llvm::AttrBuilder attrs;
     if (arg->storageClass & STClazy) {
       // Lazy arguments are lowered to delegates.
       Logger::println("lazy param");
@@ -178,17 +179,19 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
       loweredDType = ltd;
     } else if (passPointer) {
       // ref/out
-      attrs.addDereferenceable(loweredDType->size());
+      attrs.addDereferenceableAttr(loweredDType->size());
     } else {
       if (abi->passByVal(f, loweredDType)) {
         // LLVM ByVal parameters are pointers to a copy in the function
         // parameters stack. The caller needs to provide a pointer to the
         // original argument.
-        attrs.addByVal(DtoAlignment(loweredDType));
+        attrs.addAttribute(LLAttribute::ByVal);
+        if (auto alignment = DtoAlignment(loweredDType))
+          attrs.addAlignmentAttr(alignment);
         passPointer = true;
       } else {
         // Add sext/zext as needed.
-        attrs.add(DtoShouldExtend(loweredDType));
+        DtoAddExtendAttr(loweredDType, attrs);
       }
     }
 

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -121,7 +121,7 @@ static void addExplicitArguments(std::vector<LLValue *> &args, AttrSet &attrs,
   const size_t formalLLArgCount = irFty.args.size();
 
   // Number of formal arguments in the D call expression (excluding varargs).
-  const int formalDArgCount = Parameter::dim(formalParams);
+  const size_t formalDArgCount = Parameter::dim(formalParams);
 
   // The number of explicit arguments in the D call expression (including
   // varargs), not all of which necessarily generate a LLVM argument.
@@ -167,8 +167,10 @@ static void addExplicitArguments(std::vector<LLValue *> &args, AttrSet &attrs,
 
     // Make sure to evaluate argument expressions for which there's no LL
     // parameter (e.g., empty structs for some ABIs).
-    for (; dArgIndex < irArg->parametersIdx; ++dArgIndex) {
-      toElem(argexps[dArgIndex]);
+    if (irArg->parametersIdx < formalDArgCount) {
+      for (; dArgIndex < irArg->parametersIdx; ++dArgIndex) {
+        toElem(argexps[dArgIndex]);
+      }
     }
 
     Expression *const argexp = argexps[dArgIndex];

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -52,12 +52,12 @@ bool DtoIsReturnInArg(CallExp *ce) {
   return false;
 }
 
-LLAttribute DtoShouldExtend(Type *type) {
+void DtoAddExtendAttr(Type *type, llvm::AttrBuilder &attrs) {
   type = type->toBasetype();
   if (type->isintegral() && type->ty != Tvector && type->size() <= 2) {
-    return type->isunsigned() ? LLAttribute::ZExt : LLAttribute::SExt;
+    attrs.addAttribute(type->isunsigned() ? LLAttribute::ZExt
+                                          : LLAttribute::SExt);
   }
-  return LLAttribute::None;
 }
 
 LLType *DtoType(Type *t) {

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -54,8 +54,8 @@ bool DtoIsInMemoryOnly(Type *type);
 // address as additional parameter to the callee, which will set it up.
 bool DtoIsReturnInArg(CallExp *ce);
 
-// should argument be zero or sign extended
-LLAttribute DtoShouldExtend(Type *type);
+// Adds an appropriate attribute if the type should be zero or sign extended.
+void DtoAddExtendAttr(Type *type, llvm::AttrBuilder &attrs);
 
 // tuple helper
 // takes a arguments list and makes a struct type out of them

--- a/ir/irfuncty.cpp
+++ b/ir/irfuncty.cpp
@@ -17,7 +17,7 @@
 #include "gen/logger.h"
 #include "gen/tollvm.h"
 
-IrFuncTyArg::IrFuncTyArg(Type *t, bool bref, AttrBuilder a)
+IrFuncTyArg::IrFuncTyArg(Type *t, bool bref, llvm::AttrBuilder a)
     : type(t),
       ltype(t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t)),
       attrs(std::move(a)), byref(bref) {

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -53,7 +53,7 @@ struct IrFuncTyArg {
 
   /** These are the final LLVM attributes used for the function.
    *  Must be valid for the LLVM Type and byref setting */
-  AttrBuilder attrs;
+  llvm::AttrBuilder attrs;
 
   /** 'true' if the final LLVM argument is a LLVM reference type.
    *  Must be true when the D Type is a value type, but the final
@@ -76,7 +76,7 @@ struct IrFuncTyArg {
    *  @param byref Initial value for the 'byref' field. If true the initial
    *               LLVM Type will be of DtoType(type->pointerTo()), instead
    *               of just DtoType(type) */
-  IrFuncTyArg(Type *t, bool byref, AttrBuilder attrs = AttrBuilder());
+  IrFuncTyArg(Type *t, bool byref, llvm::AttrBuilder attrs = {});
   IrFuncTyArg(const IrFuncTyArg &) = delete;
 
   ~IrFuncTyArg();

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -46,7 +46,7 @@ struct IrFuncTyArg {
 
   /// The index of the declaration in the FuncDeclaration::parameters array
   /// corresponding to this argument.
-  size_t parametersIdx = 0;
+  size_t parametersIdx = -1;
 
   /// This is the final LLVM Type used for the parameter/return value type
   llvm::Type *ltype = nullptr;

--- a/tests/codegen/attr_param.d
+++ b/tests/codegen/attr_param.d
@@ -2,5 +2,15 @@
 
 import ldc.attributes;
 
-// CHECK: define{{.*}} @{{.*}}3foo{{.*}}(i8* noalias %p_arg)
+// CHECK:      define{{.*}} @{{.*}}3foo
+// CHECK-SAME: i8*{{.*}} noalias %p_arg
 void foo(@llvmAttr("noalias") void* p) {}
+
+// CHECK:      define{{.*}} @{{.*}}3bar
+// CHECK-SAME: [16 x float]*{{.*}} noalias dereferenceable(64) %kernel
+// CHECK-SAME: float*{{.*}} noalias %data_arg
+void bar(@restrict float* data, @restrict ref const float[16] kernel) {}
+
+// CHECK:      define{{.*}} @{{.*}}14classReference
+// CHECK-SAME: %object.Object*{{.*}} noalias %obj_arg
+void classReference(@restrict Object obj) {}

--- a/tests/codegen/attr_param.d
+++ b/tests/codegen/attr_param.d
@@ -1,0 +1,6 @@
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import ldc.attributes;
+
+// CHECK: define{{.*}} @{{.*}}3foo{{.*}}(i8* noalias %p_arg)
+void foo(@llvmAttr("noalias") void* p) {}


### PR DESCRIPTION
E.g., finally enabling `restrict` C(++) semantics.