### PR TITLE
Speculatively fix linkability of LDC and LDMD on Android

### DIFF
--- a/driver/main.d
+++ b/driver/main.d
@@ -59,3 +59,18 @@ version (Windows)
         SetConsoleOutputCP(originalOutputCP);
     }
 }
+
+// TLS bracketing symbols required for our custom TLS emulation on Android
+// as we don't have a D main() function for LDC and LDMD.
+version (Android)
+{
+    import ldc.attributes;
+
+    extern(C) __gshared
+    {
+        @section(".tdata")
+        int _tlsstart = 0;
+        @section(".tcommon")
+        int _tlsend = 0;
+    }
+}


### PR DESCRIPTION
An issue since eliminating the previous D `main()` functions in LDC v1.15.
Should work according to https://forum.dlang.org/post/caqgnbgynlqdrnomtzfq@forum.dlang.org.