### PR TITLE
add __traits(getTargetInfo, "dcomputeTargets")

### DIFF
--- a/dmd/expression.d
+++ b/dmd/expression.d
@@ -2758,6 +2758,11 @@ extern (C++) final class TupleExp : Expression
         }
     }
 
+    static TupleExp create(Loc loc, Expressions* exps)
+    {
+        return new TupleExp(loc, exps);
+    }
+
     override TupleExp toTupleExp()
     {
         return this;

--- a/dmd/expression.h
+++ b/dmd/expression.h
@@ -424,6 +424,7 @@ public:
      */
     Expressions *exps;
 
+    static TupleExp *create(Loc loc, Expressions *exps);
     TupleExp *toTupleExp();
     Expression *syntaxCopy();
     bool equals(RootObject *o);

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1073,9 +1073,9 @@ void codegenModules(Modules &modules) {
     if (!computeModules.empty()) {
       for (auto &mod : computeModules)
         dccg.emit(mod);
-
-      dccg.writeModules();
     }
+    dccg.writeModules();
+
     // We may have removed all object files, if so don't link.
     if (global.params.objfiles.dim == 0)
       global.params.link = false;

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -269,5 +269,20 @@ Expression *Target::getTargetInfo(const char *name_, const Loc &loc) {
   if (name == "cppStd")
     return createIntegerExp(static_cast<unsigned>(global.params.cplusplus));
 
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+  if (name == "dcomputeTargets") {
+    Expressions* exps = new Expressions();
+    for (auto &targ : opts::dcomputeTargets) {
+        exps->push(createStringExp(mem.xstrdup(targ.c_str())));
+    }
+    return TupleExp::create(loc, exps);
+  }
+
+  if (name == "dcomputeFilePrefix") {
+    return createStringExp(
+                mem.xstrdup(opts::dcomputeFilePrefix.c_str()));
+  }
+#endif
+    
   return nullptr;
 }

--- a/tests/semantic/target_traits_dcompute.d
+++ b/tests/semantic/target_traits_dcompute.d
@@ -1,0 +1,7 @@
+// Tests LDC-specific target __traits
+
+// RUN: %ldc -c %s -mdcompute-targets=cuda-350 -mdcompute-file-prefix=testing
+// REQUIRES: target_NVPTX
+
+static assert([ __traits(getTargetInfo, "dcomputeTargets") ] == ["cuda-350"]);
+static assert(__traits(getTargetInfo, "dcomputeFilePrefix") == "testing");


### PR DESCRIPTION
and __traits(getTargetInfo, "dcomputeFilePrefix”. Also fixes a segfault
when passing `-mdcompute-targets=whatever` and no compute modules were
passed to ldc. The test doubles for that fix as well.

From the correct branch this time!