### PR TITLE
Emit struct TypeInfos in referencing compilation units only

### DIFF
--- a/dmd/aggregate.h
+++ b/dmd/aggregate.h
@@ -167,10 +167,12 @@ public:
     bool hasIdentityEquals;     // true if has identity opEquals
     bool hasNoFields;           // has no fields
     bool hasCopyCtor;           // copy constructor
+#if !IN_LLVM
     // Even if struct is defined as non-root symbol, some built-in operations
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+#endif
 
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration *postblit;  // aggregate postblit

--- a/dmd/dstruct.d
+++ b/dmd/dstruct.d
@@ -104,7 +104,10 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             Scope scx;
             scx._module = sd.getModule();
             getTypeInfoType(sd.loc, t, &scx);
+version (IN_LLVM) {} else
+{
             sd.requestTypeInfo = true;
+}
         }
         else if (!sc.minst)
         {
@@ -114,7 +117,10 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
         else
         {
             getTypeInfoType(sd.loc, t, sc);
+version (IN_LLVM) {} else
+{
             sd.requestTypeInfo = true;
+}
 
             // https://issues.dlang.org/show_bug.cgi?id=15149
             // if the typeid operand type comes from a
@@ -122,6 +128,13 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             // unSpeculative(sc, sd);
         }
 
+version (IN_LLVM)
+{
+        // LDC defines a struct's TypeInfo (only) once in its owning module,
+        // including the special members, as part of StructDeclaration codegen.
+}
+else
+{
         /* Step 2: If the TypeInfo generation requires sd.semantic3, run it later.
          * This should be done even if typeid(T) exists in speculative scope.
          * Because it may appear later in non-speculative scope.
@@ -150,6 +163,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
                 Module.addDeferredSemantic3(sd);
             }
         }
+} // !IN_LLVM
     }
 
     void visitTuple(TypeTuple t)
@@ -205,10 +219,13 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     bool hasIdentityEquals;     // true if has identity opEquals
     bool hasNoFields;           // has no fields
     bool hasCopyCtor;           // copy constructor
+version (IN_LLVM) {} else
+{
     // Even if struct is defined as non-root symbol, some built-in operations
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+}
 
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration postblit;   // aggregate postblit

--- a/dmd/dstruct.d
+++ b/dmd/dstruct.d
@@ -128,13 +128,6 @@ version (IN_LLVM) {} else
             // unSpeculative(sc, sd);
         }
 
-version (IN_LLVM)
-{
-        // LDC defines a struct's TypeInfo (only) once in its owning module,
-        // including the special members, as part of StructDeclaration codegen.
-}
-else
-{
         /* Step 2: If the TypeInfo generation requires sd.semantic3, run it later.
          * This should be done even if typeid(T) exists in speculative scope.
          * Because it may appear later in non-speculative scope.
@@ -163,7 +156,6 @@ else
                 Module.addDeferredSemantic3(sd);
             }
         }
-} // !IN_LLVM
     }
 
     void visitTuple(TypeTuple t)

--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -7105,6 +7105,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (ad.dtor)
             {
+                err |= !ad.dtor.functionSemantic();
                 err |= exp.checkPurity(sc, ad.dtor);
                 err |= exp.checkSafety(sc, ad.dtor);
                 err |= exp.checkNogc(sc, ad.dtor);

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -130,13 +130,7 @@ public:
     }
 
     if (!(decl->members && decl->symtab)) {
-      // we need to emit TypeInfos for opaque structs too
-      IrStruct *ir = getIrAggr(decl, true);
-      if (!irs->dcomputetarget && !ir->suppressTypeInfo()) {
-        llvm::GlobalVariable *typeInfo = ir->getTypeInfoSymbol();
-        defineGlobal(typeInfo, ir->getTypeInfoInit(), decl);
-      }
-
+      // nothing to do for opaque structs anymore
       return;
     }
 
@@ -160,9 +154,9 @@ public:
         setLinkageAndVisibility(decl, initGlobal);
       }
 
-      // emit typeinfo
+      // Emit special __xopEquals/__xopCmp/__xtoHash member functions required
+      // for the TypeInfo.
       if (!ir->suppressTypeInfo()) {
-        // Emit __xopEquals/__xopCmp/__xtoHash.
         if (decl->xeq && decl->xeq != decl->xerreq) {
           decl->xeq->accept(this);
         }
@@ -173,9 +167,7 @@ public:
           decl->xhash->accept(this);
         }
 
-        // define the TypeInfo_Struct symbol
-        llvm::GlobalVariable *typeInfo = ir->getTypeInfoSymbol();
-        defineGlobal(typeInfo, ir->getTypeInfoInit(), decl);
+        // the TypeInfo itself is emitted into each referencing CU
       }
     }
   }

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -92,21 +92,23 @@ public:
       return;
     }
 
-    if (decl->members && decl->symtab) {
-      DtoResolveClass(decl);
-      decl->ir->setDefined();
+    if (!(decl->members && decl->symtab)) {
+      return;
+    }
 
-      // Emit any members (e.g. final functions).
-      for (auto m : *decl->members) {
-        m->accept(this);
-      }
+    DtoResolveClass(decl);
+    decl->ir->setDefined();
 
-      // Emit TypeInfo.
-      IrClass *ir = getIrAggr(decl);
-      if (!ir->suppressTypeInfo() && !isSpeculativeType(decl->type)) {
-        llvm::GlobalVariable *interfaceZ = ir->getClassInfoSymbol();
-        defineGlobal(interfaceZ, ir->getClassInfoInit(), decl);
-      }
+    // Emit any members (e.g. final functions).
+    for (auto m : *decl->members) {
+      m->accept(this);
+    }
+
+    // Emit TypeInfo.
+    IrClass *ir = getIrAggr(decl);
+    if (!ir->suppressTypeInfo()) {
+      llvm::GlobalVariable *interfaceZ = ir->getClassInfoSymbol();
+      defineGlobal(interfaceZ, ir->getClassInfoInit(), decl);
     }
   }
 
@@ -128,6 +130,13 @@ public:
     }
 
     if (!(decl->members && decl->symtab)) {
+      // we need to emit TypeInfos for opaque structs too
+      IrStruct *ir = getIrAggr(decl, true);
+      if (!irs->dcomputetarget && !ir->suppressTypeInfo()) {
+        llvm::GlobalVariable *typeInfo = ir->getTypeInfoSymbol();
+        defineGlobal(typeInfo, ir->getTypeInfoInit(), decl);
+      }
+
       return;
     }
 
@@ -153,8 +162,6 @@ public:
 
       // emit typeinfo
       if (!ir->suppressTypeInfo()) {
-        DtoTypeInfoOf(decl->type, /*base=*/false);
-
         // Emit __xopEquals/__xopCmp/__xtoHash.
         if (decl->xeq && decl->xeq != decl->xerreq) {
           decl->xeq->accept(this);
@@ -165,6 +172,10 @@ public:
         if (decl->xhash) {
           decl->xhash->accept(this);
         }
+
+        // define the TypeInfo_Struct symbol
+        llvm::GlobalVariable *typeInfo = ir->getTypeInfoSymbol();
+        defineGlobal(typeInfo, ir->getTypeInfoInit(), decl);
       }
     }
   }
