### PR TITLE
Add --ftime-trace functionality.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,7 @@ else()
 endif()
 message(STATUS "LDC version identifier: ${LDC_VERSION}")
 configure_file(driver/ldc-version.cpp.in driver/ldc-version.cpp)
+configure_file(driver/ldc_version.d.in driver/ldc_version.d)
 
 # Also add the header files to the build so that they are available in IDE
 # project files generated via CMake.
@@ -377,6 +378,7 @@ set(DRV_SRC
     driver/dcomputecodegenerator.cpp
     driver/exe_path.cpp
     driver/targetmachine.cpp
+    driver/timetrace.cpp
     driver/toobj.cpp
     driver/tool.cpp
     driver/archiver.cpp
@@ -404,6 +406,7 @@ set(DRV_HDR
     driver/linker.h
     driver/plugins.h
     driver/targetmachine.h
+    driver/timetrace.h
     driver/toobj.h
     driver/tool.h
 )

--- a/dmd/dsymbolsem.d
+++ b/dmd/dsymbolsem.d
@@ -566,8 +566,18 @@ private uint setMangleOverride(Dsymbol s, const(char)[] sym)
  */
 extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
 {
+version (IN_LLVM)
+{
+    import driver.timetrace_sema;
+    scope v = new DsymbolSemanticVisitor(sc);
+    scope vtimetrace = new SemanticTimeTraceVisitor!DsymbolSemanticVisitor(v);
+    dsym.accept(vtimetrace);
+}
+else
+{
     scope v = new DsymbolSemanticVisitor(sc);
     dsym.accept(v);
+}
 }
 
 structalign_t getAlignment(AlignDeclaration ad, Scope* sc)

--- a/dmd/semantic2.d
+++ b/dmd/semantic2.d
@@ -74,8 +74,18 @@ enum LOG = false;
  */
 extern(C++) void semantic2(Dsymbol dsym, Scope* sc)
 {
+version (IN_LLVM)
+{
+    import driver.timetrace_sema;
+    scope v = new Semantic2Visitor(sc);
+    scope vtimetrace = new SemanticTimeTraceVisitor!Semantic2Visitor(v);
+    dsym.accept(vtimetrace);
+}
+else
+{
     scope v = new Semantic2Visitor(sc);
     dsym.accept(v);
+}
 }
 
 private extern(C++) final class Semantic2Visitor : Visitor

--- a/dmd/semantic3.d
+++ b/dmd/semantic3.d
@@ -77,8 +77,18 @@ enum LOG = false;
  */
 extern(C++) void semantic3(Dsymbol dsym, Scope* sc)
 {
+version (IN_LLVM)
+{
+    import driver.timetrace_sema;
+    scope v = new Semantic3Visitor(sc);
+    scope vtimetrace = new SemanticTimeTraceVisitor!Semantic3Visitor(v);
+    dsym.accept(vtimetrace);
+}
+else
+{
     scope v = new Semantic3Visitor(sc);
     dsym.accept(v);
+}
 }
 
 private extern(C++) final class Semantic3Visitor : Visitor

--- a/driver/archiver.cpp
+++ b/driver/archiver.cpp
@@ -10,6 +10,7 @@
 #include "dmd/errors.h"
 #include "dmd/globals.h"
 #include "driver/cl_options.h"
+#include "driver/timetrace.h"
 #include "driver/tool.h"
 #include "gen/logger.h"
 #include "llvm/ADT/Triple.h"
@@ -240,6 +241,7 @@ static llvm::cl::opt<std::string> ar("ar", llvm::cl::desc("Archiver"),
 
 int createStaticLibrary() {
   Logger::println("*** Creating static library ***");
+  ::TimeTraceScope timeScope("Create static library");
 
   const bool isTargetMSVC =
       global.params.targetTriple->isWindowsMSVCEnvironment();

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -576,6 +576,20 @@ static cl::opt<DummyDataType, false, CoverageParser> coverageAnalysis(
              "Use -cov=<n> for n% minimum required coverage\n"
              "Use -cov=ctfe to include code executed during CTFE"));
 
+// Compilation time tracing options
+cl::opt<bool> fTimeTrace(
+    "ftime-trace", cl::ZeroOrMore,
+    cl::desc("Turn on time profiler. Generates JSON file "
+             "based on the output filename (also see --ftime-trace-file)."));
+cl::opt<unsigned> fTimeTraceGranularity(
+    "ftime-trace-granularity", cl::ZeroOrMore,
+    cl::desc(
+        "Minimum time granularity (in microseconds) traced by time profiler"));
+cl::opt<std::string>
+fTimeTraceFile("ftime-trace-file",
+               cl::desc("Specify time trace file destination"),
+               cl::value_desc("filename"));
+
 cl::opt<LTOKind> ltoMode(
     "flto", cl::ZeroOrMore, cl::desc("Set LTO mode, requires linker support"),
     cl::init(LTO_None),

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -97,6 +97,11 @@ extern std::vector<std::string> debugArgs;
 void createClashingOptions();
 void hideLLVMOptions();
 
+// Compilation time tracing options
+extern cl::opt<bool> fTimeTrace;
+extern cl::opt<std::string> fTimeTraceFile;
+extern cl::opt<unsigned> fTimeTraceGranularity;
+
 // LTO options
 enum LTOKind {
   LTO_None,

--- a/driver/ldc_version.d.in
+++ b/driver/ldc_version.d.in
@@ -1,0 +1,12 @@
+//===-- driver/ldc_version.d - ------------------------------------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+module driver.ldc_version;
+
+enum LLVM_VERSION_MAJOR = @LLVM_VERSION_MAJOR@;

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -11,6 +11,7 @@
 
 #include "dmd/errors.h"
 #include "driver/cl_options.h"
+#include "driver/timetrace.h"
 #include "driver/tool.h"
 #include "gen/llvm.h"
 #include "gen/logger.h"
@@ -284,6 +285,7 @@ static std::string gExePath;
 
 int linkObjToBinary() {
   Logger::println("*** Linking executable ***");
+  TimeTraceScope timeScope("Linking executable");
 
   // remember output path for later
   gExePath = getOutputName();
@@ -310,6 +312,8 @@ void deleteExeFile() {
 //////////////////////////////////////////////////////////////////////////////
 
 int runProgram() {
+  TimeTraceScope timeScope("Run user program");
+
   assert(!gExePath.empty());
 
   // Run executable

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -35,6 +35,7 @@
 #include "driver/linker.h"
 #include "driver/plugins.h"
 #include "driver/targetmachine.h"
+#include "driver/timetrace.h"
 #include "gen/abi.h"
 #include "gen/cl_helpers.h"
 #include "gen/irstate.h"
@@ -989,6 +990,8 @@ int cppmain() {
     fatal();
   }
 
+  initializeTimeTracer();
+
   // Set up the TargetMachine.
   const auto arch = getArchStr();
   if ((m32bits || m64bits) && (!arch.empty() || !mTargetTriple.empty())) {
@@ -1075,17 +1078,26 @@ int cppmain() {
 
   loadAllPlugins();
 
-  Strings libmodules;
-  const int rc = mars_mainBody(global.params, files, libmodules);
+  int status;
+  {
+    TimeTraceScope timeScope("ExecuteCompiler");
+    Strings libmodules;
+    status = mars_mainBody(global.params, files, libmodules);
+  }
+
+  writeTimeTraceProfile();
+  deinitializeTimeTracer();
 
   llvm::llvm_shutdown();
 
-  return rc;
+  return status;
 }
 
 void codegenModules(Modules &modules) {
   // Generate one or more object/IR/bitcode files/dcompute kernels.
   if (global.params.obj && !modules.empty()) {
+    TimeTraceScope timeScope("Codegen all modules");
+
 #if LDC_MLIR_ENABLED
     mlir::MLIRContext mlircontext;
     ldc::CodeGenerator cg(getGlobalContext(), mlircontext,
@@ -1115,6 +1127,7 @@ void codegenModules(Modules &modules) {
       const auto atCompute = hasComputeAttr(m);
       if (atCompute == DComputeCompileFor::hostOnly ||
           atCompute == DComputeCompileFor::hostAndDevice) {
+        TimeTraceScope timeScope(("Codegen module " + llvm::SmallString<20>(m->toChars())).str());
 #if LDC_MLIR_ENABLED
         if (global.params.output_mlir == OUTPUTFLAGset)
           cg.emitMLIR(m);
@@ -1140,8 +1153,11 @@ void codegenModules(Modules &modules) {
     }
 
     if (!computeModules.empty()) {
-      for (auto &mod : computeModules)
+      TimeTraceScope timeScope("Codegen DCompute device modules");
+      for (auto &mod : computeModules) {
+        TimeTraceScope timeScope(("Codegen DCompute device module " + llvm::SmallString<20>(mod->toChars())).str());
         dccg.emit(mod);
+      }
     }
     dccg.writeModules();
 
@@ -1150,7 +1166,10 @@ void codegenModules(Modules &modules) {
       global.params.link = false;
   }
 
-  cache::pruneCache();
+  {
+    TimeTraceScope timeScope("Prune object file cache");
+    cache::pruneCache();
+  }
 
   freeRuntime();
 }

--- a/driver/timetrace.cpp
+++ b/driver/timetrace.cpp
@@ -1,0 +1,61 @@
+//===-- driver/timetrace.cpp ------------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Compilation time tracing support implementation, --ftime-trace.
+//
+//===----------------------------------------------------------------------===//
+
+#include "driver/timetrace.h"
+
+#if LDC_WITH_TIMETRACER
+
+#include "dmd/errors.h"
+#include "driver/cl_options.h"
+#include "llvm/Support/TimeProfiler.h"
+
+void initializeTimeTracer() {
+  if (opts::fTimeTrace) {
+    llvm::timeTraceProfilerInitialize(opts::fTimeTraceGranularity,
+                                      opts::allArguments[0]);
+  }
+}
+
+void deinitializeTimeTracer() {
+  if (opts::fTimeTrace) {
+    llvm::timeTraceProfilerCleanup();
+  }
+}
+
+void writeTimeTraceProfile() {
+  if (llvm::timeTraceProfilerEnabled()) {
+    std::string filename = opts::fTimeTraceFile;
+    if (filename.empty()) {
+      filename = global.params.objfiles[0] ? global.params.objfiles[0] : "out";
+      filename += ".time-trace";
+    }
+
+    std::error_code err;
+    llvm::raw_fd_ostream outputstream(filename, err, llvm::sys::fs::OF_Text);
+    if (err) {
+      error(Loc(), "Error writing Time Trace profile: could not open %s",
+            filename.c_str());
+      return;
+    }
+
+    llvm::timeTraceProfilerWrite(outputstream);
+  }
+}
+
+void timeTraceProfilerBegin(size_t name_length, const char *name_ptr,
+                            size_t detail_length, const char *detail_ptr) {
+  llvm::timeTraceProfilerBegin(llvm::StringRef(name_ptr, name_length),
+                               llvm::StringRef(detail_ptr, detail_length));
+}
+
+#endif

--- a/driver/timetrace.d
+++ b/driver/timetrace.d
@@ -21,17 +21,17 @@ static if (LLVM_VERSION_MAJOR >= 10)
     // Forward declarations of LLVM Support functions
     extern(C++, llvm)
     {
+        struct TimeTraceProfiler;
         void timeTraceProfilerEnd();
 
         static if (LLVM_VERSION_MAJOR < 11)
         {
-            extern __gshared void* TimeTraceProfilerInstance;
+            extern __gshared TimeTraceProfiler* TimeTraceProfilerInstance;
             auto getTimeTraceProfilerInstance() { return TimeTraceProfilerInstance; }
         }
         else
         {
-            // No need to detail the return type (not part of C++ mangling).
-            void* getTimeTraceProfilerInstance();
+            TimeTraceProfiler* getTimeTraceProfilerInstance();
         }
     }
 

--- a/driver/timetrace.d
+++ b/driver/timetrace.d
@@ -1,0 +1,88 @@
+//===-- driver/timetrace.d ----------------------------------------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Compilation time tracing, --ftime-trace.
+// Supported from LLVM 10.
+//
+//===----------------------------------------------------------------------===//
+
+module driver.timetrace;
+
+import driver.ldc_version;
+
+static if (LLVM_VERSION_MAJOR >= 10)
+{
+    // Forward declarations of LLVM Support functions
+    extern(C++, llvm)
+    {
+        void timeTraceProfilerEnd();
+
+        static if (LLVM_VERSION_MAJOR < 11)
+        {
+            extern __gshared void* TimeTraceProfilerInstance;
+            auto getTimeTraceProfilerInstance() { return TimeTraceProfilerInstance; }
+        }
+        else
+        {
+            // No need to detail the return type (not part of C++ mangling).
+            void* getTimeTraceProfilerInstance();
+        }
+    }
+
+    // Forward declaration of LDC D-->C++ support function
+    extern(C++) void timeTraceProfilerBegin(size_t name_length, const(char)* name_ptr,
+                                            size_t detail_length, const(char)* detail_ptr);
+
+    pragma(inline, true)
+    bool timeTraceProfilerEnabled() {
+        version (LDC) {
+            import ldc.intrinsics: llvm_expect;
+            return llvm_expect(getTimeTraceProfilerInstance() !is null, false);
+        } else {
+            return getTimeTraceProfilerInstance() !is null;
+        }
+    }
+
+    /// RAII helper class to call the begin and end functions of the time trace
+    /// profiler.  When the object is constructed, it begins the section; and when
+    /// it is destroyed, it stops it.
+    struct TimeTraceScope
+    {
+        @disable this();
+        @disable this(this);
+
+        this(string name) {
+            if (timeTraceProfilerEnabled())
+                timeTraceProfilerBegin(name.length, name.ptr, 0, null);
+        }
+        this(string name, lazy string detail) {
+            if (timeTraceProfilerEnabled())
+                timeTraceProfilerBegin(name.length, name.ptr, detail.length, detail.ptr);
+        }
+
+        ~this() {
+            if (timeTraceProfilerEnabled())
+                timeTraceProfilerEnd();
+        }
+    }
+}
+else
+{
+    bool timeTraceProfilerEnabled() { return false; }
+    struct TimeTraceScope
+    {
+        @disable this();
+        @disable this(this);
+
+        this(string name) { }
+        this(string name, lazy string detail) { }
+
+        ~this() { }
+    }
+}

--- a/driver/timetrace.h
+++ b/driver/timetrace.h
@@ -1,0 +1,88 @@
+//===-- driver/timetrace.h --------------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Compilation time tracing, --ftime-trace.
+// Supported from LLVM 10. (LLVM 9 supports time tracing, but without
+// granularity check which makes profiles way too large)
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#if LDC_LLVM_VER >= 1000
+#define LDC_WITH_TIMETRACER 1
+#endif
+
+#if LDC_WITH_TIMETRACER
+
+#include "llvm/Support/TimeProfiler.h"
+
+void initializeTimeTracer();
+void deinitializeTimeTracer();
+void writeTimeTraceProfile();
+
+/// RAII helper class to call the begin and end functions of the time trace
+/// profiler.  When the object is constructed, it begins the section; and when
+/// it is destroyed, it stops it.
+/// The StringRefs passed are not stored.
+struct TimeTraceScope {
+  TimeTraceScope() = delete;
+  TimeTraceScope(const TimeTraceScope &) = delete;
+  TimeTraceScope &operator=(const TimeTraceScope &) = delete;
+  TimeTraceScope(TimeTraceScope &&) = delete;
+  TimeTraceScope &operator=(TimeTraceScope &&) = delete;
+
+  TimeTraceScope(llvm::StringRef Name) {
+    if (llvm::timeTraceProfilerEnabled())
+      llvm::timeTraceProfilerBegin(Name, llvm::StringRef(""));
+  }
+  TimeTraceScope(llvm::StringRef Name, llvm::StringRef Detail) {
+    if (llvm::timeTraceProfilerEnabled())
+      llvm::timeTraceProfilerBegin(Name, Detail);
+  }
+  TimeTraceScope(llvm::StringRef Name,
+                 llvm::function_ref<std::string()> Detail) {
+    if (llvm::timeTraceProfilerEnabled())
+      llvm::timeTraceProfilerBegin(Name, Detail);
+  }
+
+  ~TimeTraceScope() {
+    if (llvm::timeTraceProfilerEnabled())
+      llvm::timeTraceProfilerEnd();
+  }
+};
+
+// Helper function to interface with LLVM's `void
+// timeTraceProfilerBegin(StringRef Name, StringRef Detail)`
+void timeTraceProfilerBegin(size_t name_length, const char *name_ptr,
+                            size_t detail_length, const char *detail_ptr);
+
+#else // LDC_WITH_TIMETRACER
+
+// Provide dummy implementations when not supporting time tracing.
+inline void initializeTimeTracer() {}
+inline void deinitializeTimeTracer() {}
+inline void writeTimeTraceProfile() {}
+struct TimeTraceScope {
+  TimeTraceScope() = delete;
+  TimeTraceScope(const TimeTraceScope &) = delete;
+  TimeTraceScope &operator=(const TimeTraceScope &) = delete;
+  TimeTraceScope(TimeTraceScope &&) = delete;
+  TimeTraceScope &operator=(TimeTraceScope &&) = delete;
+
+  TimeTraceScope(llvm::StringRef Name) {}
+  TimeTraceScope(llvm::StringRef Name, llvm::StringRef Detail) {}
+  TimeTraceScope(llvm::StringRef Name,
+                 llvm::function_ref<std::string()> Detail) {}
+};
+inline void timeTraceProfilerBegin(size_t name_length, const char *name_ptr,
+                                   size_t detail_length,
+                                   const char *detail_ptr) {}
+
+#endif // LDC_WITH_TIMETRACER

--- a/driver/timetrace.h
+++ b/driver/timetrace.h
@@ -66,6 +66,9 @@ void timeTraceProfilerBegin(size_t name_length, const char *name_ptr,
 #else // LDC_WITH_TIMETRACER
 
 // Provide dummy implementations when not supporting time tracing.
+
+#include "llvm/ADT/StringRef.h"
+
 inline void initializeTimeTracer() {}
 inline void deinitializeTimeTracer() {}
 inline void writeTimeTraceProfile() {}

--- a/driver/timetrace_sema.d
+++ b/driver/timetrace_sema.d
@@ -1,0 +1,226 @@
+//===-- driver/timetrace_sema.d ------------------------------------*- D -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Visitors for adding timetracing code to DMD's semantic analysis visitors.
+//
+//===----------------------------------------------------------------------===//
+
+module driver.timetrace_sema;
+
+import dmd.aggregate;
+import dmd.aliasthis;
+import dmd.arraytypes;
+import dmd.astcodegen;
+import dmd.attrib;
+import dmd.blockexit;
+import dmd.clone;
+import dmd.compiler;
+import dmd.dcast;
+import dmd.dclass;
+import dmd.declaration;
+import dmd.denum;
+import dmd.dimport;
+import dmd.dinterpret;
+import dmd.dmangle;
+import dmd.dmodule;
+import dmd.dscope;
+import dmd.dstruct;
+import dmd.dsymbol;
+import dmd.dtemplate;
+import dmd.dversion;
+import dmd.errors;
+import dmd.escape;
+import dmd.expression;
+import dmd.expressionsem;
+import dmd.func;
+import dmd.globals;
+import dmd.id;
+import dmd.identifier;
+import dmd.init;
+import dmd.initsem;
+import dmd.hdrgen;
+import dmd.mtype;
+import dmd.nogc;
+import dmd.nspace;
+import dmd.objc;
+import dmd.opover;
+import dmd.parse;
+import dmd.root.filename;
+import dmd.root.outbuffer;
+import dmd.root.rmem;
+import dmd.root.rootobject;
+import dmd.semantic2;
+import dmd.semantic3;
+import dmd.sideeffect;
+import dmd.statementsem;
+import dmd.staticassert;
+import dmd.tokens;
+import dmd.utf;
+import dmd.utils;
+import dmd.statement;
+import dmd.target;
+import dmd.templateparamsem;
+import dmd.typesem;
+import dmd.visitor;
+import driver.timetrace;
+
+/// Time tracing visitor for semantic analysis. Only valid to instantiate and use this visitor if time tracing is enabled.
+extern(C++) final class SemanticTimeTraceVisitor(SemaVisitor) : Visitor
+{
+    static assert(checkFirstOverridesAllSecondOverides!(typeof(this), SemaVisitor));
+
+    import driver.timetrace, std.format, std.conv;
+
+    SemaVisitor semavisitor;
+
+    @disable this();
+
+    static if (SemaVisitor.stringof == "DsymbolSemanticVisitor")
+        enum pretext = "Sema1: ";
+    else static if (SemaVisitor.stringof == "Semantic2Visitor")
+        enum pretext = "Sema2: ";
+    else static if (SemaVisitor.stringof == "Semantic3Visitor")
+        enum pretext = "Sema3: ";
+    else
+        static assert (false, "did not recognize SemaVisitor ==" ~ SemaVisitor);
+
+    this(SemaVisitor semavisitor)
+    {
+        this.semavisitor = semavisitor;
+    }
+
+    alias visit = Visitor.visit;
+
+    override void visit(Dsymbol dsym) { semavisitor.visit(dsym); }
+    override void visit(ScopeDsymbol dsym) { semavisitor.visit(dsym); }
+    override void visit(Declaration dsym) { semavisitor.visit(dsym); }
+
+    override void visit(AliasThis dsym) { semavisitor.visit(dsym); }
+
+    override void visit(AliasDeclaration dsym) { semavisitor.visit(dsym); }
+
+    override void visit(VarDeclaration dsym) { semavisitor.visit(dsym); }
+
+    override void visit(TypeInfoDeclaration dsym) { semavisitor.visit(dsym); }
+
+    override void visit(Import imp)
+    {
+        auto timeScope = TimeTraceScope(text(pretext ~ "Import ", imp.id.toChars()), text(imp.toPrettyChars(), ", loc: ", imp.loc.toChars()));
+        semavisitor.visit(imp);
+    }
+
+    override void visit(AttribDeclaration atd) { semavisitor.visit(atd); }
+
+    override void visit(DeprecatedDeclaration dd) { semavisitor.visit(dd); }
+
+    override void visit(AlignDeclaration ad) { semavisitor.visit(ad); }
+
+    override void visit(AggregateDeclaration ad)  { semavisitor.visit(ad); }
+
+    override void visit(AnonDeclaration scd) { semavisitor.visit(scd); }
+
+    override void visit(PragmaDeclaration pd) { semavisitor.visit(pd); }
+
+    override void visit(StaticIfDeclaration sid) { semavisitor.visit(sid); }
+
+    override void visit(StaticForeachDeclaration sfd) { semavisitor.visit(sfd); }
+
+    override void visit(CompileDeclaration cd) { semavisitor.visit(cd); }
+
+    override void visit(CPPNamespaceDeclaration ns) { semavisitor.visit(ns); }
+
+    override void visit(UserAttributeDeclaration uad) { semavisitor.visit(uad); }
+
+    override void visit(StaticAssert sa) { semavisitor.visit(sa); }
+
+    override void visit(DebugSymbol ds) { semavisitor.visit(ds); }
+
+    override void visit(VersionSymbol vs) { semavisitor.visit(vs); }
+
+    override void visit(Package pkg) { semavisitor.visit(pkg); }
+
+    override void visit(Module m) {
+        auto timeScope = TimeTraceScope(text(pretext ~ "Module ", m.toPrettyChars()), text(m.toPrettyChars(), ", loc: ", m.loc.toChars()));
+        semavisitor.visit(m);
+    }
+
+    override void visit(EnumDeclaration ed) { semavisitor.visit(ed); }
+
+    override void visit(EnumMember em) { semavisitor.visit(em); }
+
+    override void visit(TemplateDeclaration tempdecl) { semavisitor.visit(tempdecl); }
+
+    override void visit(TemplateInstance ti) { semavisitor.visit(ti); }
+
+    override void visit(TemplateMixin tm) { semavisitor.visit(tm); }
+
+    override void visit(Nspace ns) { semavisitor.visit(ns); }
+
+    override void visit(FuncDeclaration funcdecl) {
+        auto timeScope = TimeTraceScope(text(pretext ~ "Func ", funcdecl.toChars()), text(funcdecl.toPrettyChars(), ", loc: ", funcdecl.loc.toChars()));
+        semavisitor.visit(funcdecl);
+    }
+
+    override void visit(CtorDeclaration ctd) { semavisitor.visit(ctd); }
+
+    override void visit(PostBlitDeclaration pbd) { semavisitor.visit(pbd); }
+
+    override void visit(DtorDeclaration dd) { semavisitor.visit(dd); }
+
+    override void visit(StaticCtorDeclaration scd) { semavisitor.visit(scd); }
+
+    override void visit(StaticDtorDeclaration sdd) { semavisitor.visit(sdd); }
+
+    override void visit(InvariantDeclaration invd) { semavisitor.visit(invd); }
+
+    override void visit(UnitTestDeclaration utd) { semavisitor.visit(utd); }
+
+    override void visit(NewDeclaration nd) { semavisitor.visit(nd); }
+
+    override void visit(StructDeclaration sd) { semavisitor.visit(sd); }
+
+    override void visit(ClassDeclaration cldec) { semavisitor.visit(cldec); }
+
+    override void visit(InterfaceDeclaration idec) { semavisitor.visit(idec); }
+}
+
+// Note: this is not very careful check, but is hopefully good enough to trigger upon relevant changes to the DMD frontend.
+// If the parent of First and Second already contains an override
+// function and Second overrides it, this function always returns true even if First does not override it.
+private bool checkFirstOverridesAllSecondOverides(First, Second)() {
+    foreach (der2;  __traits(derivedMembers, Second))
+    {
+        foreach (mem2; __traits(getOverloads, Second, der2))
+        {
+            if (!__traits(isOverrideFunction, mem2))
+                continue;
+            else
+            {
+                bool found = false;
+                foreach (der1;  __traits(derivedMembers, First))
+                {
+                    foreach (mem1; __traits(getOverloads, First, der1))
+                    {
+                        if (!__traits(isOverrideFunction, mem1))
+                            continue;
+                        else if (__traits(getVirtualIndex, mem1) == __traits(getVirtualIndex, mem2))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (found) break;
+                }
+                assert (found, mem2.mangleof ~ " needs override");
+                if (!found) return false;
+            }
+        }
+    }
+    return true;
+}

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -25,6 +25,7 @@
 #include "driver/cl_options.h"
 #include "driver/cl_options_instrumentation.h"
 #include "driver/cl_options_sanitizers.h"
+#include "driver/timetrace.h"
 #include "gen/abi.h"
 #include "gen/arrays.h"
 #include "gen/classes.h"
@@ -986,6 +987,14 @@ void emulateWeakAnyLinkageForMSVC(LLFunction *func, LINK linkage) {
 } // anonymous namespace
 
 void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
+  TimeTraceScope timeScope(
+      ("Codegen func " + llvm::SmallString<40>(fd->toChars())).str(), [fd]() {
+        std::string detail = fd->toPrettyChars();
+        detail += ", loc: ";
+        detail += fd->loc.toChars();
+        return detail;
+      });
+
   IF_LOG Logger::println("DtoDefineFunction(%s): %s", fd->toPrettyChars(),
                          fd->loc.toChars());
   LOG_SCOPE;

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -23,6 +23,7 @@
 #include "dmd/target.h"
 #include "dmd/template.h"
 #include "driver/cl_options_instrumentation.h"
+#include "driver/timetrace.h"
 #include "gen/abi.h"
 #include "gen/arrays.h"
 #include "gen/functions.h"
@@ -585,6 +586,8 @@ void registerModuleInfo(Module *m) {
 }
 
 void codegenModule(IRState *irs, Module *m) {
+  TimeTraceScope timeScope("Generate IR", llvm::StringRef(m->toChars()));
+
   assert(!irs->dmodule &&
          "irs->module not null, codegen already in progress?!");
   irs->dmodule = m;

--- a/tests/driver/ftime-trace.d
+++ b/tests/driver/ftime-trace.d
@@ -1,0 +1,31 @@
+// Test basic --ftime-trace functionality
+
+// REQUIRES: atleast_llvm1000
+
+// RUN: %ldc --ftime-trace --ftime-trace-file=%t.1 %s                                   && FileCheck --check-prefix=ALL --check-prefix=FINE %s < %t.1
+// RUN: %ldc --ftime-trace --ftime-trace-file=%t.2 --ftime-trace-granularity=20000 %s && FileCheck --check-prefix=ALL --check-prefix=COARSE %s < %t.2
+
+// ALL: traceEvents
+
+module ftimetrace;
+
+// COARSE-NOT: intrinsics
+// FINE: intrinsics
+// FINE: ftime-trace.d([[@LINE+1]])
+import ldc.intrinsics;
+
+// COARSE-NOT: foo
+// FINE: foo
+// FINE: ftime-trace.d([[@LINE+1]])
+int foo()
+{
+    return 1;
+}
+
+void main()
+{
+    foo();
+}
+
+// ALL: ExecuteCompiler
+// ALL: Linking executable


### PR DESCRIPTION
This uses LLVM's TimeProfiler functionality, such that LLVM's work is traced in the same profile (optimization and machine code gen).
Functionality is meant to be identical to Clang and LLD's --ftime-trace.