### PR TITLE
Cross-module inlining: Enable emission into multiple object files

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -345,7 +345,7 @@ static llvm::Function *DtoDeclareVaFunction(FuncDeclaration *fdecl) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoResolveFunction(FuncDeclaration *fdecl) {
+void DtoResolveFunction(FuncDeclaration *fdecl, const bool willDeclare) {
   if ((!global.params.useUnitTests || !fdecl->type) &&
       fdecl->isUnitTestDeclaration()) {
     IF_LOG Logger::println("Ignoring unittest %s", fdecl->toPrettyChars());
@@ -423,9 +423,13 @@ void DtoResolveFunction(FuncDeclaration *fdecl) {
   LOG_SCOPE;
 
   // queue declaration unless the function is abstract without body
-  if (!fdecl->isAbstract() || fdecl->fbody) {
+  if (!willDeclare && (!fdecl->isAbstract() || fdecl->fbody)) {
     DtoDeclareFunction(fdecl);
   }
+}
+
+void DtoResolveFunction(FuncDeclaration *fdecl) {
+  return DtoResolveFunction(fdecl, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -539,8 +543,8 @@ void onlyOneMainCheck(FuncDeclaration *fd) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoDeclareFunction(FuncDeclaration *fdecl) {
-  DtoResolveFunction(fdecl);
+void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
+  DtoResolveFunction(fdecl, /*willDeclare=*/true);
 
   if (fdecl->ir->isDeclared()) {
     return;
@@ -567,7 +571,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   // Check if fdecl should be defined too for cross-module inlining.
   // If true, semantic is fully done for fdecl which is needed for some code
   // below (e.g. code that uses fdecl->vthis).
-  const bool defineAtEnd = defineAsExternallyAvailable(*fdecl);
+  const bool defineAtEnd = !willDefine && defineAsExternallyAvailable(*fdecl);
   if (defineAtEnd) {
     IF_LOG Logger::println(
         "Function is an externally_available inline candidate.");
@@ -762,8 +766,12 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   if (defineAtEnd) {
     IF_LOG Logger::println(
         "Function is an externally_available inline candidate: define it now.");
-    DtoDefineFunction(fdecl, true);
+    DtoDefineFunction(fdecl, /*linkageAvailableExternally=*/true);
   }
+}
+
+void DtoDeclareFunction(FuncDeclaration *fdecl) {
+  return DtoDeclareFunction(fdecl, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1001,12 +1009,19 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     fatal();
   }
 
-  DtoResolveFunction(fd);
+  DtoDeclareFunction(fd, /*willDefine=*/true);
+  assert(fd->ir->isDeclared());
+
+  // DtoDeclareFunction might also set the defined flag for functions we
+  // should not touch.
+  if (fd->ir->isDefined()) {
+    return;
+  }
+  fd->ir->setDefined();
 
   if (fd->isUnitTestDeclaration() && !global.params.useUnitTests) {
     IF_LOG Logger::println("No code generation for unit test declaration %s",
                            fd->toChars());
-    fd->ir->setDefined();
     return;
   }
 
@@ -1016,26 +1031,14 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
       IF_LOG Logger::println(
           "No code generation for typeinfo member %s in @compute code",
           fd->toChars());
-      fd->ir->setDefined();
       return;
     }
   }
 
   if (!linkageAvailableExternally && !alreadyOrWillBeDefined(*fd)) {
     IF_LOG Logger::println("Skipping '%s'.", fd->toPrettyChars());
-    fd->ir->setDefined();
     return;
   }
-
-  DtoDeclareFunction(fd);
-  assert(fd->ir->isDeclared());
-
-  // DtoResolveFunction might also set the defined flag for functions we
-  // should not touch.
-  if (fd->ir->isDefined()) {
-    return;
-  }
-  fd->ir->setDefined();
 
   // We cannot emit nested functions with parents that have not gone through
   // semantic analysis. This can happen as DMD leaks some template instances

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -969,7 +969,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
 
   if (fd->ir->isDefined()) {
     llvm::Function *func = getIrFunc(fd)->getLLVMFunc();
-    assert(nullptr != func);
+    assert(func);
     if (!linkageAvailableExternally &&
         (func->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage)) {
       // Fix linkage

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -215,8 +215,11 @@ LLValue *DtoDelegateEquals(TOK op, LLValue *lhs, LLValue *rhs) {
 ////////////////////////////////////////////////////////////////////////////////
 
 LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
-  auto linkage = (DtoIsTemplateInstance(sym) ? templateLinkage
-                                             : LLGlobalValue::ExternalLinkage);
+  // Function (incl. delegate) literals are emitted into each referencing
+  // compilation unit; use template linkage to prevent conflicts.
+  auto linkage = (sym->isFuncLiteralDeclaration() || DtoIsTemplateInstance(sym))
+                     ? templateLinkage
+                     : LLGlobalValue::ExternalLinkage;
 
   // If @(ldc.attributes.weak) is applied, override the linkage to WeakAny
   if (hasWeakUDA(sym)) {

--- a/tests/codegen/inlining_gh3126.d
+++ b/tests/codegen/inlining_gh3126.d
@@ -1,14 +1,20 @@
 // Tests that functions are cross-module inlined when emitting multiple object
 // files.
 
-// Generate unoptimized IR for 2 source files as separate compilation units.
-// RUN: %ldc -c -output-ll %s %S/inputs/inlinables.d -od=%t
-// RUN: FileCheck %s < %t/inlining_gh3126.ll
+// Generate unoptimized IR for 2 source files as separate compilation units (in both orders).
+// RUN: %ldc -c -output-ll %s %S/inputs/inlinables.d -od=%t && FileCheck %s < %t/inlining_gh3126.ll
+// RUN: %ldc -c -output-ll %S/inputs/inlinables.d %s -od=%t && FileCheck %s < %t/inlining_gh3126.ll
+
+// Now test with another source file making use of inputs.inlinables instead of compiling that module directly.
+// RUN: %ldc -c -output-ll -I%S %s %S/inlining_imports_pragma.d -od=%t && FileCheck %s < %t/inlining_gh3126.ll
+// RUN: %ldc -c -output-ll -I%S %S/inlining_imports_pragma.d %s -od=%t && FileCheck %s < %t/inlining_gh3126.ll
 
 import inputs.inlinables;
 
-// no other function definitions (always_inline_chain*)
-// CHECK-NOT: define
+// no other function definitions (always_inline_chain*, call_template_foo);
+// allow template_foo to be instantiated in here though
+// CHECK-NOT: always_inline_chain
+// CHECK-NOT: call_template_foo
 
 // CHECK: define {{.*}}_D15inlining_gh31263fooFZi
 int foo()
@@ -17,4 +23,16 @@ int foo()
     return always_inline_chain0();
 }
 
-// CHECK-NOT: define
+// CHECK-NOT: always_inline_chain
+// CHECK-NOT: call_template_foo
+
+// CHECK: define {{.*}}_D15inlining_gh31263barFZi
+int bar()
+{
+    // no calls to [call_]template_foo
+    // CHECK-NOT: call {{.*}}template_foo
+    return call_template_foo(123);
+}
+
+// CHECK-NOT: always_inline_chain
+// CHECK-NOT: call_template_foo

--- a/tests/codegen/inlining_gh3126.d
+++ b/tests/codegen/inlining_gh3126.d
@@ -1,0 +1,20 @@
+// Tests that functions are cross-module inlined when emitting multiple object
+// files.
+
+// Generate unoptimized IR for 2 source files as separate compilation units.
+// RUN: %ldc -c -output-ll %s %S/inputs/inlinables.d -od=%t
+// RUN: FileCheck %s < %t/inlining_gh3126.ll
+
+import inputs.inlinables;
+
+// no other function definitions (always_inline_chain*)
+// CHECK-NOT: define
+
+// CHECK: define {{.*}}_D15inlining_gh31263fooFZi
+int foo()
+{
+    // CHECK-NEXT: ret i32 345
+    return always_inline_chain0();
+}
+
+// CHECK-NOT: define


### PR DESCRIPTION
Previously, the logic gave up early if semantic3 was run for the function to be inlined, either because the function is going to be codegen'd in some root module, or because sema3 was already run for an
`available_externally` 'copy' in a previous compilation unit. This restricted a function to being defined in at most one compilation unit per `ldc2` invocation.

So e.g. a little `pragma(inline, true)` wrapper in druntime wasn't inlined into other druntime modules, because the whole lib is built in a single cmdline by default, and sema3 was obviously run for the actual emission in the corresponding object file.

When later compiling Phobos in a single cmdline, only the first object file referencing the wrapper got lucky, running sema3 manually and getting an `available_externally` 'copy'.