### PR TITLE
Add --fno-plt option to avoid PLT external calls

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -460,6 +460,10 @@ cl::opt<bool> disableLinkerStripDead(
     cl::desc("Do not try to remove unused symbols during linking"),
     cl::cat(linkingCategory));
 
+cl::opt<bool> noPLT(
+    "fno-plt", cl::ZeroOrMore,
+    cl::desc("Do not use the PLT to make function calls"));
+
 // Math options
 bool fFastMath; // Storage for the dynamically created ffast-math option.
 llvm::FastMathFlags defaultFMF;

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -83,6 +83,7 @@ extern FloatABI::Type floatABI;
 extern cl::opt<bool> linkonceTemplates;
 extern cl::opt<bool> disableLinkerStripDead;
 extern cl::opt<unsigned char> defaultToHiddenVisibility;
+extern cl::opt<bool> noPLT;
 
 // Math options
 extern bool fFastMath;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -634,9 +634,15 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
   // add func to IRFunc
   irFunc->setLLVMFunc(func);
 
-  // First apply the TargetMachine attributes, such that they can be overridden
-  // by UDAs.
+  // First apply the TargetMachine attributes and NonLazyBind attribute,
+  // such that they can be overridden by UDAs.
   applyTargetMachineAttributes(*func, *gTargetMachine);
+  if (!fdecl->fbody && opts::noPLT) {
+      // Add `NonLazyBind` attribute to function declarations,
+      // the codegen options allow skipping PLT.
+      func->addFnAttr(LLAttribute::NonLazyBind);
+  }
+
   applyFuncDeclUDAs(fdecl, irFunc);
 
   // parameter attributes

--- a/tests/codegen/noplt.d
+++ b/tests/codegen/noplt.d
@@ -1,0 +1,9 @@
+// RUN: %ldc --output-ll --fno-plt -of=%t.ll %s && FileCheck %s -check-prefix=CHECK-NOPLT < %t.ll
+
+// CHECK-NOPLT: Function Attrs: nonlazybind
+// CHECK-NOPLT-NEXT: declare {{.*}} @{{.*}}3foo
+int foo();
+
+int bar() {
+    return foo();
+}


### PR DESCRIPTION
This patch gives new option which avoids the PLT and lazy binding while
making external calls.
Implementation inspired by `-fno-plt` support to Clang.

Clang's patch: https://reviews.llvm.org/D39079