### PR TITLE
Windows: Upgrade bundled MinGW-based libs to v7.0.0 RC1

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -148,7 +148,7 @@ steps:
 - script: |
     cd ..
     cp llvm/bin/lld-link.exe installed/bin
-    curl -L -o mingw-w64-libs.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v6.0.0/mingw-w64-libs-v6.0.0.7z 2>&1
+    curl -L -o mingw-w64-libs.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v7.0.0-rc.1/mingw-w64-libs-v7.0.0-rc.1.7z 2>&1
     mkdir mingw-w64-libs
     cd mingw-w64-libs
     7z x ../mingw-w64-libs.7z > nul


### PR DESCRIPTION
See https://github.com/ldc-developers/mingw-w64-libs/releases/tag/v7.0.0-rc.1. Fixes #3142 (tested manually) and #3212.

The druntime and Phobos test runners can still be linked and run successfully (manually, via `-link-internally -mscrtlib=vcruntime140 -L/LIBPATH:path\to\libs`), on both Win32 and Win64.