### PR TITLE
druntime: Cherry-pick libunwind-based backtrace alternative and use it for musl targets

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -643,6 +643,9 @@ void ArgsBuilder::addDefaultPlatformLibs() {
       args.push_back("-lm");
       break;
     }
+    if (triple.isMusl() && !global.params.betterC) {
+      args.push_back("-lunwind"); // for druntime backtrace
+    }
     args.push_back("-lrt");
   // fallthrough
   case llvm::Triple::Darwin:

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -765,6 +765,8 @@ void registerPredefinedTargetVersions() {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
     } else if (triple.isMusl()) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
+      // use libunwind for backtraces
+      VersionCondition::addPredefinedGlobalIdent("DRuntime_Use_Libunwind");
     } else if (global.params.isUClibcEnvironment) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
     } else {


### PR DESCRIPTION
Testing https://github.com/ldc-developers/druntime/pull/192.