### PR TITLE
Windows: Stabilize cdb-based CodeView lit-tests

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -105,7 +105,8 @@ steps:
 - script: |
     cd ..
     set PATH=%CD%\llvm\bin;%PATH%
-    :: strings_cdb has regressed for 32-bit with VS 2019 v16.6.0 (worked fine until v16.5.4)
+    :: strings_cdb has regressed for 32-bit starting with the VS 2019 v16.6.0 Azure Image (worked fine until v16.5.4)
+    :: it also works fine on my box with the same v16.7.2...
     if "%MODEL%" == "32" ( del %BUILD_SOURCESDIRECTORY%\tests\debuginfo\strings_cdb.d)
     call "%VSINSTALLDIR%Common7\Tools\VsDevCmd.bat" -arch=%ARCH%
     cd build

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -31,13 +31,12 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
             Small small, Large large,
             TypeInfo_Class ti, typeof(null) np)
 {
-// CDB: bp `args_cdb.d:34`
+// CDB: bp0 /1 `args_cdb.d:34`
 // CDB: g
-    // arguments implicitly passed by reference aren't shown if unused
-    float cim = c.im + fa[7] + dg() + small.val + large.a;
-    return 1;
+// CHECK: Breakpoint 0 hit
 // CHECK-G:  !args_cdb.byValue
 // CHECK-GC: !args_cdb::byValue
+
 // CDB: dv /t
 
 // CHECK: unsigned char ub = 0x01
@@ -121,6 +120,10 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 // CHECK-GC: object::TypeInfo_Class
 // CHECK-G-NEXT:  m_init : byte[]
 // CHECK-GC-NEXT: m_init : slice<byte>
+
+    // arguments implicitly passed by reference aren't shown if unused
+    float cim = c.im + fa[7] + dg() + small.val + large.a;
+    return 1;
 }
 
 /*
@@ -131,11 +134,12 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
  */
 size_t byValueShort(Large large)
 {
-// CDB: bp `args_cdb.d:134`
+// CDB: bp1 /1 `args_cdb.d:137`
 // CDB: g
-    return large.a;
+// CHECK: Breakpoint 1 hit
 // CHECK-G:  !args_cdb.byValueShort
 // CHECK-GC: !args_cdb::byValueShort
+
 // CDB: dv /t
 // CHECK-G:  struct args_cdb.Large large = struct args_cdb.Large
 // CHECK-GC: struct args_cdb::Large large = struct args_cdb::Large
@@ -144,6 +148,8 @@ size_t byValueShort(Large large)
 // CHECK-G:  args_cdb.Large
 // CHECK-GC: args_cdb::Large
 // CHECK-NEXT: a : 0x13
+
+    return large.a;
 }
 
 int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
@@ -154,11 +160,12 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
           Small* small, Large* large,
           TypeInfo_Class* ti, typeof(null)* np)
 {
-// CDB: bp `args_cdb.d:157`
+// CDB: bp2 /1 `args_cdb.d:163`
 // CDB: g
-    return 3;
+// CHECK: Breakpoint 2 hit
 // CHECK-G:  !args_cdb.byPtr
 // CHECK-GC: !args_cdb::byPtr
+
 // CDB: dv /t
 // CDB: ?? *ub
 // CHECK: unsigned char 0x01
@@ -216,6 +223,8 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CHECK-GC-NEXT: m_init : slice<byte>
 // CDB: ?? *np
 // CHECK: void * {{0x[0`]*}}
+
+    return 3;
 }
 
 int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
@@ -226,8 +235,9 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
           ref Small small, ref Large large,
           ref TypeInfo_Class ti, ref typeof(null) np)
 {
-// CDB: bp `args_cdb.d:229`
+// CDB: bp3 /1 `args_cdb.d:238`
 // CDB: g
+// CHECK: Breakpoint 3 hit
 // CHECK-G:  !args_cdb.byRef
 // CHECK-GC: !args_cdb::byRef
 

--- a/tests/debuginfo/baseclass_cdb.d
+++ b/tests/debuginfo/baseclass_cdb.d
@@ -23,9 +23,9 @@ int main(string[] args)
 // CDB: ld /f baseclass_cdb*
 // enable case sensitive symbol lookup
 // CDB: .symopt-1
-// CDB: bp `baseclass_cdb.d:28`
+// CDB: bp0 /1 `baseclass_cdb.d:26`
 // CDB: g
-    return 0;
+// CHECK: Breakpoint 0 hit
 // CHECK: !baseclass_cdb.D main
 
 // CDB: ?? dc
@@ -34,6 +34,8 @@ int main(string[] args)
 // CHECK: baseMember{{ *: *3}}
 // verify baseMember is not listed twice
 // CHECK-NEXT: derivedMember{{ *: *7}}
+
+    return 0;
 }
 
 // CDB: q

