### PR TITLE
Extend -linkonce-templates by matching template emission scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,9 +167,6 @@ script:
   - |
     if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
       DMD_TESTSUITE_MAKE_ARGS="-j${PARALLELISM:-3} GDB_FLAGS=OFF" ctest -V -R "dmd-testsuite"
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      # dmd-testsuite-debug only to reduce time-outs
-      DMD_TESTSUITE_MAKE_ARGS=-j${PARALLELISM:-3} ctest -V -R "build-run-dmd-testsuite|dmd-testsuite-debug"
     else
       DMD_TESTSUITE_MAKE_ARGS=-j${PARALLELISM:-3} ctest -V -R "dmd-testsuite"
     fi

--- a/dmd/dsymbolsem.d
+++ b/dmd/dsymbolsem.d
@@ -6071,8 +6071,13 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
             tempinst.inst.gagged = tempinst.gagged;
         }
 
-        tempinst.tnext = tempinst.inst.tnext;
-        tempinst.inst.tnext = tempinst;
+        // LDC: the tnext linked list is only used by TemplateInstance.needsCodegen(),
+        //      which is skipped with -linkonce-templates
+        if (!(IN_LLVM && global.params.linkonceTemplates))
+        {
+            tempinst.tnext = tempinst.inst.tnext;
+            tempinst.inst.tnext = tempinst;
+        }
 
         /* A module can have explicit template instance and its alias
          * in module scope (e,g, `alias Base64 = Base64Impl!('+', '/');`).

--- a/dmd/dsymbolsem.d
+++ b/dmd/dsymbolsem.d
@@ -6161,7 +6161,10 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
             scope v = new InstMemberWalker(tempinst.inst);
             tempinst.inst.accept(v);
 
-            if (tempinst.minst) // if inst was not speculative
+            // LDC: if `inst` was speculative, it was already appended to a root
+            //      module - unless using -linkonce-templates
+            if ((IN_LLVM && global.params.linkonceTemplates) ||
+                tempinst.minst) // if inst was not speculative
             {
                 /* Add 'inst' once again to the root module members[], then the
                  * instance members will get codegen chances.

--- a/dmd/dtemplate.d
+++ b/dmd/dtemplate.d
@@ -7318,19 +7318,18 @@ version (IN_LLVM)
 {
         if (global.params.linkonceTemplates)
         {
-            // abort if it's not a root module
+            // Skip if it's not a root module.
             if (!mi || !mi.isRoot())
                 return null;
 
-            // instantiated in a root module => make sure the primary instance gets full sema
-            if (!inst.memberOf)
-            {
-                Module.addDeferredSemantic2(inst);
-                Module.addDeferredSemantic3(inst);
-                inst.memberOf = mi; // HACK to restrict to a single pass per primary instance
-            }
+            // Skip if the primary instance has already been assigned to a root
+            // module.
+            if (inst.memberOf)
+                return null;
 
-            return null;
+            // Okay, this is the primary instance to be assigned to a root
+            // module and getting semantic3.
+            assert(this is inst);
         }
 }
 

--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -341,6 +341,8 @@ version (IN_LLVM)
     uint hashThreshold; // MD5 hash symbols larger than this threshold (0 = no hashing)
 
     bool outputSourceLocations; // if true, output line tables.
+
+    bool linkonceTemplates; // -linkonce-templates
 } // IN_LLVM
 }
 

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -302,6 +302,8 @@ struct Param
     unsigned hashThreshold; // MD5 hash symbols larger than this threshold (0 = no hashing)
 
     bool outputSourceLocations; // if true, output line tables.
+
+    bool linkonceTemplates; // -linkonce-templates
 #endif
 };
 

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -487,8 +487,9 @@ cl::opt<uint32_t, true> hashThreshold(
     "hash-threshold", cl::ZeroOrMore, cl::location(global.params.hashThreshold),
     cl::desc("Hash symbol names longer than this threshold (experimental)"));
 
-cl::opt<bool> linkonceTemplates(
+static cl::opt<bool, true> linkonceTemplates(
     "linkonce-templates", cl::ZeroOrMore,
+    cl::location(global.params.linkonceTemplates), cl::init(true),
     cl::desc(
         "Use linkonce_odr linkage for template symbols instead of weak_odr"));
 

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -489,7 +489,7 @@ cl::opt<uint32_t, true> hashThreshold(
 
 static cl::opt<bool, true> linkonceTemplates(
     "linkonce-templates", cl::ZeroOrMore,
-    cl::location(global.params.linkonceTemplates), cl::init(true),
+    cl::location(global.params.linkonceTemplates),
     cl::desc(
         "Use linkonce_odr linkage for template symbols instead of weak_odr"));
 

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -81,7 +81,6 @@ extern cl::opt<bool> m64bits;
 extern cl::opt<std::string> mTargetTriple;
 extern cl::opt<std::string> mABI;
 extern FloatABI::Type floatABI;
-extern cl::opt<bool> linkonceTemplates;
 extern cl::opt<bool> disableLinkerStripDead;
 extern cl::opt<unsigned char> defaultToHiddenVisibility;
 extern cl::opt<bool> noPLT;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -429,8 +429,9 @@ void parseCommandLine(Strings &sourceFiles) {
   global.params.output_mlir = opts::output_mlir ? OUTPUTFLAGset : OUTPUTFLAGno;
   global.params.output_s = opts::output_s ? OUTPUTFLAGset : OUTPUTFLAGno;
 
-  templateLinkage = opts::linkonceTemplates ? LLGlobalValue::LinkOnceODRLinkage
-                                            : LLGlobalValue::WeakODRLinkage;
+  templateLinkage = global.params.linkonceTemplates
+                        ? LLGlobalValue::LinkOnceODRLinkage
+                        : LLGlobalValue::WeakODRLinkage;
 
   if (global.params.run || !runargs.empty()) {
     // FIXME: how to properly detect the presence of a PositionalEatsArgs

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -324,7 +324,7 @@ public:
     }
 
     // FIXME: This is #673 all over again.
-    if (!decl->needsCodegen()) {
+    if (!global.params.linkonceTemplates && !decl->needsCodegen()) {
       Logger::println("Does not need codegen, skipping.");
       return;
     }

--- a/gen/function-inlining.cpp
+++ b/gen/function-inlining.cpp
@@ -72,13 +72,13 @@ bool isInlineCandidate(FuncDeclaration &fdecl) {
 
 } // end anonymous namespace
 
-bool alreadyOrWillBeDefined(FuncDeclaration &fdecl) {
+bool skipCodegen(FuncDeclaration &fdecl) {
   if (fdecl.isFuncLiteralDeclaration()) // emitted into each referencing CU
-    return true;
+    return false;
 
   for (FuncDeclaration *f = &fdecl; f;) {
-    if (!f->isInstantiated() && f->inNonRoot()) {
-      return false;
+    if (f->inNonRoot()) { // false if instantiated
+      return true;
     }
     if (f->isNested()) {
       f = f->toParent2()->isFuncDeclaration();
@@ -86,7 +86,7 @@ bool alreadyOrWillBeDefined(FuncDeclaration &fdecl) {
       break;
     }
   }
-  return true;
+  return false;
 }
 
 bool defineAsExternallyAvailable(FuncDeclaration &fdecl) {

--- a/gen/function-inlining.h
+++ b/gen/function-inlining.h
@@ -16,8 +16,8 @@
 class FuncDeclaration;
 
 /// Check whether the frontend knows that the function is already defined
-/// in some other module (see DMD's FuncDeclaration::toObjFile).
-bool alreadyOrWillBeDefined(FuncDeclaration &fdecl);
+/// in some other module (see DMD's `FuncDeclaration_toObjFile()`).
+bool skipCodegen(FuncDeclaration &fdecl);
 
 /// Returns whether `fdecl` should be emitted with externally_available
 /// linkage to make it available for inlining.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -575,10 +575,23 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
   // Check if fdecl should be defined too for cross-module inlining.
   // If true, semantic is fully done for fdecl which is needed for some code
   // below (e.g. code that uses fdecl->vthis).
-  const bool defineAtEnd = !willDefine && defineAsExternallyAvailable(*fdecl);
-  if (defineAtEnd) {
-    IF_LOG Logger::println(
-        "Function is an externally_available inline candidate.");
+  bool defineAtEnd = false;
+  bool defineAsAvailableExternally = false;
+  if (willDefine) {
+  } else if (defineOnDeclare(fdecl)) {
+    if (fdecl->semanticRun < PASSsemantic3done) {
+      const bool semaSuccess = fdecl->functionSemantic3();
+      assert(semaSuccess);
+      Module::runDeferredSemantic3();
+    }
+    IF_LOG Logger::println("Function is inside a linkonce_odr template, will "
+                           "be defined after declaration.");
+    defineAtEnd = true;
+  } else if (defineAsExternallyAvailable(*fdecl)) {
+    IF_LOG Logger::println("Function is an externally_available inline "
+                           "candidate, will be defined after declaration.");
+    defineAtEnd = true;
+    defineAsAvailableExternally = true;
   }
 
   // get TypeFunction*
@@ -768,9 +781,8 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
 
   // Now that this function is declared, also define it if needed.
   if (defineAtEnd) {
-    IF_LOG Logger::println(
-        "Function is an externally_available inline candidate: define it now.");
-    DtoDefineFunction(fdecl, /*linkageAvailableExternally=*/true);
+    IF_LOG Logger::println("Define function after declaration:");
+    DtoDefineFunction(fdecl, defineAsAvailableExternally);
   }
 }
 
