### PR TITLE
AVR: Add predefined version AVR and emit TLS globals as regular ones

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -651,6 +651,10 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("AArch64");
     registerPredefinedFloatABI("ARM_SoftFloat", "ARM_HardFloat", "ARM_SoftFP");
     break;
+  case llvm::Triple::avr:
+    VersionCondition::addPredefinedGlobalIdent("AVR");
+    VersionCondition::addPredefinedGlobalIdent("D_SoftFloat");
+    break;
   case llvm::Triple::mips:
   case llvm::Triple::mipsel:
     VersionCondition::addPredefinedGlobalIdent("MIPS");

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1755,10 +1755,11 @@ llvm::GlobalVariable *declareGlobal(const Loc &loc, llvm::Module &module,
                                     llvm::Type *type,
                                     llvm::StringRef mangledName,
                                     bool isConstant, bool isThreadLocal) {
-  // No TLS support for WebAssembly; spare users from having to add __gshared
-  // everywhere.
+  // No TLS support for WebAssembly and AVR; spare users from having to add
+  // __gshared everywhere.
   const auto arch = global.params.targetTriple->getArch();
-  if (arch == llvm::Triple::wasm32 || arch == llvm::Triple::wasm64)
+  if (arch == llvm::Triple::wasm32 || arch == llvm::Triple::wasm64 ||
+      arch == llvm::Triple::avr)
     isThreadLocal = false;
 
   llvm::GlobalVariable *existing =

--- a/tests/codegen/avr.d
+++ b/tests/codegen/avr.d
@@ -1,0 +1,13 @@
+// REQUIRES: atleast_llvm400, target_AVR
+
+// RUN: %ldc -mtriple=avr -betterC -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+version (AVR) {} else static assert(0);
+version (D_SoftFloat) {} else static assert(0);
+
+// make sure TLS globals are emitted as regular __gshared globals:
+
+// CHECK: @_D3avr13definedGlobali = global i32 123
+int definedGlobal = 123;
+// CHECK: @_D3avr14declaredGlobali = external global i32
+extern int declaredGlobal;


### PR DESCRIPTION
The AVR target on LLVM and AVR-GCC does not have support for TLS, so
it is necessary to emit global variables as NotThreadLocal.

Based on PR #3295