### PR TITLE
Add a GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: kinke


### PR DESCRIPTION
I'd like to try this and see how it works out. I have to look for a new job, so it's a good time for such an experiment and can potentially affect the targeted weekly hours, reserving some time for LDC/dlang development & support.

This is my profile: https://github.com/sponsors/kinke