@@ -188,31 +199,33 @@ public:
       return;
     }
 
-    if (decl->members && decl->symtab) {
-      DtoResolveClass(decl);
-      decl->ir->setDefined();
+    if (!(decl->members && decl->symtab)) {
+      return;
+    }
 
-      for (auto m : *decl->members) {
-        m->accept(this);
-      }
+    DtoResolveClass(decl);
+    decl->ir->setDefined();
 
-      IrClass *ir = getIrAggr(decl);
+    for (auto m : *decl->members) {
+      m->accept(this);
+    }
 
-      auto &initZ = ir->getInitSymbol();
-      auto initGlobal = llvm::cast<LLGlobalVariable>(initZ);
-      initZ = irs->setGlobalVarInitializer(initGlobal, ir->getDefaultInit());
-      setLinkageAndVisibility(decl, initGlobal);
+    IrClass *ir = getIrAggr(decl);
 
-      llvm::GlobalVariable *vtbl = ir->getVtblSymbol();
-      defineGlobal(vtbl, ir->getVtblInit(), decl);
+    auto &initZ = ir->getInitSymbol();
+    auto initGlobal = llvm::cast<LLGlobalVariable>(initZ);
+    initZ = irs->setGlobalVarInitializer(initGlobal, ir->getDefaultInit());
+    setLinkageAndVisibility(decl, initGlobal);
 
-      ir->defineInterfaceVtbls();
+    llvm::GlobalVariable *vtbl = ir->getVtblSymbol();
+    defineGlobal(vtbl, ir->getVtblInit(), decl);
 
-      // Emit TypeInfo.
-      if (!ir->suppressTypeInfo() && !isSpeculativeType(decl->type)) {
-        llvm::GlobalVariable *classZ = ir->getClassInfoSymbol();
-        defineGlobal(classZ, ir->getClassInfoInit(), decl);
-      }
+    ir->defineInterfaceVtbls();
+
+    // Emit TypeInfo.
+    if (!ir->suppressTypeInfo()) {
+      llvm::GlobalVariable *classZ = ir->getClassInfoSymbol();
+      defineGlobal(classZ, ir->getClassInfoInit(), decl);
     }
   }
 
