### PR TITLE
Add support for running iOS unit tests on Bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,186 @@
+format_version: '8'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: ios
+
+app:
+  envs:
+    - BITRISE_PROJECT_PATH: ldc-build-runtime.tmp/TestRunner/TestRunner.xcodeproj
+    - BITRISE_SCHEME: TestRunner
+    - BITRISE_EXPORT_METHOD: development
+    - LLVM_VERSION: 10.0.0
+    - LDC_VERSION: 1.20.1
+    - IOS_VERSION: 12.0
+
+workflows:
+  primary:
+    steps:
+      - cache-pull@2.1.4: {}
+      - certificate-and-profile-installer@1.10.3: {}
+
+      - script@1.1.6:
+          title: Download LLVM
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                curl -L "https://github.com/ldc-developers/llvm-project/releases/download/ldc-v${LLVM_VERSION}/llvm-${LLVM_VERSION}-osx-x86_64.tar.xz" -o llvm.tar.xz
+                tar xf llvm.tar.xz
+                envman add --key LLVM_ROOT_DIR --value "$(pwd)/llvm-${LLVM_VERSION}-osx-x86_64"
+
+      - script@1.1.6:
+          title: Download LDC
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                curl -L "https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-osx-x86_64.tar.xz" -o ldc.tar.xz
+                tar xf ldc.tar.xz
+                envman add --key PATH --value "$(pwd)/ldc2-${LDC_VERSION}-osx-x86_64/bin:$PATH"
+
+      - script@1.1.6:
+          title: Build LDC
+          deps:
+            brew:
+              - name: cmake
+              - name: ninja
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                mkdir build
+                cd build
+                cmake -G Ninja .. \
+                  -DD_COMPILER=ldmd2 \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DLLVM_ROOT_DIR="$LLVM_ROOT_DIR"
+                ninja -j2
+                envman add --key LDC_BINARY --value "$(pwd)/bin/ldc2"
+
+      - script@1.1.6:
+          title: Build Runtime
+          deps:
+            brew:
+              - name: cmake
+              - name: ninja
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                build/bin/ldc-build-runtime \
+                  --cFlags="-target;arm64-apple-ios${IOS_VERSION}" \
+                  --dFlags="-mtriple=arm64-apple-ios${IOS_VERSION};-fvisibility=hidden" \
+                  --ldcSrcDir=. \
+                  --ninja \
+                  -j 2 \
+                  CMAKE_SYSTEM_NAME=iOS \
+                  CMAKE_OSX_ARCHITECTURES=arm64 \
+                  CMAKE_OSX_DEPLOYMENT_TARGET="${IOS_VERSION}" \
+                  BUILD_SHARED_LIBS=OFF
+
+                cd ldc-build-runtime.tmp
+                ninja -j2 druntime-test-runner-debug phobos2-test-runner-debug
+
+      - xcode-build-for-test@0.4.0:
+          title: Build Xcode Project
+          run_if: not .IsPR
+
+      - virtual-device-testing-for-ios@0.9.10:
+          title: Run Tests on Device
+          run_if: not .IsPR
+          inputs:
+            - test_devices: iphone6,12.2,en,portrait
+            - download_test_results: true
+
+      - script@1.1.6:
+          title: Assemble Test Result
+          run_if: not .IsPR
+          is_always_run: true
+          inputs:
+            - runner_bin: "$LDC_BINARY -run"
+            - script_file_path: "$BITRISE_STEP_SOURCE_DIR/main.d"
+            - content: |-
+                import std;
+
+                /**
+                 * For some reason the xcresult produced by the previous step
+                 * has a flat file structure. The code in this step fixes that
+                 * so the next step can work. This code turns a file structure
+                 * looking like this:
+                 *
+                 * ```
+                 * ├── TestLogs_Test-Transient Testing-2020.03.21_01-45-58--0700.xcresult_Data_data.0~-O0rfKEKRY3nIhjlqYnpkA66cLiUonVgCNYwugi05n9Jx5OzM2-LySzkK1msGnDLSE8q0NRhrhw7IzkvLpyeNw==
+                 * ├── TestLogs_Test-Transient Testing-2020.03.21_01-45-58--0700.xcresult_Data_data.0~1CjDi6o46z-JhUr8R_x8s2FSUso2vKw5JRCkXMC0u_NrVR82R9FCih_SAFsZ6QBlodOkzBPOcj109apBnmq3Xw==
+                 * ```
+                 *
+                 * Into a file and directory structure like this:
+                 *
+                 * ```
+                 * TestLogs_Test-Transient Testing-2020.03.21_01-45-58--0700.xcresult
+                 * ├── Data
+                 * │   ├── data.0~-O0rfKEKRY3nIhjlqYnpkA66cLiUonVgCNYwugi05n9Jx5OzM2-LySzkK1msGnDLSE8q0NRhrhw7IzkvLpyeNw==
+                 * │   ├── data.0~1CjDi6o46z-JhUr8R_x8s2FSUso2vKw5JRCkXMC0u_NrVR82R9FCih_SAFsZ6QBlodOkzBPOcj109apBnmq3Xw==
+                 * ```
+                 */
+                void main()
+                {
+                    static void copy(string source, string target)
+                    {
+                        const splitResult = target.split(".xcresult");
+                        const xcresultDir = splitResult[0] ~ ".xcresult";
+                        const embeddedDir = splitResult[1].dirName[1 .. $];
+                        const targetDir = buildPath(xcresultDir, embeddedDir);
+
+                        mkdirRecurse(targetDir);
+                        std.file.copy(source, target);
+                    }
+
+                    const source = environment["VDTESTING_DOWNLOADED_FILES_DIR"];
+
+                    auto paths = dirEntries(source, "*.xcresult*", SpanMode.shallow)
+                        .map!(e => e.name.absolutePath)
+                        .array;
+
+                    const sourceBase = (paths.front.split(".xcresult")[0] ~ ".xcresult").baseName;
+                    const targetBasePath = "xcresult".absolutePath;
+                    const xcresultPath = targetBasePath.buildPath(sourceBase);
+
+                    spawnProcess(["envman", "add", "--key", "BITRISE_XCRESULT_PATH", "--value",
+                        xcresultPath]).wait;
+
+                    paths
+                        .map!(e => e.split(".xcresult")[1])
+                        .map!(e => e.split("."))
+                        .map!(e => tuple(e[0].split("_"), e[1]))
+                        .map!(e => tuple(e[0].filter!(a => !a.empty).array, e[1]))
+                        .map!(e => tuple(e[0][0 .. $ - 1], e[0][$ - 1 .. $].front ~ '.' ~ e[1]))
+                        .map!(e => e[0].buildPath.buildPath(e[1]))
+                        .map!(e => targetBasePath.buildPath(sourceBase, e))
+                        .zip(paths)
+                        .each!(e => copy(e[1], e[0]));
+                }
+
+      - xcparse@0.1.0:
+          title: Extract Logs
+          run_if: not .IsPR
+          is_always_run: true
+          inputs:
+            - export_to_deploy: 'yes'
+            - extract_attachments: 'no'
+            - extract_code_coverage: 'no'
+            - extract_logs: 'yes'
+            - extract_screenshots: 'no'
+
+      - script@1.1.6:
+          title: Print Logs
+          run_if: not .IsPR
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -e
+                unzip -qq "$XCPARSE_LOGS_PATH"
+                find logs -name StandardOutputAndStandardError.txt | head -1 | xargs cat
+
+      - deploy-to-bitrise-io@1.9.6: {}
+      - cache-push@2.2.3: {}

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -1,0 +1,2 @@
+xcuserdata
+DerivedData

