### PR TITLE
Mention the VisualD Windows installer in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Portable stand-alone binary builds for common platforms (incl. Linux,
 macOS and Windows) are available at the
 [GitHub release page](https://github.com/ldc-developers/ldc/releases).
 
+For Windows, the [VisualD installer](https://rainers.github.io/visuald/visuald/StartPage.html) comes with a bundled LDC.
+
 For bleeding-edge users, we also provide the [latest successful
 Continuous Integration builds](https://github.com/ldc-developers/ldc/releases/tag/CI)
 with enabled LLVM & LDC assertions (increasing compile times by roughly 50%).


### PR DESCRIPTION
My undecisive suggestion would be to just link to the VisualD installer for those users who would rather have a branded experience. I don't really have any opinion on this.

README.md would look like:
![image](https://user-images.githubusercontent.com/1067485/97109141-cab88b80-16d1-11eb-9389-0b032ebc1031.png)