@@ -1038,7 +1050,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     }
   }
 
-  if (!linkageAvailableExternally && !alreadyOrWillBeDefined(*fd)) {
+  if (!linkageAvailableExternally && skipCodegen(*fd)) {
     IF_LOG Logger::println("Skipping '%s'.", fd->toPrettyChars());
     return;
   }

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -578,18 +578,21 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
   bool defineAtEnd = false;
   bool defineAsAvailableExternally = false;
   if (willDefine) {
+    // will be defined anyway after declaration
   } else if (defineOnDeclare(fdecl)) {
+    Logger::println("Function is inside a linkonce_odr template, will be "
+                    "defined after declaration.");
     if (fdecl->semanticRun < PASSsemantic3done) {
+      // this can e.g. happen for special __xtoHash member functions
+      Logger::println("Function hasn't had sema3 run yet, running it now.");
       const bool semaSuccess = fdecl->functionSemantic3();
       assert(semaSuccess);
       Module::runDeferredSemantic3();
     }
-    IF_LOG Logger::println("Function is inside a linkonce_odr template, will "
-                           "be defined after declaration.");
     defineAtEnd = true;
   } else if (defineAsExternallyAvailable(*fdecl)) {
-    IF_LOG Logger::println("Function is an externally_available inline "
-                           "candidate, will be defined after declaration.");
+    Logger::println("Function is an externally_available inline candidate, "
+                    "will be defined after declaration.");
     defineAtEnd = true;
     defineAsAvailableExternally = true;
   }

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -795,18 +795,8 @@ DValue *DtoPaintType(Loc &loc, DValue *val, Type *to) {
  * TEMPLATE HELPERS
  ******************************************************************************/
 
-TemplateInstance *DtoIsTemplateInstance(Dsymbol *s) {
-  for (; s; s = s->parent) {
-    if (auto ti = s->isTemplateInstance()) {
-      if (!ti->isTemplateMixin())
-        return ti;
-    }
-  }
-  return nullptr;
-}
-
 bool defineOnDeclare(Dsymbol* s) {
-  return global.params.linkonceTemplates && DtoIsTemplateInstance(s);
+  return global.params.linkonceTemplates && s->isInstantiated();
 }
 
 /******************************************************************************

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -796,16 +796,17 @@ DValue *DtoPaintType(Loc &loc, DValue *val, Type *to) {
  ******************************************************************************/
 
 TemplateInstance *DtoIsTemplateInstance(Dsymbol *s) {
-  if (!s) {
-    return nullptr;
-  }
-  if (s->isTemplateInstance() && !s->isTemplateMixin()) {
-    return s->isTemplateInstance();
-  }
-  if (s->parent) {
-    return DtoIsTemplateInstance(s->parent);
+  for (; s; s = s->parent) {
+    if (auto ti = s->isTemplateInstance()) {
+      if (!ti->isTemplateMixin())
+        return ti;
+    }
   }
   return nullptr;
+}
+
+bool defineOnDeclare(Dsymbol* s) {
+  return global.params.linkonceTemplates && DtoIsTemplateInstance(s);
 }
 
 /******************************************************************************

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -103,6 +103,9 @@ DValue *DtoPaintType(Loc &loc, DValue *val, Type *to);
 
 // is template instance check, returns module where instantiated
 TemplateInstance *DtoIsTemplateInstance(Dsymbol *s);
+/// Returns true if the specified symbol is to be defined on declaration, for
+/// -linkonce-templates.
+bool defineOnDeclare(Dsymbol *s);
 
 /// Makes sure the declarations corresponding to the given D symbol have been
 /// emitted to the currently processed LLVM module.

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -101,8 +101,6 @@ DValue *DtoCast(Loc &loc, DValue *val, Type *to);
 // otherwise returns a new DValue
 DValue *DtoPaintType(Loc &loc, DValue *val, Type *to);
 
-// is template instance check, returns module where instantiated
-TemplateInstance *DtoIsTemplateInstance(Dsymbol *s);
 /// Returns true if the specified symbol is to be defined on declaration, for
 /// -linkonce-templates.
 bool defineOnDeclare(Dsymbol *s);

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -608,7 +608,7 @@ void codegenModule(IRState *irs, Module *m) {
 
   // process module members
   // NOTE: m->members may grow during codegen
-  for (unsigned k = 0; k < m->members->length; k++) {
+  for (d_size_t k = 0; k < m->members->length; k++) {
     Dsymbol *dsym = (*m->members)[k];
     assert(dsym);
     Declaration_codegen(dsym);

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -170,7 +170,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
     asmstr << "\t.section\t__TEXT,__text,regular,pure_instructions"
            << std::endl;
     asmstr << "\t.globl\t" << mangle << std::endl;
-    if (DtoIsTemplateInstance(fd)) {
+    if (fd->isInstantiated()) {
       asmstr << "\t.weak_definition\t" << mangle << std::endl;
     }
     asmstr << "\t.p2align\t4, 0x90" << std::endl;
@@ -198,7 +198,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
     asmstr << "\t.type\t32;" << std::endl;
     asmstr << "\t.endef" << std::endl;
 
-    if (DtoIsTemplateInstance(fd)) {
+    if (fd->isInstantiated()) {
       asmstr << "\t.section\t.text,\"xr\",discard," << mangle << std::endl;
     } else {
       asmstr << "\t.text" << std::endl;
@@ -207,7 +207,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
     asmstr << "\t.p2align\t4, 0x90" << std::endl;
     asmstr << mangle << ":" << std::endl;
   } else {
-    if (DtoIsTemplateInstance(fd)) {
+    if (fd->isInstantiated()) {
       asmstr << "\t.section\t.text." << mangle << ",\"axG\",@progbits,"
              << mangle << ",comdat" << std::endl;
       asmstr << "\t.weak\t" << mangle << std::endl;

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -64,10 +64,6 @@ void RTTIBuilder::push_null_vp() { push(getNullValue(getVoidPtrType())); }
 
 void RTTIBuilder::push_typeinfo(Type *t) { push(DtoTypeInfoOf(t)); }
 
-void RTTIBuilder::push_classinfo(ClassDeclaration *cd) {
-  push(getIrAggr(cd)->getClassInfoSymbol());
-}
-
 void RTTIBuilder::push_string(const char *str) { push(DtoConstString(str)); }
 
 void RTTIBuilder::push_null_void_array() {

--- a/gen/rttibuilder.h
+++ b/gen/rttibuilder.h
@@ -46,7 +46,6 @@ public:
   void push_size_as_vp(uint64_t s);
   void push_string(const char *str);
   void push_typeinfo(Type *t);
-  void push_classinfo(ClassDeclaration *cd);
 
   /// pushes the function pointer or a null void* if it cannot.
   void push_funcptr(FuncDeclaration *fd, Type *castto = nullptr);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -105,10 +105,10 @@ static void checkForImplicitGCCall(const Loc &loc, const char *name) {
 ////////////////////////////////////////////////////////////////////////////////
 
 bool initRuntime() {
-  Logger::println("*** Initializing D runtime declarations ***");
-  LOG_SCOPE;
-
   if (!M) {
+    Logger::println("*** Initializing D runtime declarations ***");
+    LOG_SCOPE;
+
     buildRuntimeModule();
   }
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -221,7 +221,7 @@ LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
   }
   // Function (incl. delegate) literals are emitted into each referencing
   // compilation unit; use template linkage to prevent conflicts.
-  else if (sym->isFuncLiteralDeclaration() || DtoIsTemplateInstance(sym)) {
+  else if (sym->isFuncLiteralDeclaration() || sym->isInstantiated()) {
     linkage = templateLinkage;
   } else {
     linkage = LLGlobalValue::ExternalLinkage;

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -215,15 +215,16 @@ LLValue *DtoDelegateEquals(TOK op, LLValue *lhs, LLValue *rhs) {
 ////////////////////////////////////////////////////////////////////////////////
 
 LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
-  // Function (incl. delegate) literals are emitted into each referencing
-  // compilation unit; use template linkage to prevent conflicts.
-  auto linkage = (sym->isFuncLiteralDeclaration() || DtoIsTemplateInstance(sym))
-                     ? templateLinkage
-                     : LLGlobalValue::ExternalLinkage;
-
-  // If @(ldc.attributes.weak) is applied, override the linkage to WeakAny
+  LLGlobalValue::LinkageTypes linkage;
   if (hasWeakUDA(sym)) {
     linkage = LLGlobalValue::WeakAnyLinkage;
+  }
+  // Function (incl. delegate) literals are emitted into each referencing
+  // compilation unit; use template linkage to prevent conflicts.
+  else if (sym->isFuncLiteralDeclaration() || DtoIsTemplateInstance(sym)) {
+    linkage = templateLinkage;
+  } else {
+    linkage = LLGlobalValue::ExternalLinkage;
   }
 
   return {linkage, needsCOMDAT()};

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -290,7 +290,7 @@ public:
     RTTIBuilder b(getInterfaceTypeInfoType());
 
     // TypeInfo base
-    b.push_classinfo(tc->sym);
+    b.push_typeinfo(tc);
 
     // finish
     b.finalize(gvar);
@@ -508,10 +508,10 @@ LLGlobalVariable *DtoResolveTypeInfo(TypeInfoDeclaration *tid) {
   assert(!gIR->dcomputetarget);
 
   if (!tid->ir->isResolved()) {
-    tid->ir->setResolved();
-
     DeclareOrDefineVisitor v;
     tid->accept(&v);
+
+    tid->ir->setResolved();
   }
 
   return llvm::cast<LLGlobalVariable>(getIrValue(tid));

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -82,6 +82,9 @@ LLConstant *IrAggr::getInitSymbol(bool define) {
     initGlobal->setAlignment(LLMaybeAlign(DtoAlignment(type)));
 
     init = initGlobal;
+
+    if (!define && defineOnDeclare(aggrdecl))
+      define = true;
   }
 
   if (define) {

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -83,8 +83,8 @@ LLConstant *IrAggr::getInitSymbol(bool define) {
 
     init = initGlobal;
 
-    if (!define && defineOnDeclare(aggrdecl))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(aggrdecl);
   }
 
   if (define) {

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -72,8 +72,8 @@ LLGlobalVariable *IrClass::getVtblSymbol(bool define) {
     vtbl = declareGlobal(aggrdecl->loc, gIR->module, vtblTy, irMangle,
                          /*isConstant=*/true);
 
-    if (!define && defineOnDeclare(aggrdecl))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(aggrdecl);
   }
 
   if (define) {
@@ -131,8 +131,8 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
           gIR->context(), llvm::makeArrayRef(mdVals, CD_NumFields)));
     }
 
