### PR TITLE
-betterC: Don't use unsupported EH for handling clean-ups

### DIFF
--- a/gen/funcgenstate.cpp
+++ b/gen/funcgenstate.cpp
@@ -117,7 +117,7 @@ llvm::CallSite FuncGenState::callOrInvoke(llvm::Value *callee,
 
   // Intrinsics don't support invoking and 'nounwind' functions don't need it.
   const bool doesNotThrow =
-      isNothrow ||
+      isNothrow || global.params.betterC ||
       (calleeFn && (calleeFn->isIntrinsic() || calleeFn->doesNotThrow()));
 
   // calls inside a funclet must be annotated with its value

--- a/tests/linking/betterc_cleanups.d
+++ b/tests/linking/betterc_cleanups.d
@@ -1,0 +1,36 @@
+// RUN: %ldc -betterC -run %s > %t.stdout
+// RUN: FileCheck %s < %t.stdout
+
+import core.stdc.stdio;
+
+void notNothrow() { printf("notNothrow\n"); }
+
+struct WithDtor
+{
+    ~this() { printf("destructing\n"); }
+}
+
+void foo(WithDtor a, bool skip)
+{
+    if (skip)
+        return;
+
+    notNothrow();
+}
+
+extern(C) int main()
+{
+    WithDtor a;
+    scope(exit) printf("exiting\n");
+
+    foo(a, true);
+    // CHECK:      destructing
+
+    foo(a, false);
+    // CHECK-NEXT: notNothrow
+    // CHECK-NEXT: destructing
+
+    return 0;
+    // CHECK-NEXT: exiting
+    // CHECK-NEXT: destructing
+}


### PR DESCRIPTION
A reboot of #3480, fixing #3479 and related issues.