### PR TITLE
Jit: better error handling and handle correctly __chkstk function

### DIFF
--- a/gen/dynamiccompile.cpp
+++ b/gen/dynamiccompile.cpp
@@ -91,9 +91,15 @@ using GlobalValsMap =
 void getPredefinedSymbols(IRState *irs, GlobalValsMap &symList) {
   assert(nullptr != irs);
   const llvm::Triple *triple = global.params.targetTriple;
-  if (!opts::dynamicCompileTlsWorkaround) {
-    if (triple->isWindowsMSVCEnvironment() ||
-        triple->isWindowsGNUEnvironment()) {
+  if (triple->isWindowsMSVCEnvironment() ||
+      triple->isWindowsGNUEnvironment()) {
+    // Actual signatures doesn't matter here, we only want it to show in
+    // symbols list
+    symList.insert(std::make_pair(
+      getPredefinedSymbol(irs->module, "__chkstk",
+                          llvm::Type::getInt32Ty(irs->context())),
+      GlobalValVisibility::Declaration));
+    if (!opts::dynamicCompileTlsWorkaround) {
       symList.insert(std::make_pair(
           getPredefinedSymbol(irs->module, "_tls_index",
                               llvm::Type::getInt32Ty(irs->context())),

--- a/runtime/jit-rt/cpp-so/compile.cpp
+++ b/runtime/jit-rt/cpp-so/compile.cpp
@@ -396,12 +396,12 @@ void rtCompileProcessImplSoInternal(const RtCompileModuleList *modlist_head,
     };
 
     CallbackOstream os(callback);
-    if (myJit.addModule(std::move(finalModule), &os)) {
-      fatal(context, "Can't codegen module");
+    if (auto err = myJit.addModule(std::move(finalModule), &os)) {
+      fatal(context, "Can't codegen module: " + llvm::toString(std::move(err)));
     }
   } else {
-    if (myJit.addModule(std::move(finalModule), nullptr)) {
-      fatal(context, "Can't codegen module");
+    if (auto err = myJit.addModule(std::move(finalModule), nullptr)) {
+      fatal(context, "Can't codegen module" + llvm::toString(std::move(err)));
     }
   }
 

--- a/runtime/jit-rt/cpp-so/compile.cpp
+++ b/runtime/jit-rt/cpp-so/compile.cpp
@@ -401,7 +401,7 @@ void rtCompileProcessImplSoInternal(const RtCompileModuleList *modlist_head,
     }
   } else {
     if (auto err = myJit.addModule(std::move(finalModule), nullptr)) {
-      fatal(context, "Can't codegen module" + llvm::toString(std::move(err)));
+      fatal(context, "Can't codegen module: " + llvm::toString(std::move(err)));
     }
   }
 

--- a/runtime/jit-rt/cpp-so/jit_context.cpp
+++ b/runtime/jit-rt/cpp-so/jit_context.cpp
@@ -132,7 +132,8 @@ llvm::Error JITContext::addModule(std::unique_ptr<llvm::Module> module,
 #else
   auto result = compileLayer.addModule(std::move(module), createResolver());
   if (!result) {
-    return llvm::make_error<StringError>("addModule failed");
+    return llvm::make_error<llvm::StringError>("addModule failed",
+                                               llvm::inconvertibleErrorCode());
   }
   moduleHandle = result.get();
 #endif

--- a/runtime/jit-rt/cpp-so/jit_context.h
+++ b/runtime/jit-rt/cpp-so/jit_context.h
@@ -117,8 +117,8 @@ public:
   llvm::TargetMachine &getTargetMachine() { return *targetmachine; }
   const llvm::DataLayout &getDataLayout() const { return dataLayout; }
 
-  bool addModule(std::unique_ptr<llvm::Module> module,
-                 llvm::raw_ostream *asmListener);
+  llvm::Error addModule(std::unique_ptr<llvm::Module> module,
+                        llvm::raw_ostream *asmListener);
 
   llvm::JITSymbol findSymbol(const std::string &name);
 

--- a/tests/dynamiccompile/array.d
+++ b/tests/dynamiccompile/array.d
@@ -20,9 +20,17 @@ __gshared int[555] arr2 = 42;
   return arr2[3];
 }
 
+@dynamicCompile int baz()
+{
+  // Large stack array to force compiler to emit __chkstk call
+  int[4 * 1024] a;
+  return a[3 * 1024];
+}
+
 void main(string[] args)
 {
   compileDynamicCode();
   assert(42 == foo());
   assert(0  == bar());
+  assert(0  == baz());
 }


### PR DESCRIPTION
Compiler need to build a list of functions jit can call back to static code. This is done via analyzing jitted IR but some special functions require special handling as they are not present in IR but reference to them can still be generated.