--- a/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.pbxproj
+++ b/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.pbxproj
@@ -1,0 +1,465 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7A0FA68E2427A262000EBFC7 /* {{ phobosArchive }} in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A0FA68D2427A262000EBFC7 /* {{ phobosArchive }} */; };
+		7A2E9BD223D8CF6500784D0E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7A2E9BD023D8CF6500784D0E /* Main.storyboard */; };
+		7A2E9BDA23D8CF6600784D0E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A2E9BD923D8CF6600784D0E /* main.m */; };
+		7A2E9BE423D8CF6600784D0E /* TestRunnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A2E9BE323D8CF6600784D0E /* TestRunnerTests.m */; };
+		7A2E9BEF23D8D0BF00784D0E /* {{ druntimeArchive }} in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A2E9BEE23D8D0BF00784D0E /* {{ druntimeArchive }} */; };
+		7A2E9BF123D8D28A00784D0E /* test_runner.o in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A2E9BF023D8D28A00784D0E /* test_runner.o */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7A2E9BE023D8CF6600784D0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7A2E9BBC23D8CF6500784D0E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7A2E9BC323D8CF6500784D0E;
+			remoteInfo = TestRunner;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7A0FA68D2427A262000EBFC7 /* {{ phobosArchive }} */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "{{ phobosArchive }}"; path = "{{ libraryPath }}/{{ phobosArchive }}"; sourceTree = "<group>"; };
+		7A2E9BC423D8CF6500784D0E /* TestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A2E9BD123D8CF6500784D0E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7A2E9BD823D8CF6600784D0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7A2E9BD923D8CF6600784D0E /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		7A2E9BDF23D8CF6600784D0E /* TestRunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestRunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A2E9BE323D8CF6600784D0E /* TestRunnerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestRunnerTests.m; sourceTree = "<group>"; };
+		7A2E9BE523D8CF6600784D0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7A2E9BEE23D8D0BF00784D0E /* {{ druntimeArchive }} */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "{{ druntimeArchive }}"; path = "{{ libraryPath }}/{{ druntimeArchive }}"; sourceTree = "<group>"; };
+		7A2E9BF023D8D28A00784D0E /* test_runner.o */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.objfile"; name = test_runner.o; path = "{{ objectPath }}/test_runner.o"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7A2E9BC123D8CF6500784D0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7A2E9BDC23D8CF6600784D0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A0FA68E2427A262000EBFC7 /* {{ phobosArchive }} in Frameworks */,
+				7A2E9BEF23D8D0BF00784D0E /* {{ druntimeArchive }} in Frameworks */,
+				7A2E9BF123D8D28A00784D0E /* test_runner.o in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7A2E9BBB23D8CF6500784D0E = {
+			isa = PBXGroup;
+			children = (
+				7A2E9BC623D8CF6500784D0E /* TestRunner */,
+				7A2E9BE223D8CF6600784D0E /* TestRunnerTests */,
+				7A2E9BC523D8CF6500784D0E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7A2E9BC523D8CF6500784D0E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7A2E9BC423D8CF6500784D0E /* TestRunner.app */,
+				7A2E9BDF23D8CF6600784D0E /* TestRunnerTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7A2E9BC623D8CF6500784D0E /* TestRunner */ = {
+			isa = PBXGroup;
+			children = (
+				7A2E9BD023D8CF6500784D0E /* Main.storyboard */,
+				7A2E9BD823D8CF6600784D0E /* Info.plist */,
+				7A2E9BD923D8CF6600784D0E /* main.m */,
+			);
+			path = TestRunner;
+			sourceTree = "<group>";
+		};
+		7A2E9BE223D8CF6600784D0E /* TestRunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				7A2E9BE323D8CF6600784D0E /* TestRunnerTests.m */,
+				7A2E9BE523D8CF6600784D0E /* Info.plist */,
+				7A2E9BEE23D8D0BF00784D0E /* {{ druntimeArchive }} */,
+				7A0FA68D2427A262000EBFC7 /* {{ phobosArchive }} */,
+				7A2E9BF023D8D28A00784D0E /* test_runner.o */,
+			);
+			path = TestRunnerTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7A2E9BC323D8CF6500784D0E /* TestRunner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7A2E9BE823D8CF6600784D0E /* Build configuration list for PBXNativeTarget "TestRunner" */;
+			buildPhases = (
+				7A2E9BC023D8CF6500784D0E /* Sources */,
+				7A2E9BC123D8CF6500784D0E /* Frameworks */,
+				7A2E9BC223D8CF6500784D0E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestRunner;
+			productName = TestRunner;
+			productReference = 7A2E9BC423D8CF6500784D0E /* TestRunner.app */;
+			productType = "com.apple.product-type.application";
+		};
+		7A2E9BDE23D8CF6600784D0E /* TestRunnerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7A2E9BEB23D8CF6600784D0E /* Build configuration list for PBXNativeTarget "TestRunnerTests" */;
+			buildPhases = (
+				7A2E9BDB23D8CF6600784D0E /* Sources */,
+				7A2E9BDC23D8CF6600784D0E /* Frameworks */,
+				7A2E9BDD23D8CF6600784D0E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7A2E9BE123D8CF6600784D0E /* PBXTargetDependency */,
+			);
+			name = TestRunnerTests;
+			productName = TestRunnerTests;
+			productReference = 7A2E9BDF23D8CF6600784D0E /* TestRunnerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7A2E9BBC23D8CF6500784D0E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				ORGANIZATIONNAME = "The LDC Team";
+				TargetAttributes = {
+					7A2E9BC323D8CF6500784D0E = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+					7A2E9BDE23D8CF6600784D0E = {
+						CreatedOnToolsVersion = 11.3.1;
+						TestTargetID = 7A2E9BC323D8CF6500784D0E;
+					};
+				};
+			};
+			buildConfigurationList = 7A2E9BBF23D8CF6500784D0E /* Build configuration list for PBXProject "TestRunner" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7A2E9BBB23D8CF6500784D0E;
+			productRefGroup = 7A2E9BC523D8CF6500784D0E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7A2E9BC323D8CF6500784D0E /* TestRunner */,
+				7A2E9BDE23D8CF6600784D0E /* TestRunnerTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7A2E9BC223D8CF6500784D0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A2E9BD223D8CF6500784D0E /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7A2E9BDD23D8CF6600784D0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7A2E9BC023D8CF6500784D0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A2E9BDA23D8CF6600784D0E /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7A2E9BDB23D8CF6600784D0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A2E9BE423D8CF6600784D0E /* TestRunnerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7A2E9BE123D8CF6600784D0E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7A2E9BC323D8CF6500784D0E /* TestRunner */;
+			targetProxy = 7A2E9BE023D8CF6600784D0E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		7A2E9BD023D8CF6500784D0E /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7A2E9BD123D8CF6500784D0E /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		7A2E9BE623D8CF6600784D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = {{ deploymentTarget }};
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		7A2E9BE723D8CF6600784D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = {{ deploymentTarget }};
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7A2E9BE923D8CF6600784D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DGM3Z2TJ7K;
+				INFOPLIST_FILE = TestRunner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ldc-developers.TestRunner";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7A2E9BEA23D8CF6600784D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DGM3Z2TJ7K;
+				INFOPLIST_FILE = TestRunner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ldc-developers.TestRunner";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		7A2E9BEC23D8CF6600784D0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DGM3Z2TJ7K;
+				INFOPLIST_FILE = TestRunnerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = {{ deploymentTarget }};
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "{{ libraryPath }}";
+				OTHER_LDFLAGS = (
+					"-force_load",
+					"{{ libraryPath }}/{{ phobosArchive }}",
+					"-force_load",
+					"{{ libraryPath }}/{{ druntimeArchive }}",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ldc-developers.TestRunnerTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestRunner.app/TestRunner";
+			};
+			name = Debug;
+		};
+		7A2E9BED23D8CF6600784D0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DGM3Z2TJ7K;
+				INFOPLIST_FILE = TestRunnerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = {{ deploymentTarget }};
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "{{ libraryPath }}";
+				OTHER_LDFLAGS = (
+					"-force_load",
+					"{{ libraryPath }}/{{ phobosArchive }}",
+					"-force_load",
+					"{{ libraryPath }}/{{ druntimeArchive }}",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ldc-developers.TestRunnerTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestRunner.app/TestRunner";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7A2E9BBF23D8CF6500784D0E /* Build configuration list for PBXProject "TestRunner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A2E9BE623D8CF6600784D0E /* Debug */,
+				7A2E9BE723D8CF6600784D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7A2E9BE823D8CF6600784D0E /* Build configuration list for PBXNativeTarget "TestRunner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A2E9BE923D8CF6600784D0E /* Debug */,
+				7A2E9BEA23D8CF6600784D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7A2E9BEB23D8CF6600784D0E /* Build configuration list for PBXNativeTarget "TestRunnerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A2E9BEC23D8CF6600784D0E /* Debug */,
+				7A2E9BED23D8CF6600784D0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7A2E9BBC23D8CF6500784D0E /* Project object */;
+}

