### PR TITLE
[Travis] Enable runtime sanitizer testing for Linux LLVM 9 and macOS LLVM 8 CI testers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - os: linux
       d: ldc
-      env: LLVM_VERSION=9.0.0 OPTS="-DBUILD_SHARED_LIBS=ON"
+      env: LLVM_VERSION=9.0.0 OPTS="-DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON"
     - os: linux
       d: ldc-beta
       env: LLVM_VERSION=8.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF"
@@ -31,7 +31,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       d: dmd
-      env: LLVM_VERSION=8.0.0 OPTS="-DBUILD_SHARED_LIBS=ON"
+      env: LLVM_VERSION=8.0.0 OPTS="-DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON"
     - os: osx
       osx_image: xcode9.2
       d: ldc-beta


### PR DESCRIPTION
It doesn't seem to slow down the runtime so let's enable the testing in more places.