### PR TITLE
Remove _d_execBss{Beg,End}Addr, used for copy-relocation check

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -279,23 +279,6 @@ void CodeGenerator::writeAndFreeLLModule(const char *filename) {
   ir_ = nullptr;
 }
 
-namespace {
-/// Emits a declaration for the given symbol, which is assumed to be of type
-/// i8*, and defines a second globally visible i8* that contains the address
-/// of the first symbol.
-void emitSymbolAddrGlobal(llvm::Module &lm, const char *symbolName,
-                          const char *addrName) {
-  llvm::Type *voidPtr =
-      llvm::PointerType::get(llvm::Type::getInt8Ty(lm.getContext()), 0);
-  auto targetSymbol = new llvm::GlobalVariable(
-      lm, voidPtr, false, llvm::GlobalValue::ExternalWeakLinkage, nullptr,
-      symbolName);
-  new llvm::GlobalVariable(
-      lm, voidPtr, false, llvm::GlobalValue::ExternalLinkage,
-      llvm::ConstantExpr::getBitCast(targetSymbol, voidPtr), addrName);
-}
-}
-
 void CodeGenerator::emit(Module *m) {
   bool const loggerWasEnabled = Logger::enabled();
   if (m->llvmForceLogging && !loggerWasEnabled) {
@@ -335,11 +318,6 @@ void CodeGenerator::emit(Module *m) {
           llvm::ConstantInt::get(ir_->module.getContext(), APInt(32, 0)),
           "_tlsend");
       endSymbol->setSection(".tcommon");
-    } else if (global.params.targetTriple->isOSLinux()) {
-      // On Linux, strongly define the excecutabe BSS bracketing symbols in
-      // the main module for druntime use (see rt.sections_elf_shared).
-      emitSymbolAddrGlobal(ir_->module, "__bss_start", "_d_execBssBegAddr");
-      emitSymbolAddrGlobal(ir_->module, "_end", "_d_execBssEndAddr");
     }
   }
 


### PR DESCRIPTION
I think we can remove the copy-relocation logic since https://github.com/ldc-developers/druntime/commit/9b97ede74f9b8840c77d7a35aaf573ace012c1d0 was comitted.