### PR TITLE
Fix issue #3501: Don't re-define struct TypeInfos

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -507,8 +507,12 @@ class DeclareOrDefineVisitor : public Visitor {
       return;
     }
 
-    defineGlobal(gvar, irstruct->getTypeInfoInit(), irstruct->aggrdecl);
-    gvar->setLinkage(TYPEINFO_LINKAGE_TYPE); // override
+    LLConstant *init = irstruct->getTypeInfoInit(); // might define gvar!
+
+    if (!gvar->hasInitializer()) {
+      defineGlobal(gvar, init, irstruct->aggrdecl);
+      gvar->setLinkage(TYPEINFO_LINKAGE_TYPE); // override
+    }
   }
 
   // Only declare class TypeInfos. They are defined once in their owning module


### PR DESCRIPTION
Surfacing now as #3486 added a corresponding assertion.

I've tested this with an older vibe-d v0.8.6 lying around on my box.
The assertion was hit for the TypeInfo of a nested struct:

https://github.com/vibe-d/vibe.d/blob/3c7ae13989003b7ebc59de23c5b6a0fb0466f119/http/vibe/http/router.d#L570-L574

I wasn't able to quickly reduce it to a stand-alone testcase and am reluctant to put any more effort into this.