### PR TITLE
Delete -L--no-warn-search-mismatch on multilib builds

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -234,7 +234,6 @@ endif()
 # DMD and GDC do). OS X doesn't need extra configuration due to the use of
 # fat binaries. Other Posixen might need to be added here.
 if(MULTILIB AND NOT "${TARGET_SYSTEM}" MATCHES "APPLE")
-    set(ADDITIONAL_DEFAULT_LDC_SWITCHES  "${ADDITIONAL_DEFAULT_LDC_SWITCHES}\n        \"-L--no-warn-search-mismatch\",")
     set(MULTILIB_ADDITIONAL_PATH         "\n        \"${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}\",")
     set(MULTILIB_ADDITIONAL_INSTALL_PATH "\n        \"${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX}\",")
 endif()


### PR DESCRIPTION
```
% ldc -linker=lld a.d
ld.lld: error: unknown argument '--no-warn-search-mismatch'
...
```

lld does not implement this option (https://bugs.llvm.org/show_bug.cgi?id=43740).
I think the option not useful because:

1) This usually indicates real library path configuration problems that should not be ignored.
2) If a .so is actually a linker script that includes other libraries,
 but without an OUTPUT_FORMAT directive, GNU ld and gold's behavior of
 skipping incompatible libraries may still not work if the linker script
 contents are different.
 For example, libncurses.so on Debian does not include an OUTPUT_FORMAT directive.

In addition, clang never passes this option.