### PR TITLE
Don't emit any column infos for CodeView by default, like clang

### DIFF
--- a/gen/cl_helpers.h
+++ b/gen/cl_helpers.h
@@ -48,6 +48,10 @@ template <> struct FlagParserDataType<cl::boolOrDefault> {
   static cl::boolOrDefault false_val() { return cl::BOU_FALSE; }
 };
 
+inline bool getFlagOrDefault(cl::boolOrDefault value, bool defaultValue) {
+  return value == cl::BOU_UNSET ? defaultValue : value == cl::BOU_TRUE;
+}
+
 template <> struct FlagParserDataType<CHECKENABLE> {
   static CHECKENABLE true_val() { return CHECKENABLEon; }
   static CHECKENABLE false_val() { return CHECKENABLEoff; }

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -209,6 +209,8 @@ private:
   bool mustEmitFullDebugInfo();
   bool mustEmitLocationsDebugInfo();
 
+  unsigned getColumn(const Loc &loc);
+
 public:
   template <typename T>
   void OpOffset(T &addr, llvm::StructType *type, int index) {

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -71,6 +71,7 @@ class DIBuilder {
 
   const bool isTargetMSVC;
   const bool isTargetMSVCx64;
+  const bool emitColumnInfo;
 
   llvm::DenseMap<Declaration*, llvm::TypedTrackingMDRef<llvm::MDNode>> StaticDataMemberCache;
 
@@ -209,7 +210,7 @@ private:
   bool mustEmitFullDebugInfo();
   bool mustEmitLocationsDebugInfo();
 
-  unsigned getColumn(const Loc &loc);
+  unsigned getColumn(const Loc &loc) const;
 
 public:
   template <typename T>

--- a/tests/debuginfo/msvc_no_colinfo.d
+++ b/tests/debuginfo/msvc_no_colinfo.d
@@ -1,11 +1,15 @@
 // REQUIRES: Windows
-// RUN: %ldc -g -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 void foo(int a)
 {
     a += 3;
 }
 
-// CHECK-NOT: column:
-// CHECK: !DILocation(line:
-// CHECK-NOT: column:
+// RUN: %ldc -g -output-ll -of=%t.ll %s               && FileCheck --check-prefix=NOCOL %s < %t.ll
+// NOCOL-NOT: column:
+// NOCOL: !DILocation(line:
+// NOCOL-NOT: column:
+
+// RUN: %ldc -g -output-ll -of=%t.ll %s -gcolumn-info && FileCheck --check-prefix=WITHCOL %s < %t.ll
+// WITHCOL: !DILocation(line:
+// WITHCOL-SAME: column:

--- a/tests/debuginfo/msvc_no_colinfo.d
+++ b/tests/debuginfo/msvc_no_colinfo.d
@@ -1,0 +1,11 @@
+// REQUIRES: Windows
+// RUN: %ldc -g -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+void foo(int a)
+{
+    a += 3;
+}
+
+// CHECK-NOT: column:
+// CHECK: !DILocation(line:
+// CHECK-NOT: column:


### PR DESCRIPTION
Fixing #3102; see https://reviews.llvm.org/D23720.