### PR TITLE
update chocolatey install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ not currently integrated into the project release process):
 | Ubuntu       | `apt install ldc`                            |
 | Snap         | `snap install --classic --channel=edge ldc2` |
 | Nix/NixOS    | `nix-env -i ldc`                             |
-| Chocolatey   | `choco ldc`                                  |
+| Chocolatey   | `choco install ldc`                          |
 | Docker       | `docker pull dlang2/ldc-ubuntu`              |
 
 #### Targeting Android


### PR DESCRIPTION
Running 'choco ldc' gives me

```bash
$ choco ldc
Chocolatey v0.10.15
Could not find a command registered that meets 'ldc'.
 Try choco -? for command reference/help.
```

It should be `choco install package-name`