### PR TITLE
Don't enforce (normal) emission for pragma(inline, true) function templates, and don't cull lambdas

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -371,28 +371,19 @@ public:
       return;
     }
 
-    // Force codegen if this is a templated function with pragma(inline, true).
-    if ((decl->members->length == 1) &&
-        ((*decl->members)[0]->isFuncDeclaration()) &&
-        ((*decl->members)[0]->isFuncDeclaration()->inlining == PINLINEalways)) {
-      Logger::println("needsCodegen() == false, but function is marked with "
-                      "pragma(inline, true), so it really does need "
-                      "codegen.");
-    } else {
-      // FIXME: This is #673 all over again.
-      if (!decl->needsCodegen()) {
-        Logger::println("Does not need codegen, skipping.");
-        return;
-      }
+    // FIXME: This is #673 all over again.
+    if (!decl->needsCodegen()) {
+      Logger::println("Does not need codegen, skipping.");
+      return;
+    }
 
-      if (irs->dcomputetarget && (decl->tempdecl == Type::rtinfo ||
-                                  decl->tempdecl == Type::rtinfoImpl)) {
-        // Emitting object.RTInfo(Impl) template instantiations in dcompute
-        // modules would require dcompute support for global variables.
-        Logger::println("Skipping object.RTInfo(Impl) template instantiations "
-                        "in dcompute modules.");
-        return;
-      }
+    if (irs->dcomputetarget && (decl->tempdecl == Type::rtinfo ||
+                                decl->tempdecl == Type::rtinfoImpl)) {
+      // Emitting object.RTInfo(Impl) template instantiations in dcompute
+      // modules would require dcompute support for global variables.
+      Logger::println("Skipping object.RTInfo(Impl) template instantiations "
+                      "in dcompute modules.");
+      return;
     }
 
     for (auto &m : *decl->members) {

--- a/gen/function-inlining.cpp
+++ b/gen/function-inlining.cpp
@@ -73,6 +73,9 @@ bool isInlineCandidate(FuncDeclaration &fdecl) {
 } // end anonymous namespace
 
 bool alreadyOrWillBeDefined(FuncDeclaration &fdecl) {
+  if (fdecl.isFuncLiteralDeclaration()) // emitted into each referencing CU
+    return true;
+
   for (FuncDeclaration *f = &fdecl; f;) {
     if (!f->isInstantiated() && f->inNonRoot()) {
       return false;

--- a/tests/codegen/inlining_templates.d
+++ b/tests/codegen/inlining_templates.d
@@ -31,10 +31,8 @@ void main()
 {
 }
 
-// CHECK-NOT: declare{{.*}}_D6inputs10inlinables__T12template_fooTiZQrUNaNbNiNfiZi
-// CHECK-NOT: declare{{.*}}_D3std9exception__T7enforce
+// CHECK-NOT: declare {{.*}}template_foo
 
-// CHECK-DAG: define{{.*}}_D6inputs10inlinables__T12template_fooTiZQrUNaNbNiNfiZi{{.*}}) #[[ATTR:[0-9]+]]
-// CHECK-DAG: define{{.*}}_D3std9exception__T7enforce{{.*}}) #[[ATTR]]
-
-// CHECK-DAG: attributes #[[ATTR]] ={{.*}} alwaysinline
+// CHECK-NOT: declare {{.*}}call_enforce_with_default_template_params
+// CHECK-NOT: declare {{.*}}__lambda
+// CHECK-NOT: declare {{.*}}_D3std9exception__T7enforce


### PR DESCRIPTION
[The remaining non-upstreamed piece from #3456.]

With the new `available_externally` emission into each referencing CU, the enforced regular emission from the module members tree shouldn't be required anymore.

After adapting the `codegen/inlining_templates.d` lit-test accordingly (no IR definitions anymore in .ll file, because `available_externally` doesn't make it there), I've noticed that a lambda in imported and inlined `call_enforce_with_default_template_params()` wasn't emitted - it got culled by `alreadyOrWillBeDefined()`.
Function/delegate literals aren't culled anymore.