### PR TITLE
Posix x86[_64]: Pass non-POD arguments indirectly by value, not just for extern(C++), and get rid of extra blits for temporaries

### DIFF
--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -262,8 +262,8 @@ bool X86_64TargetABI::returnInArg(TypeFunction *tf, bool) {
 }
 
 bool X86_64TargetABI::passByVal(TypeFunction *tf, Type *t) {
-  // indirectly by-value for extern(C++) functions and non-POD args
-  if (tf->linkage == LINKcpp && !isPOD(t))
+  // indirectly by-value for non-POD args
+  if (!isPOD(t))
     return false;
 
   return ::passByVal(t->toBasetype());
@@ -278,8 +278,8 @@ void X86_64TargetABI::rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg,
   LLType *originalLType = arg.ltype;
   Type *t = arg.type->toBasetype();
 
-  // indirectly by-value for extern(C++) functions and non-POD args
-  if (fty.type->linkage == LINKcpp && !isPOD(t)) {
+  // indirectly by-value for non-POD args
+  if (!isPOD(t)) {
     indirectByvalRewrite.applyTo(arg);
     if (regCount.int_regs > 0) {
       regCount.int_regs--;

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2871,6 +2871,11 @@ bool toInPlaceConstruction(DLValue *lhs, Expression *rhs) {
               Logger::println("success, in-place-constructing temporary");
               auto lhsLVal = DtoLVal(lhs);
               auto rhsLVal = DtoLVal(rhs);
+              if (!llvm::isa<llvm::AllocaInst>(rhsLVal)) {
+                error(rhs->loc, "lvalue of temporary is not an alloca, please "
+                                "file an LDC issue");
+                fatal();
+              }
               rhsLVal->replaceAllUsesWith(lhsLVal);
               return true;
             }

--- a/tests/codegen/in_place_construct_temporaries.d
+++ b/tests/codegen/in_place_construct_temporaries.d
@@ -1,10 +1,13 @@
 // from https://issues.dlang.org/show_bug.cgi?id=20321
 
+// Restrict to x86[_64] hosts for now, as the ABI must not perform any implicit
+// blits (e.g., via LLVM byval attribute) for non-PODs.
 // REQUIRES: host_X86
 // RUN: %ldc -run %s
 
-version (X86) // restrict to x86_64 for now (ABI)
+version (Win32)
 {
+    // ABI needs *a lot* of work: https://github.com/ldc-developers/ldc/pull/3204#discussion_r339300174
     void main() {}
 }
 else:

--- a/tests/codegen/in_place_construct_temporaries.d
+++ b/tests/codegen/in_place_construct_temporaries.d
@@ -1,0 +1,87 @@
+// from https://issues.dlang.org/show_bug.cgi?id=20321
+
+// REQUIRES: host_X86
+// RUN: %ldc -run %s
+
+version (X86) // restrict to x86_64 for now (ABI)
+{
+    void main() {}
+}
+else:
+
+__gshared bool success = true;
+
+/** Container with internal pointer
+ */
+struct Container
+{
+    long[3] data;
+    void* p;
+
+    this(int) { p = &data[0]; }
+    this(ref inout Container) inout { p = &data[0]; }
+
+    /** Ensure the internal pointer is correct */
+    void check(int line = __LINE__)
+    {
+        if (p != &data[0])
+        {
+            import core.stdc.stdio : printf;
+            printf("Check failed in line %d\n", line);
+            success = false;
+        }
+    }
+}
+
+void func(Container c) { c.check(); } // error
+
+Container get()
+{
+    auto a = Container(1);
+    auto b = a;
+    a.check(); // ok
+    b.check(); // ok
+    // no nrvo
+    if (1)
+        return a;
+    else
+        return b;
+}
+
+Container get2()
+out(r){}
+do
+{
+    auto v = Container(1);
+    v.check(); // ok
+    return v;
+}
+
+int main()
+{
+    Container v = Container(1);
+    v.check(); // ok
+
+    func(v);
+    auto r = get();
+    r.check(); // error
+
+    auto r2 = get2();
+    r.check(); // error
+
+    Container[1] slit = [v];
+    slit[0].check(); // error
+
+    Container[] dlit = [v];
+    dlit[0].check(); // error
+
+    auto b = B(v);
+    b.m.check(); // error
+
+    return success ? 0 : 1;
+}
+
+struct B
+{
+    Container m;
+}


### PR DESCRIPTION
Streamlining the D ABI with the C++ one and preventing extra blits for rvalue arguments. Non-POD arguments passed by value aren't blitted into the callee params stack any longer, but passed by reference, either directly (rvalue args) or as reference to a bitcopy on the caller stack (lvalue args).

This is also a prerequisite for a potential DIP1014 (opPostMove) implementation, as LLVM (via its `byval` attribute) has been performing the move/blit implicitly as part of the call, with no way for us to invoke the post-move hook afterwards in the callee with the address of the original argument.