### PR TITLE
Refactor toir visit(StringExp) to avoid un-necessary computations.

### DIFF
--- a/dmd/expression.h
+++ b/dmd/expression.h
@@ -390,6 +390,11 @@ public:
         assert(sz == 1);
         return {len, static_cast<const char *>(string)};
     }
+
+    DArray<const unsigned char> peekData() const
+    {
+        return {len * sz, static_cast<const unsigned char *>(string)};
+    }
 #endif
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;

--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -16,6 +16,7 @@
 #include "dmd/statement.h"
 #include "gen/funcgenstate.h"
 #include "gen/llvm.h"
+#include "gen/llvmhelpers.h"
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
 #include <cstdarg>
@@ -184,6 +185,63 @@ LLConstant *IRState::getStructLiteralConstant(StructLiteralExp *sle) const {
 void IRState::setStructLiteralConstant(StructLiteralExp *sle,
                                        LLConstant *constant) {
   structLiteralConstants[sle->origin] = constant;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+template <typename F>
+LLGlobalVariable *
+getCachedStringLiteralImpl(llvm::Module &module,
+                           llvm::StringMap<LLGlobalVariable *> &cache,
+                           llvm::StringRef key, F initFactory) {
+  auto iter = cache.find(key);
+  if (iter != cache.end()) {
+    return iter->second;
+  }
+
+  LLConstant *constant = initFactory();
+
+  auto gvar =
+      new LLGlobalVariable(module, constant->getType(), true,
+                           LLGlobalValue::PrivateLinkage, constant, ".str");
+  gvar->setUnnamedAddr(LLGlobalValue::UnnamedAddr::Global);
+
+  cache[key] = gvar;
+
+  return gvar;
+}
+}
+
+LLGlobalVariable *IRState::getCachedStringLiteral(StringExp *se) {
+  llvm::StringMap<LLGlobalVariable *> *cache;
+  switch (se->sz) {
+  default:
+    llvm_unreachable("Unknown char type");
+  case 1:
+    cache = &cachedStringLiterals;
+    break;
+  case 2:
+    cache = &cachedWstringLiterals;
+    break;
+  case 4:
+    cache = &cachedDstringLiterals;
+    break;
+  }
+
+  const DArray<const unsigned char> keyData = se->peekData();
+  const llvm::StringRef key(reinterpret_cast<const char *>(keyData.ptr),
+                            keyData.length);
+
+  return getCachedStringLiteralImpl(module, *cache, key, [se]() {
+    return buildStringLiteralConstant(se, true);
+  });
+}
+
+LLGlobalVariable *IRState::getCachedStringLiteral(llvm::StringRef s) {
+  return getCachedStringLiteralImpl(module, cachedStringLiterals, s, [&]() {
+    return llvm::ConstantDataArray::getString(context(), s, true);
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -122,6 +122,13 @@ private:
   // enough to use it directly.]
   llvm::DenseMap<void *, llvm::Constant *> structLiteralConstants;
 
+  // Global variables bound to string literals. Once created such a variable
+  // variable is reused whenever an equivalent string literal is referenced in
+  // the module, to prevent duplicates.
+  llvm::StringMap<llvm::GlobalVariable *> cachedStringLiterals;
+  llvm::StringMap<llvm::GlobalVariable *> cachedWstringLiterals;
+  llvm::StringMap<llvm::GlobalVariable *> cachedDstringLiterals;
+
 public:
   IRState(const char *name, llvm::LLVMContext &context);
   ~IRState();
@@ -207,14 +214,6 @@ public:
   /// Whether to emit array bounds checking in the current function.
   bool emitArrayBoundsChecks();
 
-  // Global variables bound to string literals.  Once created such a
-  // variable is reused whenever the same string literal is
-  // referenced in the module.  Caching them per module prevents the
-  // duplication of identical literals.
-  llvm::StringMap<llvm::GlobalVariable *> stringLiteral1ByteCache;
-  llvm::StringMap<llvm::GlobalVariable *> stringLiteral2ByteCache;
-  llvm::StringMap<llvm::GlobalVariable *> stringLiteral4ByteCache;
-
   // Sets the initializer for a global LL variable.
   // If the types don't match, this entails creating a new helper global
   // matching the initializer type and replacing all existing uses of globalVar
@@ -233,6 +232,12 @@ public:
   llvm::Constant *getStructLiteralConstant(StructLiteralExp *sle) const;
   void setStructLiteralConstant(StructLiteralExp *sle,
                                 llvm::Constant *constant);
+
+  // Constructs a global variable for a StringExp.
+  // Caches the result based on StringExp::peekData() such that any subsequent
+  // calls with a StringExp with matching data will return the same variable.
+  llvm::GlobalVariable *getCachedStringLiteral(StringExp *se);
+  llvm::GlobalVariable *getCachedStringLiteral(llvm::StringRef s);
 
   // List of functions with cpu or features attributes overriden by user
   std::vector<IrFunction *> targetCpuOrFeaturesOverridden;

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -123,8 +123,8 @@ private:
   llvm::DenseMap<void *, llvm::Constant *> structLiteralConstants;
 
   // Global variables bound to string literals. Once created such a variable
-  // variable is reused whenever an equivalent string literal is referenced in
-  // the module, to prevent duplicates.
+  // is reused whenever an equivalent string literal is referenced in the
+  // module, to prevent duplicates.
   llvm::StringMap<llvm::GlobalVariable *> cachedStringLiterals;
   llvm::StringMap<llvm::GlobalVariable *> cachedWstringLiterals;
   llvm::StringMap<llvm::GlobalVariable *> cachedDstringLiterals;

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1708,6 +1708,12 @@ llvm::Constant *DtoConstSymbolAddress(Loc &loc, Declaration *decl) {
 }
 
 llvm::Constant *buildStringLiteralConstant(StringExp *se, bool zeroTerm) {
+  if (se->sz == 1) {
+    const DString data = se->peekString();
+    return llvm::ConstantDataArray::getString(
+        gIR->context(), {data.ptr, data.length}, zeroTerm);
+  }
+
   Type *dtype = se->type->toBasetype();
   Type *cty = dtype->nextOf()->toBasetype();
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -240,10 +240,11 @@ LLConstant *toConstantArray(LLType *ct, LLArrayType *at, T *str, size_t len,
   return LLConstantArray::get(at, vals);
 }
 
-/// Returns the cache for string literals of the given character type (for the
-/// current IRState).
-llvm::StringMap<llvm::GlobalVariable *> *
-stringLiteralCacheForType(Type *charType);
+/// Constructs a GlobalVariable for a StringExp.
+/// Caches the result based on StringExp::peekData() such that
+/// any subsequent calls with a StringExp with matching data will return
+/// the same GlobalVariable.
+llvm::GlobalVariable *buildStringLiteralGlobalVariableCached(StringExp *se);
 
 llvm::Constant *buildStringLiteralConstant(StringExp *se, bool zeroTerm);
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -240,12 +240,6 @@ LLConstant *toConstantArray(LLType *ct, LLArrayType *at, T *str, size_t len,
   return LLConstantArray::get(at, vals);
 }
 
-/// Constructs a GlobalVariable for a StringExp.
-/// Caches the result based on StringExp::peekData() such that
-/// any subsequent calls with a StringExp with matching data will return
-/// the same GlobalVariable.
-llvm::GlobalVariable *buildStringLiteralGlobalVariableCached(StringExp *se);
-
 llvm::Constant *buildStringLiteralConstant(StringExp *se, bool zeroTerm);
 
 /// Tries to declare an LLVM global. If a variable with the same mangled name

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -169,7 +169,6 @@ public:
     LOG_SCOPE;
 
     Type *const t = e->type->toBasetype();
-    Type *const cty = t->nextOf()->toBasetype();
 
     if (t->ty == Tsarray) {
       result = buildStringLiteralConstant(e, false);

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -175,7 +175,7 @@ public:
       return;
     }
 
-    llvm::GlobalVariable *gvar = buildStringLiteralGlobalVariableCached(e);
+    llvm::GlobalVariable *gvar = p->getCachedStringLiteral(e);
 
     llvm::ConstantInt *zero =
         LLConstantInt::get(LLType::getInt32Ty(gIR->context()), 0, false);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -388,15 +388,17 @@ public:
 
     llvm::StringMap<llvm::GlobalVariable *> *stringLiteralCache =
         stringLiteralCacheForType(cty);
-    LLConstant *_init = buildStringLiteralConstant(e, true);
-    const auto at = _init->getType();
 
     llvm::StringRef key(e->toChars());
-    llvm::GlobalVariable *gvar =
-        (stringLiteralCache->find(key) == stringLiteralCache->end())
-            ? nullptr
-            : (*stringLiteralCache)[key];
-    if (gvar == nullptr) {
+    llvm::GlobalVariable *gvar;
+
+    auto iter = stringLiteralCache->find(key);
+    if (iter != stringLiteralCache->end()) {
+      gvar = iter->second;
+    } else {
+      LLConstant *_init = buildStringLiteralConstant(e, true);
+      const auto at = _init->getType();
+
       llvm::GlobalValue::LinkageTypes _linkage =
           llvm::GlobalValue::PrivateLinkage;
       IF_LOG {

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -389,7 +389,8 @@ public:
     llvm::StringMap<llvm::GlobalVariable *> *stringLiteralCache =
         stringLiteralCacheForType(cty);
 
-    llvm::StringRef key(e->toChars());
+    DArray<const unsigned char> keyData = e->peekData();
+    llvm::StringRef key(static_cast<const char*>(keyData.ptr), keyData.length);
     llvm::GlobalVariable *gvar;
 
     auto iter = stringLiteralCache->find(key);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -385,7 +385,7 @@ public:
     Type *cty = dtype->nextOf()->toBasetype();
     LLType *ct = DtoMemType(cty);
 
-    llvm::GlobalVariable *gvar = buildStringLiteralGlobalVariableCached(e);
+    llvm::GlobalVariable *gvar = p->getCachedStringLiteral(e);
 
     llvm::ConstantInt *zero =
         LLConstantInt::get(LLType::getInt32Ty(gIR->context()), 0, false);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -429,19 +429,7 @@ LLConstant *DtoConstFP(Type *t, const real_t value) {
 LLConstant *DtoConstCString(const char *str) {
   llvm::StringRef s(str ? str : "");
 
-  const auto it = gIR->stringLiteral1ByteCache.find(s);
-  llvm::GlobalVariable *gvar =
-      it == gIR->stringLiteral1ByteCache.end() ? nullptr : it->getValue();
-
-  if (gvar == nullptr) {
-    llvm::Constant *init =
-        llvm::ConstantDataArray::getString(gIR->context(), s, true);
-    gvar = new llvm::GlobalVariable(gIR->module, init->getType(), true,
-                                    llvm::GlobalValue::PrivateLinkage, init,
-                                    ".str");
-    gvar->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-    gIR->stringLiteral1ByteCache[s] = gvar;
-  }
+  LLGlobalVariable *gvar = gIR->getCachedStringLiteral(s);
 
   LLConstant *idxs[] = {DtoConstUint(0), DtoConstUint(0)};
   return llvm::ConstantExpr::getGetElementPtr(gvar->getInitializer()->getType(),


### PR DESCRIPTION
This doesn't include peekData() as described in https://github.com/ldc-developers/ldc/issues/3490 not sure about the process about updating the interface files, if it's fine I'll just add it into this PR.