### PR TITLE
Implement ABI stuff for -preview=in

### DIFF
--- a/dmd/target.d
+++ b/dmd/target.d
@@ -661,6 +661,8 @@ version (IN_LLVM)
     TypeTuple toArgTypes(Type t);
     bool isReturnOnStack(TypeFunction tf, bool needsThis);
     // unused: ulong parameterSize(const ref Loc loc, Type t);
+    bool preferPassByRef(Type t);
+    Expression getTargetInfo(const(char)* name, const ref Loc loc);
 }
 else // !IN_LLVM
 {
@@ -879,7 +881,6 @@ else // !IN_LLVM
         const sz = t.size(loc);
         return params.is64bit ? (sz + 7) & ~7 : (sz + 3) & ~3;
     }
-} // !IN_LLVM
 
     /**
      * Decides whether an `in` parameter of the specified POD type is to be
@@ -939,12 +940,6 @@ else // !IN_LLVM
         }
     }
 
-version (IN_LLVM)
-{
-    extern (C++) Expression getTargetInfo(const(char)* name, const ref Loc loc);
-}
-else
-{
     // this guarantees `getTargetInfo` and `allTargetInfos` remain in sync
     private enum TargetInfoKeys
     {

--- a/gen/abi-aarch64.cpp
+++ b/gen/abi-aarch64.cpp
@@ -70,6 +70,19 @@ public:
     return false;
   }
 
+  // Prefer a ref if the POD cannot be passed in registers, i.e., if
+  // IndirectByvalRewrite would be applied.
+  bool preferPassByRef(Type *t) override {
+    t = t->toBasetype();
+
+    if (!(t->ty == Tstruct || t->ty == Tsarray))
+      return false;
+
+    auto argTypes = getArgTypes(t);
+    return argTypes // not 0-sized
+        && argTypes->arguments->empty(); // cannot be passed in registers
+  }
+
   bool passByVal(TypeFunction *, Type *) override { return false; }
 
   void rewriteFunctionType(IrFuncTy &fty) override {

--- a/gen/abi-x86-64.cpp
+++ b/gen/abi-x86-64.cpp
@@ -148,6 +148,8 @@ struct X86_64TargetABI : TargetABI {
 
   bool returnInArg(TypeFunction *tf, bool needsThis) override;
 
+  bool preferPassByRef(Type *t) override;
+
   bool passByVal(TypeFunction *tf, Type *t) override;
 
   void rewriteFunctionType(IrFuncTy &fty) override;
@@ -188,6 +190,12 @@ bool X86_64TargetABI::returnInArg(TypeFunction *tf, bool) {
 
   Type *rt = tf->next->toBasetype();
   return passInMemory(rt);
+}
+
+// Prefer a ref if the POD cannot be passed in registers, i.e., if the LLVM
+// ByVal attribute would be applied, *and* the size is > 16.
+bool X86_64TargetABI::preferPassByRef(Type *t) {
+  return t->size() > 16 && passInMemory(t->toBasetype());
 }
 
 bool X86_64TargetABI::passByVal(TypeFunction *tf, Type *t) {

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -156,6 +156,14 @@ bool TargetABI::isExternD(TypeFunction *tf) {
 
 //////////////////////////////////////////////////////////////////////////////
 
+bool TargetABI::preferPassByRef(Type *t) {
+  // simple base heuristic: use a ref for all types > 2 machine words
+  d_uns64 machineWordSize = global.params.is64bit ? 8 : 4;
+  return t->size() > 2 * machineWordSize;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 bool TargetABI::reverseExplicitParams(TypeFunction *tf) {
   // Required by druntime for extern(D), except for `, ...`-style variadics.
   return isExternD(tf) && tf->parameterList.length() > 1;

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -124,6 +124,10 @@ struct TargetABI {
   /// attribute.
   virtual bool returnInArg(TypeFunction *tf, bool needsThis) = 0;
 
+  /// Returns true if the specified parameter type (a POD) should be passed by
+  /// ref for `in` params with -preview=in.
+  virtual bool preferPassByRef(Type *t);
+
   /// Returns true if the D type is passed using the LLVM ByVal attribute.
   ///
   /// ByVal arguments are bitcopied to the callee's function parameters stack in

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -216,6 +216,8 @@ bool Target::isReturnOnStack(TypeFunction *tf, bool needsThis) {
   return gABI->returnInArg(tf, needsThis);
 }
 
+bool Target::preferPassByRef(Type *t) { return gABI->preferPassByRef(t); }
+
 Expression *Target::getTargetInfo(const char *name_, const Loc &loc) {
   const llvm::StringRef name(name_);
   const auto &triple = *global.params.targetTriple;


### PR DESCRIPTION
I.e., the ABI-specific decision for which parameter types to prefer passing a ref over a value.

The x86_64 and AArch64 ABIs are pretty clear - use a ref if the POD type cannot be passed in registers. For all others, use a simple default heuristic based on the type size - if larger than 2 machine words, use a ref. Note that this includes x87 `real` for the 32-bit x86 ABI.