### PR TITLE
CircleCI: Bump the macOS image as well as host LDC & LLVM versions

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -186,10 +186,6 @@ steps:
 - script: |
     set -ex
     cd ../build
-    if [ "$CI_OS" = "osx" ]; then
-      # FIXME: macOS 10.13 broke this, see https://github.com/ldc-developers/ldc/pull/2839
-      echo 'void main() {}' > $BUILD_SOURCESDIRECTORY/runtime/druntime/test/shared/src/finalize.d
-    fi
     ctest -j$PARALLEL_JOBS --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
   displayName: Run defaultlib unittests & druntime stand-alone tests
   condition: and(succeededOrFailed(), ne(variables['CI_OS'], 'android'))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
     environment:
       - CI_OS: linux
       - LIBCLANG_COMMON_VERSION: "6.0"
-      - HOST_LDC_VERSION: 1.14.0
+      - HOST_LDC_VERSION: 1.18.0
       - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DRT_SUPPORT_SANITIZERS=ON -DBUILD_LTO_LIBS=ON -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
   Ubuntu-rolling-multilib-sharedLibsOnly:
     <<: *commonSteps
@@ -118,25 +118,25 @@ jobs:
     environment:
       - CI_OS: linux
       - LIBCLANG_COMMON_VERSION: "9"
-      - HOST_LDC_VERSION: 1.14.0
+      - HOST_LDC_VERSION: 1.18.0
       - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DBUILD_SHARED_LIBS=ON -DBUILD_LTO_LIBS=ON -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON"
   macOS-x64:
     <<: *commonSteps
     macos:
-      xcode: "9.2.0"
+      xcode: "11.1.0"
     environment:
       - CI_OS: osx
-      - LLVM_VERSION: 8.0.0
-      - HOST_LDC_VERSION: 1.14.0
+      - LLVM_VERSION: 9.0.0
+      - HOST_LDC_VERSION: 1.18.0
       - EXTRA_CMAKE_FLAGS: "-DBUILD_LTO_LIBS=ON"
   macOS-x64-sharedLibsOnly:
     <<: *commonSteps
     macos:
-      xcode: "9.2.0"
+      xcode: "11.1.0"
     environment:
       - CI_OS: osx
-      - LLVM_VERSION: 8.0.0
-      - HOST_LDC_VERSION: 1.14.0
+      - LLVM_VERSION: 9.0.0
+      - HOST_LDC_VERSION: 1.18.0
       - EXTRA_CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=ON -DBUILD_LTO_LIBS=ON"
 
 workflows:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
 - job: macOS_x64
   timeoutInMinutes: 120
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   variables:
     CI_OS: osx
     ARCH: x86_64


### PR DESCRIPTION
As our previous macOS image has been phased out, and we'd have to downgrade to the `xcode-9.0.1` image if we wanted to stick with macOS 10.12. `xcode-11.1.0` is the newest image and comes with macOS 10.14, so we'll probably hit issue #3002.

https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions