### PR TITLE
Predefine version `FreeStanding` when targeting bare-metal

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -830,7 +830,9 @@ void registerPredefinedTargetVersions() {
       VersionCondition::addPredefinedGlobalIdent("Android");
     } else {
       llvm::StringRef osName = triple.getOSName();
-      if (!osName.empty() && osName != "unknown" && osName != "none") {
+      if (osName.empty() || osName == "unknown" || osName == "none") {
+        VersionCondition::addPredefinedGlobalIdent("FreeStanding");
+      } else {
         warning(Loc(), "unknown target OS: %s", osName.str().c_str());
       }
     }

--- a/tests/codegen/unknown_critical_section_size.d
+++ b/tests/codegen/unknown_critical_section_size.d
@@ -2,13 +2,16 @@
 // RUN:     %ldc -mtriple=x86_64 -c -w %s
 // RUN: not %ldc -mtriple=x86_64 -c -w -d-version=WithSynchronized %s 2>&1 | FileCheck %s
 
+// no target OS
+version (FreeStanding) {} else static assert(0);
+
 void foo() {}
 
 version (WithSynchronized)
 void bar()
 {
     __gshared int global;
-    // CHECK: unknown_critical_section_size.d(12): Error: unknown critical section size for the selected target
+    // CHECK: unknown_critical_section_size.d(15): Error: unknown critical section size for the selected target
     synchronized
     {
         global += 10;


### PR DESCRIPTION
Resolves #3607.

This has been added 5+ years ago with dlang/dlang.org@4c9a20a75f3a577edc89abacc81902f1cb11c32c.