### PR TITLE
Handle IR collisions wrt. built-in TypeInfos and make them mutable

### DIFF
--- a/gen/linkage.h
+++ b/gen/linkage.h
@@ -18,7 +18,5 @@
 // Make it easier to test new linkage types
 
 #define TYPEINFO_LINKAGE_TYPE LLGlobalValue::LinkOnceODRLinkage
-// The One-Definition-Rule shouldn't matter for debug info, right?
-#define DEBUGINFO_LINKONCE_LINKAGE_TYPE LLGlobalValue::LinkOnceAnyLinkage
 
 extern LLGlobalValue::LinkageTypes templateLinkage;

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -569,28 +569,12 @@ llvm::Type *Analysis::getTypeFor(Value *typeinfo) const {
   const auto metaname = getMetadataName(TD_PREFIX, ti_global);
 
   NamedMDNode *meta = M.getNamedMetadata(metaname);
-  if (!meta) {
+  if (!meta || meta->getNumOperands() != 1) {
     return nullptr;
   }
 
-  MDNode *node = static_cast<MDNode *>(meta->getOperand(0));
-  if (!node) {
-    return nullptr;
-  }
-
-  if (node->getNumOperands() != TD_NumFields) {
-    return nullptr;
-  }
-
-  auto md = llvm::dyn_cast<llvm::ValueAsMetadata>(
-              node->getOperand(TD_TypeInfo).get());
-  if (md == nullptr || md->getValue()->stripPointerCasts() != ti_global) {
-    return nullptr;
-  }
-
-
-  return llvm::cast<llvm::ValueAsMetadata>(node->getOperand(TD_Type))
-      ->getType();
+  MDNode *node = meta->getOperand(0);
+  return llvm::cast<llvm::ConstantAsMetadata>(node->getOperand(0))->getType();
 }
 
 /// Returns whether Def is used by any instruction that is reachable from Alloc

--- a/gen/passes/metadata.h
+++ b/gen/passes/metadata.h
@@ -13,25 +13,13 @@
 
 #pragma once
 
-// MDNode was moved into its own header, and contains Value*s
 #include "llvm/IR/Metadata.h"
-typedef llvm::Value MDNodeField;
-
-#define METADATA_LINKAGE_TYPE llvm::GlobalValue::WeakODRLinkage
 
 // *** Metadata for TypeInfo instances ***
+// A metadata node for a TypeInfo instance will be named TD_PREFIX ~ <Name of
+// TypeInfo global>. The node contains a single operand, an arbitrary constant
+// value of the LLVM type corresponding to the D type the TypeInfo is for.
 #define TD_PREFIX "llvm.ldc.typeinfo."
-
-/// The fields in the metadata node for a TypeInfo instance.
-/// (Its name will be TD_PREFIX ~ <Name of TypeInfo global>)
-enum TypeDataFields {
-  TD_TypeInfo, /// A reference toe the TypeInfo global this node is for.
-
-  TD_Type, /// A value of the LLVM type corresponding to this D type
-
-  // Must be kept last:
-  TD_NumFields /// The number of fields in TypeInfo metadata
-};
 
 // *** Metadata for ClassInfo instances ***
 #define CD_PREFIX "llvm.ldc.classinfo."

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -86,19 +86,12 @@ void emitTypeInfoMetadata(LLGlobalVariable *typeinfoGlobal, Type *forType) {
       t->ty != Tident) {
     const auto metaname = getMetadataName(TD_PREFIX, typeinfoGlobal);
 
-    llvm::NamedMDNode *meta = gIR->module.getNamedMetadata(metaname);
-
-    if (!meta) {
-      // Construct the fields
-      llvm::Metadata *mdVals[TD_NumFields];
-      mdVals[TD_TypeInfo] = llvm::ValueAsMetadata::get(typeinfoGlobal);
-      mdVals[TD_Type] = llvm::ConstantAsMetadata::get(
-          llvm::UndefValue::get(DtoType(forType)));
-
+    if (!gIR->module.getNamedMetadata(metaname)) {
       // Construct the metadata and insert it into the module.
-      llvm::NamedMDNode *node = gIR->module.getOrInsertNamedMetadata(metaname);
-      node->addOperand(llvm::MDNode::get(
-          gIR->context(), llvm::makeArrayRef(mdVals, TD_NumFields)));
+      auto meta = gIR->module.getOrInsertNamedMetadata(metaname);
+      auto val = llvm::UndefValue::get(DtoType(forType));
+      meta->addOperand(llvm::MDNode::get(gIR->context(),
+                                         llvm::ConstantAsMetadata::get(val)));
     }
   }
 }

--- a/gen/typinf.h
+++ b/gen/typinf.h
@@ -18,6 +18,8 @@ struct Loc;
 class Type;
 class TypeInfoDeclaration;
 
+bool builtinTypeInfo(Type *t); // in dmd/typinf.d
+
 namespace llvm {
 class GlobalVariable;
 }

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -96,10 +96,11 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
     IrTypeClass *tc = stripModifiers(cinfoType)->ctype->isClass();
     assert(tc && "invalid ClassInfo type");
 
-    // classinfos cannot be constants since they're used as locks for
-    // synchronized
+    // We need to keep the symbol mutable as the type is not declared as
+    // immutable on the D side, and e.g. synchronized() can be used on the
+    // implicit monitor.
     typeInfo = declareGlobal(aggrdecl->loc, gIR->module, tc->getMemoryLLType(),
-                             irMangle, false);
+                             irMangle, /*isConstant=*/false);
 
     // Generate some metadata on this ClassInfo if it's for a class.
     if (!aggrdecl->isInterfaceDeclaration()) {

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -48,8 +48,9 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
     // We need to keep the symbol mutable as the type is not declared as
     // immutable on the D side, and e.g. synchronized() can be used on the
     // implicit monitor.
-    typeInfo = declareGlobal(aggrdecl->loc, gIR->module,
-                             getTypeInfoStructMemType(), irMangle, false);
+    typeInfo =
+        declareGlobal(aggrdecl->loc, gIR->module, getTypeInfoStructMemType(),
+                      irMangle, /*isConstant=*/false);
 
     emitTypeInfoMetadata(typeInfo, aggrdecl->type);
   }


### PR DESCRIPTION
Compiling the `rt.util.typeinfo` unittests (mostly disabled until now) leads to base-typed forward declarations of built-in TypeInfos colliding with the init symbols for their `TypeInfo_*` classes in `rt.util.typeinfo`.

We've already had a workaround for this in one place (`typinf.cpp`); extend it to the other side as well (`iraggr.cpp`).

Also make sure to emit the TypeInfo metadata even if the IR symbol already exists as init symbol.

Also keep init symbols of built-in TypeInfo classes mutable just like any other TypeInfo, so that e.g. `synchronized()` can be used on the implicit monitor.

And finally, simplify the TypeInfo metadata for the GC2Stack pass.