### PR TITLE
Fix issue #3496 - missing IR declarations for some fwd-declared functions

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -92,7 +92,6 @@ DValue *DtoNewClass(Loc &loc, TypeClass *tc, NewExp *newexp) {
   }
   // custom allocator
   else if (newexp->allocator) {
-    DtoResolveFunction(newexp->allocator);
     DFuncValue dfn(newexp->allocator, DtoCallee(newexp->allocator));
     DValue *res = DtoCallFunction(newexp->loc, nullptr, &dfn, newexp->newargs);
     mem = DtoBitCast(DtoRVal(res), DtoType(tc), ".newclass_custom");
@@ -141,7 +140,6 @@ DValue *DtoNewClass(Loc &loc, TypeClass *tc, NewExp *newexp) {
 
     Logger::println("Calling constructor");
     assert(newexp->arguments != NULL);
-    DtoResolveFunction(newexp->member);
     DFuncValue dfn(newexp->member, DtoCallee(newexp->member), mem);
     // ignore ctor return value (C++ ctors on Posix may not return `this`)
     DtoCallFunction(newexp->loc, tc, &dfn, newexp->arguments);

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1175,11 +1175,12 @@ void DIBuilder::EmitFuncEnd(FuncDeclaration *fd) {
   Logger::println("D to dwarf funcend");
   LOG_SCOPE;
 
-  assert(static_cast<llvm::MDNode *>(getIrFunc(fd)->diSubprogram) != 0);
+  auto irFunc = getIrFunc(fd);
+
+  assert(static_cast<llvm::MDNode *>(irFunc->diSubprogram) != 0);
   EmitStopPoint(fd->endloc);
 
-  // Only attach subprogram entries to function definitions
-  DtoFunction(fd)->setSubprogram(getIrFunc(fd)->diSubprogram);
+  irFunc->getLLVMFunc()->setSubprogram(irFunc->diSubprogram);
 }
 
 void DIBuilder::EmitBlockStart(Loc &loc) {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1421,7 +1421,6 @@ void callPostblit(Loc &loc, Expression *exp, LLValue *val) {
         fd->toParent()->error(
             loc, "is not copyable because it is annotated with `@disable`");
       }
-      DtoResolveFunction(fd);
       Expressions args;
       DFuncValue dfn(fd, DtoCallee(fd), val);
       DtoCallFunction(loc, Type::basic[Tvoid], &dfn, &args);
@@ -1621,9 +1620,8 @@ DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl) {
     // We need to codegen the function here, because literals are not added
     // to the module member list.
     DtoDefineFunction(flitdecl);
-    assert(DtoCallee(flitdecl));
 
-    return new DFuncValue(flitdecl, DtoCallee(flitdecl));
+    return new DFuncValue(flitdecl, DtoCallee(flitdecl, false));
   }
 
   if (FuncDeclaration *fdecl = decl->isFuncDeclaration()) {
@@ -1700,7 +1698,6 @@ llvm::Constant *DtoConstSymbolAddress(Loc &loc, Declaration *decl) {
   }
   // static function
   if (FuncDeclaration *fd = decl->isFuncDeclaration()) {
-    DtoResolveFunction(fd);
     return DtoCallee(fd);
   }
 

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -135,7 +135,6 @@ void RTTIBuilder::push_size_as_vp(uint64_t s) {
 
 void RTTIBuilder::push_funcptr(FuncDeclaration *fd, Type *castto) {
   if (fd) {
-    DtoResolveFunction(fd);
     LLConstant *F = DtoCallee(fd);
     if (castto) {
       F = DtoBitCast(F, DtoType(castto));

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -476,7 +476,7 @@ public:
     // added to the module member list.
     Declaration_codegen(fd, p);
 
-    result = DtoCallee(fd);
+    result = DtoCallee(fd, false);
     assert(result);
 
     if (fd->tok != TOKfunction) {

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -198,8 +198,6 @@ LLConstant *IrClass::getVtblInit() {
         }
       }
 
-      DtoResolveFunction(fd);
-      assert(isIrFuncCreated(fd) && "invalid vtbl function");
       c = DtoBitCast(DtoCallee(fd), voidPtrType);
 
       if (cd->isFuncHidden(fd) && !fd->isFuture()) {

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -10,6 +10,7 @@
 #include "ir/irfunction.h"
 
 #include "driver/cl_options.h"
+#include "gen/functions.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
 #include "gen/irstate.h"
@@ -102,12 +103,10 @@ bool isIrFuncCreated(FuncDeclaration *decl) {
   return t == IrDsymbol::FuncType;
 }
 
-llvm::Function *DtoFunction(FuncDeclaration *decl, bool create) {
-  assert(decl != nullptr);
-  return getIrFunc(decl, create)->getLLVMFunc();
-}
-
 llvm::Function *DtoCallee(FuncDeclaration *decl, bool create) {
   assert(decl != nullptr);
-  return getIrFunc(decl, create)->getLLVMCallee();
+  if (create) {
+    DtoDeclareFunction(decl);
+  }
+  return getIrFunc(decl)->getLLVMCallee();
 }

--- a/ir/irfunction.h
+++ b/ir/irfunction.h
@@ -105,10 +105,6 @@ private:
 IrFunction *getIrFunc(FuncDeclaration *decl, bool create = false);
 bool isIrFuncCreated(FuncDeclaration *decl);
 
-/// Returns the associated LLVM function.
-/// Use DtoCallee() for the LLVM function to be used for calls.
-llvm::Function *DtoFunction(FuncDeclaration *decl, bool create = false);
-
 /// Returns the associated LLVM function to be used for calls (potentially
 /// some sort of wrapper, e.g., a JIT wrapper).
-llvm::Function *DtoCallee(FuncDeclaration *decl, bool create = false);
+llvm::Function *DtoCallee(FuncDeclaration *decl, bool create = true);

--- a/tests/compilable/gh3496.d
+++ b/tests/compilable/gh3496.d
@@ -1,0 +1,13 @@
+// RUN: %ldc -c %s
+
+interface I
+{
+    static void staticFoo();
+    final void finalFoo();
+}
+
+void foo()
+{
+    I.staticFoo();
+    (new class I{}).finalFoo();
+}


### PR DESCRIPTION
Whenever we need an IR function, we'd better make sure it exists. Handle that in `DtoCallee()`, by invoking `DtoDeclareFunction()` by default, instead of the previous `DtoResolveFunction()` + `DtoCallee()` combo.
`DtoResolveFunction()` usually declares the function, but somehow doesn't for abstract and body-less functions.