### PR TITLE
Fix colliding WinEH TypeDescriptors for exceptions with the same TypeInfo_Class name

### DIFF
--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -272,7 +272,7 @@ public:
 
   // MS C++ compatible type descriptors
   llvm::DenseMap<size_t, llvm::StructType *> TypeDescriptorTypeMap;
-  llvm::DenseMap<llvm::Constant *, llvm::GlobalVariable *> TypeDescriptorMap;
+  llvm::DenseMap<ClassDeclaration *, llvm::GlobalVariable *> TypeDescriptorMap;
 
   // Target for dcompute. If not nullptr, it owns this.
   DComputeTarget *dcomputetarget = nullptr;

--- a/gen/mangling.cpp
+++ b/gen/mangling.cpp
@@ -134,9 +134,8 @@ std::string getIRMangledVarName(std::string baseMangle, LINK link) {
   return gABI->mangleVariableForLLVM(std::move(baseMangle), link);
 }
 
-namespace {
 std::string getIRMangledAggregateName(AggregateDeclaration *ad,
-                                    const char *suffix) {
+                                      const char *suffix) {
   std::string ret = "_D";
 
   OutBuffer mangleBuf;
@@ -153,7 +152,6 @@ std::string getIRMangledAggregateName(AggregateDeclaration *ad,
     ret += suffix;
 
   return getIRMangledVarName(std::move(ret), LINKd);
-}
 }
 
 std::string getIRMangledInitSymbolName(AggregateDeclaration *aggrdecl) {

--- a/gen/mangling.h
+++ b/gen/mangling.h
@@ -35,9 +35,12 @@ std::string getIRMangledName(VarDeclaration *vd);
 std::string getIRMangledFuncName(std::string baseMangle, LINK link);
 std::string getIRMangledVarName(std::string baseMangle, LINK link);
 
+std::string getIRMangledAggregateName(AggregateDeclaration *aggrdecl,
+                                      const char *suffix = nullptr);
 std::string getIRMangledInitSymbolName(AggregateDeclaration *aggrdecl);
 std::string getIRMangledVTableSymbolName(AggregateDeclaration *aggrdecl);
 std::string getIRMangledClassInfoSymbolName(AggregateDeclaration *aggrdecl);
 std::string getIRMangledInterfaceInfosSymbolName(ClassDeclaration *cd);
+
 std::string getIRMangledModuleInfoSymbolName(Module *module);
 std::string getIRMangledModuleRefSymbolName(const char *moduleMangle);

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -163,10 +163,11 @@ llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
                          /*isConstant=*/true);
   }
 
-  auto classInfoPtr = getIrAggr(cd, true)->getClassInfoSymbol();
-  llvm::GlobalVariable *&Var = irs.TypeDescriptorMap[classInfoPtr];
+  llvm::GlobalVariable *&Var = irs.TypeDescriptorMap[cd];
   if (Var)
     return Var;
+
+  auto classInfoPtr = getIrAggr(cd, true)->getClassInfoSymbol();
 
   // first character skipped in debugger output, so we add 'D' as prefix
   const auto TypeNameString = (llvm::Twine("D") + cd->toPrettyChars()).str();

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -1,6 +1,6 @@
 //===-- ms-cxx-helper.cpp -------------------------------------------------===//
 //
-//                         LDC – the LLVM D compiler
+//                         LDC â€“ the LLVM D compiler
 //
 // This file is distributed under the BSD-style LDC license. See the LICENSE
 // file for details.
@@ -13,6 +13,7 @@
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
+#include "gen/mangling.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/CFG.h"
@@ -168,9 +169,9 @@ llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
     return Var;
 
   // first character skipped in debugger output, so we add 'D' as prefix
-  std::string TypeNameString = "D";
-  TypeNameString.append(cd->toPrettyChars());
-  std::string TypeDescName = TypeNameString + "@TypeDescriptor";
+  const auto TypeNameString = (llvm::Twine("D") + cd->toPrettyChars()).str();
+
+  const auto TypeDescName = getIRMangledAggregateName(cd, "@TypeDescriptor");
 
   // Declare and initialize the TypeDescriptor.
   llvm::Constant *Fields[] = {

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -11,7 +11,6 @@
 
 #include "dmd/errors.h"
 #include "dmd/expression.h"
-#include "dmd/mangle.h"
 #include "dmd/statement.h"
 #include "dmd/target.h"
 #include "gen/classes.h"
@@ -165,12 +164,8 @@ void TryCatchScope::emitCatchBodies(IRState &irs, llvm::Value *ehPtrSlot) {
       // Wrap std::type_info pointers inside a __cpp_type_info_ptr class
       // instance so that the personality routine may differentiate C++ catch
       // clauses from D ones.
-      OutBuffer wrapperMangleBuf;
-      wrapperMangleBuf.writestring("_D");
-      mangleToBuffer(p.cd, &wrapperMangleBuf);
-      wrapperMangleBuf.printf("%d%s", 18, "_cpp_type_info_ptr");
       const auto wrapperMangle =
-          getIRMangledVarName(wrapperMangleBuf.peekChars(), LINKd);
+          getIRMangledAggregateName(p.cd, "18_cpp_type_info_ptr");
 
       ci = irs.module.getGlobalVariable(wrapperMangle);
       if (!ci) {

--- a/tests/compilable/gh3501.d
+++ b/tests/compilable/gh3501.d
@@ -1,0 +1,28 @@
+// Tests EH with two exception types with the same `TypeInfo_Class.name`
+// (due to template args not being fully qualified).
+
+// RUN: %ldc -c %s
+
+void foo(T)()
+{
+    // name: gh3501.foo!(S).foo.MyException
+    static class MyException : Exception
+    {
+        this() { super(null); }
+    }
+
+    try { throw new MyException(); }
+    catch (MyException) {}
+}
+
+void bar1()
+{
+    struct S {}
+    foo!S();
+}
+
+void bar2()
+{
+    struct S {}
+    foo!S();
+}


### PR DESCRIPTION
[Extracted from #3517.]

As reported in https://github.com/ldc-developers/ldc/issues/3501#issuecomment-661551187.

Previously, LDC would simply override an existing TypeDescriptor global with an equivalent definition if assertions were disabled.

Use different equivalent TypeDescriptors in this exotic case now, by using proper mangling. [The linker can presumably still fold duplicates via ICF.]

Ideally, these descriptors would be truly unique, but WinEH depends on string comparisons to check for matching catch clauses, and currently depends on `TypeInfo_Class.name` to generate these strings at runtime when throwing an exception, see https://github.com/ldc-developers/druntime/blob/19731a92a97dbe4d7f7a4e15ceaff8444a1f879a/src/ldc/eh_msvc.d#L192-L211.
So if those names were fully qualified (`cd->toPrettyChars(*true*)` during ClassInfo generation), we'd be fine, but that'd obviously be a breaking change and diverge from upstream.