--- a/tests/debuginfo/basictypes_cdb.d
+++ b/tests/debuginfo/basictypes_cdb.d
@@ -37,11 +37,12 @@ int basic_types()
     cdouble cd = 17 + 18i;
     creal cr = 19 + 20i;
     typeof(null) np = null;
-    
+
     c = c;
 // CDB: ld basictypes_cdb*
-// CDB: bp `basictypes_cdb.d:41`
+// CDB: bp0 /1 `basictypes_cdb.d:43`
 // CDB: g
+// CHECK: Breakpoint 0 hit
 // CHECK: !basictypes_cdb.basic_types
 
 // enable case sensitive symbol lookup
@@ -77,6 +78,7 @@ int basic_types()
 // CDB: ?? cr
 // CHECK: +0x000 re : 19
 // CHECK: +0x008 im : 20
+
     return 1;
 }
 // CDB: q

--- a/tests/debuginfo/nested_cdb.d
+++ b/tests/debuginfo/nested_cdb.d
@@ -12,8 +12,10 @@
 void encloser(int arg0, ref int arg1)
 {
     int enc_n = 123;
-// CDB: bp `nested_cdb.d:16`
+// CDB: bp0 /1 `nested_cdb.d:15`
 // CDB: g
+// CHECK: Breakpoint 0 hit
+
 // CDB: dv /t
 // CHECK: int arg0 = 0n1
 // (cdb displays references as pointers)
@@ -26,8 +28,9 @@ void encloser(int arg0, ref int arg1)
     void nested(int nes_i)
     {
         int blub = arg0 + arg1 + enc_n;
-// CDB: bp `nested_cdb.d:30`
+// CDB: bp1 /1 `nested_cdb.d:31`
 // CDB: g
+// CHECK: Breakpoint 1 hit
 // CDB: dv /t
 // CHECK: int arg0 = 0n1
 // CHECK-NEXT: int * arg1 = {{0x[0-9a-f`]*}}
@@ -35,8 +38,9 @@ void encloser(int arg0, ref int arg1)
 // CDB: ?? *arg1
 // CHECK: int 0n2
         arg0 = arg1 = enc_n = nes_i;
-// CDB: bp `nested_cdb.d:39`
+// CDB: bp2 /1 `nested_cdb.d:41`
 // CDB: g
+// CHECK: Breakpoint 2 hit
 // CDB: dv /t
 // CHECK: int arg0 = 0n456
 // CHECK-NEXT: int * arg1 = {{0x[0-9a-f`]*}}
@@ -46,8 +50,9 @@ void encloser(int arg0, ref int arg1)
     }
 
     nested(456);
-// CDB: bp `nested_cdb.d:50`
+// CDB: bp3 /1 `nested_cdb.d:53`
 // CDB: g
+// CHECK: Breakpoint 3 hit
 // CDB: dv /t
 // CHECK: int arg0 = 0n456
 // CHECK-NEXT: int * arg1 = {{0x[0-9a-f`]*}}

--- a/tests/debuginfo/scopes_cdb.d
+++ b/tests/debuginfo/scopes_cdb.d
@@ -24,10 +24,11 @@ template Template(int N)
     int[N] field;
     void foo()
     {
-// CDB: bp `scopes_cdb.d:27`
+// CDB: bp0 /1 `scopes_cdb.d:27`
 // CDB: g
-// CHECK-G:  !scopes_cdb.Template!1.foo+
-// CHECK-GC: !scopes_cdb::Template<1>::foo+
+// CHECK: Breakpoint 0 hit
+// CHECK-G:  !scopes_cdb.Template!1.foo
+// CHECK-GC: !scopes_cdb::Template<1>::foo
     }
 }
 
@@ -35,19 +36,21 @@ extern (C++, cppns)
 {
     void cppFoo()
     {
-// CDB: bp `scopes_cdb.d:38`
+// CDB: bp1 /1 `scopes_cdb.d:39`
 // CDB: g
-// CHECK-G:  !scopes_cdb.cppns.cppFoo+
-// CHECK-GC: !scopes_cdb::cppns::cppFoo+
+// CHECK: Breakpoint 1 hit
+// CHECK-G:  !scopes_cdb.cppns.cppFoo
+// CHECK-GC: !scopes_cdb::cppns::cppFoo
     }
 }
 
 void templatedFoo(int N)()
 {
-// CDB: bp `scopes_cdb.d:47`
+// CDB: bp2 /1 `scopes_cdb.d:49`
 // CDB: g
-// CHECK-G:  !scopes_cdb.templatedFoo!2+
-// CHECK-GC: !scopes_cdb::templatedFoo<2>+
+// CHECK: Breakpoint 2 hit
+// CHECK-G:  !scopes_cdb.templatedFoo!2
+// CHECK-GC: !scopes_cdb::templatedFoo<2>
 }
 
 mixin template Mixin(T)
