### PR TITLE
Fix potentially wrong context pointers when calling delegate literals

### DIFF
--- a/tests/codegen/gh3553.d
+++ b/tests/codegen/gh3553.d
@@ -1,0 +1,16 @@
+// https://github.com/ldc-developers/ldc/issues/3553
+// RUN: %ldc -run %s
+
+auto makeDelegate(alias fn)(long l) {
+    auto callIt() {
+        return fn() * l;
+    }
+    return &callIt;
+}
+
+void main()
+{
+    int i = 7;
+    auto dg = makeDelegate!(() => i)(3);
+    assert(dg() == 21);
+}


### PR DESCRIPTION
Don't simply forward the caller's context without checking whether the lambda actually needs a parent context. Fixes #3553.