### PR TITLE
Azure CI: Bump host clang to v10.0.1 on Linux

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -18,15 +18,16 @@ steps:
       tar -xf ninja-mac.zip -C ninja
     else
       export DEBIAN_FRONTEND=noninteractive
-      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      CLANG_MAJOR=${CLANG_VERSION%%\.*}
-      sudo add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$CLANG_MAJOR main"
       sudo dpkg --add-architecture i386
       sudo apt-get -q update
       sudo apt-get -yq install \
-        git-core cmake ninja-build clang-$CLANG_MAJOR g++-multilib \
+        git-core cmake ninja-build g++-multilib \
         libcurl3 libcurl3:i386 \
         curl gdb p7zip-full tzdata unzip zip
+      # Download & extract clang
+      curl -L -o clang.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+      mkdir clang
+      tar -xf clang.tar.xz --strip 1 -C clang
       # Use ld.gold per default, so that LTO is tested
       sudo update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 99
     fi
@@ -85,9 +86,8 @@ steps:
     export PATH="$PWD/ninja:$PATH" # for macOS
     # Linux: use clang instead of gcc, for LTO
     if [ "$CI_OS" = "linux" ]; then
-      CLANG_MAJOR=${CLANG_VERSION%%\.*}
-      export CC=/usr/bin/clang-$CLANG_MAJOR
-      export CXX=/usr/bin/clang++-$CLANG_MAJOR
+      export CC=$PWD/clang/bin/clang
+      export CXX=$PWD/clang/bin/clang++
     fi
     installDir=$PWD/install
     mkdir build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   LLVM_VERSION: 10.0.1
-  CLANG_VERSION: 10.0.0
+  CLANG_VERSION: 10.0.1
   HOST_LDC_VERSION: 1.22.0
 
 trigger:
@@ -13,6 +13,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    CLANG_VERSION: 10.0.0
     VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
   strategy:
     matrix:


### PR DESCRIPTION
While the official prebuilt 10.0.0 version was for Ubuntu 18.04 only, v10.0.1 is for 16.04 only (...) and thus usable again for us.

While their apt repo has worked fine so far AFAIK, we've had pretty bad experiences with it in the past, so I definitely prefer a GitHub
download.

Oh and there are once again no prebuilt Windows packages for an LLVM/clang point release.