### PR TITLE
Fix AArch64 ABI, based on front-end toArgTypes machinery

### DIFF
--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -7,9 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// The Procedure Call Standard can be found here:
-// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
-// https://github.com/ARM-software/software-standards/blob/master/abi/aapcs64/aapcs64.rst
+// The AArch64 Procedure Call Standard (AAPCS64) can be found here:
+// https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,28 +21,18 @@
 #include "gen/abi-generic.h"
 
 /**
- * The AAPCS64 uses a special native va_list type:
- *
- * typedef struct __va_list {
- *     void *__stack; // next stack param
- *     void *__gr_top; // end of GP arg reg save area
- *     void *__vr_top; // end of FP/SIMD arg reg save area
- *     int __gr_offs; // offset from __gr_top to next GP register arg
- *     int __vr_offs; // offset from __vr_top to next FP/SIMD register arg
- * } va_list;
- *
- * In druntime, the struct is aliased as object.__va_list.
- * Arguments of this type are never passed by value, only by reference (even
- * though the mangled function name indicates otherwise!). This requires a
- * little bit of compiler magic in the following implementations.
+ * AAPCS64 uses a special native va_list type, a struct aliased as
+ * object.__va_list in druntime. Apple diverges and uses a simple char*
+ * pointer.
+ * __va_list arguments are never passed by value, only by reference (even though
+ * the mangled function name indicates otherwise!). This requires a little bit
+ * of compiler magic in the following implementations.
  */
 struct AArch64TargetABI : TargetABI {
 private:
   const bool isDarwin;
-  IndirectByvalRewrite byvalRewrite;
-  HFVAToArray hfvaToArray;
-  CompositeToArray64 compositeToArray64;
-  IntegerRewrite integerRewrite;
+  IndirectByvalRewrite indirectByvalRewrite;
+  ArgTypesRewrite argTypesRewrite;
 
   bool isAAPCS64VaList(Type *t) {
     if (isDarwin)
@@ -62,12 +51,6 @@ private:
     return false;
   }
 
-  bool passIndirectlyByValue(Type *t) {
-    t = t->toBasetype();
-    return t->ty == Tsarray || (t->ty == Tstruct && t->size() > 16 &&
-                                !isHFVA(t, hfvaToArray.maxElements));
-  }
-
 public:
   AArch64TargetABI() : isDarwin(global.params.targetTriple->isOSDarwin()) {}
 
@@ -77,57 +60,94 @@ public:
     }
 
     Type *rt = tf->next->toBasetype();
+    if (rt->ty == Tstruct || rt->ty == Tsarray) {
+      auto argTypes = getArgTypes(rt);
+      return !argTypes // FIXME: get rid of sret workaround for 0-sized return
+                       //        values (static arrays with 0 elements)
+             || argTypes->arguments->empty();
+    }
 
