### PR TITLE
Update FindLLVM.cmake to cope with new llvm-config names

### DIFF
--- a/cmake/Modules/FindLLVM.cmake
+++ b/cmake/Modules/FindLLVM.cmake
@@ -30,9 +30,9 @@
 # We also want an user-specified LLVM_ROOT_DIR to take precedence over the
 # system default locations such as /usr/local/bin. Executing find_program()
 # multiples times is the approach recommended in the docs.
-set(llvm_config_names llvm-config-9.0 llvm-config90
-                      llvm-config-8.0 llvm-config80
-                      llvm-config-7.0 llvm-config70
+set(llvm_config_names llvm-config-9.0 llvm-config90 llvm-config-9
+                      llvm-config-8.0 llvm-config80 llvm-config-8
+                      llvm-config-7.0 llvm-config70 llvm-config-7
                       llvm-config-6.0 llvm-config60
                       llvm-config-5.0 llvm-config50
                       llvm-config-4.0 llvm-config40


### PR DESCRIPTION
Debian moved to minor-versioness llvm-config-7 instead of llvm-config-7.0, same for 8 and 9 (and in the future 10)

This fixes the build when a non-default llvm-config is used to build