### PR TITLE
Don't cast an uninitialized void __vector

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2612,7 +2612,12 @@ public:
     } else {
       Logger::println("normal (splat) expression");
       DValue *val = toElem(e->e1);
-      LLValue *llval = DtoRVal(DtoCast(e->loc, val, type->elementType()));
+      LLValue *llval;
+      if (type->elementType()->ty != Tvoid) {
+        llval = DtoRVal(DtoCast(e->loc, val, type->elementType()));
+      } else {
+        llval = DtoRVal(val);
+      }
       for (unsigned int i = 0; i < e->dim; ++i) {
         DtoStore(llval, DtoGEPi(vector, 0, i));
       }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2612,12 +2612,13 @@ public:
     } else {
       Logger::println("normal (splat) expression");
       DValue *val = toElem(e->e1);
-      LLValue *llval;
-      if (type->elementType()->ty != Tvoid) {
-        llval = DtoRVal(DtoCast(e->loc, val, type->elementType()));
-      } else {
-        llval = DtoRVal(val);
-      }
+      TypeBasic *tb = static_cast<TypeBasic *>(type->elementType());
+      tb->ty = Tuns8;  // Converrt to a ubyte
+      tb->flags = 1; // TFlags.integral
+      tb->dstring = "uns8";  // Provide a string representation for debugging.
+      tb->ctype = NULL;  // Guess that this is for caching types. Don't cache it
+                         // as we're changing it.
+      LLValue *llval = DtoRVal(DtoCast(e->loc, val, tb));
       for (unsigned int i = 0; i < e->dim; ++i) {
         DtoStore(llval, DtoGEPi(vector, 0, i));
       }

--- a/tests/codegen/vector_void_uninit.d
+++ b/tests/codegen/vector_void_uninit.d
@@ -1,7 +1,13 @@
-// RUN: %ldc -c %s
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 void foo()
 {
-    alias V = __vector(void[16]);
-    V v;
+// CHECK: %v1 = alloca <2 x i8>, align 2
+// CHECK-SAME: size/byte = 2]
+// CHECK: %v2 = alloca <4 x i8>, align 4
+// CHECK-SAME: size/byte = 4]
+// CHECK-COUNT-2: store i8 0, i8*
+// CHECK-COUNT-4: store i8 0, i8*
+    __vector(void[2]) v1;
+    __vector(void[4]) v2;
 }

--- a/tests/codegen/vector_void_uninit.d
+++ b/tests/codegen/vector_void_uninit.d
@@ -1,0 +1,7 @@
+// RUN: %ldc -c %s
+
+void foo()
+{
+    alias V = __vector(void[16]);
+    V v;
+}


### PR DESCRIPTION
I'm not really sure about this. We certainly don't want to try to cast when there's a `void` as element type (so, cast from `ubyte` to `void`). But I don't know if it's a good solution.

_Edit_: The doc seems to agree: [Void Arrays](https://dlang.org/spec/arrays.html#void_arrays).
Which is that `void[]` are mostly fancy `ubyte[]`. Although the 4th point mentions some GC stuff that I don't know how they apply to LDC. The one thing I don't know and I'll try to find is where the `ubyte` comes from in `VectorExp`.