### PR TITLE
Fixes #3324 - Assertion too strict on vtbl pointer for extern(Windows)

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -428,7 +428,8 @@ LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
   assert(inst->type->toBasetype()->ty == Tclass);
   // 0 is always ClassInfo/Interface* unless it is a CPP interface
   assert(fdecl->vtblIndex > 0 ||
-         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKcpp));
+         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKcpp) ||
+         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKwindows));
 
   // get instance
   LLValue *vthis = DtoRVal(inst);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -428,7 +428,7 @@ LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
   assert(inst->type->toBasetype()->ty == Tclass);
   // 0 is always ClassInfo/Interface* unless it is a CPP interface
   assert(fdecl->vtblIndex > 0 ||
-         (fdecl->vtblIndex == 0 && fdecl->linkage != LINKd)));
+         (fdecl->vtblIndex == 0 && fdecl->linkage != LINKd));
 
   // get instance
   LLValue *vthis = DtoRVal(inst);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -428,8 +428,7 @@ LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
   assert(inst->type->toBasetype()->ty == Tclass);
   // 0 is always ClassInfo/Interface* unless it is a CPP interface
   assert(fdecl->vtblIndex > 0 ||
-         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKcpp) ||
-         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKwindows));
+         (fdecl->vtblIndex == 0 && fdecl->linkage != LINKd)));
 
   // get instance
   LLValue *vthis = DtoRVal(inst);


### PR DESCRIPTION
The assertion is causing issues with windows headers.
This loosens a too strict assertion.