### PR TITLE
Fix naked DMD-style asm emission for non-Mac x86 Darwin targets & add prebuilt druntime/Phobos for iOS/x86_64 to macOS package

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -267,27 +267,40 @@ steps:
   displayName: 'Android: Cross-compile x86 libraries and copy to install dir'
   condition: and(succeeded(), eq(variables['CI_OS'], 'android'))
 
-# Mac: add iOS/arm64 libraries
+# Mac: add iOS libraries (arm64 and x86_64)
 - script: |
     set -ex
     cd ..
     export PATH="$PWD/ninja:$PATH"
-    triple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET"
-    # TODO: shared libs too, and look into `-fvisibility=hidden` requirement
+    triple_arm64="arm64-apple-ios$IOS_DEPLOYMENT_TARGET"
+    triple_x64="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET"
+    # TODO: build shared libs too, and look into `-fvisibility=hidden` requirement
     build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
       --buildDir=build-libs-arm64 \
-      --cFlags="-target;$triple" \
-      --dFlags="-mtriple=$triple;-fvisibility=hidden" \
+      --cFlags="-target;$triple_arm64" \
+      --dFlags="-mtriple=$triple_arm64;-fvisibility=hidden" \
       --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
       CMAKE_SYSTEM_NAME=iOS \
       CMAKE_OSX_ARCHITECTURES=arm64 \
       CMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET \
       BUILD_SHARED_LIBS=OFF \
       BUILD_LTO_LIBS=ON