-    if (!define && defineOnDeclare(aggrdecl))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(aggrdecl);
   }
 
   if (define) {
@@ -473,8 +473,8 @@ llvm::GlobalVariable *IrClass::getInterfaceVtblSymbol(BaseClass *b,
     // insert into the vtbl map
     interfaceVtblMap.insert({{b->sym, interfaces_index}, gvar});
 
-    if (!define && defineOnDeclare(aggrdecl))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(aggrdecl);
   }
 
   if (define && !gvar->hasInitializer()) {

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -71,6 +71,9 @@ LLGlobalVariable *IrClass::getVtblSymbol(bool define) {
 
     vtbl = declareGlobal(aggrdecl->loc, gIR->module, vtblTy, irMangle,
                          /*isConstant=*/true);
+
+    if (!define && defineOnDeclare(aggrdecl))
+      define = true;
   }
 
   if (define) {
@@ -127,6 +130,9 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
       node->addOperand(llvm::MDNode::get(
           gIR->context(), llvm::makeArrayRef(mdVals, CD_NumFields)));
     }
+
+    if (!define && defineOnDeclare(aggrdecl))
+      define = true;
   }
 
   if (define) {
@@ -380,7 +386,7 @@ LLConstant *IrClass::getClassInfoInit() {
   // TypeInfo_Class base
   assert(!isInterface || !cd->baseClass);
   if (cd->baseClass) {
-    b.push_classinfo(cd->baseClass);
+    b.push_typeinfo(cd->baseClass->type);
   } else {
     b.push_null(cinfoType);
   }
@@ -466,6 +472,9 @@ llvm::GlobalVariable *IrClass::getInterfaceVtblSymbol(BaseClass *b,
 
     // insert into the vtbl map
     interfaceVtblMap.insert({{b->sym, interfaces_index}, gvar});
+
+    if (!define && defineOnDeclare(aggrdecl))
+      define = true;
   }
 
   if (define && !gvar->hasInitializer()) {

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -54,8 +54,8 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
 
     emitTypeInfoMetadata(typeInfo, aggrdecl->type);
 
-    if (!define && defineOnDeclare(aggrdecl))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(aggrdecl);
   }
 
   if (define) {

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -53,6 +53,9 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
                       irMangle, /*isConstant=*/false);
 
     emitTypeInfoMetadata(typeInfo, aggrdecl->type);
+
+    if (!define && defineOnDeclare(aggrdecl))
+      define = true;
   }
 
   if (define) {

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -27,6 +27,9 @@
 LLValue *IrGlobal::getValue(bool define) {
   if (!value) {
     declare();
+
+    if (!define && defineOnDeclare(V))
+      define = true;
   }
 
   if (define && !(V->storage_class & STCextern)) {

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -28,8 +28,8 @@ LLValue *IrGlobal::getValue(bool define) {
   if (!value) {
     declare();
 
-    if (!define && defineOnDeclare(V))
-      define = true;
+    if (!define)
+      define = defineOnDeclare(V);
   }
 
   if (define && !(V->storage_class & STCextern)) {

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -52,9 +52,9 @@ set(RT_SUPPORT_SANITIZERS OFF                                 CACHE BOOL   "Buil
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
 
 set(DRUNTIME_EXTRA_FLAGS          -preview=fieldwise)
-set(DRUNTIME_EXTRA_UNITTEST_FLAGS -d-version=CoreUnittest -unittest -checkaction=context)
+set(DRUNTIME_EXTRA_UNITTEST_FLAGS -d-version=CoreUnittest -unittest -checkaction=context -linkonce-templates)
 set(PHOBOS2_EXTRA_FLAGS           -transition=complex)
-set(PHOBOS2_EXTRA_UNITTEST_FLAGS  -d-version=StdUnittest -unittest)
+set(PHOBOS2_EXTRA_UNITTEST_FLAGS  -d-version=StdUnittest -unittest -linkonce-templates)
 
 # Shadow the D_FLAGS cache variable by a regular variable containing all base D flags
 set(D_FLAGS ${D_FLAGS} ${D_EXTRA_FLAGS})
@@ -933,7 +933,7 @@ function(build_test_runners name_suffix path_suffix d_flags linkflags is_shared)
     set(test_runner_bc "")
     dc("${RUNTIME_DIR}/src/test_runner.d"
        "${RUNTIME_DIR}/src"
-       "${d_flags}"
+       "${d_flags};-linkonce-templates"
        "${PROJECT_BINARY_DIR}/objects-unittest${target_suffix}"
        "OFF"
        "OFF"

--- a/tests/d2/CMakeLists.txt
+++ b/tests/d2/CMakeLists.txt
@@ -64,10 +64,10 @@ string(REGEX REPLACE "[^0-9]*([0-9]+[0-9.]*).*" "\\1" GDB_VERSION "${GDB_VERSION
 # tests (e.g. 'testdstress') depend on contracts and invariants being active.
 # Need a solution integrated with d_do_test.
 add_testsuite("-debug" "-g -link-defaultlib-debug" "${gdb_flags}" "${host_model}" "all")
-add_testsuite("" "-O" "OFF" "${host_model}" "runnable")
+add_testsuite("" "-O -linkonce-templates" "OFF" "${host_model}" "runnable")
 
 if(MULTILIB AND host_model EQUAL 64)
     # Also test in 32 bit mode on x86_64 multilib builds.
     add_testsuite("-debug_32" "-g -link-defaultlib-debug" "${gdb_flags}" "32" "all")
-    add_testsuite("_32" "-O" "OFF" "32" "runnable")
+    add_testsuite("_32" "-O -linkonce-templates" "OFF" "32" "runnable")
 endif()


### PR DESCRIPTION
[In essence, a revised version of the remaining stuff from #3422.]

I.e., *define* templated symbols in each referencing compilation unit (=> object file) when using discardable `linkonce_odr` linkage, analogous to C++.

This makes each compilation unit self-sufficient wrt. templated symbols, which also means increased opportunity for inlining and less need for LTO. There should be no more undefined symbol issues caused by buggy template culling.

The biggest advantage is that the optimizer can discard unused `linkonce_odr` symbols early instead of optimizing and forwarding to the assembler. So this is especially useful with `-O` to decrease compilation times and can at least in some scenarios greatly outweigh the (potentially very much) higher number of symbols defined by the glue layer.

Libraries compiled with `-linkonce-templates` can generally not be linked against dependent code compiled without `-linkonce-templates`; the other way around works.