### PR TITLE
Refactoring: Free TargetABI from legacy magic C++ structs

### DIFF
--- a/gen/abi-win64.cpp
+++ b/gen/abi-win64.cpp
@@ -42,11 +42,6 @@ private:
   }
 
   bool passPointerToHiddenCopy(Type *t, bool isReturnValue, LINK linkage) const {
-    // Pass magic C++ structs directly as LL aggregate with a single i32/double
-    // element, which LLVM handles as if it was a scalar.
-    if (isMagicCppStruct(t))
-      return false;
-
     // 80-bit real/ireal:
     // * returned on the x87 stack (for DMD inline asm compliance and what LLVM
     //   defaults to)
@@ -110,8 +105,7 @@ public:
     Type *rt = tf->next->toBasetype();
 
     // for non-static member functions, MSVC++ enforces sret for all structs
-    if (isMSVC && tf->linkage == LINKcpp && needsThis && rt->ty == Tstruct &&
-        !isMagicCppStruct(rt)) {
+    if (isMSVC && tf->linkage == LINKcpp && needsThis && rt->ty == Tstruct) {
       return true;
     }
 
@@ -172,7 +166,7 @@ public:
     if (passPointerToHiddenCopy(t, isReturnValue, fty.type->linkage)) {
       // the caller allocates a hidden copy and passes a pointer to that copy
       byvalRewrite.applyTo(arg);
-    } else if (isAggregate(t) && canRewriteAsInt(t) && !isMagicCppStruct(t)) {
+    } else if (isAggregate(t) && canRewriteAsInt(t)) {
       integerRewrite.applyToIfNotObsolete(arg);
     }
 

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -91,8 +91,8 @@ struct X86TargetABI : TargetABI {
     const bool externD =
         (tf->linkage == LINKd && tf->parameterList.varargs != VARARGvariadic);
 
-    // non-aggregates and magic C++ structs are returned directly
-    if (!isAggregate(rt) || isMagicCppStruct(rt))
+    // non-aggregates are returned directly
+    if (!isAggregate(rt))
       return false;
 
     // complex numbers
@@ -143,7 +143,7 @@ struct X86TargetABI : TargetABI {
     // return value:
     if (!fty.ret->byref) {
       Type *rt = fty.type->next->toBasetype(); // for sret, rt == void
-      if (isAggregate(rt) && !isMagicCppStruct(rt) && canRewriteAsInt(rt) &&
+      if (isAggregate(rt) && canRewriteAsInt(rt) &&
           // don't rewrite cfloat for extern(D)
           !(externD && rt->ty == Tcomplex32)) {
         integerRewrite.applyToIfNotObsolete(*fty.ret);

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -200,18 +200,6 @@ bool TargetABI::isAggregate(Type *t) {
          /*ty == Tarray ||*/ ty == Tdelegate || t->iscomplex();
 }
 
-bool TargetABI::isMagicCppStruct(Type *t) {
-  t = t->toBasetype();
-  if (t->ty != Tstruct) {
-    return false;
-  }
-
-  Identifier *id = static_cast<TypeStruct *>(t)->sym->ident;
-  return (id == Id::__c_long) || (id == Id::__c_ulong) ||
-         (id == Id::__c_longlong) || (id == Id::__c_ulonglong) ||
-         (id == Id::__c_long_double);
-}
-
 namespace {
 bool hasCtor(StructDeclaration *s) {
   if (s->ctor)

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -191,10 +191,6 @@ protected:
   /// * complex number
   static bool isAggregate(Type *t);
 
-  /// The frontend uses magic structs to express some primitive C types
-  /// ((unsigned) long (long), long double) for C++ mangling purposes.
-  static bool isMagicCppStruct(Type *t);
-
   /// Returns true if the D type is a Plain-Old-Datatype, optionally excluding
   /// structs with constructors from that definition.
   static bool isPOD(Type *t, bool excludeStructsWithCtor = false);


### PR DESCRIPTION
Which have been superseded by magic enums (in `core.stdc.config`).