### PR TITLE
Simplify IR names of virtual function pointers

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -419,8 +419,7 @@ DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *_to) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
-                                   const char *name) {
+LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl) {
   // sanity checks
   assert(fdecl->isVirtual());
   assert(!fdecl->isFinalFunc());
@@ -440,8 +439,8 @@ LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
   // load vtbl ptr
   funcval = DtoLoad(funcval);
   // index vtbl
-  std::string vtblname = name;
-  vtblname.append("@vtbl");
+  const std::string name = fdecl->toChars();
+  const auto vtblname = name + "@vtbl";
   funcval = DtoGEP(funcval, 0, fdecl->vtblIndex, vtblname.c_str());
   // load opaque pointer
   funcval = DtoAlignedLoad(funcval);

--- a/gen/classes.h
+++ b/gen/classes.h
@@ -35,5 +35,4 @@ DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *to);
 
 DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *to);
 
-llvm::Value *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
-                                       const char *name);
+llvm::Value *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -973,7 +973,7 @@ public:
       LLValue *funcval = nullptr;
       if (nonFinal) {
         DtoResolveFunction(fdecl);
-        funcval = DtoVirtualFunctionPointer(l, fdecl, e->toChars());
+        funcval = DtoVirtualFunctionPointer(l, fdecl);
       } else {
         funcval = DtoCallee(fdecl);
       }
@@ -1862,7 +1862,7 @@ public:
 
     if (e->e1->op != TOKsuper && e->e1->op != TOKdottype &&
         e->func->isVirtual() && !e->func->isFinalFunc()) {
-      castfptr = DtoVirtualFunctionPointer(u, e->func, e->toChars());
+      castfptr = DtoVirtualFunctionPointer(u, e->func);
     } else if (e->func->isAbstract()) {
       llvm_unreachable("Delegate to abstract method not implemented.");
     } else if (e->func->toParent()->isInterfaceDeclaration()) {


### PR DESCRIPTION
This works around #3526 (but makes sense in general IMO).
For that testcase, the v1.22 IR was:

```ll
  %"(bar() , foo)().length@vtbl" = getelementptr inbounds [6 x i8*], [6 x i8*]* %4, i32 0, i32 5 ; [#uses = 1, type = i8**]
  %5 = load i8*, i8** %"(bar() , foo)().length@vtbl", align 8 ; [#uses = 1]
  %"(bar() , foo)().length" = bitcast i8* %5 to i64 (%current.Foo*)* ; [#uses = 1]
  %6 = call x86_vectorcallcc i64 %"(bar() , foo)().length"(%current.Foo* nonnull %2) ; [#uses = 1]
```

Now it's:

```ll
  %"length@vtbl" = getelementptr inbounds [6 x i8*], [6 x i8*]* %4, i32 0, i32 5 ; [#uses = 1, type = i8**]
  %5 = load i8*, i8** %"length@vtbl", align 8     ; [#uses = 1]
  %length = bitcast i8* %5 to i64 (%current.Foo*)* ; [#uses = 1]
  %6 = call x86_vectorcallcc i64 %length(%current.Foo* nonnull %2) ; [#uses = 1]
```