### PR TITLE
Use function attribute "frame-pointer" instead of "no-frame-pointer-elim"/"no-frame-pointer-elim-non-leaf"

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -480,15 +480,13 @@ void applyTargetMachineAttributes(llvm::Function &func,
 #if LDC_LLVM_VER >= 800
   switch (whichFramePointersToEmit()) {
     case llvm::FramePointer::None:
-      func.addFnAttr("no-frame-pointer-elim", "false");
+      func.addFnAttr("frame-pointer", "none");
       break;
     case llvm::FramePointer::NonLeaf:
-      func.addFnAttr("no-frame-pointer-elim", "false");
-      func.addFnAttr("no-frame-pointer-elim-non-leaf");
+      func.addFnAttr("frame-pointer", "non-leaf");
       break;
     case llvm::FramePointer::All:
-      func.addFnAttr("no-frame-pointer-elim", "true");
-      func.addFnAttr("no-frame-pointer-elim-non-leaf");
+      func.addFnAttr("frame-pointer", "all");
       break;
   }
 #else
@@ -1131,12 +1129,14 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   // disable frame-pointer-elimination for functions with inline asm
   if (fd->hasReturnExp & 8) // has inline asm
   {
+#if LDC_LLVM_VER >= 800
+    func->addFnAttr(
+        llvm::Attribute::get(gIR->context(), "frame-pointer", "all"));
+#else
     func->addAttribute(
         LLAttributeSet::FunctionIndex,
         llvm::Attribute::get(gIR->context(), "no-frame-pointer-elim", "true"));
-    func->addAttribute(
-        LLAttributeSet::FunctionIndex,
-        llvm::Attribute::get(gIR->context(), "no-frame-pointer-elim-non-leaf"));
+#endif
   }
 
   // give the 'this' parameter (an lvalue) storage and debug info

--- a/tests/codegen/attr_targetoptions.d
+++ b/tests/codegen/attr_targetoptions.d
@@ -1,3 +1,4 @@
+// REQUIRES: atleast_llvm800
 // Tests that our TargetMachine options are added as function attributes
 
 // RUN: %ldc -c -output-ll -of=%t.ll %s
@@ -21,7 +22,7 @@ void foo()
 // COMMON-DAG: "no-infs-fp-math"="false"
 // COMMON-DAG: "no-nans-fp-math"="false"
 
-// WITH_FP-DAG: "no-frame-pointer-elim"="true"
-// NO_FP-DAG:   "no-frame-pointer-elim"="false"
+// WITH_FP-DAG: "frame-pointer"="all"
+// NO_FP-DAG:   "frame-pointer"="none"
 
 // ATTR-DAG: "target-features"="{{[^"]*}}+test

--- a/tests/codegen/frame_pointer_x86.d
+++ b/tests/codegen/frame_pointer_x86.d
@@ -1,0 +1,25 @@
+// REQUIRES: target_X86
+
+// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s
+// RUN: FileCheck %s --check-prefixes=COMMON,FP < %t.s
+// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s -O2
+// RUN: FileCheck %s --check-prefixes=COMMON,NO_FP < %t.s
+// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s -O2 %disable_fp_elim
+// RUN: FileCheck %s --check-prefixes=COMMON,FP < %t.s
+// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s %enable_fp_elim
+// RUN: FileCheck %s --check-prefixes=COMMON,NO_FP < %t.s
+
+// COMMON-LABEL: _D17frame_pointer_x8613inlineAsmLeafFZv:
+// COMMON:       pushq %rbp
+// COMMON-LABEL: _D17frame_pointer_x8616inlineAsmNonLeafFZv:
+// COMMON:       pushq %rbp
+
+// COMMON-LABEL: _D17frame_pointer_x863fooFZv:
+// FP:           pushq %rbp
+// NO_FP-NOT:    pushq %rbp
+
+void externalFunc();
+void inlineAsmLeaf() { asm { nop; } }
+void inlineAsmNonLeaf() { asm { nop; } externalFunc(); }
+
+void foo() {}


### PR DESCRIPTION
LLVM 8 ([D56351](http://reviews.llvm.org/D56351)) introduced "frame-pointer" which was intended to replace
"no-frame-pointer-elim"/"no-frame-pointer-elim-non-leaf".

-----

In the LLVM monorepo, run `git show origin/release/8.x:llvm/lib/CodeGen/TargetOptionsImpl.cpp` to see the effect of `"frame-pointer"`.