### PR TITLE
Give user possibility to avoid passing -fuse-ld to cc with `--linker=`.

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -577,7 +577,7 @@ void ArgsBuilder::addLinker() {
     // Default to ld.gold on Linux due to ld.bfd issues with ThinLTO (see #2278)
     // and older bfd versions stripping llvm.used symbols (e.g., ModuleInfo
     // refs) with --gc-sections (see #2870).
-    // Can be overriden by `-linker=` (explicitly empty).
+    // Can be overridden by `-linker=` (explicitly empty).
     if (opts::linker.getNumOccurrences() == 0)
       args.push_back("-fuse-ld=gold");
   }

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -577,7 +577,9 @@ void ArgsBuilder::addLinker() {
     // Default to ld.gold on Linux due to ld.bfd issues with ThinLTO (see #2278)
     // and older bfd versions stripping llvm.used symbols (e.g., ModuleInfo
     // refs) with --gc-sections (see #2870).
-    args.push_back("-fuse-ld=gold");
+    // Can be overriden by `-linker=` (explicitly empty).
+    if (opts::linker.getNumOccurrences() == 0)
+      args.push_back("-fuse-ld=gold");
   }
 }
 

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -27,12 +27,12 @@
 //////////////////////////////////////////////////////////////////////////////
 
 namespace opts {
-llvm::cl::opt<std::string>
-    linker("linker", llvm::cl::ZeroOrMore, llvm::cl::desc("Linker to use"),
-           llvm::cl::value_desc(
-               "lld-link|lld|gold|bfd|...|<nothing>. When explicitly set to "
-               "nothing, prevents LDC from passing -fuse-ld to cc."),
-           llvm::cl::cat(opts::linkingCategory));
+llvm::cl::opt<std::string> linker(
+    "linker", llvm::cl::ZeroOrMore,
+    llvm::cl::value_desc("lld-link|lld|gold|bfd|..."),
+    llvm::cl::desc("Set the linker to use. When explicitly set to '' "
+                   "(nothing), prevents LDC from passing `-fuse-ld` to `cc`."),
+    llvm::cl::cat(opts::linkingCategory));
 }
 
 static llvm::cl::opt<std::string>

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -29,7 +29,9 @@
 namespace opts {
 llvm::cl::opt<std::string>
     linker("linker", llvm::cl::ZeroOrMore, llvm::cl::desc("Linker to use"),
-           llvm::cl::value_desc("lld-link|lld|gold|bfd|..."),
+           llvm::cl::value_desc(
+               "lld-link|lld|gold|bfd|...|<nothing>. When explicitly set to "
+               "nothing, prevents LDC from passing -fuse-ld to cc."),
            llvm::cl::cat(opts::linkingCategory));
 }
 

--- a/tests/linking/linker_empty.d
+++ b/tests/linking/linker_empty.d
@@ -1,0 +1,9 @@
+// Check that the user can override LDC passing `-fuse-ld` to `cc`.
+
+// REQUIRES: target_X86
+
+// RUN: %ldc --gcc=echo --mtriple=x86_64-linux --linker= %s | FileCheck %s
+
+// CHECK-NOT: -fuse-ld
+// CHECK: linker_empty
+// CHECK-NOT: -fuse-ld


### PR DESCRIPTION
This is needed for example when you want to use `lld` but `-fuse-ld=lld` is not supported by the C compiler yet. Manually symlinking `ld` to `ld.lld` and passing `-linker=` to LDC will work with this patch.