### PR TITLE
gccbuiltins: Add AMD GCN and Nvidia PTX

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -337,8 +337,8 @@ if(TARGET gen_gccbuiltins)
     )
   endfunction()
 
-  set(target_arch "AArch64;ARM;Mips;PowerPC;SystemZ;X86")
-  set(target_name "aarch64;arm;mips;ppc;s390;x86")
+  set(target_arch "AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;SystemZ;X86")
+  set(target_name "aarch64;amdgcn;arm;mips;nvvm;ppc;s390;x86")
 
   foreach(target ${LLVM_TARGETS_TO_BUILD})
     list(FIND target_arch ${target} idx)


### PR DESCRIPTION
This is sort of a reboot of #2556. @thewilsonator: The generated files are .di headers, do those really need any special dcompute handling?