### PR TITLE
Make gccbuiltins_*.di files available to non-installed compiler

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -207,7 +207,7 @@ steps:
       #
       mkdir install/import
       cp -r $BUILD_SOURCESDIRECTORY/runtime/druntime/src/{core,etc,ldc,object.d} install/import
-      cp bootstrap-ldc/runtime/gccbuiltins_{aarch64,arm,x86}.di install/import/ldc
+      cp bootstrap-ldc/runtime/import/ldc/gccbuiltins_{aarch64,arm,x86}.di install/import/ldc
       cp -r $BUILD_SOURCESDIRECTORY/runtime/phobos/etc/c install/import/etc
       rm -rf install/import/etc/c/zlib
       cp -r $BUILD_SOURCESDIRECTORY/runtime/phobos/std install/import

--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -23,6 +23,7 @@ default:
     // default switches appended after all explicit command-line switches
     post-switches = [
         "-I@RUNTIME_DIR@/src",
+        "-I@LDC_BUILD_IMPORT_DIR@",
         "-I@JITRT_DIR@/d",
     ];
     // default directories to be searched for libraries when linking

--- a/ldc2_phobos.conf.in
+++ b/ldc2_phobos.conf.in
@@ -23,6 +23,7 @@ default:
     // default switches appended after all explicit command-line switches
     post-switches = [
         "-I@RUNTIME_DIR@/src",
+        "-I@LDC_BUILD_IMPORT_DIR@",
         "-I@JITRT_DIR@/d",
         "-I@PHOBOS2_DIR@",
     ];

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -266,6 +266,9 @@ if(NOT (LDC_LLVM_VER LESS 800))
     set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--export-dynamic\",")
 endif()
 
+# Directory filled with auto-generated import files
+set(LDC_BUILD_IMPORT_DIR "${PROJECT_BINARY_DIR}/import")
+
 # Only generate the config files if this CMake project is embedded in the LDC CMake project.
 if(LDC_EXE)
     if(PHOBOS2_DIR)
@@ -284,7 +287,7 @@ endif()
 set(GCCBUILTINS "")
 if(TARGET gen_gccbuiltins)
   function(gen_gccbuiltins name)
-    set(module "${PROJECT_BINARY_DIR}/gccbuiltins_${name}.di")
+    set(module "${LDC_BUILD_IMPORT_DIR}/ldc/gccbuiltins_${name}.di")
     if (GCCBUILTINS STREQUAL "")
       set(GCCBUILTINS "${module}" PARENT_SCOPE)
     else()

--- a/tests/compilable/gh3194.d
+++ b/tests/compilable/gh3194.d
@@ -1,0 +1,4 @@
+// REQUIRES: target_X86
+// RUN: %ldc -c %s
+
+import ldc.gccbuiltins_x86; // should be importable by non-installed compiler


### PR DESCRIPTION
Fixes #3194.