### PR TITLE
Windows extern(D) ABIs: Pass non-PODs by ref to hidden copy

### DIFF
--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -126,8 +126,9 @@ struct X86TargetABI : TargetABI {
   }
 
   bool passByVal(TypeFunction *tf, Type *t) override {
-    // indirectly by-value for non-POD args on Posix
-    if (!isMSVC && !isPOD(t))
+    // indirectly by-value for non-POD args (except for MSVC++)
+    const bool isMSVCpp = isMSVC && tf->linkage == LINKcpp;
+    if (!isMSVCpp && !isPOD(t))
       return false;
 
     // pass all structs and static arrays with the LLVM byval attribute
@@ -147,8 +148,9 @@ struct X86TargetABI : TargetABI {
       }
     }
 
-    // Posix: non-POD args are passed indirectly by-value
-    if (!isMSVC) {
+    // non-POD args are passed indirectly by-value (except for MSVC++)
+    const bool isMSVCpp = isMSVC && fty.type->linkage == LINKcpp;
+    if (!isMSVCpp) {
       for (auto arg : fty.args) {
         if (!arg->byref && !isPOD(arg->type))
           indirectByvalRewrite.applyTo(*arg);

--- a/tests/codegen/no_abi_blit_for_nonpod.d
+++ b/tests/codegen/no_abi_blit_for_nonpod.d
@@ -1,0 +1,26 @@
+// Tests that a small non-POD isn't implicitly blit when being passed to/
+// returned from a called function.
+
+// RUN: %ldc -run %s
+
+struct S
+{
+    S* self;
+    this(this) { self = &this; }
+    ~this() { assert(self == &this); }
+}
+
+S foo(S param)
+{
+    return param; // copy-construct return value
+    // destruct param
+}
+
+void main()
+{
+    S s;
+    s.self = &s;
+
+    S r = foo(s); // copy-construct tmp arg from s
+    // destruct r and s
+}


### PR DESCRIPTION
Streamlining this with the other ABIs and preventing small non-PODs from being passed in a register or on the stack, which breaks interior pointers and hinders adding move ctors.