### PR TITLE
Fix LTO with -link-internally for MSVC targets

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -68,9 +68,8 @@ steps:
 - script: |
     echo on
     cd ..
-    :: LLVM bin dir in PATH required for lld-link.exe
-    :: git's usr/bin required to make GNU find precede MS one in C:\Windows\System32
-    set PATH=%CD%\llvm\bin;C:\Program Files\LLVM\bin;%CD%\ninja;%CD%\gnu;C:\Program Files\Git\usr\bin;%PATH%
+    :: git's usr/bin required to make GNU `find` precede MS one in C:\Windows\System32
+    set PATH=C:\Program Files\LLVM\bin;%CD%\ninja;%CD%\gnu;C:\Program Files\Git\usr\bin;%PATH%
     call "%VSINSTALLDIR%Common7\Tools\VsDevCmd.bat" -arch=%ARCH%
     echo on
     cmake --version
@@ -85,7 +84,7 @@ steps:
 - script: |
     echo on
     cd ..
-    set PATH=%CD%\llvm\bin;C:\Program Files\LLVM\bin;%CD%\ninja;%CD%\gnu;C:\Program Files\Git\usr\bin;%PATH%
+    set PATH=C:\Program Files\LLVM\bin;%CD%\ninja;%CD%\gnu;C:\Program Files\Git\usr\bin;%PATH%
     call "%VSINSTALLDIR%Common7\Tools\VsDevCmd.bat" -arch=%ARCH%
     echo on
     set INSTALL_DIR=%CD%/install
@@ -104,7 +103,6 @@ steps:
   condition: succeededOrFailed()
 - script: |
     cd ..
-    set PATH=%CD%\llvm\bin;%PATH%
     :: strings_cdb has regressed for 32-bit starting with the VS 2019 v16.6.0 Azure Image (worked fine until v16.5.4)
     :: it also works fine on my box with the same v16.7.2...
     if "%MODEL%" == "32" ( del %BUILD_SOURCESDIRECTORY%\tests\debuginfo\strings_cdb.d)
@@ -149,13 +147,12 @@ steps:
   displayName: Install LDC, make portable & copy curl
 - script: |
     cd ..
-    cp llvm/bin/lld-link.exe installed/bin
     curl -L -o mingw-w64-libs.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v7.0.0/mingw-w64-libs-v7.0.0.7z 2>&1
     mkdir mingw-w64-libs
     cd mingw-w64-libs
     7z x ../mingw-w64-libs.7z > nul
     cp -r lib%MODEL% ../installed/lib/mingw
-  displayName: Copy lld-link.exe & MinGW-w64-based libs
+  displayName: Copy MinGW-w64-based libs
 - script: |
     cd ..
     call "%VSINSTALLDIR%Common7\Tools\VsDevCmd.bat" -arch=%ARCH%

--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -240,7 +240,7 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath,
 
 #if LDC_WITH_LLD
   if (useInternalLLDForLinking() ||
-      (useInternalToolchain && opts::linker.empty() && !opts::isUsingLTO())) {
+      (useInternalToolchain && opts::linker.empty())) {
     const auto fullArgs = getFullArgs("lld-link", args, global.params.verbose);
 
     const bool success = lld::coff::link(fullArgs,

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -202,10 +202,11 @@ bool useInternalLLDForLinking() {
   return linkInternally
 #if LDC_WITH_LLD
          ||
-         // DWARF debuginfos for MSVC require LLD
-         (opts::emitDwarfDebugInfo && linkInternally.getNumOccurrences() == 0 &&
-          opts::linker.empty() && !opts::isUsingLTO() &&
-          global.params.targetTriple->isWindowsMSVCEnvironment())
+         // MSVC: DWARF debuginfos and LTO require LLD
+         (linkInternally.getNumOccurrences() == 0 && // not explicitly disabled
+          opts::linker.empty() && // no explicitly selected linker
+          global.params.targetTriple->isWindowsMSVCEnvironment() &&
+          (opts::emitDwarfDebugInfo || opts::isUsingLTO()))
 #endif
       ;
 }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1073,7 +1073,11 @@ int cppmain() {
   loadAllPlugins();
 
   Strings libmodules;
-  return mars_mainBody(global.params, files, libmodules);
+  const int rc = mars_mainBody(global.params, files, libmodules);
+
+  llvm::llvm_shutdown();
+
+  return rc;
 }
 
 void codegenModules(Modules &modules) {
@@ -1146,5 +1150,4 @@ void codegenModules(Modules &modules) {
   cache::pruneCache();
 
   freeRuntime();
-  llvm::llvm_shutdown();
 }

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -131,11 +131,7 @@ elif (platform.system() == 'Linux'):
     if ("plugin: missing argument" in text and os.path.isfile(config.ldc2_lib_dir + '/LLVMgold-ldc.so')):
         canDoLTO = True
 elif (platform.system() == 'Windows'):
-    try:
-        if (subprocess.call(["lld-link.exe", "--version"]) == 0):
-            canDoLTO = True
-    except OSError:
-        pass
+    canDoLTO = config.ldc_with_lld
 if canDoLTO:
     config.available_features.add('LTO')
 


### PR DESCRIPTION
Fixes #2657 by deferring the `llvm_shutdown()` call.

This allows to remove bundled `lld-link.exe` for the prebuilt Windows packages.