### PR TITLE
Fix missing location information for error reporting of TypeInfo in b…

### DIFF
--- a/gen/aa.cpp
+++ b/gen/aa.cpp
@@ -35,7 +35,7 @@ static LLConstant *to_keyti(DValue *aa, LLType *targetType) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DLValue *DtoAAIndex(Loc &loc, Type *type, DValue *aa, DValue *key,
+DLValue *DtoAAIndex(const Loc &loc, Type *type, DValue *aa, DValue *key,
                     bool lvalue) {
   // D2:
   // call:
@@ -101,7 +101,7 @@ DLValue *DtoAAIndex(Loc &loc, Type *type, DValue *aa, DValue *key,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoAAIn(Loc &loc, Type *type, DValue *aa, DValue *key) {
+DValue *DtoAAIn(const Loc &loc, Type *type, DValue *aa, DValue *key) {
   // D1:
   // call:
   // extern(C) void* _aaIn(AA aa*, TypeInfo keyti, void* pkey)
@@ -145,7 +145,7 @@ DValue *DtoAAIn(Loc &loc, Type *type, DValue *aa, DValue *key) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoAARemove(Loc &loc, DValue *aa, DValue *key) {
+DValue *DtoAARemove(const Loc &loc, DValue *aa, DValue *key) {
   // D1:
   // call:
   // extern(C) void _aaDel(AA aa, TypeInfo keyti, void* pkey)
@@ -183,7 +183,7 @@ DValue *DtoAARemove(Loc &loc, DValue *aa, DValue *key) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoAAEquals(Loc &loc, TOK op, DValue *l, DValue *r) {
+LLValue *DtoAAEquals(const Loc &loc, TOK op, DValue *l, DValue *r) {
   Type *t = l->type->toBasetype();
   assert(t == r->type->toBasetype() &&
          "aa equality is only defined for aas of same type");

--- a/gen/aa.cpp
+++ b/gen/aa.cpp
@@ -61,7 +61,7 @@ DLValue *DtoAAIndex(Loc &loc, Type *type, DValue *aa, DValue *key,
   LLValue *ret;
   if (lvalue) {
     LLValue *rawAATI =
-        DtoTypeInfoOf(aa->type->unSharedOf()->mutableOf(), /*base=*/false);
+        DtoTypeInfoOf(aa->type->unSharedOf()->mutableOf(), /*base=*/false, loc);
     LLValue *castedAATI = DtoBitCast(rawAATI, funcTy->getParamType(1));
     LLValue *valsize = DtoConstSize_t(getTypeAllocSize(DtoType(type)));
     ret = gIR->CreateCallOrInvoke(func, aaval, castedAATI, valsize, pkey,
@@ -192,7 +192,7 @@ LLValue *DtoAAEquals(Loc &loc, TOK op, DValue *l, DValue *r) {
 
   LLValue *aaval = DtoBitCast(DtoRVal(l), funcTy->getParamType(1));
   LLValue *abval = DtoBitCast(DtoRVal(r), funcTy->getParamType(2));
-  LLValue *aaTypeInfo = DtoTypeInfoOf(t);
+  LLValue *aaTypeInfo = DtoTypeInfoOf(t, /*base=*/true, loc);
   LLValue *res =
       gIR->CreateCallOrInvoke(func, aaTypeInfo, aaval, abval, "aaEqRes");
 

--- a/gen/aa.h
+++ b/gen/aa.h
@@ -23,7 +23,8 @@ namespace llvm {
 class Value;
 }
 
-DLValue *DtoAAIndex(Loc &loc, Type *type, DValue *aa, DValue *key, bool lvalue);
-DValue *DtoAAIn(Loc &loc, Type *type, DValue *aa, DValue *key);
-DValue *DtoAARemove(Loc &loc, DValue *aa, DValue *key);
-llvm::Value *DtoAAEquals(Loc &loc, TOK op, DValue *l, DValue *r);
+DLValue *DtoAAIndex(const Loc &loc, Type *type, DValue *aa, DValue *key,
+                    bool lvalue);
+DValue *DtoAAIn(const Loc &loc, Type *type, DValue *aa, DValue *key);
+DValue *DtoAARemove(const Loc &loc, DValue *aa, DValue *key);
+llvm::Value *DtoAAEquals(const Loc &loc, TOK op, DValue *l, DValue *r);

--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -108,7 +108,7 @@ void DtoSetArrayToNull(LLValue *v) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static void DtoArrayInit(Loc &loc, LLValue *ptr, LLValue *length,
+static void DtoArrayInit(const Loc &loc, LLValue *ptr, LLValue *length,
                          DValue *elementValue) {
   IF_LOG Logger::println("DtoArrayInit");
   LOG_SCOPE;
@@ -193,8 +193,9 @@ static LLValue *computeSize(LLValue *length, size_t elementSize) {
              : gIR->ir->CreateMul(length, DtoConstSize_t(elementSize));
 };
 
-static void copySlice(Loc &loc, LLValue *dstarr, LLValue *dstlen, LLValue *srcarr,
-                      LLValue *srclen, size_t elementSize, bool knownInBounds) {
+static void copySlice(const Loc &loc, LLValue *dstarr, LLValue *dstlen,
+                      LLValue *srcarr, LLValue *srclen, size_t elementSize,
+                      bool knownInBounds) {
   const bool checksEnabled =
       global.params.useAssert == CHECKENABLEon || gIR->emitArrayBoundsChecks();
   if (checksEnabled && !knownInBounds) {
@@ -224,7 +225,7 @@ static bool arrayNeedsPostblit(Type *t) {
 
 // Does array assignment (or initialization) from another array of the same
 // element type or from an appropriate single element.
-void DtoArrayAssign(Loc &loc, DValue *lhs, DValue *rhs, int op,
+void DtoArrayAssign(const Loc &loc, DValue *lhs, DValue *rhs, int op,
                     bool canSkipPostblit) {
   IF_LOG Logger::println("DtoArrayAssign");
   LOG_SCOPE;
@@ -675,7 +676,7 @@ static DSliceValue *getSlice(Type *arrayType, LLValue *array) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-DSliceValue *DtoNewDynArray(Loc &loc, Type *arrayType, DValue *dim,
+DSliceValue *DtoNewDynArray(const Loc &loc, Type *arrayType, DValue *dim,
                             bool defaultInit) {
   IF_LOG Logger::println("DtoNewDynArray : %s", arrayType->toChars());
   LOG_SCOPE;
@@ -710,8 +711,8 @@ DSliceValue *DtoNewDynArray(Loc &loc, Type *arrayType, DValue *dim,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
-                                  size_t ndims) {
+DSliceValue *DtoNewMulDimDynArray(const Loc &loc, Type *arrayType,
+                                  DValue **dims, size_t ndims) {
   IF_LOG Logger::println("DtoNewMulDimDynArray : %s", arrayType->toChars());
   LOG_SCOPE;
 
@@ -778,7 +779,7 @@ DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-DSliceValue *DtoResizeDynArray(Loc &loc, Type *arrayType, DValue *array,
+DSliceValue *DtoResizeDynArray(const Loc &loc, Type *arrayType, DValue *array,
                                LLValue *newdim) {
   IF_LOG Logger::println("DtoResizeDynArray : %s", arrayType->toChars());
   LOG_SCOPE;
@@ -807,7 +808,7 @@ DSliceValue *DtoResizeDynArray(Loc &loc, Type *arrayType, DValue *array,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
+void DtoCatAssignElement(const Loc &loc, DValue *array, Expression *exp) {
   IF_LOG Logger::println("DtoCatAssignElement");
   LOG_SCOPE;
 
@@ -839,7 +840,7 @@ void DtoCatAssignElement(Loc &loc, DValue *array, Expression *exp) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue *DtoCatAssignArray(Loc &loc, DValue *arr, Expression *exp) {
+DSliceValue *DtoCatAssignArray(const Loc &loc, DValue *arr, Expression *exp) {
   IF_LOG Logger::println("DtoCatAssignArray");
   LOG_SCOPE;
   Type *arrayType = arr->type;
@@ -857,7 +858,7 @@ DSliceValue *DtoCatAssignArray(Loc &loc, DValue *arr, Expression *exp) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue *DtoCatArrays(Loc &loc, Type *arrayType, Expression *exp1,
+DSliceValue *DtoCatArrays(const Loc &loc, Type *arrayType, Expression *exp1,
                           Expression *exp2) {
   IF_LOG Logger::println("DtoCatAssignArray");
   LOG_SCOPE;
@@ -925,7 +926,7 @@ DSliceValue *DtoCatArrays(Loc &loc, Type *arrayType, Expression *exp1,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue *DtoAppendDChar(Loc &loc, DValue *arr, Expression *exp,
+DSliceValue *DtoAppendDChar(const Loc &loc, DValue *arr, Expression *exp,
                             const char *func) {
   LLValue *valueToAppend = DtoRVal(exp);
 
@@ -943,7 +944,8 @@ DSliceValue *DtoAppendDChar(Loc &loc, DValue *arr, Expression *exp,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue *DtoAppendDCharToString(Loc &loc, DValue *arr, Expression *exp) {
+DSliceValue *DtoAppendDCharToString(const Loc &loc, DValue *arr,
+                                    Expression *exp) {
   IF_LOG Logger::println("DtoAppendDCharToString");
   LOG_SCOPE;
   return DtoAppendDChar(loc, arr, exp, "_d_arrayappendcd");
@@ -951,7 +953,7 @@ DSliceValue *DtoAppendDCharToString(Loc &loc, DValue *arr, Expression *exp) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DSliceValue *DtoAppendDCharToUnicodeString(Loc &loc, DValue *arr,
+DSliceValue *DtoAppendDCharToUnicodeString(const Loc &loc, DValue *arr,
                                            Expression *exp) {
   IF_LOG Logger::println("DtoAppendDCharToUnicodeString");
   LOG_SCOPE;
@@ -961,8 +963,8 @@ DSliceValue *DtoAppendDCharToUnicodeString(Loc &loc, DValue *arr,
 ////////////////////////////////////////////////////////////////////////////////
 namespace {
 // helper for eq and cmp
-LLValue *DtoArrayEqCmp_impl(Loc &loc, const char *func, DValue *l,
-                                   DValue *r, bool useti) {
+LLValue *DtoArrayEqCmp_impl(const Loc &loc, const char *func, DValue *l,
+                            DValue *r, bool useti) {
   IF_LOG Logger::println("comparing arrays");
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, func);
   assert(fn);
@@ -1054,7 +1056,7 @@ bool validCompareWithMemcmp(DValue *l, DValue *r) {
 }
 
 // Create a call instruction to memcmp.
-llvm::CallInst *callMemcmp(Loc &loc, IRState &irs, LLValue *l_ptr,
+llvm::CallInst *callMemcmp(const Loc &loc, IRState &irs, LLValue *l_ptr,
                            LLValue *r_ptr, LLValue *numElements) {
   assert(l_ptr && r_ptr && numElements);
   LLFunction *fn = getRuntimeFunction(loc, gIR->module, "memcmp");
@@ -1076,7 +1078,8 @@ llvm::CallInst *callMemcmp(Loc &loc, IRState &irs, LLValue *l_ptr,
 /// with memcmp.
 ///
 /// Note: the dynamic array length check is not covered by (LDC's) PGO.
-LLValue *DtoArrayEqCmp_memcmp(Loc &loc, DValue *l, DValue *r, IRState &irs) {
+LLValue *DtoArrayEqCmp_memcmp(const Loc &loc, DValue *l, DValue *r,
+                              IRState &irs) {
   IF_LOG Logger::println("Comparing arrays using memcmp");
 
   auto *l_ptr = DtoArrayPtr(l);
@@ -1120,7 +1123,7 @@ LLValue *DtoArrayEqCmp_memcmp(Loc &loc, DValue *l, DValue *r, IRState &irs) {
 } // end anonymous namespace
 
 ////////////////////////////////////////////////////////////////////////////////
-LLValue *DtoArrayEquals(Loc &loc, TOK op, DValue *l, DValue *r) {
+LLValue *DtoArrayEquals(const Loc &loc, TOK op, DValue *l, DValue *r) {
   LLValue *res = nullptr;
 
   if (r->isNull()) {
@@ -1216,7 +1219,7 @@ LLValue *DtoArrayPtr(DValue *v) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-DValue *DtoCastArray(Loc &loc, DValue *u, Type *to) {
+DValue *DtoCastArray(const Loc &loc, DValue *u, Type *to) {
   IF_LOG Logger::println("DtoCastArray");
   LOG_SCOPE;
 
@@ -1309,7 +1312,7 @@ DValue *DtoCastArray(Loc &loc, DValue *u, Type *to) {
   return new DLValue(to, castedPtr);
 }
 
-void DtoIndexBoundsCheck(Loc &loc, DValue *arr, DValue *index) {
+void DtoIndexBoundsCheck(const Loc &loc, DValue *arr, DValue *index) {
   Type *arrty = arr->type->toBasetype();
   assert(
       (arrty->ty == Tsarray || arrty->ty == Tarray || arrty->ty == Tpointer) &&
@@ -1341,7 +1344,7 @@ void DtoIndexBoundsCheck(Loc &loc, DValue *arr, DValue *index) {
   gIR->ir->SetInsertPoint(okbb);
 }
 
-void DtoBoundsCheckFailCall(IRState *irs, Loc &loc) {
+void DtoBoundsCheckFailCall(IRState *irs, const Loc &loc) {
   Module *const module = irs->func()->decl->getModule();
 
   if (global.params.checkAction == CHECKACTION_C) {

--- a/gen/arrays.h
+++ b/gen/arrays.h
@@ -54,36 +54,38 @@ llvm::Constant *arrayLiteralToConst(IRState *p, ArrayLiteralExp *ale);
 /// dstMem is expected to be a pointer to the array allocation.
 void initializeArrayLiteral(IRState *p, ArrayLiteralExp *ale, LLValue *dstMem);
 
-void DtoArrayAssign(Loc &loc, DValue *lhs, DValue *rhs, int op,
+void DtoArrayAssign(const Loc &loc, DValue *lhs, DValue *rhs, int op,
                     bool canSkipPostblit);
 void DtoSetArrayToNull(LLValue *v);
 
-DSliceValue *DtoNewDynArray(Loc &loc, Type *arrayType, DValue *dim,
+DSliceValue *DtoNewDynArray(const Loc &loc, Type *arrayType, DValue *dim,
                             bool defaultInit = true);
-DSliceValue *DtoNewMulDimDynArray(Loc &loc, Type *arrayType, DValue **dims,
-                                  size_t ndims);
-DSliceValue *DtoResizeDynArray(Loc &loc, Type *arrayType, DValue *array,
+DSliceValue *DtoNewMulDimDynArray(const Loc &loc, Type *arrayType,
+                                  DValue **dims, size_t ndims);
+DSliceValue *DtoResizeDynArray(const Loc &loc, Type *arrayType, DValue *array,
                                llvm::Value *newdim);
 
-void DtoCatAssignElement(Loc &loc, DValue *arr, Expression *exp);
-DSliceValue *DtoCatAssignArray(Loc &loc, DValue *arr, Expression *exp);
-DSliceValue *DtoCatArrays(Loc &loc, Type *type, Expression *e1, Expression *e2);
-DSliceValue *DtoAppendDCharToString(Loc &loc, DValue *arr, Expression *exp);
-DSliceValue *DtoAppendDCharToUnicodeString(Loc &loc, DValue *arr,
+void DtoCatAssignElement(const Loc &loc, DValue *arr, Expression *exp);
+DSliceValue *DtoCatAssignArray(const Loc &loc, DValue *arr, Expression *exp);
+DSliceValue *DtoCatArrays(const Loc &loc, Type *type, Expression *e1,
+                          Expression *e2);
+DSliceValue *DtoAppendDCharToString(const Loc &loc, DValue *arr,
+                                    Expression *exp);
+DSliceValue *DtoAppendDCharToUnicodeString(const Loc &loc, DValue *arr,
                                            Expression *exp);
 
-LLValue *DtoArrayEquals(Loc &loc, TOK op, DValue *l, DValue *r);
+LLValue *DtoArrayEquals(const Loc &loc, TOK op, DValue *l, DValue *r);
 
 LLValue *DtoDynArrayIs(TOK op, DValue *l, DValue *r);
 
 LLValue *DtoArrayLen(DValue *v);
 LLValue *DtoArrayPtr(DValue *v);
 
-DValue *DtoCastArray(Loc &loc, DValue *val, Type *to);
+DValue *DtoCastArray(const Loc &loc, DValue *val, Type *to);
 
 // generates an array bounds check
-void DtoIndexBoundsCheck(Loc &loc, DValue *arr, DValue *index);
+void DtoIndexBoundsCheck(const Loc &loc, DValue *arr, DValue *index);
 
 /// Inserts a call to the druntime function that throws the range error, with
 /// the given location.
-void DtoBoundsCheckFailCall(IRState *p, Loc &loc);
+void DtoBoundsCheckFailCall(IRState *p, const Loc &loc);

--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -21,7 +21,7 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
-dinteger_t undoStrideMul(Loc &loc, Type *t, dinteger_t offset) {
+dinteger_t undoStrideMul(const Loc &loc, Type *t, dinteger_t offset) {
   assert(t->ty == Tpointer);
   d_uns64 elemSize = t->nextOf()->size(loc);
   assert((offset % elemSize) == 0 &&
@@ -146,7 +146,7 @@ DValue *isAssociativeArrayAndNull(Type *type, LLValue *lhs, LLValue *rhs) {
 
 //////////////////////////////////////////////////////////////////////////////
 
-DValue *binAdd(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binAdd(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   Type *lhsType = lhs->type->toBasetype();
   Type *rhsType = rhs->type->toBasetype();
@@ -177,7 +177,7 @@ DValue *binAdd(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 
 //////////////////////////////////////////////////////////////////////////////
 
-DValue *binMin(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMin(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   Type *lhsType = lhs->type->toBasetype();
   Type *rhsType = rhs->type->toBasetype();
@@ -221,7 +221,7 @@ DValue *binMin(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 
 //////////////////////////////////////////////////////////////////////////////
 
-DValue *binMul(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMul(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   auto rvals = evalSides(lhs, rhs, loadLhsAfterRhs);
 
@@ -238,7 +238,7 @@ DValue *binMul(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 
 //////////////////////////////////////////////////////////////////////////////
 
-DValue *binDiv(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binDiv(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   auto rvals = evalSides(lhs, rhs, loadLhsAfterRhs);
 
@@ -261,7 +261,7 @@ DValue *binDiv(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 
 //////////////////////////////////////////////////////////////////////////////
 
-DValue *binMod(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMod(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   auto rvals = evalSides(lhs, rhs, loadLhsAfterRhs);
 
@@ -285,8 +285,9 @@ DValue *binMod(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 //////////////////////////////////////////////////////////////////////////////
 
 namespace {
-DValue *binBitwise(llvm::Instruction::BinaryOps binOp, Loc &loc, Type *type,
-                   DValue *lhs, Expression *rhs, bool loadLhsAfterRhs) {
+DValue *binBitwise(llvm::Instruction::BinaryOps binOp, const Loc &loc,
+                   Type *type, DValue *lhs, Expression *rhs,
+                   bool loadLhsAfterRhs) {
   auto rvals = evalSides(lhs, rhs, loadLhsAfterRhs);
 
   LLValue *l = DtoRVal(DtoCast(loc, rvals.lhs, type));
@@ -297,38 +298,38 @@ DValue *binBitwise(llvm::Instruction::BinaryOps binOp, Loc &loc, Type *type,
 }
 }
 
-DValue *binAnd(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binAnd(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   return binBitwise(llvm::Instruction::And, loc, type, lhs, rhs,
                     loadLhsAfterRhs);
 }
 
-DValue *binOr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binOr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
               bool loadLhsAfterRhs) {
   return binBitwise(llvm::Instruction::Or, loc, type, lhs, rhs,
                     loadLhsAfterRhs);
 }
 
-DValue *binXor(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binXor(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   return binBitwise(llvm::Instruction::Xor, loc, type, lhs, rhs,
                     loadLhsAfterRhs);
 }
 
-DValue *binShl(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binShl(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   return binBitwise(llvm::Instruction::Shl, loc, type, lhs, rhs,
                     loadLhsAfterRhs);
 }
 
-DValue *binShr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binShr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs) {
   auto op = (isLLVMUnsigned(type) ? llvm::Instruction::LShr
                                   : llvm::Instruction::AShr);
   return binBitwise(op, loc, type, lhs, rhs, loadLhsAfterRhs);
 }
 
-DValue *binUshr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binUshr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                 bool loadLhsAfterRhs) {
   return binBitwise(llvm::Instruction::LShr, loc, type, lhs, rhs,
                     loadLhsAfterRhs);
@@ -336,7 +337,7 @@ DValue *binUshr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
 
 //////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoBinNumericEquals(Loc &loc, DValue *lhs, DValue *rhs, TOK op) {
+LLValue *DtoBinNumericEquals(const Loc &loc, DValue *lhs, DValue *rhs, TOK op) {
   assert(op == TOKequal || op == TOKnotequal || op == TOKidentity ||
          op == TOKnotidentity);
   Type *t = lhs->type->toBasetype();
@@ -358,7 +359,7 @@ LLValue *DtoBinNumericEquals(Loc &loc, DValue *lhs, DValue *rhs, TOK op) {
 
 //////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoBinFloatsEquals(Loc &loc, DValue *lhs, DValue *rhs, TOK op) {
+LLValue *DtoBinFloatsEquals(const Loc &loc, DValue *lhs, DValue *rhs, TOK op) {
   LLValue *res = nullptr;
   if (op == TOKequal || op == TOKnotequal) {
     LLValue *l = DtoRVal(lhs);

--- a/gen/binops.h
+++ b/gen/binops.h
@@ -1,6 +1,6 @@
 //===-- gen/binops.h - Binary numeric operations ----------------*- C++ -*-===//
 //
-//                         LDC – the LLVM D compiler
+//                         LDC â€“ the LLVM D compiler
 //
 // This file is distributed under the BSD-style LDC license. See the LICENSE
 // file for details.
@@ -21,42 +21,44 @@ class Value;
 class DValue;
 
 // lhs + rhs
-DValue *binAdd(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binAdd(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs - rhs
-DValue *binMin(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMin(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs * rhs
-DValue *binMul(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMul(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs / rhs
-DValue *binDiv(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binDiv(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs % rhs
-DValue *binMod(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binMod(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 
 // lhs & rhs
-DValue *binAnd(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binAnd(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs | rhs
-DValue *binOr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binOr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
               bool loadLhsAfterRhs = false);
 // lhs ^ rhs
-DValue *binXor(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binXor(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs << rhs
-DValue *binShl(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binShl(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs >> rhs
-DValue *binShr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binShr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                bool loadLhsAfterRhs = false);
 // lhs >>> rhs
-DValue *binUshr(Loc &loc, Type *type, DValue *lhs, Expression *rhs,
+DValue *binUshr(const Loc &loc, Type *type, DValue *lhs, Expression *rhs,
                 bool loadLhsAfterRhs = false);
 
-llvm::Value *DtoBinNumericEquals(Loc &loc, DValue *lhs, DValue *rhs, TOK op);
-llvm::Value *DtoBinFloatsEquals(Loc &loc, DValue *lhs, DValue *rhs, TOK op);
+llvm::Value *DtoBinNumericEquals(const Loc &loc, DValue *lhs, DValue *rhs,
+                                 TOK op);
+llvm::Value *DtoBinFloatsEquals(const Loc &loc, DValue *lhs, DValue *rhs,
+                                TOK op);
 llvm::Value *mergeVectorEquals(llvm::Value *resultsVector, TOK op);
 
-dinteger_t undoStrideMul(Loc &loc, Type *t, dinteger_t offset);
+dinteger_t undoStrideMul(const Loc &loc, Type *t, dinteger_t offset);

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -71,7 +71,7 @@ void DtoResolveClass(ClassDeclaration *cd) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoNewClass(Loc &loc, TypeClass *tc, NewExp *newexp) {
+DValue *DtoNewClass(const Loc &loc, TypeClass *tc, NewExp *newexp) {
   // resolve type
   DtoResolveClass(tc->sym);
 
@@ -186,7 +186,7 @@ void DtoInitClass(TypeClass *tc, LLValue *dst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoFinalizeClass(Loc &loc, LLValue *inst) {
+void DtoFinalizeClass(const Loc &loc, LLValue *inst) {
   // get runtime function
   llvm::Function *fn =
       getRuntimeFunction(loc, gIR->module, "_d_callfinalizer");
@@ -197,7 +197,7 @@ void DtoFinalizeClass(Loc &loc, LLValue *inst) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoFinalizeScopeClass(Loc &loc, LLValue *inst, bool hasDtor) {
+void DtoFinalizeScopeClass(const Loc &loc, LLValue *inst, bool hasDtor) {
   if (!isOptimizationEnabled() || hasDtor) {
     DtoFinalizeClass(loc, inst);
     return;
@@ -223,7 +223,7 @@ void DtoFinalizeScopeClass(Loc &loc, LLValue *inst, bool hasDtor) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoCastClass(Loc &loc, DValue *val, Type *_to) {
+DValue *DtoCastClass(const Loc &loc, DValue *val, Type *_to) {
   IF_LOG Logger::println("DtoCastClass(%s, %s)", val->type->toChars(),
                          _to->toChars());
   LOG_SCOPE;
@@ -341,7 +341,7 @@ static void resolveObjectAndClassInfoClasses() {
   DtoResolveClass(Type::typeinfoclass);
 }
 
-DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *_to) {
+DValue *DtoDynamicCastObject(const Loc &loc, DValue *val, Type *_to) {
   // call:
   // Object _d_dynamic_cast(Object o, ClassInfo c)
 
@@ -378,7 +378,7 @@ DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *_to) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *_to) {
+DValue *DtoDynamicCastInterface(const Loc &loc, DValue *val, Type *_to) {
   // call:
   // Object _d_interface_cast(void* p, ClassInfo c)
 

--- a/gen/classes.h
+++ b/gen/classes.h
@@ -25,14 +25,14 @@ class TypeClass;
 /// Resolves the llvm type for a class declaration
 void DtoResolveClass(ClassDeclaration *cd);
 
-DValue *DtoNewClass(Loc &loc, TypeClass *type, NewExp *newexp);
+DValue *DtoNewClass(const Loc &loc, TypeClass *type, NewExp *newexp);
 void DtoInitClass(TypeClass *tc, llvm::Value *dst);
-void DtoFinalizeClass(Loc &loc, llvm::Value *inst);
-void DtoFinalizeScopeClass(Loc &loc, llvm::Value *inst, bool hasDtor);
+void DtoFinalizeClass(const Loc &loc, llvm::Value *inst);
+void DtoFinalizeScopeClass(const Loc &loc, llvm::Value *inst, bool hasDtor);
 
-DValue *DtoCastClass(Loc &loc, DValue *val, Type *to);
-DValue *DtoDynamicCastObject(Loc &loc, DValue *val, Type *to);
+DValue *DtoCastClass(const Loc &loc, DValue *val, Type *to);
+DValue *DtoDynamicCastObject(const Loc &loc, DValue *val, Type *to);
 
-DValue *DtoDynamicCastInterface(Loc &loc, DValue *val, Type *to);
+DValue *DtoDynamicCastInterface(const Loc &loc, DValue *val, Type *to);
 
 llvm::Value *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl);

--- a/gen/complex.cpp
+++ b/gen/complex.cpp
@@ -68,7 +68,7 @@ LLConstant *DtoConstComplex(Type *_ty, real_t re, real_t im) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoComplex(Loc &loc, Type *to, DValue *val) {
+DValue *DtoComplex(const Loc &loc, Type *to, DValue *val) {
   LLType *complexTy = DtoType(to);
 
   Type *baserety;
@@ -114,7 +114,7 @@ void DtoComplexSet(LLValue *c, LLValue *re, LLValue *im) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoGetComplexParts(Loc &loc, Type *to, DValue *val, DValue *&re,
+void DtoGetComplexParts(const Loc &loc, Type *to, DValue *val, DValue *&re,
                         DValue *&im) {
   Type *baserety;
   Type *baseimty;
@@ -172,7 +172,7 @@ void DtoGetComplexParts(Loc &loc, Type *to, DValue *val, DValue *&re,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DtoGetComplexParts(Loc &loc, Type *to, DValue *val, LLValue *&re,
+void DtoGetComplexParts(const Loc &loc, Type *to, DValue *val, LLValue *&re,
                         LLValue *&im) {
   DValue *dre, *dim;
   DtoGetComplexParts(loc, to, val, dre, dim);
@@ -182,7 +182,8 @@ void DtoGetComplexParts(Loc &loc, Type *to, DValue *val, LLValue *&re,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexAdd(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
+DImValue *DtoComplexAdd(const Loc &loc, Type *type, DRValue *lhs,
+                        DRValue *rhs) {
   llvm::Value *lhs_re, *lhs_im, *rhs_re, *rhs_im, *res_re, *res_im;
 
   // lhs values
@@ -213,7 +214,8 @@ DImValue *DtoComplexAdd(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexMin(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
+DImValue *DtoComplexMin(const Loc &loc, Type *type, DRValue *lhs,
+                        DRValue *rhs) {
   llvm::Value *lhs_re, *lhs_im, *rhs_re, *rhs_im, *res_re, *res_im;
 
   // lhs values
@@ -244,7 +246,8 @@ DImValue *DtoComplexMin(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexMul(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
+DImValue *DtoComplexMul(const Loc &loc, Type *type, DRValue *lhs,
+                        DRValue *rhs) {
   llvm::Value *lhs_re, *lhs_im, *rhs_re, *rhs_im, *res_re, *res_im;
 
   // lhs values
@@ -297,7 +300,8 @@ DImValue *DtoComplexMul(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexDiv(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
+DImValue *DtoComplexDiv(const Loc &loc, Type *type, DRValue *lhs,
+                        DRValue *rhs) {
   llvm::Value *lhs_re, *lhs_im, *rhs_re, *rhs_im, *res_re, *res_im;
 
   // lhs values
@@ -370,7 +374,8 @@ DImValue *DtoComplexDiv(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexMod(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
+DImValue *DtoComplexMod(const Loc &loc, Type *type, DRValue *lhs,
+                        DRValue *rhs) {
   llvm::Value *lhs_re, *lhs_im, *rhs_re, *rhs_im, *res_re, *res_im, *divisor;
 
   // lhs values
@@ -391,7 +396,7 @@ DImValue *DtoComplexMod(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DImValue *DtoComplexNeg(Loc &loc, Type *type, DRValue *val) {
+DImValue *DtoComplexNeg(const Loc &loc, Type *type, DRValue *val) {
   llvm::Value *a, *b, *re, *im;
 
   // values
@@ -408,7 +413,7 @@ DImValue *DtoComplexNeg(Loc &loc, Type *type, DRValue *val) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-LLValue *DtoComplexEquals(Loc &loc, TOK op, DValue *lhs, DValue *rhs) {
+LLValue *DtoComplexEquals(const Loc &loc, TOK op, DValue *lhs, DValue *rhs) {
   DValue *lhs_re, *lhs_im, *rhs_re, *rhs_im;
 
   // lhs values
@@ -426,7 +431,7 @@ LLValue *DtoComplexEquals(Loc &loc, TOK op, DValue *lhs, DValue *rhs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DValue *DtoCastComplex(Loc &loc, DValue *val, Type *_to) {
+DValue *DtoCastComplex(const Loc &loc, DValue *val, Type *_to) {
   Type *to = _to->toBasetype();
   Type *vty = val->type->toBasetype();
   if (to->iscomplex()) {

--- a/gen/complex.h
+++ b/gen/complex.h
@@ -32,22 +32,22 @@ llvm::Constant *DtoConstComplex(Type *t, real_t re, real_t im);
 
 llvm::Constant *DtoComplexShuffleMask(unsigned a, unsigned b);
 
-DValue *DtoComplex(Loc &loc, Type *to, DValue *val);
+DValue *DtoComplex(const Loc &loc, Type *to, DValue *val);
 
 void DtoComplexSet(llvm::Value *c, llvm::Value *re, llvm::Value *im);
 
-void DtoGetComplexParts(Loc &loc, Type *to, DValue *c, DValue *&re,
+void DtoGetComplexParts(const Loc &loc, Type *to, DValue *c, DValue *&re,
                         DValue *&im);
-void DtoGetComplexParts(Loc &loc, Type *to, DValue *c, llvm::Value *&re,
+void DtoGetComplexParts(const Loc &loc, Type *to, DValue *c, llvm::Value *&re,
                         llvm::Value *&im);
 
-DImValue *DtoComplexAdd(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
-DImValue *DtoComplexMin(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
-DImValue *DtoComplexMul(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
-DImValue *DtoComplexDiv(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
-DImValue *DtoComplexMod(Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
-DImValue *DtoComplexNeg(Loc &loc, Type *type, DRValue *val);
+DImValue *DtoComplexAdd(const Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
+DImValue *DtoComplexMin(const Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
+DImValue *DtoComplexMul(const Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
+DImValue *DtoComplexDiv(const Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
+DImValue *DtoComplexMod(const Loc &loc, Type *type, DRValue *lhs, DRValue *rhs);
+DImValue *DtoComplexNeg(const Loc &loc, Type *type, DRValue *val);
 
-llvm::Value *DtoComplexEquals(Loc &loc, TOK op, DValue *lhs, DValue *rhs);
+llvm::Value *DtoComplexEquals(const Loc &loc, TOK op, DValue *lhs, DValue *rhs);
 
-DValue *DtoCastComplex(Loc &loc, DValue *val, Type *to);
+DValue *DtoCastComplex(const Loc &loc, DValue *val, Type *to);

--- a/gen/coverage.cpp
+++ b/gen/coverage.cpp
@@ -13,7 +13,7 @@
 #include "gen/irstate.h"
 #include "gen/logger.h"
 
-void emitCoverageLinecountInc(Loc &loc) {
+void emitCoverageLinecountInc(const Loc &loc) {
   Module *m = gIR->dmodule;
 
   // Only emit coverage increment for locations in the source of the current

--- a/gen/coverage.h
+++ b/gen/coverage.h
@@ -16,4 +16,4 @@
 
 struct Loc;
 
-void emitCoverageLinecountInc(Loc &loc);
+void emitCoverageLinecountInc(const Loc &loc);

--- a/gen/functions.h
+++ b/gen/functions.h
@@ -39,7 +39,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl);
 void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally = false);
 
 void DtoDefineNakedFunction(FuncDeclaration *fd);
-void emitABIReturnAsmStmt(IRAsmBlock *asmblock, Loc &loc,
+void emitABIReturnAsmStmt(IRAsmBlock *asmblock, const Loc &loc,
                           FuncDeclaration *fdecl);
 
 DValue *DtoArgument(Parameter *fnarg, Expression *argexp);

--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -99,7 +99,7 @@ void DtoCheckInlineIRPragma(Identifier *ident, Dsymbol *s) {
   }
 }
 
-DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
+DValue *DtoInlineIRExpr(const Loc &loc, FuncDeclaration *fdecl,
                         Expressions *arguments, LLValue *sretPointer) {
   IF_LOG Logger::println("DtoInlineIRExpr @ %s", loc.toChars());
   LOG_SCOPE;

--- a/gen/inlineir.h
+++ b/gen/inlineir.h
@@ -28,6 +28,6 @@ class Value;
 /// Will call fatal() in case of errors
 void DtoCheckInlineIRPragma(Identifier *ident, Dsymbol *s);
 
-DValue *DtoInlineIRExpr(Loc &loc, FuncDeclaration *fdecl,
+DValue *DtoInlineIRExpr(const Loc &loc, FuncDeclaration *fdecl,
                         Expressions *arguments,
                         llvm::Value *sretPointer = nullptr);

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -29,13 +29,13 @@ template <class T> using ArrayParam = llvm::ArrayRef<T>;
 llvm::LLVMContext& getGlobalContext();
 
 // dynamic memory helpers
-LLValue *DtoNew(Loc &loc, Type *newtype);
-LLValue *DtoNewStruct(Loc &loc, TypeStruct *newtype);
-void DtoDeleteMemory(Loc &loc, DValue *ptr);
-void DtoDeleteStruct(Loc &loc, DValue *ptr);
-void DtoDeleteClass(Loc &loc, DValue *inst);
-void DtoDeleteInterface(Loc &loc, DValue *inst);
-void DtoDeleteArray(Loc &loc, DValue *arr);
+LLValue *DtoNew(const Loc &loc, Type *newtype);
+LLValue *DtoNewStruct(const Loc &loc, TypeStruct *newtype);
+void DtoDeleteMemory(const Loc &loc, DValue *ptr);
+void DtoDeleteStruct(const Loc &loc, DValue *ptr);
+void DtoDeleteClass(const Loc &loc, DValue *inst);
+void DtoDeleteInterface(const Loc &loc, DValue *inst);
+void DtoDeleteArray(const Loc &loc, DValue *arr);
 
 unsigned DtoAlignment(Type *type);
 unsigned DtoAlignment(VarDeclaration *vd);
@@ -47,7 +47,7 @@ llvm::AllocaInst *DtoArrayAlloca(Type *type, unsigned arraysize,
                                  const char *name = "");
 llvm::AllocaInst *DtoRawAlloca(LLType *lltype, size_t alignment,
                                const char *name = "");
-LLValue *DtoGcMalloc(Loc &loc, LLType *lltype, const char *name = "");
+LLValue *DtoGcMalloc(const Loc &loc, LLType *lltype, const char *name = "");
 
 LLValue *DtoAllocaDump(DValue *val, const char *name = "");
 LLValue *DtoAllocaDump(DValue *val, int alignment, const char *name = "");
@@ -60,46 +60,46 @@ LLValue *DtoAllocaDump(LLValue *val, LLType *asType, int alignment = 0,
                        const char *name = "");
 
 // assertion generator
-void DtoAssert(Module *M, Loc &loc, DValue *msg);
-void DtoCAssert(Module *M, Loc &loc, LLValue *msg);
+void DtoAssert(Module *M, const Loc &loc, DValue *msg);
+void DtoCAssert(Module *M, const Loc &loc, LLValue *msg);
 
 // returns module file name
 LLConstant *DtoModuleFileName(Module *M, const Loc &loc);
 
 /// emits goto to LabelStatement with the target identifier
-void DtoGoto(Loc &loc, LabelDsymbol *target);
+void DtoGoto(const Loc &loc, LabelDsymbol *target);
 
 /// Enters a critical section.
-void DtoEnterCritical(Loc &loc, LLValue *g);
+void DtoEnterCritical(const Loc &loc, LLValue *g);
 /// leaves a critical section.
-void DtoLeaveCritical(Loc &loc, LLValue *g);
+void DtoLeaveCritical(const Loc &loc, LLValue *g);
 
 /// Enters a monitor lock.
-void DtoEnterMonitor(Loc &loc, LLValue *v);
+void DtoEnterMonitor(const Loc &loc, LLValue *v);
 /// Leaves a monitor lock.
-void DtoLeaveMonitor(Loc &loc, LLValue *v);
+void DtoLeaveMonitor(const Loc &loc, LLValue *v);
 
 // basic operations
-void DtoAssign(Loc &loc, DValue *lhs, DValue *rhs, int op,
+void DtoAssign(const Loc &loc, DValue *lhs, DValue *rhs, int op,
                bool canSkipPostblit = false);
 
-DValue *DtoSymbolAddress(Loc &loc, Type *type, Declaration *decl);
-llvm::Constant *DtoConstSymbolAddress(Loc &loc, Declaration *decl);
+DValue *DtoSymbolAddress(const Loc &loc, Type *type, Declaration *decl);
+llvm::Constant *DtoConstSymbolAddress(const Loc &loc, Declaration *decl);
 
 /// Create a null DValue.
-DValue *DtoNullValue(Type *t, Loc loc = Loc());
+DValue *DtoNullValue(Type *t, const Loc loc = Loc());
 
 // casts
-DValue *DtoCastInt(Loc &loc, DValue *val, Type *to);
-DValue *DtoCastPtr(Loc &loc, DValue *val, Type *to);
-DValue *DtoCastFloat(Loc &loc, DValue *val, Type *to);
-DValue *DtoCastDelegate(Loc &loc, DValue *val, Type *to);
-DValue *DtoCastVector(Loc &loc, DValue *val, Type *to);
-DValue *DtoCast(Loc &loc, DValue *val, Type *to);
+DValue *DtoCastInt(const Loc &loc, DValue *val, Type *to);
+DValue *DtoCastPtr(const Loc &loc, DValue *val, Type *to);
+DValue *DtoCastFloat(const Loc &loc, DValue *val, Type *to);
+DValue *DtoCastDelegate(const Loc &loc, DValue *val, Type *to);
+DValue *DtoCastVector(const Loc &loc, DValue *val, Type *to);
+DValue *DtoCast(const Loc &loc, DValue *val, Type *to);
 
 // return the same val as passed in, modified to the target type, if possible,
 // otherwise returns a new DValue
-DValue *DtoPaintType(Loc &loc, DValue *val, Type *to);
+DValue *DtoPaintType(const Loc &loc, DValue *val, Type *to);
 
 /// Returns true if the specified symbol is to be defined on declaration, for
 /// -linkonce-templates.
@@ -121,12 +121,12 @@ DValue *DtoDeclarationExp(Dsymbol *declaration);
 LLValue *DtoRawVarDeclaration(VarDeclaration *var, LLValue *addr = nullptr);
 
 // initializer helpers
-LLConstant *DtoConstInitializer(Loc &loc, Type *type,
+LLConstant *DtoConstInitializer(const Loc &loc, Type *type,
                                 Initializer *init = nullptr);
-LLConstant *DtoConstExpInit(Loc &loc, Type *targetType, Expression *exp);
+LLConstant *DtoConstExpInit(const Loc &loc, Type *targetType, Expression *exp);
 
 // getting typeinfo of type, base=true casts to object.TypeInfo
-LLConstant *DtoTypeInfoOf(Type *ty, bool base = true, const Loc& loc = Loc());
+LLConstant *DtoTypeInfoOf(Type *type, bool base = true, const Loc &loc = Loc());
 
 // target stuff
 void findDefaultTarget();
@@ -145,7 +145,8 @@ LLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
 unsigned getFieldGEPIndex(AggregateDeclaration *ad, VarDeclaration *vd);
 
 ///
-DValue *DtoInlineAsmExpr(Loc &loc, FuncDeclaration *fd, Expressions *arguments,
+DValue *DtoInlineAsmExpr(const Loc &loc, FuncDeclaration *fd,
+                         Expressions *arguments,
                          LLValue *sretPointer = nullptr);
 ///
 llvm::CallInst *DtoInlineAsmExpr(const Loc &loc, llvm::StringRef code,
@@ -160,9 +161,9 @@ size_t getMemberSize(Type *type);
 /// Returns the llvm::Value of the passed DValue, making sure that it is an
 /// lvalue (has a memory address), so it can be passed to the D runtime
 /// functions without problems.
-LLValue *makeLValue(Loc &loc, DValue *value);
+LLValue *makeLValue(const Loc &loc, DValue *value);
 
-void callPostblit(Loc &loc, Expression *exp, LLValue *val);
+void callPostblit(const Loc &loc, Expression *exp, LLValue *val);
 
 /// Returns whether the given variable is a DMD-internal "ref variable".
 ///
@@ -216,7 +217,7 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
                             DValue *&result);
 
 ///
-DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
+DValue *DtoCallFunction(const Loc &loc, Type *resulttype, DValue *fnval,
                         Expressions *arguments, LLValue *sretPointer = nullptr);
 
 Type *stripModifiers(Type *type, bool transitive = false);

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -126,7 +126,7 @@ LLConstant *DtoConstInitializer(const Loc &loc, Type *type,
 LLConstant *DtoConstExpInit(const Loc &loc, Type *targetType, Expression *exp);
 
 // getting typeinfo of type, base=true casts to object.TypeInfo
-LLConstant *DtoTypeInfoOf(Type *type, bool base = true, const Loc &loc = Loc());
+LLConstant *DtoTypeInfoOf(const Loc &loc, Type *type, bool base = true);
 
 // target stuff
 void findDefaultTarget();

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -126,7 +126,7 @@ LLConstant *DtoConstInitializer(Loc &loc, Type *type,
 LLConstant *DtoConstExpInit(Loc &loc, Type *targetType, Expression *exp);
 
 // getting typeinfo of type, base=true casts to object.TypeInfo
-LLConstant *DtoTypeInfoOf(Type *ty, bool base = true);
+LLConstant *DtoTypeInfoOf(Type *ty, bool base = true, const Loc& loc = Loc());
 
 // target stuff
 void findDefaultTarget();

--- a/gen/logger.cpp
+++ b/gen/logger.cpp
@@ -114,7 +114,7 @@ void print(const char *fmt, ...) {
     va_end(va);
   }
 }
-void attention(Loc &loc, const char *fmt, ...) {
+void attention(const Loc &loc, const char *fmt, ...) {
   va_list va;
   va_start(va, fmt);
   vwarning(loc, fmt, va);

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -253,7 +253,7 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void emitABIReturnAsmStmt(IRAsmBlock *asmblock, Loc &loc,
+void emitABIReturnAsmStmt(IRAsmBlock *asmblock, const Loc &loc,
                           FuncDeclaration *fdecl) {
   IF_LOG Logger::println("emitABIReturnAsmStmt(%s)", mangleExact(fdecl));
   LOG_SCOPE;
@@ -403,8 +403,8 @@ void emitABIReturnAsmStmt(IRAsmBlock *asmblock, Loc &loc,
 
 // sort of kinda related to naked ...
 
-DValue *DtoInlineAsmExpr(Loc &loc, FuncDeclaration *fd, Expressions *arguments,
-                         LLValue *sretPointer) {
+DValue *DtoInlineAsmExpr(const Loc &loc, FuncDeclaration *fd,
+                         Expressions *arguments, LLValue *sretPointer) {
   assert(fd->toParent()->isTemplateInstance() && "invalid inline __asm expr");
   assert(arguments->length >= 2 && "invalid __asm call");
 

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -29,7 +29,7 @@ static unsigned getVthisIdx(AggregateDeclaration *ad) {
 
 static void DtoCreateNestedContextType(FuncDeclaration *fd);
 
-DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
+DValue *DtoNestedVariable(const Loc &loc, Type *astype, VarDeclaration *vd,
                           bool byref) {
   IF_LOG Logger::println("DtoNestedVariable for %s @ %s", vd->toChars(),
                          loc.toChars());
@@ -178,7 +178,7 @@ DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
   return makeVarDValue(astype, vd, val);
 }
 
-void DtoResolveNestedContext(Loc &loc, AggregateDeclaration *decl,
+void DtoResolveNestedContext(const Loc &loc, AggregateDeclaration *decl,
                              LLValue *value) {
   IF_LOG Logger::println("Resolving nested context");
   LOG_SCOPE;
@@ -202,7 +202,7 @@ void DtoResolveNestedContext(Loc &loc, AggregateDeclaration *decl,
   }
 }
 
-LLValue *DtoNestedContext(Loc &loc, Dsymbol *sym) {
+LLValue *DtoNestedContext(const Loc &loc, Dsymbol *sym) {
   IF_LOG Logger::println("DtoNestedContext for %s", sym->toPrettyChars());
   LOG_SCOPE;
 

--- a/gen/nested.h
+++ b/gen/nested.h
@@ -30,13 +30,13 @@ class FuncGenState;
 void DtoCreateNestedContext(FuncGenState &funcGen);
 
 /// Resolves the nested context for classes and structs with arbitrary nesting.
-void DtoResolveNestedContext(Loc &loc, AggregateDeclaration *decl,
+void DtoResolveNestedContext(const Loc &loc, AggregateDeclaration *decl,
                              LLValue *value);
 
 /// Gets the context value for a call to a nested function or creating a nested
 /// class or struct with arbitrary nesting.
-llvm::Value *DtoNestedContext(Loc &loc, Dsymbol *sym);
+llvm::Value *DtoNestedContext(const Loc &loc, Dsymbol *sym);
 
 /// Gets the DValue of a nested variable with arbitrary nesting.
-DValue *DtoNestedVariable(Loc &loc, Type *astype, VarDeclaration *vd,
+DValue *DtoNestedVariable(const Loc &loc, Type *astype, VarDeclaration *vd,
                           bool byref = false);

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -62,7 +62,7 @@ void RTTIBuilder::push_null(Type *T) { push(getNullValue(DtoType(T))); }
 
 void RTTIBuilder::push_null_vp() { push(getNullValue(getVoidPtrType())); }
 
-void RTTIBuilder::push_typeinfo(Type *t) { push(DtoTypeInfoOf(t)); }
+void RTTIBuilder::push_typeinfo(Type *t) { push(DtoTypeInfoOf(Loc(), t)); }
 
 void RTTIBuilder::push_string(const char *str) { push(DtoConstString(str)); }
 

--- a/gen/structs.cpp
+++ b/gen/structs.cpp
@@ -32,7 +32,7 @@
 
 void DtoResolveStruct(StructDeclaration *sd) { DtoResolveStruct(sd, sd->loc); }
 
-void DtoResolveStruct(StructDeclaration *sd, Loc &callerLoc) {
+void DtoResolveStruct(StructDeclaration *sd, const Loc &callerLoc) {
   // Make sure to resolve each struct type exactly once.
   if (sd->ir->isResolved()) {
     return;

--- a/gen/structs.h
+++ b/gen/structs.h
@@ -36,7 +36,7 @@ class Value;
  * (only for better diagnosis)
  */
 void DtoResolveStruct(StructDeclaration *sd);
-void DtoResolveStruct(StructDeclaration *sd, Loc &callerLoc);
+void DtoResolveStruct(StructDeclaration *sd, const Loc &callerLoc);
 
 /// Returns a boolean=true if the two structs are equal.
 llvm::Value *DtoStructEquals(TOK op, DValue *lhs, DValue *rhs);

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -250,7 +250,8 @@ static LLValue *getTypeinfoArrayArgumentForDVarArg(Expressions *argexps,
   std::vector<LLConstant *> vtypeinfos;
   vtypeinfos.reserve(numVariadicArgs);
   for (size_t i = begin; i < numArgExps; i++) {
-    vtypeinfos.push_back(DtoTypeInfoOf((*argexps)[i]->type, /*base=*/true, (*argexps)[i]->loc));
+    Expression *argExp = (*argexps)[i];
+    vtypeinfos.push_back(DtoTypeInfoOf(argExp->loc, argExp->type));
   }
 
   // apply initializer

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -250,7 +250,7 @@ static LLValue *getTypeinfoArrayArgumentForDVarArg(Expressions *argexps,
   std::vector<LLConstant *> vtypeinfos;
   vtypeinfos.reserve(numVariadicArgs);
   for (size_t i = begin; i < numArgExps; i++) {
-    vtypeinfos.push_back(DtoTypeInfoOf((*argexps)[i]->type));
+    vtypeinfos.push_back(DtoTypeInfoOf((*argexps)[i]->type, /*base=*/true, (*argexps)[i]->loc));
   }
 
   // apply initializer

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -636,7 +636,7 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
 class ImplicitArgumentsBuilder {
 public:
   ImplicitArgumentsBuilder(std::vector<LLValue *> &args, AttrSet &attrs,
-                           Loc &loc, DValue *fnval,
+                           const Loc &loc, DValue *fnval,
                            LLFunctionType *llCalleeType, Expressions *argexps,
                            Type *resulttype, LLValue *sretPointer)
       : args(args), attrs(attrs), loc(loc), fnval(fnval), argexps(argexps),
@@ -663,7 +663,7 @@ private:
   // passed:
   std::vector<LLValue *> &args;
   AttrSet &attrs;
-  Loc &loc;
+  const Loc &loc;
   DValue *const fnval;
   Expressions *const argexps;
   Type *const resulttype;
@@ -795,7 +795,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 // FIXME: this function is a mess !
-DValue *DtoCallFunction(Loc &loc, Type *resulttype, DValue *fnval,
+DValue *DtoCallFunction(const Loc &loc, Type *resulttype, DValue *fnval,
                         Expressions *arguments, LLValue *sretPointer) {
   IF_LOG Logger::println("DtoCallFunction()");
   LOG_SCOPE

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -82,7 +82,7 @@ public:
     }
 
     if (TypeInfoDeclaration *ti = e->var->isTypeInfoDeclaration()) {
-      result = DtoTypeInfoOf(ti->tinfo, false);
+      result = DtoTypeInfoOf(ti->tinfo, false, e->loc);
       result = DtoBitCast(result, DtoType(e->type));
       return;
     }
@@ -685,7 +685,7 @@ public:
       return;
     }
 
-    result = DtoTypeInfoOf(t, /*base=*/false);
+    result = DtoTypeInfoOf(t, /*base=*/false, e->loc);
     result = DtoBitCast(result, DtoType(e->type));
   }
 

--- a/gen/toconstelem.cpp
+++ b/gen/toconstelem.cpp
@@ -82,7 +82,7 @@ public:
     }
 
     if (TypeInfoDeclaration *ti = e->var->isTypeInfoDeclaration()) {
-      result = DtoTypeInfoOf(ti->tinfo, false, e->loc);
+      result = DtoTypeInfoOf(e->loc, ti->tinfo, /*base=*/false);
       result = DtoBitCast(result, DtoType(e->type));
       return;
     }
@@ -685,7 +685,7 @@ public:
       return;
     }
 
-    result = DtoTypeInfoOf(t, /*base=*/false, e->loc);
+    result = DtoTypeInfoOf(e->loc, t, /*base=*/false);
     result = DtoBitCast(result, DtoType(e->type));
   }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2402,9 +2402,9 @@ public:
       llvm::Function *func =
           getRuntimeFunction(e->loc, gIR->module, "_d_assocarrayliteralTX");
       LLFunctionType *funcTy = func->getFunctionType();
-      LLValue *aaTypeInfo =
-          DtoBitCast(DtoTypeInfoOf(stripModifiers(aatype), /*base=*/false, e->loc),
-                     DtoType(getAssociativeArrayTypeInfoType()));
+      LLValue *aaTypeInfo = DtoBitCast(
+          DtoTypeInfoOf(e->loc, stripModifiers(aatype), /*base=*/false),
+          DtoType(getAssociativeArrayTypeInfoType()));
 
       LLConstant *idxs[2] = {DtoConstUint(0), DtoConstUint(0)};
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2403,7 +2403,7 @@ public:
           getRuntimeFunction(e->loc, gIR->module, "_d_assocarrayliteralTX");
       LLFunctionType *funcTy = func->getFunctionType();
       LLValue *aaTypeInfo =
-          DtoBitCast(DtoTypeInfoOf(stripModifiers(aatype), /*base=*/false),
+          DtoBitCast(DtoTypeInfoOf(stripModifiers(aatype), /*base=*/false, e->loc),
                      DtoType(getAssociativeArrayTypeInfoType()));
 
       LLConstant *idxs[2] = {DtoConstUint(0), DtoConstUint(0)};

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -587,7 +587,7 @@ public:
 
   //////////////////////////////////////////////////////////////////////////////
 
-  using BinOpFunc = DValue *(Loc &, Type *, DValue *, Expression *, bool);
+  using BinOpFunc = DValue *(const Loc &, Type *, DValue *, Expression *, bool);
 
   static Expression *getLValExp(Expression *e) {
     e = skipOverCasts(e);

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -314,7 +314,7 @@ public:
     LLType *tiTy = DtoType(getTypeInfoType());
 
     for (auto arg : *tu->arguments) {
-      arrInits.push_back(DtoTypeInfoOf(arg->type));
+      arrInits.push_back(DtoTypeInfoOf(decl->loc, arg->type));
     }
 
     // build array

--- a/tests/fail_compilation/betterC_typeinfo_diag.d
+++ b/tests/fail_compilation/betterC_typeinfo_diag.d
@@ -1,0 +1,10 @@
+// https://github.com/ldc-developers/ldc/issues/3631
+
+// RUN: not %ldc -betterC %s 2> %t.stderr
+// RUN: FileCheck %s < %t.stderr
+
+extern(C) void main()
+{
+    // CHECK: betterC_typeinfo_diag.d([[@LINE+1]]): Error: `TypeInfo` cannot be used with -betterC
+    int[] foo = [1];
+}


### PR DESCRIPTION
…etterC

This fixes an issue where any instantiation of TypeInfo in the final
output would lead to a cryptic error with no file or line information.
This change brings ldc in line with dmd's reporting of the same error,
which at least gives file and line information to discover the problem.