### PR TITLE
Azure CI Windows: Build LDC itself with LTO

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -78,7 +78,7 @@ steps:
     clang-cl --version
     mkdir bootstrap-ldc
     cd bootstrap-ldc
-    cmake -G Ninja %BUILD_SOURCESDIRECTORY% -DCMAKE_C_COMPILER:PATH=clang-cl.exe -DCMAKE_CXX_COMPILER:PATH=clang-cl.exe -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=%CD%/../llvm -DD_COMPILER=%CD%/../host-ldc/bin/ldmd2
+    cmake -G Ninja %BUILD_SOURCESDIRECTORY% -DCMAKE_C_COMPILER:PATH=clang-cl.exe -DCMAKE_CXX_COMPILER:PATH=clang-cl.exe -DCMAKE_BUILD_TYPE=Release -DLLVM_ROOT_DIR=%CD%/../llvm -DD_COMPILER=%CD%/../host-ldc/bin/ldmd2 -DBUILD_LTO_LIBS=ON
     ninja -j2 || exit /b
     bin\ldc2 --version
   displayName: Build bootstrap LDC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,10 +525,18 @@ endif()
 #
 # Set up the main ldc/ldc2 target.
 #
+set(LDC_LIB_LANGUAGE CXX)
 if(BUILD_SHARED)
     set(LDC_LIB_TYPE SHARED)
 else()
     set(LDC_LIB_TYPE STATIC)
+    if("${D_COMPILER_ID}" STREQUAL "LDMD" AND D_COMPILER_FE_VERSION GREATER 2074)
+        # Define a 'HOST_D' CMake linker language for the static LDCShared
+        # library, using the host ldmd2 compiler ≥ v1.5 as archiver, which
+        # supports LTO objects and cross-archiving.
+        set(CMAKE_HOST_D_CREATE_STATIC_LIBRARY "${D_COMPILER} -lib ${D_COMPILER_FLAGS} ${DDMD_DFLAGS} -of=<TARGET> <OBJECTS>")
+        set(LDC_LIB_LANGUAGE HOST_D)
+    endif()
 endif()
 
 set(LDC_LIB LDCShared)
@@ -546,6 +554,7 @@ set_target_properties(
     LIBRARY_OUTPUT_NAME ldc
     RUNTIME_OUTPUT_NAME ldc
     COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS} ${EXTRA_CXXFLAGS}"
+    LINKER_LANGUAGE ${LDC_LIB_LANGUAGE}
     LINK_FLAGS "${SANITIZE_LDFLAGS}"
 )
 # LDFLAGS should actually be in target property LINK_FLAGS, but this works, and gets around linking problems
@@ -568,7 +577,7 @@ if(MSVC)
     # VS 2017+: Use undocumented /NOOPTTLS MS linker switch to keep on emitting
     # a .tls section. Required for older host druntime versions, otherwise the
     # GC TLS ranges are garbage starting with VS 2017 Update 15.3.
-    if(MSVC_VERSION GREATER 1900) # VS 2017+
+    if(MSVC_VERSION GREATER 1900 AND D_COMPILER_FE_VERSION LESS 2076)
         list(APPEND LDC_LINKERFLAG_LIST "/NOOPTTLS")
     endif()
 endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   variables:
     CLANG_VERSION: 9.0.0
     VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
-    EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=thin
+    EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=full
   strategy:
     matrix:
       x64:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,17 +15,19 @@ jobs:
   variables:
     CLANG_VERSION: 9.0.0
     VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
-    EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=full
   strategy:
     matrix:
       x64:
         OS: windows
         MODEL: 64
         ARCH: x64
+        EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=full
       x86:
         OS: windows
         MODEL: 32
         ARCH: x86
+        # Undefined symbol errors with FullLTO; ThinLTO works.
+        EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=thin
         # Let CMake configure 64-bit clang-cl for 32-bit code emission.
         CFLAGS: -m32
         CXXFLAGS: -m32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   variables:
     CLANG_VERSION: 9.0.0
     VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
-    EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON
+    EXTRA_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DD_COMPILER_FLAGS="-flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=thin
   strategy:
     matrix:
       x64:


### PR DESCRIPTION
We use clang 9 as C++ compiler and the non-LTO'd bootstrap compiler is linked against matching LLVM 9, so everything's set up for LLVM 9 LTO already.

So when building the 2nd, final compiler:
* let clang compile the C++ parts of the ldc2 executable as LTO objects (the LDC parts, i.e., excluding LLVM libs)
* use the bootstrap LDC for archiving the static LDCShared library (as it only contains the C++ LTO objects)
* let the bootstrap compiler produce LTO objects only (for all D executables, not just ldc2)
* let the bootstrap compiler link all D executables with LTO, incl. LTO-able druntime & Phobos (via `lld-link` v9)