### PR TITLE
CMake: Exclude rt.memset from druntime

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -161,6 +161,7 @@ list(REMOVE_ITEM DRUNTIME_D ${DRUNTIME_D_STDCPP})
 list(REMOVE_ITEM DRUNTIME_D
     ${RUNTIME_DIR}/src/rt/alloca.d
     ${RUNTIME_DIR}/src/rt/llmath.d
+    ${RUNTIME_DIR}/src/rt/memset.d
 )
 # only include core/sys/ modules matching the platform
 file(GLOB_RECURSE DRUNTIME_D_BIONIC  ${RUNTIME_DIR}/src/core/sys/bionic/*.d)


### PR DESCRIPTION
As it's useless for LDC *and* seems to trigger LLVM bugs for ARM soft-float targets, according to https://forum.dlang.org/post/ihddbsxxctlicxirwtjt@forum.dlang.org.