### PR TITLE
Fix linker cmdline length limitation via response files

### DIFF
--- a/driver/args.h
+++ b/driver/args.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Program.h"
 
 namespace args {
 
@@ -35,7 +36,16 @@ int forwardToDruntime(int argc, const CArgChar **argv);
 
 // Returns true if the specified arg is either `-run` or `--run`.
 bool isRunArg(const char *arg);
-}
+
+// Executes a command line and returns its exit code.
+// Optionally uses a response file to overcome cmdline length limitations.
+int executeAndWait(std::vector<const char *> fullArgs,
+                   llvm::Optional<llvm::sys::WindowsEncodingMethod>
+                       responseFileEncoding = {llvm::None},
+                   std::string *errorMsg = nullptr);
+} // namespace args
+
+////////////////////////////////////////////////////////////////////////////////
 
 namespace env {
 
@@ -47,4 +57,4 @@ bool has(const wchar_t *wname);
 
 // Returns the value of the specified environment variable (in UTF-8).
 std::string get(const char *name);
-}
+} // namespace env

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -813,7 +813,7 @@ int cppmain() {
 
   int rspFd;
   llvm::SmallString<128> rspPath;
-  if (ls::fs::createUniqueFile("ldmd-%%-%%-%%-%%.rsp", rspFd, rspPath)) {
+  if (ls::fs::createTemporaryFile("ldmd", "rsp", rspFd, rspPath)) {
     error("Could not open temporary response file.");
   }
 
@@ -821,7 +821,7 @@ int cppmain() {
     llvm::raw_fd_ostream rspOut(rspFd, /*shouldClose=*/true);
     // skip argv[0] and terminating NULL
     for (auto it = args.begin() + 1, end = args.end() - 1; it != end; ++it) {
-      rspOut << *it << '\n';
+      rspOut << '"' << *it << "\"\n";
     }
   }
 

--- a/driver/tool.h
+++ b/driver/tool.h
@@ -38,7 +38,7 @@ std::vector<const char *> getFullArgs(const char *tool,
                                       bool printVerbose);
 
 int executeToolAndWait(const std::string &tool,
-                       std::vector<std::string> const &args,
+                       const std::vector<std::string> &args,
                        bool verbose = false);
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes #3535 and an issue for ldmd2 wrt. unquoted args containing spaces in response files for ldc2 (uncovered during manual tests). Also create the temporary response files in the temp directory, not in the current working dir.