### PR TITLE
Add inbounds where possible

### DIFF
--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -115,7 +115,7 @@ DValue *emitPointerOffset(Loc loc, DValue *base, Expression *offset,
   if (!llResult) {
     if (negateOffset)
       llOffset = gIR->ir->CreateNeg(llOffset);
-    llResult = DtoGEP1(llBase, llOffset, false);
+    llResult = DtoGEP1(llBase, llOffset, /* inBounds = */ true);
   }
 
   return new DImValue(resultType, DtoBitCast(llResult, DtoType(resultType)));

--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -115,7 +115,7 @@ DValue *emitPointerOffset(Loc loc, DValue *base, Expression *offset,
   if (!llResult) {
     if (negateOffset)
       llOffset = gIR->ir->CreateNeg(llOffset);
-    llResult = DtoGEP1(llBase, llOffset, /* inBounds = */ true);
+    llResult = DtoGEP1(llBase, llOffset);
   }
 
   return new DImValue(resultType, DtoBitCast(llResult, DtoType(resultType)));

--- a/gen/complex.cpp
+++ b/gen/complex.cpp
@@ -108,8 +108,8 @@ DValue *DtoComplex(Loc &loc, Type *to, DValue *val) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void DtoComplexSet(LLValue *c, LLValue *re, LLValue *im) {
-  DtoStore(re, DtoGEPi(c, 0, 0));
-  DtoStore(im, DtoGEPi(c, 0, 1));
+  DtoStore(re, DtoGEP(c, 0u, 0));
+  DtoStore(im, DtoGEP(c, 0, 1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,10 +141,8 @@ void DtoGetComplexParts(Loc &loc, Type *to, DValue *val, DValue *&re,
     DValue *v = DtoCastComplex(loc, val, to);
     if (to->iscomplex()) {
       if (v->isLVal()) {
-        LLValue *reVal =
-            DtoGEPi(DtoLVal(v), 0, 0, ".re_part");
-        LLValue *imVal =
-            DtoGEPi(DtoLVal(v), 0, 1, ".im_part");
+        LLValue *reVal = DtoGEP(DtoLVal(v), 0u, 0, ".re_part");
+        LLValue *imVal = DtoGEP(DtoLVal(v), 0, 1, ".im_part");
         re = new DLValue(baserety, reVal);
         im = new DLValue(baseimty, imVal);
       } else {

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1151,7 +1151,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
         LLType *targetThisType = thismem->getType();
         thismem = DtoBitCast(thismem, getVoidPtrType());
         auto off = DtoConstInt(-fd->interfaceVirtual->offset);
-        thismem = DtoGEP1(thismem, off, true);
+        thismem = DtoGEP1(thismem, off);
         thismem = DtoBitCast(thismem, targetThisType);
       }
       thismem = DtoAllocaDump(thismem, 0, "this");

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1874,12 +1874,12 @@ LLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
   static_cast<IrTypeAggr *>(ad->type->ctype)
       ->getMemberLocation(vd, fieldIndex, byteOffset);
 
-  LLValue *val = DtoGEPi(src, 0, fieldIndex);
+  LLValue *val = DtoGEP(src, 0, fieldIndex);
 
   if (byteOffset) {
     // Cast to void* to apply byte-wise offset.
     val = DtoBitCast(val, getVoidPtrType());
-    val = DtoGEPi1(val, byteOffset);
+    val = DtoGEP1(val, byteOffset);
   }
 
   // Cast the (possibly void*) pointer to the canonical variable type.

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -314,7 +314,7 @@ void emitABIReturnAsmStmt(IRAsmBlock *asmblock, Loc &loc,
       as->out_c = "=*m,=*m,";
       LLValue* tmp = DtoRawAlloca(llretTy, 0, ".tmp_asm_ret");
       as->out.push_back( tmp );
-      as->out.push_back( DtoGEPi(tmp, 0,1) );
+      as->out.push_back( DtoGEP(tmp, 0, 1) );
       as->code = "movd %eax, $<<out0>>" "\n\t" "mov %edx, $<<out1>>";
 
       // fix asmblock

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -74,7 +74,7 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
     if (cd->isClassDeclaration()) {
       val = DtoLoad(val);
     }
-    ctx = DtoLoad(DtoGEPi(val, 0, getVthisIdx(cd), ".vthis"));
+    ctx = DtoLoad(DtoGEP(val, 0, getVthisIdx(cd), ".vthis"));
     skipDIDeclaration = true;
   } else {
     Logger::println("Regular nested function, using context arg");
@@ -118,7 +118,7 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   const auto offsetToNthField = [&val, &dwarfAddrOps](unsigned fieldIndex,
                                                       const char *name = "") {
     gIR->DBuilder.OpOffset(dwarfAddrOps, val, fieldIndex);
-    val = DtoGEPi(val, 0, fieldIndex, name);
+    val = DtoGEP(val, 0, fieldIndex, name);
   };
   const auto dereference = [&val, &dwarfAddrOps](const char *name = "") {
     gIR->DBuilder.OpDeref(dwarfAddrOps);
@@ -199,7 +199,7 @@ void DtoResolveNestedContext(Loc &loc, AggregateDeclaration *decl,
     DtoResolveDsymbol(decl);
 
     unsigned idx = getVthisIdx(decl);
-    LLValue *gep = DtoGEPi(value, 0, idx, ".vthis");
+    LLValue *gep = DtoGEP(value, 0, idx, ".vthis");
     DtoStore(DtoBitCast(nest, gep->getType()->getContainedType(0)), gep);
   }
 }
@@ -256,7 +256,7 @@ LLValue *DtoNestedContext(Loc &loc, Dsymbol *sym) {
       // function (but without any variables in the nested context).
       return val;
     }
-    val = DtoLoad(DtoGEPi(val, 0, getVthisIdx(ad), ".vthis"));
+    val = DtoLoad(DtoGEP(val, 0, getVthisIdx(ad), ".vthis"));
   } else {
     if (sym->isFuncDeclaration()) {
       // If we are here, the function actually needs its nested context
@@ -300,7 +300,7 @@ LLValue *DtoNestedContext(Loc &loc, Dsymbol *sym) {
     } else {
       val = DtoBitCast(val,
                        LLPointerType::getUnqual(getIrFunc(ctxfd)->frameType));
-      val = DtoGEPi(val, 0, neededDepth);
+      val = DtoGEP(val, 0, neededDepth);
       val = DtoAlignedLoad(
           val, (std::string(".frame.") + frameToPass->toChars()).c_str());
     }
@@ -466,7 +466,7 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
         if (cd->isStructDeclaration()) {
           src = DtoExtractValue(thisval, getVthisIdx(cd), ".vthis");
         } else {
-          src = DtoLoad(DtoGEPi(thisval, 0, getVthisIdx(cd), ".vthis"));
+          src = DtoLoad(DtoGEP(thisval, 0, getVthisIdx(cd), ".vthis"));
         }
       }
       if (depth > 1) {
@@ -478,7 +478,7 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
       // Copy nestArg into framelist; the outer frame is not in the list of
       // pointers
       src = DtoBitCast(src, frameType->getContainedType(depth - 1));
-      LLValue *gep = DtoGEPi(frame, 0, depth - 1);
+      LLValue *gep = DtoGEP(frame, 0, depth - 1);
       DtoAlignedStore(src, gep);
     }
 
@@ -493,7 +493,7 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
       }
 
       IrLocal *irLocal = getIrLocal(vd);
-      LLValue *gep = DtoGEPi(frame, 0, irLocal->nestedIndex, vd->toChars());
+      LLValue *gep = DtoGEP(frame, 0, irLocal->nestedIndex, vd->toChars());
       if (vd->isParameter()) {
         IF_LOG Logger::println("nested param: %s", vd->toChars());
         LOG_SCOPE

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -1258,7 +1258,7 @@ public:
 
     // get value for this iteration
     LLValue *loadedKey = irs->ir->CreateLoad(keyvar);
-    LLValue *gep = DtoGEP1(val, loadedKey, true);
+    LLValue *gep = DtoGEP1(val, loadedKey);
 
     if (!stmt->value->isRef() && !stmt->value->isOut()) {
       // Copy value to local variable, and use it as the value variable.

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -83,7 +83,7 @@ LLValue *DtoCallableValue(DValue *fn) {
   if (type->ty == Tdelegate) {
     if (fn->isLVal()) {
       LLValue *dg = DtoLVal(fn);
-      LLValue *funcptr = DtoGEPi(dg, 0, 1);
+      LLValue *funcptr = DtoGEP(dg, 0, 1);
       return DtoLoad(funcptr, ".funcptr");
     }
     LLValue *dg = DtoRVal(fn);
@@ -581,7 +581,7 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
     assert(bitmask == 31 || bitmask == 63);
     // auto q = cast(size_t*)ptr + (bitnum >> (64bit ? 6 : 5));
     LLValue *q = DtoBitCast(ptr, DtoSize_t()->getPointerTo());
-    q = DtoGEP1(q, p->ir->CreateLShr(bitnum, bitmask == 63 ? 6 : 5), true, "bitop.q");
+    q = DtoGEP1(q, p->ir->CreateLShr(bitnum, bitmask == 63 ? 6 : 5), "bitop.q");
 
     // auto mask = 1 << (bitnum & bitmask);
     LLValue *mask =
@@ -762,7 +762,7 @@ private:
       // ... or a delegate context arg
       LLValue *ctxarg;
       if (fnval->isLVal()) {
-        ctxarg = DtoLoad(DtoGEPi(DtoLVal(fnval), 0, 0), ".ptr");
+        ctxarg = DtoLoad(DtoGEP(DtoLVal(fnval), 0u, 0), ".ptr");
       } else {
         ctxarg = gIR->ir->CreateExtractValue(DtoRVal(fnval), 0, ".ptr");
       }

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -312,7 +312,7 @@ public:
         assert(i_index != ~0UL);
 
         // offset pointer
-        instance = DtoGEPi(instance, 0, i_index);
+        instance = DtoGEP(instance, 0, i_index);
       }
       result = DtoBitCast(instance, DtoType(tb));
     } else {
@@ -643,7 +643,7 @@ public:
         assert(i_index != ~0UL);
 
         // offset pointer
-        result = DtoGEPi(result, 0, i_index);
+        result = DtoGEP(result, 0, i_index);
       }
     }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -573,7 +573,7 @@ public:
     }
   }
 
-//////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
 
 #define BIN_OP(Op, Func)                                                       \
   void visit(Op##Exp *e) override {                                            \
@@ -1080,7 +1080,7 @@ public:
 
     LLValue *arrptr = nullptr;
     if (e1type->ty == Tpointer) {
-      arrptr = DtoGEP1(DtoRVal(l), DtoRVal(r), false);
+      arrptr = DtoGEP1(DtoRVal(l), DtoRVal(r), /* inBounds = */ true);
     } else if (e1type->ty == Tsarray) {
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);
@@ -1420,7 +1420,7 @@ public:
       assert(e->e2->op == TOKint64);
       LLConstant *offset =
           e->op == TOKplusplus ? DtoConstUint(1) : DtoConstInt(-1);
-      post = DtoGEP1(val, offset, false, "", p->scopebb());
+      post = DtoGEP1(val, offset, /* inBounds = */ true, "", p->scopebb());
     } else if (e1type->iscomplex()) {
       assert(e2type->iscomplex());
       LLValue *one = LLConstantFP::get(DtoComplexBaseType(e1type), 1.0);
@@ -2700,7 +2700,7 @@ public:
     llvm_unreachable("Unknown TypeidExp argument kind");
   }
 
-////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////
 
 #define STUB(x)                                                                \
   void visit(x *e) override {                                                  \

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1085,13 +1085,13 @@ public:
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);
       }
-      arrptr =
-          DtoGEP(DtoLVal(l), DtoConstUint(0), DtoRVal(r), e->indexIsInBounds);
+      arrptr = DtoGEP(DtoLVal(l), DtoConstUint(0), DtoRVal(r),
+                      /* inBounds = */ true);
     } else if (e1type->ty == Tarray) {
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);
       }
-      arrptr = DtoGEP1(DtoArrayPtr(l), DtoRVal(r), e->indexIsInBounds);
+      arrptr = DtoGEP1(DtoArrayPtr(l), DtoRVal(r), /* inBounds = */ true);
     } else if (e1type->ty == Taarray) {
       result = DtoAAIndex(e->loc, e->type, l, r, e->modifiable);
       return;

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -66,7 +66,7 @@ bool walkPostorder(Expression *e, StoppableVisitor *v);
 
 static LLValue *write_zeroes(LLValue *mem, unsigned start, unsigned end) {
   mem = DtoBitCast(mem, getVoidPtrType());
-  LLValue *gep = DtoGEPi1(mem, start, ".padding");
+  LLValue *gep = DtoGEP1(mem, start, ".padding");
   DtoMemSetZero(gep, DtoConstSize_t(end - start));
   return mem;
 }
@@ -843,7 +843,7 @@ public:
         uint64_t elemSize = gDataLayout->getTypeAllocSize(elemType);
         if (e->offset % elemSize == 0) {
           // We can turn this into a "nice" GEP.
-          offsetValue = DtoGEPi1(baseValue, e->offset / elemSize);
+          offsetValue = DtoGEP1(baseValue, e->offset / elemSize);
         }
       }
 
@@ -851,7 +851,7 @@ public:
         // Offset isn't a multiple of base type size, just cast to i8* and
         // apply the byte offset.
         offsetValue =
-            DtoGEPi1(DtoBitCast(baseValue, getVoidPtrType()), e->offset);
+            DtoGEP1(DtoBitCast(baseValue, getVoidPtrType()), e->offset);
       }
     }
 
