### PR TITLE
Revamp rt.sections_android, getting rid of some magic symbols

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -128,7 +128,7 @@ steps:
       -e "s|@LLVM_TARGETS@|AArch64 ARM X86 WebAssembly|g" > llvm-$ARCH/bin/llvm-config
     chmod 755 llvm-$ARCH/bin/llvm-config
     # Set up DFLAGS for cross-compiling/linking with host ldmd2
-    DFLAGS="-mtriple=$LLVM_TRIPLE -L-L$PWD/ldc-build-runtime.tmp/lib -linker=bfd -gcc=$PWD/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/$ARCH-linux-${androidEnv}21-clang"
+    DFLAGS="-mtriple=$LLVM_TRIPLE -L-L$PWD/ldc-build-runtime.tmp/lib -gcc=$PWD/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/$ARCH-linux-${androidEnv}21-clang"
     if [ "$ARCH" = "armv7a" ]; then DFLAGS="$DFLAGS -mcpu=cortex-a8"; fi
     set +x
     echo "##vso[task.setvariable variable=DFLAGS]$DFLAGS"
@@ -151,8 +151,8 @@ steps:
     installDir=$PWD/install
     mkdir build-$ARCH
     cd build-$ARCH
-    DEFAULT_LDC_SWITCHES=' "-linker=bfd",'
-    if [ "$ARCH" = "armv7a" ]; then DEFAULT_LDC_SWITCHES="$DEFAULT_LDC_SWITCHES \"-mcpu=cortex-a8\","; fi
+    DEFAULT_LDC_SWITCHES=''
+    if [ "$ARCH" = "armv7a" ]; then DEFAULT_LDC_SWITCHES=" \"-mcpu=cortex-a8\","; fi
     IFS=$'\n' extraFlags=( $(xargs -n1 <<<"$EXTRA_CMAKE_FLAGS $EXTRA_CMAKE_FLAGS_ANDROID") )
     cmake -G Ninja $BUILD_SOURCESDIRECTORY \
       -DCMAKE_BUILD_TYPE=Release \
@@ -160,7 +160,7 @@ steps:
       -DD_COMPILER=$PWD/../bootstrap-ldc/bin/ldmd2 \
       -DCMAKE_INSTALL_PREFIX=$installDir \
       -DINCLUDE_INSTALL_DIR=$installDir/import \
-      -DD_LINKER_ARGS="-fuse-ld=bfd;-L$PWD/../ldc-build-runtime.tmp/lib;-lphobos2-ldc;-ldruntime-ldc" \
+      -DD_LINKER_ARGS="-L$PWD/../ldc-build-runtime.tmp/lib;-lphobos2-ldc;-ldruntime-ldc" \
       -DADDITIONAL_DEFAULT_LDC_SWITCHES="$DEFAULT_LDC_SWITCHES" \
       "${extraFlags[@]}"
     ninja -j$PARALLEL_JOBS -v ldc2 ldmd2 ldc-build-runtime ldc-profdata ldc-prune-cache

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -335,26 +335,6 @@ void CodeGenerator::emit(Module *m) {
 
   codegenModule(ir_, m);
 
-  if (m == rootHasMain) {
-    if (global.params.targetTriple->getEnvironment() == llvm::Triple::Android) {
-      // On Android, bracket TLS data with the symbols _tlsstart and _tlsend, as
-      // done with dmd
-      auto startSymbol = new llvm::GlobalVariable(
-          ir_->module, llvm::Type::getInt32Ty(ir_->module.getContext()), false,
-          llvm::GlobalValue::ExternalLinkage,
-          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32, 0)),
-          "_tlsstart", &*(ir_->module.global_begin()));
-      startSymbol->setSection(".tdata");
-
-      auto endSymbol = new llvm::GlobalVariable(
-          ir_->module, llvm::Type::getInt32Ty(ir_->module.getContext()), false,
-          llvm::GlobalValue::ExternalLinkage,
-          llvm::ConstantInt::get(ir_->module.getContext(), APInt(32, 0)),
-          "_tlsend");
-      endSymbol->setSection(".tcommon");
-    }
-  }
-
   finishLLModule(m);
 
   if (m->llvmForceLogging && !loggerWasEnabled) {


### PR DESCRIPTION
This should resolve #3350 and also gets rid of the previous Android-specific requirement wrt. having a D main *and* making sure that object file is the first one fed to the linker.