### PR TITLE
Fix default cross-linker for MSVC targets on non-Windows hosts

### DIFF
--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -247,8 +247,12 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath,
   // try to call linker
   std::string linker = opts::linker;
   if (linker.empty()) {
+#ifdef _WIN32
     // default to lld-link.exe for LTO
     linker = opts::isUsingLTO() ? "lld-link.exe" : "link.exe";
+#else
+    linker = "lld-link";
+#endif
   }
 
   return executeToolAndWait(linker, args, global.params.verbose);


### PR DESCRIPTION
Fixes an annoyance reported in #3281, affecting non-LLD-enabled builds as well as linker invocations involving LTO.