### PR TITLE
MSVC: Work around /DEBUG:FASTLINK incompatibility of release default …

### DIFF
--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -106,7 +106,13 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath,
 
   // output debug information
   if (global.params.symdebug) {
-    args.push_back("/DEBUG");
+    // MS link.exe defaults to "/DEBUG:FASTLINK" when invoked from within VS for
+    // a debug build (since VS 2017). That flag and release druntime/Phobos
+    // archived with LLVM don't work out nicely for the VS debugger, see
+    // https://github.com/ldc-developers/ldc/issues/3083.
+    bool enforceFull = !useInternalToolchain && !useInternalLLDForLinking() &&
+                       !linkAgainstDebugDefaultLibs();
+    args.push_back(enforceFull ? "/DEBUG:FULL" : "/DEBUG");
   }
 
   // remove dead code and fold identical COMDATs

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -172,6 +172,8 @@ bool useInternalLLDForLinking() { return linkInternally; }
 
 cl::boolOrDefault linkFullyStatic() { return staticFlag; }
 
+bool linkAgainstDebugDefaultLibs() { return linkDefaultLibDebug; }
+
 bool linkAgainstSharedDefaultLibs() {
   // -static enforces static default libs.
   // Default to shared default libs for DLLs.

--- a/driver/linker.h
+++ b/driver/linker.h
@@ -34,6 +34,12 @@ bool useInternalLLDForLinking();
 llvm::cl::boolOrDefault linkFullyStatic();
 
 /**
+ * Indicates whether the command-line options select debug druntime/Phobos for
+ * linking.
+ */
+bool linkAgainstDebugDefaultLibs();
+
+/**
  * Indicates whether the command-line options select shared druntime/Phobos for
  * linking.
  */


### PR DESCRIPTION
…libs archived with llvm-lib. Works around #3083.