### PR TITLE
specify clang because otherwise it tries /bin/cc which may be gcc on …

### DIFF
--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -169,6 +169,7 @@ void runCMake() {
         "-DD_FLAGS=" ~ config.dFlags.join(";"),
         "-DRT_CFLAGS=" ~ config.cFlags.join(" "),
         "-DLD_FLAGS=" ~ config.linkerFlags.join(" "),
+	"-DCMAKE_C_COMPILER=clang",
     ];
     if(config.targetPreset.matchFirst("^Android"))
         args ~= ["-DCMAKE_SYSTEM_NAME=Linux", "-DCMAKE_C_COMPILER_WORKS=True"];


### PR DESCRIPTION
…some systems and it assumes clang -target argument syntax