-    if (!isPOD(rt))
-      return true;
-
-    return passIndirectlyByValue(rt);
+    return false;
   }
 
   bool passByVal(TypeFunction *, Type *) override { return false; }
 
   void rewriteFunctionType(IrFuncTy &fty) override {
-    Type *rt = fty.ret->type->toBasetype();
-    if (!fty.ret->byref && rt->ty != Tvoid) {
-      rewriteArgument(fty, *fty.ret, true);
+    if (!fty.ret->byref && fty.ret->type->toBasetype()->ty != Tvoid) {
+      rewriteArgument(fty, *fty.ret, /*isReturnVal=*/true);
     }
 
     for (auto arg : fty.args) {
-      if (!arg->byref) {
-        rewriteArgument(fty, *arg);
-      }
+      if (!arg->byref)
+        rewriteArgument(fty, *arg, /*isReturnVal=*/false);
     }
-  }
 
-  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg, bool isReturnVal) {
-    const auto t = arg.type->toBasetype();
+    // remove 0-sized args (static arrays with 0 elements) and, for Darwin,
+    // empty structs too
+    size_t i = 0;
+    while (i < fty.args.size()) {
+      auto tb = fty.args[i]->type->toBasetype();
 
-    if (t->ty != Tstruct && t->ty != Tsarray)
-      return;
-
-    if (!isReturnVal && isAAPCS64VaList(t)) {
-      // compiler magic: pass va_list args implicitly by reference
-      arg.byref = true;
-      arg.ltype = arg.ltype->getPointerTo();
-    } else if (!isReturnVal && passIndirectlyByValue(t)) {
-      byvalRewrite.applyTo(arg);
-    }
-    // Rewrite HFAs only because union HFAs are turned into IR types that are
-    // non-HFA and messes up register selection
-    else if (t->ty == Tstruct &&
-             isHFVA(t, hfvaToArray.maxElements, &arg.ltype)) {
-      hfvaToArray.applyTo(arg, arg.ltype);
-    } else {
-      if (isReturnVal) {
-        integerRewrite.applyTo(arg);
-      } else {
-        compositeToArray64.applyTo(arg);
+      if (tb->size() == 0) {
+        fty.args.erase(fty.args.begin() + i);
+        continue;
       }
+
+      // https://developer.apple.com/library/archive/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html#//apple_ref/doc/uid/TP40013702-SW1
+      if (isDarwin) {
+        if (auto ts = tb->isTypeStruct()) {
+          if (ts->sym->fields.empty()) {
+            fty.args.erase(fty.args.begin() + i);
+            continue;
+          }
+        }
+      }
+
+      ++i;
     }
   }
 
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
-    rewriteArgument(fty, arg, false);
+    return rewriteArgument(fty, arg, /*isReturnVal=*/false);
+  }
+
+  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg, bool isReturnVal) {
+    Type *t = arg.type->toBasetype();
+
+    if (!isAggregate(t))
+      return;
+
+    // compiler magic: pass va_list args implicitly by reference
+    if (!isReturnVal && isAAPCS64VaList(t)) {
+      arg.byref = true;
+      arg.ltype = arg.ltype->getPointerTo();
+      return;
+    }
+
+    auto argTypes = getArgTypes(t);
+    if (!argTypes)
+      return; // don't rewrite 0-sized types
+
+    if (argTypes->arguments->empty()) {
+      // non-PODs and larger non-HFVA aggregates are passed as pointer to
+      // hidden copy
+      indirectByvalRewrite.applyTo(arg);
+      return;
+    }
+
+    // LLVM seems to take care of the rest when rewriting as follows, close to
+    // what clang emits:
+
+    auto rewrittenType = getRewrittenArgType(t, argTypes);
+    if (!rewrittenType)
+      return;
+
+    if (rewrittenType->isIntegerTy()) {
+      argTypesRewrite.applyToIfNotObsolete(arg, rewrittenType);
+    } else {
+      // in most cases, a LL array of either floats/vectors (HFVAs) or i64
+      argTypesRewrite.applyTo(arg, rewrittenType);
+    }
   }
 
   Type *vaListType() override {
@@ -136,8 +156,8 @@ public:
 
     // We need to pass the actual va_list type for correct mangling. Simply
     // using TypeIdentifier here is a bit wonky but works, as long as the name
-    // is actually available in the scope (this is what DMD does, so if a better
-    // solution is found there, this should be adapted).
+    // is actually available in the scope (this is what DMD does, so if a
+    // better solution is found there, this should be adapted).
     return createTypeIdentifier(Loc(), Identifier::idPool("__va_list"));
   }
 

