### PR TITLE
Add support for iOS, tvOS and watchOS

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -802,6 +802,22 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("AIX");
     VersionCondition::addPredefinedGlobalIdent("Posix");
     break;
+  case llvm::Triple::IOS:
+    VersionCondition::addPredefinedGlobalIdent("iOS");
+    VersionCondition::addPredefinedGlobalIdent("Posix");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
+    break;
+  case llvm::Triple::TvOS:
+    VersionCondition::addPredefinedGlobalIdent("TVOS");
+    VersionCondition::addPredefinedGlobalIdent("Posix");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
+    break;
+  case llvm::Triple::WatchOS:
+    VersionCondition::addPredefinedGlobalIdent("WatchOS");
+    VersionCondition::addPredefinedGlobalIdent("Posix");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
+    break;
+  break;
   default:
     if (triple.getEnvironment() == llvm::Triple::Android) {
       VersionCondition::addPredefinedGlobalIdent("Android");

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -817,7 +817,6 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
     break;
-  break;
   default:
     if (triple.getEnvironment() == llvm::Triple::Android) {
       VersionCondition::addPredefinedGlobalIdent("Android");

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -9,6 +9,7 @@
 //
 // The Procedure Call Standard can be found here:
 // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
+// https://github.com/ARM-software/software-standards/blob/master/abi/aapcs64/aapcs64.rst
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,7 +21,7 @@
 #include "gen/abi-generic.h"
 
 /**
- * The AACPS64 uses a special native va_list type:
+ * The AAPCS64 uses a special native va_list type:
  *
  * typedef struct __va_list {
  *     void *__stack; // next stack param
@@ -38,20 +39,16 @@
  */
 struct AArch64TargetABI : TargetABI {
 private:
+  const bool isDarwin;
   IndirectByvalRewrite byvalRewrite;
   HFAToArray hfaToArray;
   CompositeToArray64 compositeToArray64;
   IntegerRewrite integerRewrite;
 
-  bool isVaList(Type *t) {
-    if (global.params.targetTriple->isOSDarwin())
-    {
-      return t->ty == Tpointer &&
-        static_cast<TypePointer*>(t)->next->ty == Tchar;
-    }
-    else
-      return t->ty == Tstruct && strcmp(t->toPrettyChars(true),
-                                      "ldc.internal.vararg.std.__va_list") == 0;
+  bool isAAPCS64VaList(Type *t) {
+    return !isDarwin && t->ty == Tstruct &&
+           strcmp(t->toPrettyChars(true),
+                  "ldc.internal.vararg.std.__va_list") == 0;
   }
 
   bool passIndirectlyByValue(Type *t) {
@@ -61,6 +58,8 @@ private:
   }
 
 public:
+  AArch64TargetABI() : isDarwin(global.params.targetTriple->isOSDarwin()) {}
+
   bool returnInArg(TypeFunction *tf, bool) override {
     if (tf->isref) {
       return false;
@@ -95,7 +94,7 @@ public:
     if (t->ty != Tstruct && t->ty != Tsarray)
       return;
 
-    if (!isReturnVal && isVaList(t)) {
+    if (!isReturnVal && isAAPCS64VaList(t)) {
       // compiler magic: pass va_list args implicitly by reference
       arg.byref = true;
       arg.ltype = arg.ltype->getPointerTo();
@@ -121,15 +120,14 @@ public:
   }
 
   Type *vaListType() override {
-    if (global.params.targetTriple->isOSDarwin())
-      return Type::tchar->pointerTo();
-    else {
-      // We need to pass the actual va_list type for correct mangling. Simply
-      // using TypeIdentifier here is a bit wonky but works, as long as the name
-      // is actually available in the scope (this is what DMD does, so if a better
-      // solution is found there, this should be adapted).
-      return createTypeIdentifier(Loc(), Identifier::idPool("__va_list"));
-    }
+    if (isDarwin)
+      return TargetABI::vaListType(); // char*
+
+    // We need to pass the actual va_list type for correct mangling. Simply
+    // using TypeIdentifier here is a bit wonky but works, as long as the name
+    // is actually available in the scope (this is what DMD does, so if a better
+    // solution is found there, this should be adapted).
+    return createTypeIdentifier(Loc(), Identifier::idPool("__va_list"));
   }
 
   const char *objcMsgSendFunc(Type *ret, IrFuncTy &fty) override {

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -124,7 +124,7 @@ RegistryStyle getModuleRegistryStyle() {
     return RegistryStyle::sectionMSVC;
   }
 
-  if (t->isMacOSX()) {
+  if (t->isOSDarwin()) {
     return RegistryStyle::sectionDarwin;
   }
 

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -48,6 +48,10 @@ unsigned getCriticalSectionSize(const Param &params) {
   // POSIX: sizeof(pthread_mutex_t)
   // based on druntime/src/core/sys/posix/sys/types.d
   const auto &triple = *params.targetTriple;
+
+  if (triple.isOSDarwin())
+    return is64bit ? 64 : 44;
+
   const auto arch = triple.getArch();
   switch (triple.getOS()) {
   case llvm::Triple::Linux:
@@ -58,10 +62,6 @@ unsigned getCriticalSectionSize(const Param &params) {
     if (arch == llvm::Triple::aarch64 || arch == llvm::Triple::aarch64_be)
       return 48;
     return is64bit ? 40 : 24;
-
-  case llvm::Triple::Darwin:
-  case llvm::Triple::MacOSX:
-    return is64bit ? 64 : 44;
 
   case llvm::Triple::NetBSD:
     return is64bit ? 48 : 28;
@@ -287,6 +287,6 @@ Expression *Target::getTargetInfo(const char *name_, const Loc &loc) {
                 mem.xstrdup(opts::dcomputeFilePrefix.c_str()));
   }
 #endif
-    
+
   return nullptr;
 }

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -61,7 +61,8 @@ llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
     return llvm::Type::getX86_FP80Ty(ctx);
   }
 
-  if (anyAarch64 || (isAndroid && a == llvm::Triple::x86_64)) {
+  if ((anyAarch64 && !global.params.targetTriple->isOSDarwin()) ||
+      (isAndroid && a == llvm::Triple::x86_64)) {
     return llvm::Type::getFP128Ty(ctx);
   }
 

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -48,24 +48,27 @@ LLType *IrTypeBasic::getComplexType(llvm::LLVMContext &ctx, LLType *type) {
 
 namespace {
 llvm::Type *getReal80Type(llvm::LLVMContext &ctx) {
-  llvm::Triple::ArchType const a = global.params.targetTriple->getArch();
-  bool const anyX86 = (a == llvm::Triple::x86) || (a == llvm::Triple::x86_64);
-  bool const anyAarch64 =
+  const auto &triple = *global.params.targetTriple;
+  const auto a = triple.getArch();
+  const bool anyX86 = (a == llvm::Triple::x86) || (a == llvm::Triple::x86_64);
+  const bool anyAarch64 =
       (a == llvm::Triple::aarch64) || (a == llvm::Triple::aarch64_be);
-  bool const isAndroid =
-      global.params.targetTriple->getEnvironment() == llvm::Triple::Android;
+  const bool isAndroid = triple.getEnvironment() == llvm::Triple::Android;
 
-  // only x86 has 80bit float - but no support with MS C Runtime!
-  if (anyX86 && !global.params.targetTriple->isWindowsMSVCEnvironment() &&
-      !isAndroid) {
+  // Only x86 has 80-bit extended precision.
+  // MSVC and Android/x86 use double precision, Android/x64 quadruple.
+  if (anyX86 && !triple.isWindowsMSVCEnvironment() && !isAndroid) {
     return llvm::Type::getX86_FP80Ty(ctx);
   }
 
-  if ((anyAarch64 && !global.params.targetTriple->isOSDarwin()) ||
+  // AArch64 targets except Darwin (64-bit) use 128-bit quadruple precision.
+  // FIXME: PowerPC, SystemZ, ...
+  if ((anyAarch64 && !triple.isOSDarwin()) ||
       (isAndroid && a == llvm::Triple::x86_64)) {
     return llvm::Type::getFP128Ty(ctx);
   }
 
+  // 64-bit double precision for all other targets.
   return llvm::Type::getDoubleTy(ctx);
 }
 }


### PR DESCRIPTION
I've only tested this on a 64 bit iPhone running iOS 12. 32 bit is obsolete and I don't have access to the other platforms. All unit tests in druntime pass and most in Phobos.

I'm not sure about the correct workflow here but I created PRs for the druntime and Phobos changes to upstream those. I assume those will get pulled in next time LDC updates to the latest frontend version.

There are one or two changes in druntime that should not be upstreamed. How should those be handled?

druntime PR: https://github.com/dlang/druntime/pull/2910.
Phobos PR: https://github.com/dlang/phobos/pull/7355.