### PR TITLE
Add `-gdwarf` CLI option to emit DWARF debuginfos for MSVC targets

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -183,6 +183,10 @@ static cl::opt<unsigned char, true> debugInfo(
         clEnumValN(3, "gline-tables-only", "Add line tables only")),
     cl::location(global.params.symdebug), cl::init(0));
 
+cl::opt<bool> emitDwarfDebugInfo(
+    "gdwarf", cl::ZeroOrMore,
+    cl::desc("Emit DWARF debuginfo (instead of CodeView) for MSVC targets"));
+
 cl::opt<bool> noAsm("noasm", cl::desc("Disallow use of inline assembler"),
                     cl::ZeroOrMore);
 

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -45,6 +45,7 @@ extern cl::list<std::string> fileList;
 extern cl::list<std::string> runargs;
 extern cl::opt<bool> invokedByLDMD;
 extern cl::opt<bool> compileOnly;
+extern cl::opt<bool> emitDwarfDebugInfo;
 extern cl::opt<bool> noAsm;
 extern cl::opt<bool> dontWriteObj;
 extern cl::opt<std::string> objectFile;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -169,7 +169,17 @@ static std::vector<std::string> getDefaultLibNames() {
 
 //////////////////////////////////////////////////////////////////////////////
 
-bool useInternalLLDForLinking() { return linkInternally; }
+bool useInternalLLDForLinking() {
+  return linkInternally
+#if LDC_WITH_LLD
+         ||
+         // DWARF debuginfos for MSVC require LLD
+         (opts::emitDwarfDebugInfo && linkInternally.getNumOccurrences() == 0 &&
+          opts::linker.empty() && !opts::isUsingLTO() &&
+          global.params.targetTriple->isWindowsMSVCEnvironment())
+#endif
+      ;
+}
 
 cl::boolOrDefault linkFullyStatic() { return staticFlag; }
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1045,6 +1045,11 @@ int cppmain() {
       global.obj_ext = {3, "obj"};
   }
 
+  // -gdwarf implies -g if not specified explicitly
+  if (opts::emitDwarfDebugInfo && global.params.symdebug == 0) {
+    global.params.symdebug = 1;
+  }
+
   // allocate the target abi
   gABI = TargetABI::getTarget();
 

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -63,8 +63,7 @@ class DIBuilder {
 
   DICompileUnit CUNode;
 
-  const bool isTargetMSVC;
-  const bool isTargetMSVCx64;
+  const bool emitCodeView;
   const bool emitColumnInfo;
 
   llvm::DenseMap<Declaration*, llvm::TypedTrackingMDRef<llvm::MDNode>> StaticDataMemberCache;

--- a/tests/debuginfo/msvc_dwarf.d
+++ b/tests/debuginfo/msvc_dwarf.d
@@ -1,0 +1,16 @@
+// REQUIRES: Windows
+
+// RUN: %ldc -gdwarf -of=%t.exe %s 2> %t_stderr.log
+// RUN: FileCheck %s < %t_stderr.log
+// CHECK: lld-link: warning: section name .debug_info is longer than 8 characters and will use a non-standard string table
+
+int foo(int p)
+{
+    auto r = 2 * p;
+    return r;
+}
+
+void main()
+{
+    foo(123);
+}


### PR DESCRIPTION
Analogous to clang.