### PR TITLE
 Enable gc-sections on FreeBSD when not using old ld.bfd linker

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -549,7 +549,11 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
       addLdFlag("-rpath", rpath);
   }
 
-  if (global.params.targetTriple->getOS() == llvm::Triple::Linux) {
+  if (global.params.targetTriple->getOS() == llvm::Triple::Linux ||
+      (global.params.targetTriple->getOS() == llvm::Triple::FreeBSD &&
+       (useInternalLLDForLinking() ||
+        (!opts::linker.empty() && opts::linker != "bfd") ||
+        (opts::linker.empty() && isLldDefaultLinker())))) {
     // Make sure we don't do --gc-sections when generating a profile-
     // instrumented binary. The runtime relies on magic sections, which
     // would be stripped by gc-section on older version of ld, see bug:

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -470,11 +470,12 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
   }
 
   // Right now, we only support linker-level dead code elimination on Linux
-  // using the GNU toolchain (based on ld's --gc-sections flag). The Apple ld
-  // on OS X supports a similar flag (-dead_strip) that doesn't require
-  // emitting the symbols into different sections. The MinGW ld doesn't seem
-  // to support --gc-sections at all, and FreeBSD needs more investigation.
+  // and FreeBSD using GNU or LLD linkers (based on the --gc-sections flag).
+  // The Apple ld on OS X supports a similar flag (-dead_strip) that doesn't
+  // require emitting the symbols into different sections. The MinGW ld doesn't
+  // seem to support --gc-sections at all.
   if (!noLinkerStripDead && (triple.getOS() == llvm::Triple::Linux ||
+                             triple.getOS() == llvm::Triple::FreeBSD ||
                              triple.getOS() == llvm::Triple::Win32)) {
     targetOptions.FunctionSections = true;
     targetOptions.DataSections = true;


### PR DESCRIPTION
(Requires #3105 for `isLldDefaultLinker`)

The ancient ld.bfd doesn't like this:

```
.dub/obj/dtest.o: In function `ldc.register_dso':
app.d:(.text.ldc.register_dso+0x1c): undefined reference to `__stop___minfo'
app.d:(.text.ldc.register_dso+0x28): undefined reference to `__start___minfo'
/usr/bin/ld.bfd: .dub/build/application-release-posix.freebsd-x86_64-ldc_2086-54657107D68790E5698D25167B20AC6A/dtest: hidden symbol `__start___minfo' isn't defined
/usr/bin/ld.bfd: final link failed: Nonrepresentable section on output
```

(miiight be the same bug that's mentioned in the context of PGO on Linux)

but other linkers are of course fine, so let's just enable it when we know BFD is not used. (Eventually it won't be used by default at all: as of FreeBSD 12, LLD is default on amd64 and aarch64 already.)