### PR TITLE
Azure CI Windows: Upgrade bundled libcurl to v7.65.3

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -14,7 +14,7 @@ steps:
     echo on
     cd ..
     :: Download & extract libcurl
-    curl -L -o libcurl.zip https://dl.dropboxusercontent.com/s/jxwohqax4e2avyt/libcurl-7.48.0-WinSSL-zlib-x86-x64.zip?dl=0 2>&1
+    curl -L -o libcurl.zip https://dl.dropboxusercontent.com/s/ccthbw233qs7kpv/libcurl-7.65.3-WinSSL-zlib-x86-x64.zip?dl=0 2>&1
     mkdir libcurl
     cd libcurl
     7z x ../libcurl.zip > nul


### PR DESCRIPTION
Now that Rainer figured out why anything newer than v7.48.0 wouldn't work (hanging `std.net.curl` unittests) in dlang/installer#399.

I built the binaries on my box using VS 2019 v16.2.2.

zlib v1.2.11 was built using `contrib/vstudio/vc14/zlibvc.sln` (static release lib incl. asm, which needs to be built separately, e.g., `cd contrib/masmx64 && bld_ml64.bat`). MSCRT was set to `/MT`.

libcurl was built with a command line like this in the `winbuild` dir:

> nmake /f Makefile.vc mode=dll VC=15 WITH_DEVEL=C:\LDC\curl-7.65.3\deps WITH_ZLIB=static GEN_PDB=no DEBUG=no MACHINE=x64 RTLIBCFG=static

The CFLAGS in `winbuild/MakefileBuild.vc` need to be extended by `/DDONT_USE_RECV_BEFORE_SEND_WORKAROUND` to fix the hanging tests.