-    mkdir installed/lib-ios-arm64
+    build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
+      --buildDir=build-libs-x86_64 \
+      --cFlags="-target;$triple_x64" \
+      --dFlags="-mtriple=$triple_x64;-fvisibility=hidden" \
+      --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
+      CMAKE_SYSTEM_NAME=iOS \
+      CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
+      CMAKE_OSX_ARCHITECTURES=x86_64 \
+      CMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET \
+      BUILD_SHARED_LIBS=OFF \
+      BUILD_LTO_LIBS=ON
+    mkdir installed/lib-ios-{arm64,x86_64}
     cp build-libs-arm64/lib/*.a installed/lib-ios-arm64
-    rm installed/lib-ios-arm64/*-lto-debug.a
-    section="
+    cp build-libs-x86_64/lib/*.a installed/lib-ios-x86_64
+    rm installed/lib-ios-{arm64,x86_64}/*-lto-debug.a
+    sections="
     \"arm64-apple-ios\":
     {
         switches = [
@@ -295,7 +308,7 @@ steps:
             \"-link-defaultlib-shared=false\",
             \"-fvisibility=hidden\",
             \"-Xcc=-target\",
-            \"-Xcc=$triple\",
+            \"-Xcc=$triple_arm64\",
             \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",
             \"-Xcc=-isysroot\",
             \"-Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\",
@@ -304,10 +317,28 @@ steps:
             \"%%ldcbinarypath%%/../lib-ios-arm64\",
         ];
         rpath = \"%%ldcbinarypath%%/../lib-ios-arm64\";
+    };
+    
+    \"x86_64-apple-ios\":
+    {
+        switches = [
+            \"-defaultlib=phobos2-ldc,druntime-ldc\",
+            \"-link-defaultlib-shared=false\",
+            \"-fvisibility=hidden\",
+            \"-Xcc=-target\",
+            \"-Xcc=$triple_x64\",
+            \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",
+            \"-Xcc=-isysroot\",
+            \"-Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\",
+        ];
+        lib-dirs = [
+            \"%%ldcbinarypath%%/../lib-ios-x86_64\",
+        ];
+        rpath = \"%%ldcbinarypath%%/../lib-ios-x86_64\";
     };"
-    echo "$section" >> installed/etc/ldc2.conf
+    echo "$sections" >> installed/etc/ldc2.conf
     cat installed/etc/ldc2.conf
-  displayName: 'Mac: Cross-compile iOS/arm64 libraries, copy to install dir and extend ldc2.conf'
+  displayName: 'Mac: Cross-compile iOS libraries (arm64 and x86_64), copy to install dir and extend ldc2.conf'
   condition: and(succeeded(), eq(variables['CI_OS'], 'osx'))
 
 # Integration tests
@@ -326,7 +357,8 @@ steps:
 - script: |
     set -ex
     cd ..
-    installed/bin/ldc2 -mtriple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios
+    installed/bin/ldc2 -mtriple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_arm64
+    installed/bin/ldc2 -mtriple="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_x86_64
   displayName: 'Mac: Cross-compile & -link hello-world for iOS'
   condition: and(succeeded(), eq(variables['CI_OS'], 'osx'))
 - script: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -58,7 +58,30 @@ workflows:
                 envman add --key LDC_BINARY --value "$(pwd)/bin/ldc2"
 
       - script@1.1.6:
-          title: Build Runtime
+          title: Cross-compile (iOS/x86_64) druntime & Phobos
+          deps:
+            brew:
+              - name: cmake
+              - name: ninja
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                build/bin/ldc-build-runtime \
+                  --buildDir="ldc-build-runtime.x86_64" \
+                  --cFlags="-target;x86_64-apple-ios${IOS_VERSION}" \
+                  --dFlags="-mtriple=x86_64-apple-ios${IOS_VERSION};-fvisibility=hidden" \
+                  --ldcSrcDir=. \
+                  --ninja \
+                  -j 2 \
+                  CMAKE_SYSTEM_NAME=iOS \
+                  CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
+                  CMAKE_OSX_ARCHITECTURES=x86_64 \
+                  CMAKE_OSX_DEPLOYMENT_TARGET="${IOS_VERSION}" \
+                  BUILD_SHARED_LIBS=OFF
+
+      - script@1.1.6:
+          title: Cross-compile (iOS/arm64) druntime & Phobos, incl. debug unittest runners
           deps:
             brew:
               - name: cmake
@@ -86,7 +109,7 @@ workflows:
           run_if: not .IsPR
 
       - virtual-device-testing-for-ios@0.9.10:
-          title: Run Tests on Device
+          title: Run druntime & Phobos debug unittests on iPhone
           run_if: not .IsPR
           inputs:
             - test_devices: iphone6s,12.0,en,portrait

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -418,6 +418,9 @@ void ArgsBuilder::addCppStdlibLinkFlags(const llvm::Triple &triple) {
     break;
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
+  case llvm::Triple::IOS:
+  case llvm::Triple::WatchOS:
+  case llvm::Triple::TvOS:
   case llvm::Triple::FreeBSD:
     args.push_back("-lc++");
     break;

--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -19,14 +19,14 @@
 #include "ir/irfuncty.h"
 
 struct X86TargetABI : TargetABI {
-  const bool isOSX;
+  const bool isDarwin;
   const bool isMSVC;
   bool returnStructsInRegs;
   IntegerRewrite integerRewrite;
   IndirectByvalRewrite indirectByvalRewrite;
 
   X86TargetABI()
-      : isOSX(global.params.targetTriple->isMacOSX()),
+      : isDarwin(global.params.targetTriple->isOSDarwin()),
         isMSVC(global.params.targetTriple->isWindowsMSVCEnvironment()) {
     using llvm::Triple;
     auto os = global.params.targetTriple->getOS();
@@ -206,8 +206,8 @@ struct X86TargetABI : TargetABI {
 
     // Clang does not pass empty structs, while it seems that GCC does,
     // at least on Linux x86. We don't know whether the C compiler will
-    // be Clang or GCC, so just assume Clang on OS X and G++ on Linux.
-    if (externD || !isOSX)
+    // be Clang or GCC, so just assume Clang on Darwin and G++ on Linux.
+    if (externD || !isDarwin)
       return;
 
     size_t i = 0;
@@ -247,7 +247,7 @@ struct X86TargetABI : TargetABI {
 
   const char *objcMsgSendFunc(Type *ret, IrFuncTy &fty) override {
     // see objc/message.h for objc_msgSend selection rules
-    assert(isOSX);
+    assert(isDarwin);
     if (fty.arg_sret) {
       return "objc_msgSend_stret";
     }

--- a/gen/asm-x86.h
+++ b/gen/asm-x86.h
@@ -2322,11 +2322,10 @@ struct AsmProcessor {
   // OSX and 32-bit Windows need an extra leading underscore when mangling a
   // symbol name.
   static bool prependExtraUnderscore(LINK link) {
-    return global.params.targetTriple->getOS() == llvm::Triple::MacOSX ||
-           global.params.targetTriple->getOS() == llvm::Triple::Darwin ||
+    const auto &triple = *global.params.targetTriple;
+    return triple.isOSDarwin() ||
            // Win32: all symbols except for MSVC++ ones
-           (global.params.targetTriple->isOSWindows() &&
-            global.params.targetTriple->isArch32Bit() && link != LINKcpp);
+           (triple.isOSWindows() && triple.isArch32Bit() && link != LINKcpp);
   }
 
   void addOperand(const char *fmt, AsmArgType type, Expression *e,

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -158,12 +158,11 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
 
   const auto &triple = *global.params.targetTriple;
   bool const isWin = triple.isOSWindows();
-  bool const isOSX = (triple.getOS() == llvm::Triple::Darwin ||
-                      triple.getOS() == llvm::Triple::MacOSX);
+  bool const isDarwin = triple.isOSDarwin();
 
   // osx is different
   // also mangling has an extra underscore prefixed
-  if (isOSX) {
+  if (isDarwin) {
     fullmangle += '_';
     fullmangle += mangle;
     mangle = fullmangle.c_str();
@@ -233,7 +232,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
 
   // emit size after body
   // llvm does this on linux, but not on osx or Win
-  if (!(isWin || isOSX)) {
+  if (!(isWin || isDarwin)) {
     asmstr << "\t.size\t" << mangle << ", .-" << mangle << std::endl
            << std::endl;
   }


### PR DESCRIPTION
This fixes the issue reported in https://forum.dlang.org/thread/hgkramhteqhfxirigxpq@forum.dlang.org.