### PR TITLE
Embed linker directives in ELF and Mach-O object files

### DIFF
--- a/dmd/dsymbolsem.d
+++ b/dmd/dsymbolsem.d
@@ -1851,25 +1851,27 @@ version (IN_LLVM)
         const(char)* arg1str = null;
 }
 
-        if (global.params.mscoff)
+        // IN_LLVM: extended pragma(linkerDirective) support - not just for COFF
+        //          object files, and not restricted to a single string arg
+        if (pd.ident == Id.linkerDirective)
         {
-            if (pd.ident == Id.linkerDirective)
+            if (!pd.args || pd.args.dim == 0)
+                pd.error("one or more string arguments expected for pragma(linkerDirective)");
+            else
             {
-                if (!pd.args || pd.args.dim != 1)
-                    pd.error("one string argument expected for pragma(linkerDirective)");
-                else
+                for (size_t i = 0; i < pd.args.dim; ++i)
                 {
-                    auto se = semanticString(sc, (*pd.args)[0], "linker directive");
+                    auto se = semanticString(sc, (*pd.args)[i], "linker directive");
                     if (!se)
-                        goto Lnodecl;
-                    (*pd.args)[0] = se;
+                        break;
+                    (*pd.args)[i] = se;
                     if (global.params.verbose)
                         message("linkopt   %.*s", cast(int)se.len, se.peekString().ptr);
                 }
-                goto Lnodecl;
             }
+            goto Lnodecl;
         }
-        if (pd.ident == Id.msg)
+        else if (pd.ident == Id.msg)
         {
             if (pd.args)
             {

--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -192,6 +192,21 @@ void IRState::setStructLiteralConstant(StructLiteralExp *sle,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void IRState::addLinkerOption(llvm::ArrayRef<llvm::StringRef> options) {
+  llvm::SmallVector<llvm::Metadata *, 2> mdStrings;
+  mdStrings.reserve(options.size());
+  for (const auto &s : options)
+    mdStrings.push_back(llvm::MDString::get(context(), s));
+  linkerOptions.push_back(llvm::MDNode::get(context(), mdStrings));
+}
+
+void IRState::addLinkerDependentLib(llvm::StringRef libraryName) {
+  auto n = llvm::MDString::get(context(), libraryName);
+  linkerDependentLibs.push_back(llvm::MDNode::get(context(), n));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 IRBuilder<> *IRBuilderHelper::operator->() {
   IRBuilder<> &b = state->scope().builder;
   assert(b.GetInsertBlock() != NULL);

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -252,10 +252,15 @@ public:
 
 /// Vector of options passed to the linker as metadata in object file.
 #if LDC_LLVM_VER >= 500
-  llvm::SmallVector<llvm::MDNode *, 5> LinkerMetadataArgs;
+  llvm::SmallVector<llvm::MDNode *, 5> linkerOptions;
+  llvm::SmallVector<llvm::MDNode *, 5> linkerDependentLibs;
 #else
-  llvm::SmallVector<llvm::Metadata *, 5> LinkerMetadataArgs;
+  llvm::SmallVector<llvm::Metadata *, 5> linkerOptions;
+  llvm::SmallVector<llvm::Metadata *, 5> linkerDependentLibs;
 #endif
+
+  void addLinkerOption(llvm::ArrayRef<llvm::StringRef> options);
+  void addLinkerDependentLib(llvm::StringRef libraryName);
 
   // MS C++ compatible type descriptors
   llvm::DenseMap<size_t, llvm::StructType *> TypeDescriptorTypeMap;

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -245,8 +245,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
     // Embed a linker switch telling the MS linker to export the naked function.
     // This mimics the effect of the dllexport attribute for regular functions.
     const auto linkerSwitch = std::string("/EXPORT:") + mangle;
-    auto Value = llvm::MDString::get(gIR->context(), linkerSwitch);
-    gIR->LinkerMetadataArgs.push_back(llvm::MDNode::get(gIR->context(), Value));
+    gIR->addLinkerOption(llvm::StringRef(linkerSwitch));
   }
 
   gIR->funcGenStates.pop_back();

--- a/tests/codegen/linker_directives_linux.d
+++ b/tests/codegen/linker_directives_linux.d
@@ -1,0 +1,11 @@
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// REQUIRES: atleast_llvm500, target_X86
+
+// CHECK: !llvm.dependent-libraries = !{!0}
+// CHECK: !0 = !{!"mylib"}
+pragma(lib, "mylib");
+
+// silently ignored because not (yet?) embeddable in ELF object file:
+pragma(linkerDirective, "-myflag");
+pragma(linkerDirective, "-framework", "CoreFoundation");

--- a/tests/codegen/linker_directives_mac.d
+++ b/tests/codegen/linker_directives_mac.d
@@ -1,0 +1,13 @@
+// RUN: %ldc -mtriple=x86_64-apple-darwin -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// REQUIRES: atleast_llvm500, target_X86
+
+// CHECK: !llvm.linker.options = !{!0, !1, !2}
+
+// CHECK: !0 = !{!"-lmylib"}
+pragma(lib, "mylib");
+
+// CHECK: !1 = !{!"-myflag"}
+pragma(linkerDirective, "-myflag");
+// CHECK: !2 = !{!"-framework", !"CoreFoundation"}
+pragma(linkerDirective, "-framework", "CoreFoundation");

--- a/tests/codegen/linker_directives_win.d
+++ b/tests/codegen/linker_directives_win.d
@@ -1,0 +1,13 @@
+// RUN: %ldc -mtriple=x86_64-pc-windows-msvc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// REQUIRES: atleast_llvm500, target_X86
+
+// CHECK: !llvm.linker.options = !{!0, !1, !2}
+
+// CHECK: !0 = !{!"/DEFAULTLIB:\22mylib\22"}
+pragma(lib, "mylib");
+
+// CHECK: !1 = !{!"-myflag"}
+pragma(linkerDirective, "-myflag");
+// CHECK: !2 = !{!"-framework", !"CoreFoundation"}
+pragma(linkerDirective, "-framework", "CoreFoundation");


### PR DESCRIPTION
Resolves #3245 by adding `pragma(lib, <name>)` library names to `llvm.dependent-libraries` for ELF object files.

For Mach-O, embed appropriate linker options for `pragma(lib)` and support generic `pragma(linkerDirective, <flag>, ...)` as well.