### PR TITLE
Add option for RELRO

### DIFF
--- a/tests/linking/relro_level.d
+++ b/tests/linking/relro_level.d
@@ -1,0 +1,6 @@
+// REQUIRES: Linux
+// RUN: %ldc --gcc=echo --relro-level=full %s | grep -e \\-Wl,-z,relro -e \\-Wl,-z,now
+// RUN: %ldc --gcc=echo --relro-level=partial %s | grep \\-Wl,-z,relro
+// RUN: %ldc --gcc=echo --relro-level=off %s | grep \\-Wl,-z,norelro
+
+void main() {}


### PR DESCRIPTION
This patch gives support for fullRELRO/partialRELRO/noRELRO option.
Some linux distributions apply fullRELRO(`-Wl,-z,relro -Wl,-z,now`) by
default, but this option would be useful for others.