### PR TITLE
Azure CI Windows: Upgrade bundled libcurl to v7.74.0

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -18,7 +18,7 @@ steps:
     echo on
     cd ..
     :: Download & extract libcurl
-    curl -L -o libcurl.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v7.0.0/libcurl-7.69.1-zlib-static-ipv6-sspi-winssl.7z 2>&1
+    curl -L -o libcurl.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v8.0.0/libcurl-7.74.0-zlib-static-ipv6-sspi-schannel.7z 2>&1
     mkdir libcurl
     cd libcurl
     7z x ../libcurl.7z > nul


### PR DESCRIPTION
Build steps:

- Build zlib v1.2.11 using `contrib\vstudio\vc14\zlibvc.sln` (static release lib incl. asm, which needs to be built separately, e.g., `cd contrib\masmx64 && bld_ml64.bat` - I've added `/safeseh` in `contrib\masmx86\bld_ml32.bat`).
  MSCRT was set to `/MT`, and `/GS- /Zl` used for MinGW-based libs compatibility.
  Includes (`{zconf,zlib}.h`) and lib (`zlibstat.{lib,pdb}`) copied to `C:\LDC\curl-7.74.0\deps[_x86]`.
- Patch `winbuild\MakefileBuild.vc`:
  - Extend `CFLAGS` by `/DDONT_USE_RECV_BEFORE_SEND_WORKAROUND`.
  - Extend `CFLAGS_LIBCURL_STATIC` by `/GS- /Zl` (for MinGW-based libs compatibility...).
- Build DLL + import lib + .exp file:
  `nmake /f Makefile.vc mode=dll VC=16 WITH_DEVEL=C:\LDC\curl-7.74.0\deps[_x86] WITH_ZLIB=static GEN_PDB=no DEBUG=no MACHINE=x{64,86} RTLIBCFG=static`
- Build static lib:
  `nmake /f Makefile.vc mode=static VC=16 WITH_DEVEL=C:\LDC\curl-7.74.0\deps[_x86] WITH_ZLIB=static GEN_PDB=no DEBUG=no MACHINE=x{64,86} RTLIBCFG=static`
- Strip `lib` prefix from `libcurl*.{lib,exp}` filenames.