### PR TITLE
Do not fallback to host for critical section size of unknown targets

### DIFF
--- a/dmd/statementsem.d
+++ b/dmd/statementsem.d
@@ -3749,7 +3749,14 @@ version (IN_LLVM)
              *  try { body } finally { _d_criticalexit(&__critsec[0]); }
              */
             auto id = Identifier.generateId("__critsec");
+version (IN_LLVM)
+{
+            auto t = Type.tint8.sarrayOf(target.ptrsize + target.critsecsize(ss.loc));
+}
+else
+{
             auto t = Type.tint8.sarrayOf(target.ptrsize + target.critsecsize());
+}
             auto tmp = new VarDeclaration(ss.loc, t, id, null);
             tmp.storage_class |= STC.temp | STC.shared_ | STC.static_;
             Expression tmpExp = new VarExp(ss.loc, tmp);

--- a/dmd/target.d
+++ b/dmd/target.d
@@ -105,12 +105,12 @@ version (IN_LLVM)
     uint alignsize(Type type);
     uint fieldalign(Type type);
 
-    uint critsecsize()
+    uint critsecsize(const ref Loc loc)
     {
         if (c.criticalSectionSize == 0)
         {
             import dmd.errors;
-            error(Loc.initial, "Unknown critical section size");
+            error(loc, "unknown critical section size for the selected target");
             fatal();
         }
         return c.criticalSectionSize;

--- a/dmd/target.h
+++ b/dmd/target.h
@@ -97,7 +97,11 @@ struct Target
     // Type sizes and support.
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
+#if IN_LLVM
+    unsigned critsecsize(const Loc &loc);
+#else
     unsigned critsecsize();
+#endif
     Type *va_listType();  // get type of va_list
     int isVectorTypeSupported(int sz, Type *type);
     bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -842,8 +842,11 @@ void registerPredefinedTargetVersions() {
   default:
     if (triple.getEnvironment() == llvm::Triple::Android) {
       VersionCondition::addPredefinedGlobalIdent("Android");
-    } else if (triple.getOSName() != "unknown") {
-      warning(Loc(), "unknown target OS: %s", triple.getOSName().str().c_str());
+    } else {
+      llvm::StringRef osName = triple.getOSName();
+      if (!osName.empty() && osName != "unknown" && osName != "none") {
+        warning(Loc(), "unknown target OS: %s", osName.str().c_str());
+      }
     }
     break;
   }

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -20,10 +20,6 @@
 #include "gen/llvmhelpers.h"
 #include <assert.h>
 
-#if !defined(_MSC_VER)
-#include <pthread.h>
-#endif
-
 using llvm::APFloat;
 
 // in dmd/argtypes.d:
@@ -75,19 +71,8 @@ unsigned getCriticalSectionSize(const Param &params) {
     return 24;
 
   default:
-    break;
+    return 0; // leads to an error whenever requested
   }
-
-  if (arch == llvm::Triple::wasm32 || arch == llvm::Triple::wasm64)
-    return 0;
-
-#ifndef _MSC_VER
-  unsigned hostSize = sizeof(pthread_mutex_t);
-  warning(Loc(), "Assuming critical section size = %u bytes", hostSize);
-  return hostSize;
-#else
-  return 0;
-#endif
 }
 } // anonymous namespace
 

--- a/tests/codegen/unknown_critical_section_size.d
+++ b/tests/codegen/unknown_critical_section_size.d
@@ -1,0 +1,16 @@
+// REQUIRES: target_X86
+// RUN:     %ldc -mtriple=x86_64 -c -w %s
+// RUN: not %ldc -mtriple=x86_64 -c -w -d-version=WithSynchronized %s 2>&1 | FileCheck %s
+
+void foo() {}
+
+version (WithSynchronized)
+void bar()
+{
+    __gshared int global;
+    // CHECK: unknown_critical_section_size.d(12): Error: unknown critical section size for the selected target
+    synchronized
+    {
+        global += 10;
+    }
+}


### PR DESCRIPTION
Instead, error out whenever requested by an expression-less `synchronized` statement, including source LoC to track it down.

This is safer, especially since the previous initial warning may likely be suppressed, and makes this host-agnostic.

Also suppress previous warnings about unknown empty and `none` OS, treating these like `unknown`.

This is a follow-up on https://forum.dlang.org/post/agupeguvxftrucpjvpho@forum.dlang.org.