### PR TITLE
irstate.h: fix -Wdeprecated-copy

### DIFF
--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -65,6 +65,7 @@ struct IRScope {
   IRBuilder<> builder;
 
   IRScope();
+  IRScope(const IRScope &) = default;
   explicit IRScope(llvm::BasicBlock *b);
 
   IRScope &operator=(const IRScope &rhs);


### PR DESCRIPTION
Since C++11, [depr.impldec] says:

> The implicit definition of a copy constructor as defaulted is deprecated
> if the class has a user-declared copy assignment operator or a
> user-declared destructor.

clang 10 will have a warning -Wdeprecated-copy (included by -Wextra)
which flags the code.