--- a/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TestRunner.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/runtime/TestRunnerTemplate/TestRunner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/runtime/TestRunnerTemplate/TestRunner.xcodeproj/xcshareddata/xcschemes/TestRunner.xcscheme
+++ b/runtime/TestRunnerTemplate/TestRunner.xcodeproj/xcshareddata/xcschemes/TestRunner.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7A2E9BC323D8CF6500784D0E"
+               BuildableName = "TestRunner.app"
+               BlueprintName = "TestRunner"
+               ReferencedContainer = "container:TestRunner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7A2E9BDE23D8CF6600784D0E"
+               BuildableName = "TestRunnerTests.xctest"
+               BlueprintName = "TestRunnerTests"
+               ReferencedContainer = "container:TestRunner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7A2E9BC323D8CF6500784D0E"
+            BuildableName = "TestRunner.app"
+            BlueprintName = "TestRunner"
+            ReferencedContainer = "container:TestRunner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7A2E9BC323D8CF6500784D0E"
+            BuildableName = "TestRunner.app"
+            BlueprintName = "TestRunner"
+            ReferencedContainer = "container:TestRunner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/runtime/TestRunnerTemplate/TestRunner/Base.lproj/Main.storyboard
+++ b/runtime/TestRunnerTemplate/TestRunner/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/runtime/TestRunnerTemplate/TestRunner/Info.plist
+++ b/runtime/TestRunnerTemplate/TestRunner/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/runtime/TestRunnerTemplate/TestRunner/main.m
+++ b/runtime/TestRunnerTemplate/TestRunner/main.m
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+int main(int argc, char * argv[])
+{
+    return UIApplicationMain(argc, argv, nil, nil);
+}

