### PR TITLE
Remove bitrig support

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -134,9 +134,6 @@ static std::string getX86TargetCPU(const llvm::Triple &triple) {
   if (triple.getOSName().startswith("openbsd")) {
     return "i486";
   }
-  if (triple.getOSName().startswith("bitrig")) {
-    return "i686";
-  }
   if (triple.getOSName().startswith("freebsd")) {
     return "i486";
   }


### PR DESCRIPTION
Bitrig is now defunct OpenBSD fork. It released 1.0 in 2014 and hasn't had another release since.
I'm not sure if LDC officially supports it, just delete an occurence of bitrig from the source.