### PR TITLE
Emit lambdas as linkonce_odr, including contained globals

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -269,13 +269,7 @@ public:
              "manifest constant being codegen'd!");
       assert(!irs->dcomputetarget);
 
-      // Check if we are defining or just declaring the global in this module.
-      // If we reach here during codegen of an available_externally function,
-      // new variable declarations should stay external and therefore must not
-      // have an initializer.
-      bool define = !(decl->storage_class & STCextern) && !decl->inNonRoot();
-
-      getIrGlobal(decl)->getValue(define);
+      getIrGlobal(decl)->getValue(/*define=*/true);
     }
   }
 

--- a/gen/function-inlining.cpp
+++ b/gen/function-inlining.cpp
@@ -109,6 +109,11 @@ bool defineAsExternallyAvailable(FuncDeclaration &fdecl) {
     return false;
   }
 
+  if (fdecl.isFuncLiteralDeclaration()) {
+    // defined as discardable linkonce_odr in each referencing CU
+    IF_LOG Logger::println("isFuncLiteralDeclaration() == true");
+    return false;
+  }
   if (fdecl.isUnitTestDeclaration()) {
     IF_LOG Logger::println("isUnitTestDeclaration() == true");
     return false;

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -229,8 +229,6 @@ LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
   LLGlobalValue::LinkageTypes linkage = LLGlobalValue::ExternalLinkage;
   if (hasWeakUDA(sym)) {
     linkage = LLGlobalValue::WeakAnyLinkage;
-  } else if (sym->isInstantiated()) {
-    linkage = templateLinkage;
   } else {
     // Function (incl. delegate) literals are emitted into each referencing
     // compilation unit, so use linkonce_odr for all lambdas and all global
@@ -241,8 +239,11 @@ LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
         potentialLambda = vd->toParent2();
     }
 
-    if (potentialLambda->isFuncLiteralDeclaration())
+    if (potentialLambda->isFuncLiteralDeclaration()) {
       linkage = LLGlobalValue::LinkOnceODRLinkage;
+    } else if (sym->isInstantiated()) {
+      linkage = templateLinkage;
+    }
   }
 
   return {linkage, needsCOMDAT()};

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -32,12 +32,20 @@ LLValue *IrGlobal::getValue(bool define) {
       define = defineOnDeclare(V);
   }
 
-  if (define && !(V->storage_class & STCextern)) {
-    auto gvar = llvm::dyn_cast<LLGlobalVariable>(value);
-    const bool isDefined = !gvar // bitcast pointer to a helper global
-                           || gvar->hasInitializer();
-    if (!isDefined)
-      this->define();
+  if (define) {
+    if (V->storage_class & STCextern) {
+      // external
+    } else if (!gIR->funcGenStates.empty() &&
+               gIR->topfunc()->getLinkage() ==
+                   LLGlobalValue::AvailableExternallyLinkage) {
+      // don't define globals while codegen'ing available_externally functions
+    } else {
+      auto gvar = llvm::dyn_cast<LLGlobalVariable>(value);
+      const bool isDefined = !gvar // bitcast pointer to a helper global
+                             || gvar->hasInitializer();
+      if (!isDefined)
+        this->define();
+    }
   }
 
   return value;

--- a/tests/codegen/lambdas_gh3648.d
+++ b/tests/codegen/lambdas_gh3648.d
@@ -1,0 +1,35 @@
+// Tests that lambdas and contained globals are emitted as linkonce_odr.
+
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+enum bar = ()
+{
+    static int global_bar;
+};
+
+enum bar_inlined = ()
+{
+    pragma(inline, true);
+    shared static int global_bar_inlined;
+};
+
+void foo()
+{
+    bar();
+    bar_inlined();
+}
+
+// the global variables should be defined as linkonce_odr:
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr global
+
+// foo() should only call one lambda:
+// CHECK: define {{.*}}_D14lambdas_gh36483fooFZv
+// CHECK-NEXT: call {{.*}}__lambda
+// CHECK-NEXT: ret void
+
+// bar() should be defined as linkonce_odr:
+// CHECK: define linkonce_odr {{.*}}__lambda
+
+// bar_inlined() should NOT have made it to the .ll:
+// CHECK-NOT: define {{.*}}__lambda

--- a/tests/codegen/lambdas_gh3648.d
+++ b/tests/codegen/lambdas_gh3648.d
@@ -17,19 +17,30 @@ void foo()
 {
     bar();
     bar_inlined();
+
+    (x) // template
+    {
+        __gshared int lambda_templ;
+        return x + lambda_templ;
+    }(123);
 }
 
 // the global variables should be defined as linkonce_odr:
 // CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr thread_local global
 // CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr global
+// CHECK: _D14lambdas_gh36483fooFZ__T9__lambda1TiZQnFiZ12lambda_templi{{.*}} = linkonce_odr global
 
-// foo() should only call one lambda:
+// foo() should only call two lambdas:
 // CHECK: define {{.*}}_D14lambdas_gh36483fooFZv
-// CHECK-NEXT: call {{.*}}__lambda
+// CHECK-NEXT: call {{.*}}__lambda5
+// CHECK-NEXT: call {{.*}}__T9__lambda1
 // CHECK-NEXT: ret void
 
 // bar() should be defined as linkonce_odr:
-// CHECK: define linkonce_odr {{.*}}__lambda
+// CHECK: define linkonce_odr {{.*}}__lambda5
 
 // bar_inlined() should NOT have made it to the .ll:
-// CHECK-NOT: define {{.*}}__lambda
+// CHECK-NOT: define {{.*}}__lambda6
+
+// the template lambda instance should be defined as linkonce_odr:
+// CHECK: define linkonce_odr {{.*}}__T9__lambda1

--- a/tests/codegen/lambdas_gh3648b.d
+++ b/tests/codegen/lambdas_gh3648b.d
@@ -1,0 +1,26 @@
+// Tests that *imported* lambdas and contained globals are emitted as linkonce_odr.
+
+// RUN: %ldc -output-ll -of=%t.ll %s -I%S && FileCheck %s < %t.ll
+
+import lambdas_gh3648;
+
+void foo()
+{
+    bar();
+    bar_inlined();
+}
+
+// the global variables should be defined as linkonce_odr:
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr global
+
+// foo() should only call one lambda:
+// CHECK: define {{.*}}_D15lambdas_gh3648b3fooFZv
+// CHECK-NEXT: call {{.*}}__lambda5
+// CHECK-NEXT: ret void
+
+// bar() should be defined as linkonce_odr:
+// CHECK: define linkonce_odr {{.*}}__lambda5
+
+// bar_inlined() should NOT have made it to the .ll:
+// CHECK-NOT: define {{.*}}__lambda6


### PR DESCRIPTION
As they are emitted into each referencing object file anyway.
Handling the globals resolves issue #3648.

I think this also solves issue #2968 - in the presumably rare event that you absolutely don't want to emit a function into its owning CU and only into each referencing CU, an enum-lambda can be used as shown in the testcase.
With `pragma(inline, true)`, it'll most likely be actually inlined and not make it to the object files.