--- a/runtime/TestRunnerTemplate/TestRunnerTests/Info.plist
+++ b/runtime/TestRunnerTemplate/TestRunnerTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/runtime/TestRunnerTemplate/TestRunnerTests/TestRunnerTests.m
+++ b/runtime/TestRunnerTemplate/TestRunnerTests/TestRunnerTests.m
@@ -1,0 +1,33 @@
+#import <XCTest/XCTest.h>
+#import <stdbool.h>
+
+typedef struct
+{
+    size_t executed;
+    size_t passed;
+    bool runMain;
+    bool summarize;
+} UnitTestResult;
+
+extern int rt_init(void);
+extern int rt_term(void);
+extern UnitTestResult runModuleUnitTests(void);
+
+@interface TestRunnerTests : XCTestCase
+@end
+
+@implementation TestRunnerTests
+
+- (void)tearDown
+{
+    XCTAssertTrue(rt_term());
+}
+
+- (void)test
+{
+    XCTAssertTrue(rt_init());
+    UnitTestResult result = runModuleUnitTests();
+    XCTAssertLessThanOrEqual(result.executed, result.passed);
+}
+
+@end

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -46,6 +46,7 @@ int main(string[] args) {
     prepareLdcSource();
     runCMake();
     build();
+    generateTestRunnerXcodeProjects();
 
     writefln(".: Runtime libraries built successfully into: %s", config.buildDir);
     return 0;
@@ -185,6 +186,81 @@ void build() {
         args ~= "all-test-runners";
 
     exec(args);
+}
+
+/**
+ * Generates Xcode projects for running the unit test for druntime and Phobos
+ * on an iOS device.
+ *
+ * This works by coping the `runtime/TestRunnerTemplate` directory to the build
+ * directory. Inside the `runtime/TestRunnerTemplate` directory is an Xcode
+ * project located. This project acts as a template. The `project.pbxproj` file
+ * inside the Xcode project contains variables, denoted by `{{ var }}`, which
+ * are replaced with the actual values when the template is rendered.
+ *
+ * The Xcode project has been created using Xcode 11.3.1 (11C504) and then the
+ * `project.pbxproj` file has been manually edited to replace the original
+ * values with variables.
+ */
+void generateTestRunnerXcodeProjects() {
+    import std.uni : icmp;
+
+    const struct ProjectContext {
+        string druntimeArchive;
+        string phobosArchive;
+        string deploymentTarget;
+        string objectPath;
+        string libraryPath;
+    }
+
+    static string renderTemplate(string temp, ProjectContext context) {
+        import std.conv : text;
+
+        string result = temp;
+
+        foreach (i, _; typeof(ProjectContext.tupleof)) {
+            enum name = __traits(identifier, ProjectContext.tupleof[i]);
+            result = result.replace("{{ " ~ name ~ " }}", context.tupleof[i].text);
+        }
+
+        return result;
+    }
+
+    static void copyRecurse(string source, string destination) {
+        mkdirRecurse(destination);
+
+        foreach (e; dirEntries(source, SpanMode.breadth)) {
+            const newPath = destination.buildPath(e[source.length + 1.. $]);
+
+            if (e.isDir)
+                mkdirRecurse(newPath);
+            else
+                copy(e.name, newPath);
+        }
+    }
+
+    const systemName = config.cmakeVars.get("CMAKE_SYSTEM_NAME", null);
+
+    if (systemName.icmp("iOS") != 0)
+        return;
+
+    const templatePath = config.ldcSourceDir.buildPath("runtime", "TestRunnerTemplate");
+    const targetPath = config.buildDir.buildPath("TestRunner").absolutePath;
+
+    copyRecurse(templatePath, targetPath);
+
+    ProjectContext context = {
+        druntimeArchive: "libdruntime-ldc-unittest-debug.a",
+        phobosArchive: "libphobos2-ldc-unittest-debug.a",
+        deploymentTarget: config.cmakeVars["CMAKE_OSX_DEPLOYMENT_TARGET"],
+        objectPath: config.buildDir.buildPath("objects-unittest-debug"),
+        libraryPath: config.buildDir.buildPath("lib")
+    };
+
+    const pbxprojPath = targetPath.buildPath("TestRunner.xcodeproj", "project.pbxproj");
+    const projectContent = readText(pbxprojPath);
+    const result = renderTemplate(projectContent, context);
+    std.file.write(pbxprojPath, result);
 }
 
 /*** helpers ***/


### PR DESCRIPTION
This setups up a CI pipeline for iOS to run on http://bitrise.io. It consists of a template for an Xcode project and a bitrise.yml file to configure the pipeline. When running `ldc-build-runtime`, the template will be used to create a real Xcode project. The Xcode project will run the unit tests for both druntime and Phobos.

This will run the unit tests on a real physical device on Bitrise.

For this review, the main interesting files would be:

* bitrise.yml
* runtime/TestRunnerTemplate/TestRunnerTests/TestRunnerTests.m
* runtime/ldc-build-runtime.d.in

For this to work, an account on Bitrise needs to be connected to this repository, an Apple developer account needs to be connected to the Bitrise account and the Bitrise workflow needs to be configured to use the bitrise.yml file.

Example of test run: https://app.bitrise.io/build/b6bb5ec7bbb732f2.