### PR TITLE
Don't define __initZ and friends, but instead only declare, for nonroot structs, classes, and interfaces (happens when force-inlining a function and that function contains internal aggregates)

### DIFF
--- a/tests/compilable/gh3548.d
+++ b/tests/compilable/gh3548.d
@@ -1,0 +1,16 @@
+// Test inner struct initZ linking for a pragma(inline) function and separate compilation.
+
+// RUN: %ldc -c %S/inputs/gh3548a.d -of=%t.a.o
+// RUN: %ldc -I%S/inputs %s %t.a.o
+
+module b;
+
+import gh3548a;
+
+void main() {
+    S s;
+    s.innerStruct();
+    s.innerInnerStruct();
+    s.innerClass();
+    s.innerInnerClass();
+}

--- a/tests/compilable/inputs/gh3548a.d
+++ b/tests/compilable/inputs/gh3548a.d
@@ -1,0 +1,56 @@
+module gh3548a;
+
+struct S {
+    pragma(inline, true) auto innerStruct() {
+        static struct InnerStruct {
+            int nonZero = 1;
+        }
+        return InnerStruct();
+    }
+    pragma(inline, true) auto innerInnerStruct() {
+        struct InnerStruct {
+            struct InnerInnerStruct {
+                int nonZero = 1;
+            }
+            int nonZero = 1;
+        }
+        return InnerStruct.InnerInnerStruct();
+    }
+    pragma(inline, true) auto innerClass() {
+        interface I { void foo(); }
+        class InnerClass : I {
+            void foo() {}
+            int nonZero = 1;
+        }
+        return new InnerClass();
+    }
+    pragma(inline, true) auto innerInnerClass() {
+        static class InnerClass {
+            static interface I { void foo(); }
+            static class InnerInnerClass : I {
+                void foo() {}
+                int nonZero = 1;
+            }
+            int nonZero = 1;
+        }
+        return new InnerClass.InnerInnerClass();
+    }
+}
+
+//Not needed but simply making sure we generate code for the types.
+auto fooInnerStruct() {
+    S s;
+    return s.innerStruct();
+}
+auto fooInnerInnerStruct() {
+    S s;
+    return s.innerInnerStruct();
+}
+auto fooInnerClass() {
+    S s;
+    return s.innerClass();
+}
+auto fooInnerInnerClass() {
+    S s;
+    return s.innerInnerClass();
+}


### PR DESCRIPTION
Fixes issue #3548

I'm not super happy with this fix, but it works. If you agree, I will add more commentary to explain the if() statements. 

Note that this does not prevent inlining/optimization of the init values themselves: when only compiling module b (the one that imports the struct), then functions are still optimized to
```llvm
define %gh3548a.S.innerInnerStruct.InnerStruct.InnerInnerStruct @_D1b3fooFNaNbNiNfZS7gh3548a1S16innerInnerStructMFZ11InnerStruct16InnerInnerStruct() local_unnamed_addr #0 {
  ret %gh3548a.S.innerInnerStruct.InnerStruct.InnerInnerStruct { i32 1 }
}
```
so no referencing to some opaque `__initZ` variable.

I did not check for vtables. It will probably hurt devirtualization, because the vtbl is unknown. But I think that should be part of a different PR, probably we then always want to emit vtbls as linkonce_odr.
