### PR TITLE
Fix ICE when returning a void expression

### DIFF
--- a/tests/codegen/gh3094.d
+++ b/tests/codegen/gh3094.d
@@ -1,0 +1,13 @@
+// RUN: %ldc -run %s
+
+void foo(void delegate() sink)
+{
+    return (0, sink());
+}
+
+void main()
+{
+    bool called;
+    foo(() { called = true; });
+    assert(called);
+}


### PR DESCRIPTION
Fixes #3094, a regression introduced in v1.16 due to AST changes.