### PR TITLE
Windows: Add *some* support for -fsanitize=fuzzer and enable ASan tests

### DIFF
--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -67,6 +67,10 @@ void addSanitizerLibs(std::vector<std::string> &args) {
   if (opts::isSanitizerEnabled(opts::AddressSanitizer)) {
     args.push_back("ldc_rt.asan.lib");
   }
+  if (opts::isSanitizerEnabled(opts::FuzzSanitizer)) {
+    args.push_back("ldc_rt.fuzzer.lib");
+    args.push_back("/SUBSYSTEM:CONSOLE"); // pull main() from fuzzer lib
+  }
 
   // TODO: remaining sanitizers
 }

--- a/tests/sanitizers/link_fuzzer.d
+++ b/tests/sanitizers/link_fuzzer.d
@@ -1,6 +1,7 @@
 // Test linking C++ stdlib (or not) with -fsanitize=fuzzer
 
 // REQUIRES: Fuzzer
+// UNSUPPORTED: Windows
 
 // RUN: %ldc -v -fsanitize=fuzzer %s | FileCheck %s
 // "lib(ldc|clang)_rt.fuzzer.*.a" since LLVM 6.0

--- a/tests/sanitizers/lit.local.cfg
+++ b/tests/sanitizers/lit.local.cfg
@@ -8,10 +8,12 @@ for file in os.listdir(config.ldc2_lib_dir):
     if m is not None:
         config.available_features.add('ASan')
         continue
-    m = re.match('.*tsan.*', file)
-    if m is not None:
-        config.available_features.add('TSan')
-        continue
+    # FreeBSD TSan needs https://reviews.llvm.org/D85292
+    if platform.system() != 'FreeBSD':
+        m = re.match('.*tsan.*', file)
+        if m is not None:
+            config.available_features.add('TSan')
+            continue
     m = re.match('.*(F|f)uzzer.*', file)
     if m is not None:
         config.available_features.add('Fuzzer')

--- a/tests/sanitizers/lit.local.cfg
+++ b/tests/sanitizers/lit.local.cfg
@@ -3,22 +3,19 @@ import platform
 import re
 
 # Add "ASan" and "Fuzzer" feature if the runtime library is available.
-# On Windows, the ASan library is apparently quite fragile and only works
-# with certain versions of Microsoft's runtime.
-if (platform.system() == 'Darwin') or (platform.system() == 'Linux'):
-    for file in os.listdir(config.ldc2_lib_dir):
-        m = re.match('.*asan.*', file)
-        if m is not None:
-            config.available_features.add('ASan')
-            continue
-        m = re.match('.*tsan.*', file)
-        if m is not None:
-            config.available_features.add('TSan')
-            continue
-        m = re.match('.*(F|f)uzzer.*', file)
-        if m is not None:
-            config.available_features.add('Fuzzer')
-            continue
+for file in os.listdir(config.ldc2_lib_dir):
+    m = re.match('.*asan.*', file)
+    if m is not None:
+        config.available_features.add('ASan')
+        continue
+    m = re.match('.*tsan.*', file)
+    if m is not None:
+        config.available_features.add('TSan')
+        continue
+    m = re.match('.*(F|f)uzzer.*', file)
+    if m is not None:
+        config.available_features.add('Fuzzer')
+        continue
 if 'ASan' in config.available_features:
     # On Darwin, ASan defaults to `abort_on_error=1`, which would make tests run
     # much slower. Let's override this and run lit tests with 'abort_on_error=0'.


### PR DESCRIPTION
Lit-test `sanitizers/fuzz_asan.d` works, while `fuzz_{basic,mixin}.d` fail with linker errors, as (implied & apparently required) `-fsanitize-coverage=inline-8bit-counters` isn't supported on Windows yet (see https://bugs.llvm.org/show_bug.cgi?id=35674; I've tried the `trace-pc-guard` variant as well as excluding the tracing altogether...), e.g.:
```
fuzz_basic.d.tmp.obj : error LNK2019: unresolved external symbol __start___sancov_cntrs referenced in function sancov.module_ctor_8bit_counters
fuzz_basic.d.tmp.obj : error LNK2019: unresolved external symbol __stop___sancov_cntrs referenced in function sancov.module_ctor_8bit_counters
fuzz_basic.d.tmp.obj : error LNK2019: unresolved external symbol __start___sancov_pcs referenced in function sancov.module_ctor_8bit_counters
fuzz_basic.d.tmp.obj : error LNK2019: unresolved external symbol __stop___sancov_pcs referenced in function sancov.module_ctor_8bit_counters
```

The ASan tests now work with LLVM 10 and the VS 2019 runtime at least, so enabling the tests resolves #3566. Actual support was added with LDC v1.8, see b7d12fe52f69ba13e32cd1bac8508d9a4598de80.