### PR TITLE
Fix PGO instrumentation crash for final switch(enum) statements together with -release

### DIFF
--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -1019,7 +1019,8 @@ public:
           llvm::BasicBlock *defaultcntr =
               irs->insertBBBefore(defaultTargetBB, "defaultcntr");
           irs->scope() = IRScope(defaultcntr);
-          PGO.emitCounterIncrement(stmt->sdefault);
+          if (stmt->sdefault)
+              PGO.emitCounterIncrement(stmt->sdefault);
           llvm::BranchInst::Create(defaultTargetBB, defaultcntr);
           // Create switch
           si = llvm::SwitchInst::Create(condVal, defaultcntr, caseCount,
@@ -1063,7 +1064,7 @@ public:
       llvm::BasicBlock *nextbb = irs->insertBBBefore(endbb, "checkcase");
       llvm::BranchInst::Create(nextbb, irs->scopebb());
 
-      if (PGO.emitsInstrumentation()) {
+      if (stmt->sdefault && PGO.emitsInstrumentation()) {
         // Prepend extra BB to "default:" to increment profiling counter.
         llvm::BasicBlock *defaultcntr =
             irs->insertBBBefore(defaultTargetBB, "defaultcntr");

--- a/tests/PGO/final_switch_release.d
+++ b/tests/PGO/final_switch_release.d
@@ -1,0 +1,43 @@
+// See GH issue 3375
+
+// Test instrumentation for final switches without default case.
+// The frontend creates hidden default case to catch runtime errors. We disable
+// that using `-release`.
+
+// RUN: %ldc -release -fprofile-instr-generate=%t.profraw -run %s  \
+// RUN:   &&  %profdata merge %t.profraw -o %t.profdata \
+// RUN:   &&  %ldc -release -c -output-ll -of=%t.ll -fprofile-instr-use=%t.profdata %s \
+// RUN:   &&  FileCheck %s < %t.ll
+
+extern (C): // Simplify matching by disabling function name mangling
+
+enum A
+{
+    Start,
+    End
+}
+
+// CHECK-LABEL: @final_switch(
+// CHECK-SAME: !prof ![[SW0:[0-9]+]]
+void final_switch(A state)
+{
+    // CHECK: switch {{.*}} [
+    // CHECK: ], !prof ![[SW1:[0-9]+]]
+    final switch (state)
+    {
+    case A.Start:
+        break;
+    case A.End:
+        break;
+    }
+}
+
+void main()
+{
+    final_switch(A.Start);
+    final_switch(A.End);
+    final_switch(A.Start);
+}
+
+// CHECK-DAG: ![[SW0]] = !{!"function_entry_count", i64 3}
+// CHECK-DAG: ![[SW1]] = !{!"branch_weights", i32 1, i32 3, i32 2}


### PR DESCRIPTION
See GH issue #3375 (it fixes the instrumentation part of that bug on my machine, but apparently there are other bugs troubling PGO still).

This change includes checking of whether there is a default statement when using `case <variable>` (LLVM IR switch instruction cannot be used), although that is currently not allowed in the D language. Therefore there is no testcase that covers that.
