### PR TITLE
Fix partial discarding of function hash info for PGO

### DIFF
--- a/gen/pgo_ASTbased.cpp
+++ b/gen/pgo_ASTbased.cpp
@@ -135,8 +135,11 @@ public:
       return Working;
 
     // Check for remaining work in Working.
-    if (Working)
-      MD5.update(Working);
+    if (Working) {
+      using namespace llvm::support;
+      uint64_t Swapped = endian::byte_swap<uint64_t, little>(Working);
+      MD5.update(llvm::makeArrayRef((uint8_t *)&Swapped, sizeof(Swapped)));
+    }
 
     // Finalize the MD5 and return the hash.
     llvm::MD5::MD5Result Result;

--- a/tests/PGO/hash_smallchange.d
+++ b/tests/PGO/hash_smallchange.d
@@ -1,0 +1,47 @@
+// Test that a small code change changes the function hash.
+
+// See: https://github.com/ldc-developers/ldc/pull/3511 and https://reviews.llvm.org/D79961
+
+// REQUIRES: PGO_RT
+
+// RUN: %ldc -fprofile-instr-generate=%t.profraw -run %s  \
+// RUN:   &&  %profdata merge %t.profraw -o %t.profdata \
+// RUN:   &&  %ldc -d-version=WithChange -c -wi -fprofile-instr-use=%t.profdata %s 2>&1 | FileCheck %s
+
+// CHECK: Warning: Ignoring profile data for function {{.*}}.foo{{.*}} control-flow hash mismatch
+// CHECK: Warning: Ignoring profile data for function {{.*}}.longerfunction{{.*}} control-flow hash mismatch
+
+bool bar;
+
+void foo() {
+  if (bar) {}
+  version(WithChange)
+    if (bar) {}
+}
+
+// Function with more controlflow to trigger MD5 hashing
+void longerfunction() {
+  version(WithChange)
+    if (bar) {}
+
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+  if (bar) {}
+}
+
+void main() {
+  foo();
+  longerfunction();
+}


### PR DESCRIPTION
See Clang PR: https://reviews.llvm.org/D79961

Note that we do not include versioning code for our PGO files: PGO files from older LDC versions are not guarantee to work with newer versions of LDC. The user will see warnings about different function hashes, so he is aware the profile is not applied for those functions. Hash clashes may occur (old version hash corresponding to different function newer version hash), which is unfortunate but I think we do not need to go to the length of solving that as it only concerns optimization, not miscompilation. (it is similar that we don't guarantee object files from older compiler to work with newer compiler due to potential ABI changes which may also be silent)

Thanks @jondegenhardt 