### PR TITLE
GCC-style asm: Add support for indirect input operands

### DIFF
--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -146,10 +146,10 @@ unsigned getFieldGEPIndex(AggregateDeclaration *ad, VarDeclaration *vd);
 DValue *DtoInlineAsmExpr(Loc &loc, FuncDeclaration *fd, Expressions *arguments,
                          LLValue *sretPointer = nullptr);
 ///
-llvm::CallInst *DtoInlineAsmExpr(
-    const Loc &loc, llvm::StringRef code, llvm::StringRef constraints,
-    llvm::ArrayRef<llvm::Value *> indirectOutputLVals,
-    llvm::ArrayRef<Expression *> arguments, llvm::Type *returnType);
+llvm::CallInst *DtoInlineAsmExpr(const Loc &loc, llvm::StringRef code,
+                                 llvm::StringRef constraints,
+                                 llvm::ArrayRef<llvm::Value *> operands,
+                                 llvm::Type *returnType);
 
 /// Returns the size the LLVM type for a member variable of the given type will
 /// take up in a struct (in bytes). This does not include padding in any way.

--- a/tests/codegen/asm_gcc.d
+++ b/tests/codegen/asm_gcc.d
@@ -56,6 +56,15 @@ void indirectOutput(uint eax)
     }
 }
 
+// CHECK: define void @_D7asm_gcc13indirectInputFkZv
+void indirectInput(uint eax)
+{
+    // CHECK-NEXT: %eax = alloca i32
+    // CHECK-NEXT: store i32 %eax_arg, i32* %eax
+    // CHECK-NEXT: call void asm sideeffect "movl %eax, $0", "*m,~{eax}"(i32* %eax), !srcloc
+    asm { "movl %%eax, %0" : : "m" (eax) : "eax"; }
+}
+
 // CHECK: define void @_D7asm_gcc15specialNamesX86FZv
 void specialNamesX86()
 {

--- a/tests/fail_compilation/asm_gcc_indirect.d
+++ b/tests/fail_compilation/asm_gcc_indirect.d
@@ -1,0 +1,17 @@
+// REQUIRES: target_X86
+
+// RUN: not %ldc -mtriple=x86_64-linux-gnu %s 2> %t.stderr
+// RUN: FileCheck %s < %t.stderr
+
+void indirectInput(int x)
+{
+    asm
+    {
+        "movl %%eax, %0"
+        :
+        : "m" (&x)
+        : "eax";
+    }
+}
+
+// CHECK: {{.}}asm_gcc_indirect.d(12): Error: indirect `"m"` input operands require an lvalue, but `& x` is an rvalue


### PR DESCRIPTION
I.e., use the expression's lvalue as operand for `"m"` memory inputs, like GDC. Previously, this was restricted to output operands (`"=m"`); input operands were still using the expression's rvalue (and so required an explicit address-of operator for variables).