### PR TITLE
-cleanup-obj: Put object files into temporary directory by default

### DIFF
--- a/dmd/dmodule.d
+++ b/dmd/dmodule.d
@@ -50,6 +50,9 @@ version (IN_LLVM)
     import dmd.root.aav;
     import dmd.root.array;
     import dmd.root.rmem;
+
+    // in driver/main.cpp
+    extern (C++) const(char)* createTempObjectsDir();
 }
 
 version(Windows) {
@@ -702,6 +705,17 @@ else
             // If argdoc doesn't have an absolute path, make it relative to dir
             if (!FileName.absolute(argdoc))
             {
+version (IN_LLVM)
+{
+                if (!dir.length && global.params.cleanupObjectFiles)
+                {
+                    __gshared const(char)[] tempObjectsDir;
+                    if (!tempObjectsDir.length)
+                        tempObjectsDir = createTempObjectsDir().toDString;
+
+                    dir = tempObjectsDir;
+                }
+}
                 //FileName::ensurePathExists(dir);
                 argdoc = FileName.combine(dir, argdoc);
             }
@@ -1525,7 +1539,6 @@ version (IN_LLVM)
 {
     //llvm::Module* genLLVMModule(llvm::LLVMContext& context);
     void checkAndAddOutputFile(const ref FileName file);
-    void makeObjectFilenameUnique();
 
     bool llvmForceLogging;
     bool noModuleInfo; /// Do not emit any module metadata.

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -546,12 +546,6 @@ version (IN_LLVM)
                 m.hdrfile = m.setOutfilename(params.hdrname, params.hdrdir, m.arg, global.hdr_ext);
         }
 
-        // If `-run` is passed, the obj file is temporary and is removed after execution.
-        // Make sure the name does not collide with other files from other processes by
-        // creating a unique filename.
-        if (params.run)
-            m.makeObjectFilenameUnique();
-
         // Set object filename in params.objfiles.
         for (size_t j = 0; j < params.objfiles.dim; j++)
         {
@@ -886,8 +880,7 @@ version (IN_LLVM)
         else if (params.lib)
             status = createStaticLibrary();
 
-        if (status == EXIT_SUCCESS &&
-            (params.cleanupObjectFiles || params.run))
+        if (status == EXIT_SUCCESS && params.cleanupObjectFiles)
         {
             for (size_t i = 0; i < modules.dim; i++)
             {

--- a/dmd/module.h
+++ b/dmd/module.h
@@ -151,7 +151,6 @@ public:
 #if IN_LLVM
     llvm::Module *genLLVMModule(llvm::LLVMContext &context);
     void checkAndAddOutputFile(const FileName &file);
-    void makeObjectFilenameUnique();
 
     bool llvmForceLogging;
     bool noModuleInfo; /// Do not emit any module metadata.

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -466,6 +466,12 @@ void parseCommandLine(Strings &sourceFiles) {
       global.params.run = false;
       error(Loc(), "Expected at least one argument to '-run'\n");
     }
+
+    // -run: enforce -oq and -cleanup-obj for non-conflicting temporary objects
+    if (global.params.run) {
+      global.params.fullyQualifiedObjectFiles = true;
+      global.params.cleanupObjectFiles = true;
+    }
   }
 
   sourceFiles.reserve(fileList.size());
@@ -929,6 +935,25 @@ void registerPredefinedVersions() {
 #undef STR
 }
 
+static llvm::SmallString<32> tempObjectsDir;
+
+// With -cleanup-obj, potentially invoked (once) by Module.setOutfilename() to
+// create a unique temporary directory for generated object files (if -od hasn't
+// been specified), e.g., `/tmp/objtmp-ldc-688445`.
+const char *createTempObjectsDir() {
+  assert(tempObjectsDir.empty());
+
+  auto ec = llvm::sys::fs::createUniqueDirectory("objtmp-ldc", tempObjectsDir);
+  if (ec) {
+    error(Loc(),
+          "failed to create temporary directory for object files: %s\n%s",
+          tempObjectsDir.c_str(), ec.message().c_str());
+    fatal();
+  }
+
+  return tempObjectsDir.c_str();
+}
+
 /// LDC's entry point, C main.
 /// Without `-lowmem`, we need to switch to the bump-pointer allocation scheme
 /// right from the start, before any module ctors are run, so we need this hook
@@ -1108,6 +1133,10 @@ int cppmain() {
     Strings libmodules;
     status = mars_mainBody(global.params, files, libmodules);
   }
+
+  // try to remove the temp objects dir if created for -cleanup-obj
+  if (!tempObjectsDir.empty())
+    llvm::sys::fs::remove(tempObjectsDir);
 
   writeTimeTraceProfile();
   deinitializeTimeTracer();

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -82,19 +82,6 @@ void Module::checkAndAddOutputFile(const FileName &file) {
   files.emplace(std::move(key), this);
 }
 
-void Module::makeObjectFilenameUnique() {
-  assert(objfile.toChars());
-
-  const char *ext = FileName::ext(objfile.toChars());
-  const char *stem = FileName::removeExt(objfile.toChars());
-
-  llvm::SmallString<128> unique;
-  auto EC = llvm::sys::fs::createUniqueFile(
-      llvm::Twine(stem) + "-%%%%%%%." + ext, unique);
-  if (!EC) // success
-    objfile.reset(unique.c_str());
-}
-
 namespace {
 /// Ways the druntime module registry system can be implemented.
 enum class RegistryStyle {

--- a/tests/driver/cleanup_obj_gh3643.d
+++ b/tests/driver/cleanup_obj_gh3643.d
@@ -1,0 +1,5 @@
+module tests.driver.cleanup_obj;
+
+// RUN: %ldc -cleanup-obj -oq -gcc=echo -mtriple=x86_64-linux %s | FileCheck %s
+
+// CHECK: objtmp-ldc-{{([a-zA-Z0-9]{6})[/\\]}}tests.driver.cleanup_obj.o


### PR DESCRIPTION
To prevent conflicts for concurrent LDC processes in the same working dir, resolving #3643.

Re-use this for the temporary object files of `-run` by enforcing `-cleanup-obj` in that case. Additionally enforcing `-oq` prevents
conflicting filenames in that dir and allows to get rid of previous `Module.makeObjectFilenameUnique()`.