### PR TITLE
Fix ICE for *captured* parameters *not* passed on the LLVM level

### DIFF
--- a/dmd/semantic3.d
+++ b/dmd/semantic3.d
@@ -411,29 +411,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 }
             }
 
-version (IN_LLVM)
-{
-            // Make sure semantic analysis has been run on argument types. This is
-            // e.g. needed for TypeTuple!(int, int) to be picked up as two int
-            // parameters by the Parameter functions.
-            for (size_t i = 0; i < f.parameterList.length; i++)
-            {
-                Parameter arg = f.parameterList[i];
-                Type nw = arg.type.typeSemantic(Loc.initial, sc);
-                if (arg.type != nw)
-                {
-                    arg.type = nw;
-                    // Examine this index again.
-                    // This is important if it turned into a tuple.
-                    // In particular, the empty tuple should be handled or the
-                    // next parameter will be skipped.
-                    // LDC_FIXME: Maybe we only need to do this for tuples,
-                    //            and can add tuple.length after decrement?
-                    i--;
-                }
-            }
-}
-
             /* Declare all the function parameters as variables
              * and install them in parameters[]
              */

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -392,14 +392,17 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
       builder.alignCurrentOffset(alignment);
     }
 
-    IrLocal &irLocal = *getIrLocal(vd, true);
+    const bool isParam = vd->isParameter();
+
+    IrLocal &irLocal =
+        *(isParam ? getIrParameter(vd, true) : getIrLocal(vd, true));
     irLocal.nestedIndex = builder.currentFieldIndex();
     irLocal.nestedDepth = depth;
 
     LLType *t = nullptr;
     if (vd->isRef() || vd->isOut()) {
       t = DtoType(vd->type->pointerTo());
-    } else if (vd->isParameter() && (vd->storage_class & STClazy)) {
+    } else if (isParam && (vd->storage_class & STClazy)) {
       // the type is a delegate (LL struct)
       Type *dt = TypeFunction::create(nullptr, vd->type, VARARGnone, LINKd);
       dt = createTypeDelegate(dt);

--- a/tests/compilable/captured_nonpassed_params.d
+++ b/tests/compilable/captured_nonpassed_params.d
@@ -1,0 +1,35 @@
+// Some ABIs don't pass empty static arrays or empty PODs as arguments.
+// This can get hairy, e.g., if such a parameter is captured.
+
+// RUN: %ldc -c -g %s
+
+struct EmptyPOD {}
+
+EmptyPOD emptyPOD(EmptyPOD e)
+{
+    EmptyPOD nested() { return e; }
+    nested();
+    return e;
+}
+
+int[0] emptySArray(int[0] a)
+{
+    int[0] nested() { return a; }
+    nested();
+    return a;
+}
+
+void tuple()
+{
+    auto test(T...)(T params)
+    {
+        auto nested() { return params[0]; }
+        nested();
+        return params[0];
+    }
+
+    test(EmptyPOD());
+
+    int[0] a;
+    test(a);
+}


### PR DESCRIPTION
Fixing the iOS regressions seen in #3379 after the rebase.