@@ -60,10 +63,11 @@ mixin template Mixin(T)
         void mixedInFoo()
         {
             MixedInStruct local;
-// CDB: bp `scopes_cdb.d:63`
+// CDB: bp3 /1 `scopes_cdb.d:66`
 // CDB: g
-// CHECK-G:  !scopes_cdb.S.mixedInFoo+
-// CHECK-GC: !scopes_cdb::S::mixedInFoo+
+// CHECK: Breakpoint 3 hit
+// CHECK-G:  !scopes_cdb.S.mixedInFoo
+// CHECK-GC: !scopes_cdb::S::mixedInFoo
 // CDB: dv /t
 // CHECK-G:  struct scopes_cdb.S.MixedInStruct local =
 // CHECK-GC: struct scopes_cdb::S::MixedInStruct local =
@@ -92,10 +96,11 @@ void test()
         T[N] field;
         void foo()
         {
-// CDB: bp `scopes_cdb.d:95`
+// CDB: bp4 /1 `scopes_cdb.d:99`
 // CDB: g
-// CHECK-G:  !scopes_cdb.test.TemplatedNestedStruct!(S, 3).foo+
-// CHECK-GC: !scopes_cdb::test::TemplatedNestedStruct<S, 3>::foo+
+// CHECK: Breakpoint 4 hit
+// CHECK-G:  !scopes_cdb.test.TemplatedNestedStruct!(S, 3).foo
+// CHECK-GC: !scopes_cdb::test::TemplatedNestedStruct<S, 3>::foo
         }
     }
 
@@ -107,18 +112,20 @@ void test()
         int field;
         void foo()
         {
-// CDB: bp `scopes_cdb.d:110`
+// CDB: bp5 /1 `scopes_cdb.d:115`
 // CDB: g
-// CHECK-G:  !scopes_cdb.test.NestedStruct.foo+
-// CHECK-GC: !scopes_cdb::test::NestedStruct::foo+
+// CHECK: Breakpoint 5 hit
+// CHECK-G:  !scopes_cdb.test.NestedStruct.foo
+// CHECK-GC: !scopes_cdb::test::NestedStruct::foo
         }
     }
 
     NestedStruct ns;
     ns.foo();
 
-// CDB: bp `scopes_cdb.d:120`
+// CDB: bp6 /1 `scopes_cdb.d:126`
 // CDB: g
+// CHECK: Breakpoint 6 hit
 // CDB: dv /t
 // CHECK-G:       struct scopes_cdb.S s =
 // CHECK-GC:      struct scopes_cdb::S s =

--- a/tests/debuginfo/strings_cdb.d
+++ b/tests/debuginfo/strings_cdb.d
@@ -17,9 +17,9 @@ int main(string[] args)
 // CDB: ld /f strings_cdb*
 // enable case sensitive symbol lookup
 // CDB: .symopt-1
-// CDB: bp `strings_cdb.d:22`
+// CDB: bp0 /1 `strings_cdb.d:20`
 // CDB: g
-    return 0;
+// CHECK: Breakpoint 0 hit
 // CHECK: !strings_cdb.D main
 
 // CDB: dt string
@@ -55,6 +55,8 @@ int main(string[] args)
 // CDB: ?? args.ptr[0]
 // CHECK: +0x000 length
 // CHECK: +[[OFF]] ptr {{ *}}: 0x{{[0-9a-f`]* *".*exe.*"}}
+
+    return 0;
 }
 
 // CDB: q

--- a/tests/debuginfo/vector_cdb.d
+++ b/tests/debuginfo/vector_cdb.d
@@ -12,8 +12,9 @@ import core.simd;
 // CDB: ld /f vector_cdb*
 // enable case sensitive symbol lookup
 // CDB: .symopt-1
-// CDB: bp `vector_cdb.d:91`
+// CDB: bp0 /1 `vector_cdb.d:92`
 // CDB: g
+// CHECK: Breakpoint 0 hit
 // CDB: dv /t
 
 int main()


### PR DESCRIPTION
Investigating the spurious failures showed that sometimes a breakpoint can be hit twice consecutively. Use `bp /1` to remove the breakpoint after it's been hit to work around this.

I've hit no failures anymore after running the 7 cdb tests >500 times in a row on my box.