### PR TITLE
Win64 extern(D) ABI: Pass/return Homogeneous Vector Aggregates in SIMD registers

### DIFF
--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -68,6 +68,17 @@ bool TargetABI::isHFVA(Type *t, int maxNumElements, LLType **hfvaType) {
   return false;
 }
 
+bool TargetABI::isHVA(Type *t, int maxNumElements, LLType **hvaType) {
+  Type *rewriteType = nullptr;
+  if (::isHFVA(t, maxNumElements, &rewriteType) &&
+      rewriteType->nextOf()->ty == Tvector) {
+    if (hvaType)
+      *hvaType = DtoType(rewriteType);
+    return true;
+  }
+  return false;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 TypeTuple *TargetABI::getArgTypes(Type *t) {

--- a/gen/abi.h
+++ b/gen/abi.h
@@ -178,6 +178,11 @@ struct TargetABI {
   static bool isHFVA(Type *t, int maxNumElements,
                      llvm::Type **hfvaType = nullptr);
 
+  /// Check if `t` is a Homogeneous Vector Aggregate (HVA). If so, optionally
+  /// produce the rewriteType: an array of its fundamental type.
+  static bool isHVA(Type *t, int maxNumElements,
+                    llvm::Type **hvaType = nullptr);
+
   /// Uses the front-end toArgTypes* machinery and returns an appropriate LL
   /// type if arguments of the specified D type are to be rewritten in order to
   /// be passed correctly in registers.

--- a/tests/codegen/vector_abi_x86.d
+++ b/tests/codegen/vector_abi_x86.d
@@ -3,17 +3,37 @@
 
 // REQUIRES: host_X86
 
-// RUN: %ldc -O -output-s -of=%t.s %s && FileCheck %s < %t.s
+// RUN: %ldc -O -output-s -m32 -of=%t_32.s %s -mattr=+sse2
+// RUN: FileCheck --check-prefix=COMMON %s < %t_32.s
+
+// RUN: %ldc -O -output-s -m64 -of=%t_64.s %s
+// RUN: FileCheck --check-prefix=COMMON --check-prefix=X64 %s < %t_64.s
 
 import core.simd;
 
-// CHECK: _D14vector_abi_x863foo
+// COMMON: _D14vector_abi_x863foo
 int4 foo(int4 param)
 {
-    // CHECK-NOT: mov
-    // CHECK: paddd
-    // CHECK-SAME: %xmm0
+    // COMMON-NOT: mov
+    // COMMON: paddd
+    // COMMON-SAME: %xmm0
     return param + 3;
-    // CHECK-NOT: mov
-    // CHECK: ret
+    // COMMON-NOT: mov
+    // COMMON: ret
+}
+
+version (X86_64)
+{
+    struct Int4 { int4 v; }
+
+    // X64: _D14vector_abi_x863barFSQw4Int4ZQj
+    Int4 bar(Int4 param)
+    {
+        // X64-NOT: mov
+        // X64: paddd
+        // X64-SAME: %xmm0
+        return Int4(param.v + 3);
+        // X64-NOT: mov
+        // X64: ret
+    }
 }


### PR DESCRIPTION
Corresponding to Microsoft's `__vectorcall`, see https://docs.microsoft.com/en-us/cpp/cpp/vectorcall?view=msvc-160.