@@ -503,8 +516,7 @@ public:
   //////////////////////////////////////////////////////////////////////////
 
   void visit(TypeInfoDeclaration *decl) override {
-    if (!irs->dcomputetarget)
-      TypeInfoDeclaration_codegen(decl);
+    llvm_unreachable("Should be emitted from codegen layer only");
   }
 };
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -827,8 +827,9 @@ void DtoResolveDsymbol(Dsymbol *dsym) {
 }
 
 void DtoResolveVariable(VarDeclaration *vd) {
-  if (vd->isTypeInfoDeclaration()) {
-    return DtoResolveTypeInfo(static_cast<TypeInfoDeclaration *>(vd));
+  if (auto tid = vd->isTypeInfoDeclaration()) {
+    DtoResolveTypeInfo(tid);
+    return;
   }
 
   IF_LOG Logger::println("DtoResolveVariable(%s)", vd->toPrettyChars());
@@ -1263,17 +1264,12 @@ LLConstant *DtoTypeInfoOf(Type *type, bool base) {
                          type->toChars(), base);
   LOG_SCOPE
 
-  TypeInfoDeclaration *tidecl =
-      getOrCreateTypeInfoDeclaration(Loc(), type, nullptr);
-  assert(tidecl);
-  Declaration_codegen(tidecl);
-  assert(getIrGlobal(tidecl)->value != NULL);
-  LLConstant *c = isaConstant(getIrGlobal(tidecl)->value);
-  assert(c != NULL);
+  auto tidecl = getOrCreateTypeInfoDeclaration(Loc(), type);
+  auto tiglobal = DtoResolveTypeInfo(tidecl);
   if (base) {
-    return llvm::ConstantExpr::getBitCast(c, DtoType(getTypeInfoType()));
+    return llvm::ConstantExpr::getBitCast(tiglobal, DtoType(getTypeInfoType()));
   }
-  return c;
+  return tiglobal;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1560,10 +1556,8 @@ DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl) {
     // typeinfo
     if (TypeInfoDeclaration *tid = vd->isTypeInfoDeclaration()) {
       Logger::println("TypeInfoDeclaration");
-      DtoResolveTypeInfo(tid);
-      assert(getIrValue(tid));
       LLType *vartype = DtoType(type);
-      LLValue *m = getIrValue(tid);
+      LLValue *m = DtoResolveTypeInfo(tid);
       if (m->getType() != getPtrToType(vartype)) {
         m = gIR->ir->CreateBitCast(m, vartype);
       }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2669,8 +2669,8 @@ public:
 
   void visit(TypeidExp *e) override {
     if (Type *t = isType(e->obj)) {
-      result = DtoSymbolAddress(
-          e->loc, e->type, getOrCreateTypeInfoDeclaration(e->loc, t, nullptr));
+      result = DtoSymbolAddress(e->loc, e->type,
+                                getOrCreateTypeInfoDeclaration(e->loc, t));
       return;
     }
     if (Expression *ex = isExpression(e->obj)) {

--- a/gen/typinf.h
+++ b/gen/typinf.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-struct Scope;
 struct Loc;
 class Type;
 class TypeInfoDeclaration;
@@ -23,13 +22,9 @@ namespace llvm {
 class GlobalVariable;
 }
 
-void DtoResolveTypeInfo(TypeInfoDeclaration *tid);
-TypeInfoDeclaration *getOrCreateTypeInfoDeclaration(const Loc &loc, Type *t,
-                                                    Scope *sc);
-void TypeInfoDeclaration_codegen(TypeInfoDeclaration *decl);
+TypeInfoDeclaration *getOrCreateTypeInfoDeclaration(const Loc &loc,
+                                                    Type *forType);
+llvm::GlobalVariable *DtoResolveTypeInfo(TypeInfoDeclaration *tid);
 
 // Adds some metadata for use by optimization passes.
 void emitTypeInfoMetadata(llvm::GlobalVariable *typeinfoGlobal, Type *forType);
-
-// defined in dmd/typinf.d:
-bool isSpeculativeType(Type *t);

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -101,42 +101,6 @@ LLConstant *IrStruct::getTypeInfoInit() {
   // we need (dummy) TypeInfos for opaque structs too
   const bool isOpaque = !sd->members;
 
-  if (!isOpaque) {
-    DtoResolveStruct(sd);
-
-    if (TemplateInstance *ti = sd->isInstantiated()) {
-      if (!ti->needsCodegen()) {
-        assert(ti->minst || sd->requestTypeInfo);
-
-        // We won't emit ti, so emit the special member functions in here.
-        if (sd->xeq && sd->xeq != StructDeclaration::xerreq &&
-            sd->xeq->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->xeq);
-        }
-        if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp &&
-            sd->xcmp->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->xcmp);
-        }
-        if (FuncDeclaration *ftostr = search_toString(sd)) {
-          if (ftostr->semanticRun >= PASSsemantic3)
-            Declaration_codegen(ftostr);
-        }
-        if (sd->xhash && sd->xhash->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->xhash);
-        }
-        if (sd->postblit && sd->postblit->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->postblit);
-        }
-        if (sd->dtor && sd->dtor->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->dtor);
-        }
-        if (sd->tidtor && sd->tidtor->semanticRun >= PASSsemantic3) {
-          Declaration_codegen(sd->tidtor);
-        }
-      }
-    }
-  }
-
   // string name
   if (isOpaque) {
     b.push_null_void_array();

--- a/tests/codegen/export_aggregate_symbols.d
+++ b/tests/codegen/export_aggregate_symbols.d
@@ -51,5 +51,7 @@ export struct ExportedS { int nonZero = 1; }
 
 // DEFAULT:    _D45TypeInfo_S24export_aggregate_symbols8DefaultS6__initZ
 // HIDDEN-NOT: _D45TypeInfo_S24export_aggregate_symbols8DefaultS6__initZ
+auto ti_defaultS = typeid(DefaultS);
 
 // BOTH: _D46TypeInfo_S24export_aggregate_symbols9ExportedS6__initZ
+auto ti_exportedS = typeid(ExportedS);

--- a/tests/codegen/gh2346.d
+++ b/tests/codegen/gh2346.d
@@ -67,3 +67,13 @@ struct AnotherContainer {
 static assert(AnotherContainer.alignof == 2);
 static assert(AnotherContainer.sizeof == 6);
 static assert(AnotherContainer.two.offsetof == 2);
+
+// reference all types
+void foo()
+{
+    Container a;
+    Container2 b;
+    PackedContainer2 c;
+    WeirdContainer d;
+    AnotherContainer e;
+}

--- a/tests/codegen/pragma_no_typeinfo.d
+++ b/tests/codegen/pragma_no_typeinfo.d
@@ -5,7 +5,7 @@
 pragma(LDC_no_moduleinfo); // prevent ModuleInfo from referencing class TypeInfos
 
 
-// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = linkonce_odr global %object.TypeInfo_Struct
+// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = global %object.TypeInfo_Struct
 struct StructWithTypeInfo {}
 
 // CHECK: _D18pragma_no_typeinfo17ClassWithTypeInfo7__ClassZ = global %object.TypeInfo_Class

--- a/tests/codegen/pragma_no_typeinfo.d
+++ b/tests/codegen/pragma_no_typeinfo.d
@@ -5,8 +5,10 @@
 pragma(LDC_no_moduleinfo); // prevent ModuleInfo from referencing class TypeInfos
 
 
-// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = global %object.TypeInfo_Struct
+// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = linkonce_odr global %object.TypeInfo_Struct
 struct StructWithTypeInfo {}
+// force emission
+auto ti = typeid(StructWithTypeInfo);
 
 // CHECK: _D18pragma_no_typeinfo17ClassWithTypeInfo7__ClassZ = global %object.TypeInfo_Class
 class ClassWithTypeInfo {}

--- a/tests/codegen/static_array_huge.d
+++ b/tests/codegen/static_array_huge.d
@@ -7,6 +7,7 @@ struct Stuff
 {
     byte[1024*1024*200] a;
 }
+Stuff stuff;
 
 // CHECK: hugeArrayG209715200g{{\"?}} ={{.*}} [209715200 x i8]
 byte[1024*1024*200] hugeArray;

--- a/tests/codegen/static_typeid_gh1540.d
+++ b/tests/codegen/static_typeid_gh1540.d
@@ -23,6 +23,6 @@ auto classvar = typeid(C);
 // CHECK-DAG: _D{{.*}}interfacevarC18TypeInfo_Interface{{\"?}} = thread_local global %object.TypeInfo_Interface* {{.*}}TypeInfo_C{{.*}}1I6__initZ
 auto interfacevar = typeid(I);
 
-// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Struct
+// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = global %object.TypeInfo_Struct
 // CHECK-DAG: _D{{.*}}structvarC15TypeInfo_Struct{{\"?}} = thread_local global %object.TypeInfo_Struct* {{.*}}TypeInfo_S{{.*}}1S6__initZ
 auto structvar = typeid(S);

--- a/tests/codegen/static_typeid_gh1540.d
+++ b/tests/codegen/static_typeid_gh1540.d
@@ -23,6 +23,6 @@ auto classvar = typeid(C);
 // CHECK-DAG: _D{{.*}}interfacevarC18TypeInfo_Interface{{\"?}} = thread_local global %object.TypeInfo_Interface* {{.*}}TypeInfo_C{{.*}}1I6__initZ
 auto interfacevar = typeid(I);
 
-// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = global %object.TypeInfo_Struct
+// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Struct
 // CHECK-DAG: _D{{.*}}structvarC15TypeInfo_Struct{{\"?}} = thread_local global %object.TypeInfo_Struct* {{.*}}TypeInfo_S{{.*}}1S6__initZ
 auto structvar = typeid(S);


### PR DESCRIPTION
**First commit only**:

Analogous to ClassInfos, incl. normal linkage (external for non-templates, weak_odr for templates).

This enables to get rid of frontend logic wrt. whether to add `TypeInfoStructDeclarations` to a module's members tree - previously,
it was defined as linkonce_odr in the owning module and each referencing module (unless speculative) - and related extra semantic and codegen for the special member functions.
I've gone a bit further and moved the entire TypeInfo emission for LDC to the codegen layer; no `TypeInfoDeclarations` are added to the module members anymore. Whenever we need a TypeInfo symbol during codegen, it is declared or defined, and we don't need to rely on brittle frontend logic with speculative-ness complications.

This might slightly increase compilation speed due to less emitted TypeInfos and functions (possibly less work for the linker too).

It might require LTO to avoid performance regressions though and delegates the job of stripping unused struct TypeInfos to the linker, as the TypeInfo is guaranteed to end up in the owning object file due to no linkonce_odr.

Re-emitting the struct TypeInfos (and optionally the special member functions too) into each referencing CU could be handled in our codegen layer, which should be much simpler and more robust than the upstream scheme.
