### PR TITLE
Azure CI: Include macOS arm64 libraries in prebuilt Mac package

### DIFF
--- a/.azure-pipelines/posix.yml
+++ b/.azure-pipelines/posix.yml
@@ -12,6 +12,7 @@ steps:
     set -ex
     cd ..
     if [ "$CI_OS" = "osx" ]; then
+      sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
       # Download & extract Ninja
       curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-mac.zip
       mkdir ninja
@@ -269,18 +270,28 @@ steps:
   displayName: 'Android: Cross-compile x86 libraries and copy to install dir'
   condition: and(succeeded(), eq(variables['CI_OS'], 'android'))
 
-# Mac: add iOS libraries (arm64 and x86_64)
+# Mac: add arm64 and iOS (arm64, x86_64) libraries
 - script: |
     set -ex
     cd ..
     export PATH="$PWD/ninja:$PATH"
-    triple_arm64="arm64-apple-ios$IOS_DEPLOYMENT_TARGET"
-    triple_x64="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET"
-    # TODO: build shared libs too, and look into `-fvisibility=hidden` requirement
+    triple_arm64="arm64-apple-macos"
+    triple_ios_arm64="arm64-apple-ios$IOS_DEPLOYMENT_TARGET"
+    triple_ios_x64="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET"
     build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
       --buildDir=build-libs-arm64 \
       --cFlags="-target;$triple_arm64" \
-      --dFlags="-mtriple=$triple_arm64;-fvisibility=hidden" \
+      --dFlags="-mtriple=$triple_arm64" \
+      --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
+      CMAKE_OSX_SYSROOT=/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk \
+      CMAKE_OSX_ARCHITECTURES=arm64 \
+      CMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+      BUILD_LTO_LIBS=ON
+    # TODO: build shared libs too, and look into `-fvisibility=hidden` requirement
+    build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
+      --buildDir=build-libs-ios-arm64 \
+      --cFlags="-target;$triple_ios_arm64" \
+      --dFlags="-mtriple=$triple_ios_arm64;-fvisibility=hidden" \
       --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
       CMAKE_SYSTEM_NAME=iOS \
       CMAKE_OSX_ARCHITECTURES=arm64 \
@@ -288,9 +299,9 @@ steps:
       BUILD_SHARED_LIBS=OFF \
       BUILD_LTO_LIBS=ON
     build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
-      --buildDir=build-libs-x86_64 \
-      --cFlags="-target;$triple_x64" \
-      --dFlags="-mtriple=$triple_x64;-fvisibility=hidden" \
+      --buildDir=build-libs-ios-x86_64 \
+      --cFlags="-target;$triple_ios_x64" \
+      --dFlags="-mtriple=$triple_ios_x64;-fvisibility=hidden" \
       --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
       CMAKE_SYSTEM_NAME=iOS \
       CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
@@ -298,11 +309,27 @@ steps:
       CMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET \
       BUILD_SHARED_LIBS=OFF \
       BUILD_LTO_LIBS=ON
-    mkdir installed/lib-ios-{arm64,x86_64}
-    cp build-libs-arm64/lib/*.a installed/lib-ios-arm64
-    cp build-libs-x86_64/lib/*.a installed/lib-ios-x86_64
-    rm installed/lib-ios-{arm64,x86_64}/*-lto-debug.a
+    mkdir installed/lib-{arm64,ios-arm64,ios-x86_64}
+    cp -a build-libs-arm64/lib/*.{a,dylib} installed/lib-arm64
+    cp build-libs-ios-arm64/lib/*.a installed/lib-ios-arm64
+    cp build-libs-ios-x86_64/lib/*.a installed/lib-ios-x86_64
+    rm installed/lib-{arm64,ios-arm64,ios-x86_64}/*-lto-debug.a
     sections="
+    \"arm64-apple-macos\":
+    {
+        switches = [
+            \"-defaultlib=phobos2-ldc,druntime-ldc\",
+            \"-Xcc=-target\",
+            \"-Xcc=$triple_arm64\",
+            \"-Xcc=-isysroot\",
+            \"-Xcc=/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk\",
+        ];
+        lib-dirs = [
+            \"%%ldcbinarypath%%/../lib-arm64\",
+        ];
+        rpath = \"%%ldcbinarypath%%/../lib-arm64\";
+    };
+    
     \"arm64-apple-ios\":
     {
         switches = [
@@ -310,7 +337,7 @@ steps:
             \"-link-defaultlib-shared=false\",
             \"-fvisibility=hidden\",
             \"-Xcc=-target\",
-            \"-Xcc=$triple_arm64\",
+            \"-Xcc=$triple_ios_arm64\",
             \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",
             \"-Xcc=-isysroot\",
             \"-Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\",
@@ -328,7 +355,7 @@ steps:
             \"-link-defaultlib-shared=false\",
             \"-fvisibility=hidden\",
             \"-Xcc=-target\",
-            \"-Xcc=$triple_x64\",
+            \"-Xcc=$triple_ios_x64\",
             \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",
             \"-Xcc=-isysroot\",
             \"-Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\",
@@ -340,7 +367,7 @@ steps:
     };"
     echo "$sections" >> installed/etc/ldc2.conf
     cat installed/etc/ldc2.conf
-  displayName: 'Mac: Cross-compile iOS libraries (arm64 and x86_64), copy to install dir and extend ldc2.conf'
+  displayName: 'Mac: Cross-compile arm64 and iOS (arm64, x86_64) libraries, copy to install dir and extend ldc2.conf'
   condition: and(succeeded(), eq(variables['CI_OS'], 'osx'))
 
 # Integration tests
@@ -359,9 +386,11 @@ steps:
 - script: |
     set -ex
     cd ..
+    installed/bin/ldc2 -mtriple="arm64-apple-macos" hello.d -of=hello_arm64
+    installed/bin/ldc2 -mtriple="arm64-apple-macos" hello.d -of=hello_arm64_shared -link-defaultlib-shared
     installed/bin/ldc2 -mtriple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_arm64
     installed/bin/ldc2 -mtriple="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_x86_64
-  displayName: 'Mac: Cross-compile & -link hello-world for iOS'
+  displayName: 'Mac: Cross-compile & -link hello-world for arm64 and iOS'
   condition: and(succeeded(), eq(variables['CI_OS'], 'osx'))
 - script: |
     set -ex


### PR DESCRIPTION
For simple cross-compilation via `-mtriple=arm64-apple-macos` as long as a suited Xcode version >= 12.0 (?) is installed.