@@ -1080,18 +1080,17 @@ public:
 
     LLValue *arrptr = nullptr;
     if (e1type->ty == Tpointer) {
-      arrptr = DtoGEP1(DtoRVal(l), DtoRVal(r), /* inBounds = */ true);
+      arrptr = DtoGEP1(DtoRVal(l), DtoRVal(r));
     } else if (e1type->ty == Tsarray) {
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);
       }
-      arrptr = DtoGEP(DtoLVal(l), DtoConstUint(0), DtoRVal(r),
-                      /* inBounds = */ true);
+      arrptr = DtoGEP(DtoLVal(l), DtoConstUint(0), DtoRVal(r));
     } else if (e1type->ty == Tarray) {
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);
       }
-      arrptr = DtoGEP1(DtoArrayPtr(l), DtoRVal(r), /* inBounds = */ true);
+      arrptr = DtoGEP1(DtoArrayPtr(l), DtoRVal(r));
     } else if (e1type->ty == Taarray) {
       result = DtoAAIndex(e->loc, e->type, l, r, e->modifiable);
       return;
@@ -1178,7 +1177,7 @@ public:
       }
 
       // offset by lower
-      eptr = DtoGEP1(getBasePointer(), vlo, !needCheckLower, "lowerbound");
+      eptr = DtoGEP1(getBasePointer(), vlo, "lowerbound");
 
       // adjust length
       elen = p->ir->CreateSub(vup, vlo);
