### PR TITLE
WebAssembly: Use --export-dynamic when linking with LLD 8+

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -260,7 +260,11 @@ elseif(${BUILD_SHARED_LIBS} STREQUAL "OFF")
 endif()
 
 if(LDC_WITH_LLD)
-    set(WASM_DEFAULT_LDC_SWITCHES "\n        \"-link-internally\",")
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-link-internally\",")
+endif()
+# LLD 8+ requires (new) `--export-dynamic` for WebAssembly (https://github.com/ldc-developers/ldc/issues/3023).
+if(NOT (LDC_LLVM_VER LESS 800))
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--export-dynamic\",")
 endif()
 
 # Only generate the config files if this CMake project is embedded in the LDC CMake project.

--- a/tests/baremetal/wasm2.d
+++ b/tests/baremetal/wasm2.d
@@ -2,7 +2,13 @@
 
 // REQUIRES: target_WebAssembly
 // REQUIRES: link_WebAssembly
-// RUN: %ldc -mtriple=wasm32-unknown-unknown-wasm -betterC %s
+
+// RUN: %ldc -mtriple=wasm32-unknown-unknown-wasm -betterC %s -of=%t.wasm
+// RUN: %ldc -mtriple=wasm32-unknown-unknown-wasm -betterC -fvisibility=hidden %s -of=%t_hidden.wasm
+
+// make sure the .wasm files contain `myExportedFoo` (https://github.com/ldc-developers/ldc/issues/3023)
+// RUN: grep myExportedFoo %t.wasm
+// RUN: grep myExportedFoo %t_hidden.wasm
 
 extern(C):
 
@@ -10,7 +16,7 @@ void _start() {}
 
 void __assert(const(char)* msg, const(char)* file, uint line) {}
 
-int foo()
+export int myExportedFoo()
 {
     import std.algorithm, std.range;
     auto range = 100.iota().stride(2).take(5);


### PR DESCRIPTION
This fixes issue #3023 and restores the behavior of previous LLD versions (of exporting/not stripping all symbols with default/public visibility).