### PR TITLE
Windows hosts: Handle LDC_VSDIR set to non-existing path

### DIFF
--- a/dmd/vsoptions.d
+++ b/dmd/vsoptions.d
@@ -252,7 +252,12 @@ private:
 version (IN_LLVM)
 {
         if (VSInstallDir is null)
+        {
             VSInstallDir = getenv("LDC_VSDIR"w);
+            // only use it if it's an existing directory
+            if (VSInstallDir && FileName.exists(VSInstallDir) != 2)
+                VSInstallDir = null;
+        }
 }
 
         if (VSInstallDir is null)


### PR DESCRIPTION
As that was the way to request MSVC auto-detection in v1.20 and older.