@@ -1420,7 +1419,7 @@ public:
       assert(e->e2->op == TOKint64);
       LLConstant *offset =
           e->op == TOKplusplus ? DtoConstUint(1) : DtoConstInt(-1);
-      post = DtoGEP1(val, offset, /* inBounds = */ true, "", p->scopebb());
+      post = DtoGEP1(val, offset, "", p->scopebb());
     } else if (e1type->iscomplex()) {
       assert(e2type->iscomplex());
       LLValue *one = LLConstantFP::get(DtoComplexBaseType(e1type), 1.0);
@@ -2205,7 +2204,7 @@ public:
           cval =
               ad->isClassDeclaration() ? DtoLoad(irfn.thisArg) : irfn.thisArg;
           cval = DtoLoad(
-              DtoGEPi(cval, 0, getFieldGEPIndex(ad, ad->vthis), ".vthis"));
+              DtoGEP(cval, 0, getFieldGEPIndex(ad, ad->vthis), ".vthis"));
         }
       } else {
         cval = getNullPtr(getVoidPtrType());
@@ -2471,7 +2470,7 @@ public:
                         .getInstruction();
       if (basetype->ty != Taarray) {
         LLValue *tmp = DtoAlloca(e->type, "aaliteral");
-        DtoStore(aa, DtoGEPi(tmp, 0, 0));
+        DtoStore(aa, DtoGEP(tmp, 0u, 0));
         result = new DLValue(e->type, tmp);
       } else {
         result = new DImValue(e->type, aa);
@@ -2511,7 +2510,7 @@ public:
   DValue *toGEP(UnaExp *exp, unsigned index) {
     // (&a.foo).funcptr is a case where toElem(e1) is genuinely not an l-value.
     LLValue *val = makeLValue(exp->loc, toElem(exp->e1));
-    LLValue *v = DtoGEPi(val, 0, index);
+    LLValue *v = DtoGEP(val, 0, index);
     return new DLValue(exp->type, DtoBitCast(v, DtoPtrToType(exp->type)));
   }
 
@@ -2572,7 +2571,7 @@ public:
     for (size_t i = 0; i < e->exps->dim; i++) {
       Expression *el = (*e->exps)[i];
       DValue *ep = toElem(el);
-      LLValue *gep = DtoGEPi(val, 0, i);
+      LLValue *gep = DtoGEP(val, 0, i);
       if (DtoIsInMemoryOnly(el->type)) {
         DtoMemCpy(gep, DtoLVal(ep));
       } else if (el->type->ty != Tvoid) {
@@ -2623,7 +2622,7 @@ public:
         DtoStore(vectorConstant, dstMem);
       } else {
         for (unsigned i = 0; i < N; ++i) {
-          DtoStore(llElements[i], DtoGEPi(dstMem, 0, i));
+          DtoStore(llElements[i], DtoGEP(dstMem, 0, i));
         }
       }
     } else {
@@ -2635,7 +2634,7 @@ public:
         DtoStore(vectorConstant, dstMem);
       } else {
         for (unsigned int i = 0; i < N; ++i) {
-          DtoStore(llElement, DtoGEPi(dstMem, 0, i));
+          DtoStore(llElement, DtoGEP(dstMem, 0, i));
         }
       }
     }
@@ -2676,10 +2675,10 @@ public:
       LLValue *val = DtoRVal(ex);
 
       // Get and load vtbl pointer.
-      llvm::Value *vtbl = DtoLoad(DtoGEPi(val, 0, 0));
+      llvm::Value *vtbl = DtoLoad(DtoGEP(val, 0u, 0));
 
       // TypeInfo ptr is first vtbl entry.
-      llvm::Value *typinf = DtoGEPi(vtbl, 0, 0);
+      llvm::Value *typinf = DtoGEP(vtbl, 0u, 0);
 
       Type *resultType;
       if (static_cast<TypeClass *>(t)->sym->isInterfaceDeclaration()) {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -279,46 +279,45 @@ LLIntegerType *DtoSize_t() {
 
 namespace {
 llvm::GetElementPtrInst *DtoGEP(LLValue *ptr, llvm::ArrayRef<LLValue *> indices,
-                                bool inBounds, const char *name,
-                                llvm::BasicBlock *bb) {
+                                const char *name, llvm::BasicBlock *bb) {
   LLPointerType *p = isaPointer(ptr);
   assert(p && "GEP expects a pointer type");
-  auto gep = llvm::GetElementPtrInst::Create(
-      p->getElementType(), ptr, indices, name, bb ? bb : gIR->scopebb());
-  gep->setIsInBounds(inBounds);
+  auto gep = llvm::GetElementPtrInst::Create(p->getElementType(), ptr, indices,
+                                             name, bb ? bb : gIR->scopebb());
+  gep->setIsInBounds(true);
   return gep;
 }
 }
 
-LLValue *DtoGEP1(LLValue *ptr, LLValue *i0, bool inBounds, const char *name,
+LLValue *DtoGEP1(LLValue *ptr, LLValue *i0, const char *name,
                  llvm::BasicBlock *bb) {
-  return DtoGEP(ptr, i0, inBounds, name, bb);
+  return DtoGEP(ptr, i0, name, bb);
 }
 
-LLValue *DtoGEP(LLValue *ptr, LLValue *i0, LLValue *i1, bool inBounds,
-                const char *name, llvm::BasicBlock *bb) {
+LLValue *DtoGEP(LLValue *ptr, LLValue *i0, LLValue *i1, const char *name,
+                llvm::BasicBlock *bb) {
   LLValue *indices[] = {i0, i1};
-  return DtoGEP(ptr, indices, inBounds, name, bb);
+  return DtoGEP(ptr, indices, name, bb);
 }
 
-LLValue *DtoGEPi1(LLValue *ptr, unsigned i0, const char *name,
-                  llvm::BasicBlock *bb) {
-  return DtoGEP(ptr, DtoConstUint(i0), /* inBounds = */ true, name, bb);
-}
-
-LLValue *DtoGEPi(LLValue *ptr, unsigned i0, unsigned i1, const char *name,
+LLValue *DtoGEP1(LLValue *ptr, unsigned i0, const char *name,
                  llvm::BasicBlock *bb) {
-  LLValue *indices[] = {DtoConstUint(i0), DtoConstUint(i1)};
-  return DtoGEP(ptr, indices, /* inBounds = */ true, name, bb);
+  return DtoGEP(ptr, DtoConstUint(i0), name, bb);
 }
 
-LLConstant *DtoGEPi(LLConstant *ptr, unsigned i0, unsigned i1) {
+LLValue *DtoGEP(LLValue *ptr, unsigned i0, unsigned i1, const char *name,
+                llvm::BasicBlock *bb) {
+  LLValue *indices[] = {DtoConstUint(i0), DtoConstUint(i1)};
+  return DtoGEP(ptr, indices, name, bb);
+}
+
+LLConstant *DtoGEP(LLConstant *ptr, unsigned i0, unsigned i1) {
   LLPointerType *p = isaPointer(ptr);
   (void)p;
   assert(p && "GEP expects a pointer type");
   LLValue *indices[] = {DtoConstUint(i0), DtoConstUint(i1)};
-  return llvm::ConstantExpr::getGetElementPtr(
-      p->getElementType(), ptr, indices, /* InBounds = */ true);
+  return llvm::ConstantExpr::getGetElementPtr(p->getElementType(), ptr, indices,
+                                              /* InBounds = */ true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -83,16 +83,16 @@ LLIntegerType *DtoSize_t();
 LLStructType *DtoModuleReferenceType();
 
 // getelementptr helpers
-LLValue *DtoGEP1(LLValue *ptr, LLValue *i0, bool inBounds,
-                 const char *name = "", llvm::BasicBlock *bb = nullptr);
-LLValue *DtoGEP(LLValue *ptr, LLValue *i0, LLValue *i1, bool inBounds,
-                const char *name = "", llvm::BasicBlock *bb = nullptr);
-
-LLValue *DtoGEPi1(LLValue *ptr, unsigned i0, const char *name = "",
-                  llvm::BasicBlock *bb = nullptr);
-LLValue *DtoGEPi(LLValue *ptr, unsigned i0, unsigned i1, const char *name = "",
+LLValue *DtoGEP1(LLValue *ptr, LLValue *i0, const char *name = "",
                  llvm::BasicBlock *bb = nullptr);
-LLConstant *DtoGEPi(LLConstant *ptr, unsigned i0, unsigned i1);
+LLValue *DtoGEP(LLValue *ptr, LLValue *i0, LLValue *i1, const char *name = "",
+                llvm::BasicBlock *bb = nullptr);
+
+LLValue *DtoGEP1(LLValue *ptr, unsigned i0, const char *name = "",
+                 llvm::BasicBlock *bb = nullptr);
+LLValue *DtoGEP(LLValue *ptr, unsigned i0, unsigned i1, const char *name = "",
+                llvm::BasicBlock *bb = nullptr);
+LLConstant *DtoGEP(LLConstant *ptr, unsigned i0, unsigned i1);
 
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -452,7 +452,7 @@ void IrAggr::defineInterfaceVtbl(BaseClass *b, bool new_instance,
       LLValue *&thisArg = args[thisArgIndex];
       LLType *targetThisType = thisArg->getType();
       thisArg = DtoBitCast(thisArg, getVoidPtrType());
-      thisArg = DtoGEP1(thisArg, DtoConstInt(-thunkOffset), true);
+      thisArg = DtoGEP1(thisArg, DtoConstInt(-thunkOffset));
       thisArg = DtoBitCast(thisArg, targetThisType);
 
       // all calls that might be subject to inlining into a caller with debug

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -6,51 +6,72 @@ struct S {
 
 extern(C):  // Avoid name mangling
 
-// IndexExp in array with const exp
+// IndexExp in static array with const exp
 // CHECK-LABEL: @foo1
 int foo1(int[3] a) {
     // CHECK: getelementptr inbounds [3 x i32]
     return a[1];
 }
 
-// IndexExp in pointer
+// IndexExp in static array with variable exp
 // CHECK-LABEL: @foo2
-int foo2(int* p, int i) {
+int foo2(int[3] a, int i) {
+    // CHECK: getelementptr inbounds [3 x i32]
+    return a[i];
+}
+
+// IndexExp in pointer
+// CHECK-LABEL: @foo3
+int foo3(int* p, int i) {
     // CHECK: getelementptr inbounds
     return p[i];
 }
 
 // PostExp in pointer
-// CHECK-LABEL: @foo3
-int foo3(int* p) {
+// CHECK-LABEL: @foo4
+int foo4(int* p) {
     // CHECK: getelementptr inbounds
     return *p++;
 }
 
 // PreExp in pointer
-// CHECK-LABEL: @foo4
-int foo4(int* p) {
+// CHECK-LABEL: @foo5
+int foo5(int* p) {
     // CHECK: getelementptr inbounds
     return *++p;
 }
 
 // Add offset to pointer
-// CHECK-LABEL: @foo5
-int foo5(int* p, int i) {
+// CHECK-LABEL: @foo6
+int foo6(int* p, int i) {
     // CHECK: getelementptr inbounds
     return *(p + i);
 }
 
 // Subtract offset from pointer
-// CHECK-LABEL: @foo6
-int foo6(int* p, int i) {
+// CHECK-LABEL: @foo7
+int foo7(int* p, int i) {
     // CHECK: getelementptr inbounds
     return *(p - i);
 }
 
 // Struct field
-// CHECK-LABEL: @foo7
-float foo7(S s) {
+// CHECK-LABEL: @foo8
+float foo8(S s) {
     // CHECK: getelementptr inbounds
     return s.y;
+}
+
+// IndexExp in dynamic array with const exp
+// CHECK-LABEL: @foo9
+int foo9(int[] a) {
+    // CHECK: getelementptr inbounds i32, i32*
+    return a[1];
+}
+
+// IndexExp in dynamic array with variable exp
+// CHECK-LABEL: @foo10
+int foo10(int[] a, int i) {
+    // CHECK: getelementptr inbounds i32, i32*
+    return a[i];
 }

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -75,3 +75,17 @@ int foo10(int[] a, int i) {
     // CHECK: getelementptr inbounds i32, i32*
     return a[i];
 }
+
+// SliceExp for static array with const lower bound
+// CHECK-LABEL: @foo11
+int[] foo11(ref int[3] a) {
+    // CHECK: getelementptr inbounds i32, i32*
+    return a[1 .. $];
+}
+
+// SliceExp for dynamic array with variable lower bound
+// CHECK-LABEL: @foo12
+int[] foo12(int[] a, int i) {
+    // CHECK: getelementptr inbounds i32, i32*
+    return a[i .. $];
+}

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -1,0 +1,56 @@
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+struct S {
+    float x, y;
+};
+
+extern(C):  // Avoid name mangling
+
+// IndexExp in array with const exp
+// CHECK-LABEL: @foo1
+int foo1(int[3] a) {
+    // CHECK: getelementptr inbounds [3 x i32]
+    return a[1];
+}
+
+// IndexExp in pointer
+// CHECK-LABEL: @foo2
+int foo2(int* p, int i) {
+    // CHECK: getelementptr inbounds
+    return p[i];
+}
+
+// PostExp in pointer
+// CHECK-LABEL: @foo3
+int foo3(int* p) {
+    // CHECK: getelementptr inbounds
+    return *p++;
+}
+
+// PreExp in pointer
+// CHECK-LABEL: @foo4
+int foo4(int* p) {
+    // CHECK: getelementptr inbounds
+    return *++p;
+}
+
+// Add offset to pointer
+// CHECK-LABEL: @foo5
+int foo5(int* p, int i) {
+    // CHECK: getelementptr inbounds
+    return *(p + i);
+}
+
+// Subtract offset from pointer
+// CHECK-LABEL: @foo6
+int foo6(int* p, int i) {
+    // CHECK: getelementptr inbounds
+    return *(p - i);
+}
+
+// Struct field
+// CHECK-LABEL: @foo7
+float foo7(S s) {
+    // CHECK: getelementptr inbounds
+    return s.y;
+}


### PR DESCRIPTION
Issue: https://github.com/ldc-developers/ldc/issues/392

I don't get the reasoning behind how arrays are handled currently so I didn't change them.

For static arrays and constant index, the generated IR is the expected. i.e. if it's in bounds, then `GEP inbounds` is generated, otherwise compile-time error.
If though say we have a static array and the index is not known (in which case bounds-checking code is generated) e.g.
```
int foo(int[3] a, int i)
{
    return a[i];
}
```
then `inbounds` is _not_ generated for the `bounds.ok` BB. I could "just" change that, but [in the code](https://github.com/baziotis/ldc/blob/73e6f4442744603c55128d8e5ab35667e3d52768/gen/toir.cpp#L1094), it seems as if someone has thought about it (i.e. there is not just a `true` or a `false`).
However, the way I think of it, there are 2 cases:
1) The index is constant, in which case either:
     a) It is out of bounds and it will be caught by the front-end.
     b) The condition is in bounds, in which case `e->indexIsInBounds` is `true`.
2) The index is not constant, in which case if it is in bounds, we should generate `inbounds`.
If it isn't we probably (more on that below) should generate it, but it won't reach that code anway.

Considering the cases, it seems that it should just be `true` there. Same for dynamic arrays.

A note on Clang: [Clang generates](https://godbolt.org/z/IVibHT) `inbouds` even when we're accessing an array of known size _out_ of bounds. [According to the manual](https://llvm.org/docs/LangRef.html#id231) this seems better (it generates a poison value instead of just undefined behavior).