--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -113,10 +113,58 @@ struct RemoveStructPadding : ABIRewrite {
 //////////////////////////////////////////////////////////////////////////////
 
 /**
+ * Base for ABI rewrites bit-casting an argument to another LL type.
+ * If the argument isn't in memory already, it is dumped to memory to perform
+ * the bit-cast.
+ */
+struct BaseBitcastABIRewrite : ABIRewrite {
+  LLValue *put(DValue *dv, bool, bool) override {
+    LLValue *address = dv->isLVal() ? DtoLVal(dv) : nullptr;
+    LLType *asType = type(dv->type);
+    const char *name = ".BaseBitcastABIRewrite_arg";
+
+    if (!address) {
+      address = DtoAllocaDump(dv, asType, 0, ".BaseBitcastABIRewrite_arg_storage");
+    }
+
+    LLType *pointeeType = address->getType()->getPointerElementType();
+
+    if (asType == pointeeType) {
+      return DtoLoad(address, name);
+    }
+
+    if (getTypeStoreSize(asType) > getTypeAllocSize(pointeeType)) {
+      // not enough allocated memory
+      LLValue *paddedDump =
+          DtoRawAlloca(asType, 0, ".BaseBitcastABIRewrite_padded_arg_storage");
+      DtoMemCpy(paddedDump, address,
+                DtoConstSize_t(getTypeAllocSize(pointeeType)));
+      return DtoLoad(paddedDump, name);
+    }
+
+    address = DtoBitCast(address, getPtrToType(asType));
+    return DtoLoad(address, name);
+  }
+
+  LLValue *getLVal(Type *dty, LLValue *v) override {
+    return DtoAllocaDump(v, dty, ".BaseBitcastABIRewrite_param_storage");
+  }
+
+  void applyToIfNotObsolete(IrFuncTyArg &arg, LLType *finalLType = nullptr) {
+    if (!finalLType)
+      finalLType = type(arg.type);
+    if (!LLTypeMemoryLayout::typesAreEquivalent(arg.ltype, finalLType))
+      applyTo(arg, finalLType);
+  }
+};
+
+//////////////////////////////////////////////////////////////////////////////
+
+/**
  * Rewrites any parameter to an integer of the same or next bigger size via
  * bit-casting.
  */
-struct IntegerRewrite : ABIRewrite {
+struct IntegerRewrite : BaseBitcastABIRewrite {
   static LLType *getIntegerType(unsigned minSizeInBytes) {
     if (minSizeInBytes > 16) {
       return nullptr;
@@ -151,31 +199,7 @@ struct IntegerRewrite : ABIRewrite {
     return LLIntegerType::get(gIR->context(), size * 8);
   }
 
-  LLValue *put(DValue *dv, bool, bool) override {
-    LLValue *address = getAddressOf(dv);
-    LLType *integerType = getIntegerType(dv->type->size());
-    return loadFromMemory(address, integerType);
-  }
-
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    return DtoAllocaDump(v, dty, ".IntegerRewrite_dump");
-  }
-
   LLType *type(Type *t) override { return getIntegerType(t->size()); }
-
-  void applyToIfNotObsolete(IrFuncTyArg &arg) {
-    LLType *ltype = arg.ltype;
-    if (!ltype->isSized()) // e.g., opaque types
-    {
-      IF_LOG Logger::cout()
-          << "IntegerRewrite: not rewriting non-sized type " << *ltype << '\n';
-      return;
-    }
-
-    LLType *integerType = getIntegerType(getTypeStoreSize(ltype));
-    if (!LLTypeMemoryLayout::typesAreEquivalent(ltype, integerType))
-      applyTo(arg, integerType);
-  }
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -223,25 +247,16 @@ struct IndirectByvalRewrite : ABIRewrite {
   }
 };
 
+//////////////////////////////////////////////////////////////////////////////
+
 /**
  * Bit-casts a Homogeneous Floating-point/Vector Aggregate (HFVA) to an array
  * of floats/vectors.
  */
-struct HFVAToArray : ABIRewrite {
+struct HFVAToArray : BaseBitcastABIRewrite {
   const int maxElements;
 
   HFVAToArray(int max = 4) : maxElements(max) {}
-
-  LLValue *put(DValue *dv, bool, bool) override {
-    Logger::println("rewriting HFVA %s -> as array", dv->type->toChars());
-    LLType *t = type(dv->type);
-    return DtoLoad(DtoBitCast(DtoLVal(dv), getPtrToType(t)));
-  }
-
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    Logger::println("rewriting array -> as HFA %s", dty->toChars());
-    return DtoAllocaDump(v, dty, ".HFVAToArray_dump");
-  }
 
   LLType *type(Type *t) override {
     LLType *hfvaType = nullptr;
@@ -251,46 +266,20 @@ struct HFVAToArray : ABIRewrite {
   }
 };
 
+//////////////////////////////////////////////////////////////////////////////
+
 /**
- * Rewrite a composite as array of i64.
+ * Bit-casts an argument to an array of integers of the specified size.
  */
-struct CompositeToArray64 : ABIRewrite {
-  LLValue *put(DValue *dv, bool, bool) override {
-    Logger::println("rewriting %s -> as i64 array", dv->type->toChars());
-    LLType *t = type(dv->type);
-    return DtoLoad(DtoBitCast(DtoLVal(dv), getPtrToType(t)));
-  }
-
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    Logger::println("rewriting i64 array -> as %s", dty->toChars());
-    return DtoAllocaDump(v, dty, ".CompositeToArray64_dump");
-  }
-
+template <int elementSize> struct CompositeToArray : BaseBitcastABIRewrite {
   LLType *type(Type *t) override {
-    // An i64 array that will hold Type 't'
-    size_t sz = (t->size() + 7) / 8;
-    return LLArrayType::get(LLIntegerType::get(gIR->context(), 64), sz);
+    size_t length = (t->size() + elementSize - 1) / elementSize;
+    return LLArrayType::get(LLIntegerType::get(gIR->context(), elementSize * 8),
+                            length);
   }
 };
 
-/**
- * Rewrite a composite as array of i32.
- */
-struct CompositeToArray32 : ABIRewrite {
-  LLValue *put(DValue *dv, bool, bool) override {
-    Logger::println("rewriting %s -> as i32 array", dv->type->toChars());
-    LLType *t = type(dv->type);
-    return DtoLoad(DtoBitCast(DtoLVal(dv), getPtrToType(t)));
-  }
-
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    Logger::println("rewriting i32 array -> as %s", dty->toChars());
-    return DtoAllocaDump(v, dty, ".CompositeToArray32_dump");
-  }
-
-  LLType *type(Type *t) override {
-    // An i32 array that will hold Type 't'
-    size_t sz = (t->size() + 3) / 4;
-    return LLArrayType::get(LLIntegerType::get(gIR->context(), 32), sz);
-  }
-};
+// Bit-casts to an array of i32.
+using CompositeToArray32 = CompositeToArray<4>;
+// Bit-casts to an array of i64.
+using CompositeToArray64 = CompositeToArray<8>;

--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -161,8 +161,20 @@ struct BaseBitcastABIRewrite : ABIRewrite {
 //////////////////////////////////////////////////////////////////////////////
 
 /**
- * Rewrites any parameter to an integer of the same or next bigger size via
- * bit-casting.
+ * Bit-casts an argument based on the front-end toArgTypes* machinery.
+ */
+struct ArgTypesRewrite : BaseBitcastABIRewrite {
+  LLType *type(Type *t) override {
+    LLType *rewrittenType = TargetABI::getRewrittenArgType(t->toBasetype());
+    assert(rewrittenType);
+    return rewrittenType;
+  }
+};
+
+//////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Bit-casts an argument to an integer of the same or next bigger size.
  */
 struct IntegerRewrite : BaseBitcastABIRewrite {
   static LLType *getIntegerType(unsigned minSizeInBytes) {

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -171,20 +171,7 @@ struct RegCount {
  * This type performs the actual struct/cfloat rewriting by simply storing to
  * memory so that it's then readable as the other type (i.e., bit-casting).
  */
-struct X86_64_C_struct_rewrite : ABIRewrite {
-  LLValue *put(DValue *v, bool, bool) override {
-    LLValue *address = getAddressOf(v);
-
-    LLType *abiTy = getAbiType(v->type->toBasetype());
-    assert(abiTy && "Why are we rewriting a non-rewritten type?");
-
-    return loadFromMemory(address, abiTy, ".X86_64_C_struct_rewrite_putResult");
-  }
-
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    return DtoAllocaDump(v, dty, ".X86_64_C_struct_rewrite_dump");
-  }
-
+struct X86_64_C_struct_rewrite : BaseBitcastABIRewrite {
   LLType *type(Type *t) override { return getAbiType(t->toBasetype()); }
 };
 

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -141,7 +141,7 @@ struct X86TargetABI : TargetABI {
 
     // return value:
     if (!fty.ret->byref) {
-      Type *rt = fty.type->next->toBasetype(); // for sret, rt == void
+      Type *rt = fty.ret->type->toBasetype(); // for sret, rt == void
       if (isAggregate(rt) && canRewriteAsInt(rt) &&
           // don't rewrite cfloat for extern(D)
           !(externD && rt->ty == Tcomplex32)) {

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -87,8 +87,7 @@ struct X86TargetABI : TargetABI {
       return false;
 
     Type *rt = tf->next->toBasetype();
-    const bool externD =
-        (tf->linkage == LINKd && tf->parameterList.varargs != VARARGvariadic);
+    const bool externD = isExternD(tf);
 
     // non-aggregates are returned directly
     if (!isAggregate(rt))
@@ -136,8 +135,7 @@ struct X86TargetABI : TargetABI {
   }
 
   void rewriteFunctionType(IrFuncTy &fty) override {
-    const bool externD = (fty.type->linkage == LINKd &&
-                          fty.type->parameterList.varargs != VARARGvariadic);
+    const bool externD = isExternD(fty.type);
 
     // return value:
     if (!fty.ret->byref) {

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -104,13 +104,15 @@ bool TargetABI::canRewriteAsInt(Type *t, bool include64bit) {
   return size == 1 || size == 2 || size == 4 || (include64bit && size == 8);
 }
 
+bool TargetABI::isExternD(TypeFunction *tf) {
+  return tf->linkage == LINKd && tf->parameterList.varargs != VARARGvariadic;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 bool TargetABI::reverseExplicitParams(TypeFunction *tf) {
   // Required by druntime for extern(D), except for `, ...`-style variadics.
-  return tf->linkage == LINKd &&
-         tf->parameterList.varargs != VARARGvariadic &&
-         tf->parameterList.length() > 1;
+  return isExternD(tf) && tf->parameterList.length() > 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -12,6 +12,7 @@
 #include "dmd/expression.h"
 #include "dmd/id.h"
 #include "dmd/identifier.h"
+#include "dmd/target.h"
 #include "gen/abi-aarch64.h"
 #include "gen/abi-arm.h"
 #include "gen/abi-generic.h"
@@ -66,6 +67,40 @@ bool TargetABI::isHFVA(Type *t, int maxNumElements, LLType **hfvaType) {
   }
   return false;
 }
+
+//////////////////////////////////////////////////////////////////////////////
+
+TypeTuple *TargetABI::getArgTypes(Type *t) {
+  // try to reuse cached argTypes of StructDeclarations
+  if (auto ts = t->toBasetype()->isTypeStruct()) {
+    auto sd = ts->sym;
+    if (sd->sizeok == SIZEOKdone)
+      return sd->argTypes;
+  }
+
+  return target.toArgTypes(t);
+}
+
+LLType *TargetABI::getRewrittenArgType(Type *t, TypeTuple *argTypes) {
+  if (!argTypes || argTypes->arguments->empty() ||
+      (argTypes->arguments->length == 1 &&
+       argTypes->arguments->front()->type == t)) {
+    return nullptr; // don't rewrite
+  }
+
+  auto &args = *argTypes->arguments;
+  assert(args.length <= 2);
+  return args.length == 1
+             ? DtoType(args[0]->type)
+             : LLStructType::get(gIR->context(), {DtoType(args[0]->type),
+                                                  DtoType(args[1]->type)});
+}
+
+LLType *TargetABI::getRewrittenArgType(Type *t) {
+  return getRewrittenArgType(t, getArgTypes(t));
+}
+
+//////////////////////////////////////////////////////////////////////////////
 
 bool TargetABI::isAggregate(Type *t) {
   TY ty = t->toBasetype()->ty;

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -55,29 +55,6 @@ LLValue *ABIRewrite::getAddressOf(DValue *v) {
   return DtoAllocaDump(v, ".getAddressOf_dump");
 }
 
-LLValue *ABIRewrite::loadFromMemory(LLValue *address, LLType *asType,
-                                    const char *name) {
-  LLType *pointerType = address->getType();
-  assert(pointerType->isPointerTy());
-  LLType *pointeeType = pointerType->getPointerElementType();
-
-  if (asType == pointeeType) {
-    return DtoLoad(address, name);
-  }
-
-  if (getTypeStoreSize(asType) > getTypeAllocSize(pointeeType)) {
-    // not enough allocated memory
-    LLValue *paddedDump = DtoRawAlloca(asType, 0, ".loadFromMemory_paddedDump");
-    DtoMemCpy(paddedDump, address,
-              DtoConstSize_t(getTypeAllocSize(pointeeType)));
-    return DtoLoad(paddedDump, name);
-  }
-
-  address = DtoBitCast(address, getPtrToType(asType),
-                       ".loadFromMemory_bitCastAddress");
-  return DtoLoad(address, name);
-}
-
 //////////////////////////////////////////////////////////////////////////////
 
 bool TargetABI::isHFVA(Type *t, int maxNumElements, LLType **hfvaType) {

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -65,12 +65,6 @@ protected:
 
   /// Returns the address of a D value, storing it to memory first if need be.
   static llvm::Value *getAddressOf(DValue *v);
-
-  /// Loads a LL value of a specified type from memory. The element type of the
-  /// provided pointer doesn't need to match the value type (=> suitable for
-  /// bit-casting).
-  static llvm::Value *loadFromMemory(llvm::Value *address, llvm::Type *asType,
-                                     const char *name = ".bitcast_result");
 };
 
 // interface called by codegen

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -24,6 +24,7 @@
 class Type;
 class TypeFunction;
 class TypeStruct;
+class TypeTuple;
 struct IrFuncTy;
 struct IrFuncTyArg;
 class FuncDeclaration;
@@ -177,6 +178,11 @@ struct TargetABI {
   static bool isHFVA(Type *t, int maxNumElements,
                      llvm::Type **hfvaType = nullptr);
 
+  /// Uses the front-end toArgTypes* machinery and returns an appropriate LL
+  /// type if arguments of the specified D type are to be rewritten in order to
+  /// be passed correctly in registers.
+  static llvm::Type *getRewrittenArgType(Type *t);
+
 protected:
 
   /// Returns true if the D type is an aggregate:
@@ -196,4 +202,9 @@ protected:
   /// Returns true if the D function type uses extern(D) linkage *and* isn't a
   /// D-style variadic function.
   static bool isExternD(TypeFunction *tf);
+
+  /// Returns the type tuple produced by the front-end's toArgTypes* machinery.
+  static TypeTuple *getArgTypes(Type *t);
+
+  static llvm::Type *getRewrittenArgType(Type *t, TypeTuple *argTypes);
 };

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -192,4 +192,8 @@ protected:
 
   /// Returns true if the D type can be bit-cast to an integer of the same size.
   static bool canRewriteAsInt(Type *t, bool include64bit = true);
+
+  /// Returns true if the D function type uses extern(D) linkage *and* isn't a
+  /// D-style variadic function.
+  static bool isExternD(TypeFunction *tf);
 };

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -116,9 +116,12 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
   llvm::Triple const &t = *global.params.targetTriple;
   if (!(t.getArch() == llvm::Triple::x86 ||
         t.getArch() == llvm::Triple::x86_64)) {
-    s->error("the `asm` statement is not supported for the \"%s\" "
-             "architecture, use `ldc.llvmasm.__asm` instead",
-             t.getArchName().str().c_str());
+    s->error(
+        "DMD-style `asm { op; }` statements are not supported for the \"%s\" "
+        "architecture.",
+        t.getArchName().str().c_str());
+    errorSupplemental(s->loc, "Use GDC-style `asm { \"op\" : …; }` syntax or "
+                              "`ldc.llvmasm.__asm` instead.");
     err = true;
   }
   if (!global.params.useInlineAsm) {

--- a/gen/dcompute/abi-rewrites.h
+++ b/gen/dcompute/abi-rewrites.h
@@ -13,26 +13,11 @@
 
 #pragma once
 
-#include "gen/abi.h"
-#include "gen/dcompute/druntime.h"
-#include "gen/irstate.h"
-#include "gen/llvmhelpers.h"
-#include "gen/logger.h"
-#include "gen/structs.h"
-#include "gen/tollvm.h"
+#include "gen/abi-generic.h"
 
-struct DComputePointerRewrite : ABIRewrite {
+struct DComputePointerRewrite : BaseBitcastABIRewrite {
   LLType *type(Type *t) override {
     auto ptr = toDcomputePointer(static_cast<TypeStruct *>(t)->sym);
     return ptr->toLLVMType(true);
-  }
-  LLValue *getLVal(Type *dty, LLValue *v) override {
-    // TODO: Is this correct?
-    return DtoAllocaDump(v, this->type(dty));
-  }
-  LLValue *put(DValue *dv, bool, bool) override {
-    LLValue *address = getAddressOf(dv);
-    LLType *t = this->type(dv->type);
-    return loadFromMemory(address, t);
   }
 };

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -178,7 +178,7 @@ llvm::FunctionType *DtoFunctionType(Type *type, IrFuncTy &irFty, Type *thistype,
       Logger::println("lazy param");
       auto ltf = TypeFunction::create(nullptr, arg->type, VARARGnone, LINKd);
       auto ltd = createTypeDelegate(ltf);
-      loweredDType = ltd;
+      loweredDType = merge(ltd);
     } else if (passPointer) {
       // ref/out
       attrs.addDereferenceableAttr(loweredDType->size());

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1197,7 +1197,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   }
 
   // D varargs: prepare _argptr and _arguments
-  if (f->linkage == LINKd && f->parameterList.varargs == VARARGvariadic) {
+  if (f->isDstyleVariadic()) {
     // allocate _argptr (of type core.stdc.stdarg.va_list)
     Type *tvalist = target.va_listType(fd->loc, fd->_scope);
     LLValue *argptrMem = DtoAlloca(tvalist, "_argptr_mem");

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -10,6 +10,7 @@
 #include "gen/nested.h"
 
 #include "dmd/errors.h"
+#include "dmd/ldcbindings.h"
 #include "dmd/target.h"
 #include "gen/dvalue.h"
 #include "gen/funcgenstate.h"
@@ -399,13 +400,10 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
     if (vd->isRef() || vd->isOut()) {
       t = DtoType(vd->type->pointerTo());
     } else if (vd->isParameter() && (vd->storage_class & STClazy)) {
-      // The LL type is a delegate (LL struct).
-      // Depending on the used TargetABI, the LL parameter is either a struct or
-      // a pointer to a struct (`byval` attribute, IndirectByvalRewrite).
-      t = getIrParameter(vd)->value->getType();
-      if (t->isPointerTy())
-        t = t->getPointerElementType();
-      assert(t->isStructTy());
+      // the type is a delegate (LL struct)
+      Type *dt = TypeFunction::create(nullptr, vd->type, VARARGnone, LINKd);
+      dt = createTypeDelegate(dt);
+      t = DtoType(dt);
     } else {
       t = DtoMemType(vd->type);
     }
@@ -502,7 +500,8 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
         assert(parm->value->getType()->isPointerTy());
 
         if (vd->isRef() || vd->isOut()) {
-          Logger::println("Captured by reference, copying pointer to nested frame");
+          Logger::println(
+              "Captured by reference, copying pointer to nested frame");
           DtoAlignedStore(parm->value, gep);
           // pass GEP as reference lvalue to EmitLocalVariable()
         } else {

--- a/shippable.yml
+++ b/shippable.yml
@@ -82,14 +82,15 @@ build:
     - ninja -j16 all-test-runners
     # Run LDC D unittests
     - ctest --output-on-failure -R "ldc2-unittest"
+    # FIXME: all gdb tests fail (might have to do with the Shippable/Packet setup) and are disabled
+    - rm ../tests/debuginfo/*_gdb.d
+    - rm ../tests/d2/dmd-testsuite/runnable/b18504.d
     # Run LIT testsuite, ignore the errors
     - cd tests
     - PATH="$PWD/../../llvm/bin:$PATH" python runlit.py -v -j 32 . || true
     - cd ..
     # Run DMD testsuite
-    # FIXME: the gdb tests fail and are disabled, runnable/b18504.d needs to be disabled manually
     - export DMD_TESTSUITE_MAKE_ARGS='-j32 GDB_FLAGS=OFF'
-    - rm ../tests/d2/dmd-testsuite/runnable/b18504.d
     - ctest -V -R "build-run-dmd-testsuite|dmd-testsuite-debug"
     # FIXME: for non-debug dmd-testsuite, run-dmd-testsuite fails due to an 'internal pointer'
     #        assertion in Phobos sorting code

--- a/shippable.yml
+++ b/shippable.yml
@@ -86,8 +86,14 @@ build:
     - cd tests
     - PATH="$PWD/../../llvm/bin:$PATH" python runlit.py -v -j 32 . || true
     - cd ..
-    # Run DMD testsuite, ignore the errors
-    - DMD_TESTSUITE_MAKE_ARGS='-j32 GDB_FLAGS=OFF' ctest -V -R "dmd-testsuite" || true
+    # Run DMD testsuite
+    # FIXME: the gdb tests fail and are disabled, runnable/b18504.d needs to be disabled manually
+    - export DMD_TESTSUITE_MAKE_ARGS='-j32 GDB_FLAGS=OFF'
+    - rm ../tests/d2/dmd-testsuite/runnable/b18504.d
+    - ctest -V -R "build-run-dmd-testsuite|dmd-testsuite-debug"
+    # FIXME: for non-debug dmd-testsuite, run-dmd-testsuite fails due to an 'internal pointer'
+    #        assertion in Phobos sorting code
+    - ctest -V -R "dmd-testsuite" -E "-debug" || true
     # Run defaultlib unittests (excl. hanging core.thread.fiber)
     # & druntime stand-alone tests, ignore the errors
     - ctest -j32 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^core.thread.fiber($|-)" || true


### PR DESCRIPTION
Cleaned-up version of #3393, rebased onto the upstreamed stuff.