### PR TITLE
 gccbuiltins: Lift 256-bit vector limit, adding 174 builtins for x86 with LLVM 10

### DIFF
--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -52,18 +52,6 @@ string dtype(Record* rec, bool readOnlyMem)
         type = type.substr(i);
     }
 
-    if(vec.size() > 0 && type.size() > 0)
-    {
-        int typeSize, vecElements;
-        if(
-            sscanf(vec.c_str(), "%d", &vecElements) == 1 &&
-            sscanf(type.c_str() + 1, "%d", &typeSize) == 1 &&
-            typeSize * vecElements > 256)
-        {
-            return "";
-        }
-    }
-
     if(type == "i8")
         return "byte" + vec;
     else if(type == "i16")


### PR DESCRIPTION
Among which:
```D
pragma(LDC_intrinsic, "llvm.x86.avx512.pshuf.b.512")
    byte64 __builtin_ia32_pshufb512(byte64, byte64) pure @safe;
```
and thus fixing #3405.