### PR TITLE
druntime: Define rt.aaA.AA as naked pointer, no struct wrapper

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -488,7 +488,7 @@ static void buildRuntimeModule() {
   Type *wstringTy = Type::twchar->arrayOf();
   Type *dstringTy = Type::tdchar->arrayOf();
 
-  // The AA type is a struct that only contains a ptr
+  // LDC's AA type is rt.aaA.Impl*; use void* for the prototypes
   Type *aaTy = voidPtrTy;
 
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
To fix ABI incompatibilities between the previous struct and `void*` used by the hardcoded compiler prototypes, e.g., for WebAssembly, which uses the default `UnknownTargetABI`, which uses LLVM `byval` for all structs and static arrays.