### PR TITLE
Travis CI: Cut down to Linux AArch64 only

### DIFF
--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -1,4 +1,4 @@
-name: Test supported LLVM versions and misc. D host compilers
+name: Vanilla LLVM
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -7,6 +7,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - job_name: Ubuntu 16.04, LLVM 11, latest LDC beta
+            os: ubuntu-16.04
+            host_dc: ldc-beta
+            llvm_version: "11.0.1"
+            cmake_opts: "-DRT_SUPPORT_SANITIZERS=ON"
           - job_name: Ubuntu 16.04, LLVM 9, latest LDC beta
             os: ubuntu-16.04
             host_dc: ldc-beta
@@ -77,7 +82,7 @@ jobs:
             suffix='x86_64-linux-gnu-${{ matrix.os }}'
           fi
           version='${{ matrix.llvm_version }}'
-          if [[ "$version" == 10.* ]]; then
+          if [[ "$version" == 1?.* ]]; then
             llvm_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/clang+llvm-$version-$suffix.tar.xz"
           else
             llvm_url="http://releases.llvm.org/$version/clang+llvm-$version-$suffix.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - os: linux
       arch: arm64
       d: ldc-beta
-      env: LLVM_VERSION=11.0.1 PARALLELISM=16 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
+      env: LLVM_VERSION=11.0.1 PARALLELISM=8 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,49 +10,17 @@ matrix:
       arch: arm64
       d: ldc-beta
       env: LLVM_VERSION=11.0.1 PARALLELISM=16 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-            - gdb
-            - ninja-build
-    - os: linux
-      d: ldc-beta
-      env: LLVM_VERSION=9.0.0 OPTS="-DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON"
-    - os: linux
-      d: ldc-0.17.6
-      env: LLVM_VERSION=8.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF -DLDC_LINK_MANUALLY=ON"
-    # FIXME: strange crashes, possibly due to C++ compiler mismatch
-    #- os: linux
-    #  d: ldc
-    #  env: LLVM_VERSION=7.0.1 OPTS="-DBUILD_SHARED_LIBS=ON"
-    - os: linux
-      d: dmd-beta
-      env: LLVM_VERSION=6.0.1 OPTS="-DLIB_SUFFIX=64 -DLDC_LINK_MANUALLY=ON"
-    - os: osx
-      osx_image: xcode11.3
-      d: dmd-beta
-      env: LLVM_VERSION=10.0.0 OPTS="-DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON -DLDC_LINK_MANUALLY=ON"
-    - os: osx
-      osx_image: xcode11.3
-      d: ldc-beta
-      env: LLVM_VERSION=7.0.0 OPTS="-DBUILD_SHARED_LIBS=OFF"
 
 cache:
   directories:
     - llvm-11.0.1
-    - llvm-10.0.0
-    - llvm-9.0.0
-    - llvm-8.0.0
-    - llvm-7.0.1
-    - llvm-7.0.0
-    - llvm-6.0.1
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - g++-8
       - gdb
       - ninja-build
 
@@ -63,23 +31,7 @@ before_install:
   - export LLVM_ROOT_DIR="$PWD/llvm-$LLVM_VERSION"
   - |
     if [ ! -e "$LLVM_ROOT_DIR/bin/llvm-config" ]; then
-      if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-        llvm_url="https://github.com/ldc-developers/llvm-project/releases/download/ldc-v$LLVM_VERSION/llvm-$LLVM_VERSION-linux-aarch64-withAsserts.tar.xz"
-      else
-        if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-          LLVM_ARCH="x86_64-linux-gnu-ubuntu-16.04"
-        elif [ "$LLVM_VERSION" = "9.0.0" ]; then
-          LLVM_ARCH="x86_64-darwin-apple"
-        else
-          LLVM_ARCH="x86_64-apple-darwin"
-        fi
-        if [ "${LLVM_VERSION:0:1}" = "1" ]; then
-          # v10+
-          llvm_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VERSION/clang+llvm-$LLVM_VERSION-$LLVM_ARCH.tar.xz"
-        else
-          llvm_url="http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-$LLVM_ARCH.tar.xz"
-        fi
-      fi
+      llvm_url="https://github.com/ldc-developers/llvm-project/releases/download/ldc-v$LLVM_VERSION/llvm-$LLVM_VERSION-linux-aarch64-withAsserts.tar.xz"
       wget -nv -O llvm.tar.xz $llvm_url
       mkdir -p $LLVM_ROOT_DIR
       tar -xf llvm.tar.xz --strip 1 -C $LLVM_ROOT_DIR
@@ -87,26 +39,8 @@ before_install:
     fi
 
 install:
-  - |
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      # Install pip
-      wget -O get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
-      sudo python get-pip.py
-      rm get-pip.py
-      # Download & extract Ninja & add to PATH
-      wget -O ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip
-      mkdir ninja
-      tar -xf ninja-mac.zip -C ninja
-      rm ninja-mac.zip
-      export PATH="$PWD/ninja:$PATH"
-    fi
   # Install lit
-  - |
-    if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-      python -m pip install --user lit
-    else
-      pip install --user lit
-    fi
+  - python -m pip install --user lit
   - python -c "import lit.main; lit.main.main();" --version . | head -n 1
 
 script:
@@ -124,60 +58,27 @@ script:
   # Build LDC & LDC D unittests & defaultlib unittest runners
   - |
     numJobs=${PARALLELISM:-3}
-    # The OSX VM has only 4 GB of memory (Linux: 7.5)
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      numJobs=2
-    fi
-    # Work around out-of-memory errors - retry once with full numJobs, and another time with halved numJobs (ceiled)
+    # Work around out-of-memory errors - retry with decreasing jobs
     targets='all ldc2-unittest all-test-runners'
     currentNumJobs=$numJobs
-    for i in {1..3}; do
+    for i in {1..5}; do
       ninja -j$currentNumJobs $targets && break || true
       currentNumJobs=$(( ($numJobs + $i - 1) / $i ))
     done
   - bin/ldc2 -version || exit 1
   # Run LDC D unittests
   - ctest --output-on-failure -R "ldc2-unittest"
-  # AArch64 FIXME: all gdb tests fail and are disabled
-  - |
-    if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-      rm tests/debuginfo/*_gdb.d
-      rm tests/d2/dmd-testsuite/runnable/b18504.d
-    fi
+  # FIXME: all gdb tests fail and are disabled
+  - rm tests/debuginfo/*_gdb.d
+  - rm tests/d2/dmd-testsuite/runnable/b18504.d
   # Run LIT testsuite
-  - |
-    if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-      # AArch64 FIXME: don't ignore errors
-      ctest -V -R "lit-tests" || true
-    else
-      ctest -V -R "lit-tests"
-    fi
+  # FIXME: don't ignore errors
+  - ctest -V -R "lit-tests" || true
   # Run DMD testsuite
-  - |
-    if [[ "$($DC --version | head -n 1)" == *0.17.* ]]; then
-      # The -lowmem tests don't work with an ltsmaster host compiler
-      rm tests/d2/dmd-testsuite/runnable/{testptrref,xtest46}_gc.d
-      rm tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
-      # The @live tests neither (LDC segfaults)
-      rm tests/d2/dmd-testsuite/compilable/ob1.d
-      rm tests/d2/dmd-testsuite/fail_compilation/fob{1,2}.d
-      # A __traits(getOverloads) test neither
-      rm tests/d2/dmd-testsuite/compilable/test21050.d
-    fi
-  - |
-    if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-      DMD_TESTSUITE_MAKE_ARGS="-j${PARALLELISM:-3} GDB_FLAGS=OFF" ctest -V -R "dmd-testsuite"
-    else
-      DMD_TESTSUITE_MAKE_ARGS=-j${PARALLELISM:-3} ctest -V -R "dmd-testsuite"
-    fi
-  # Run defaultlib unittests & druntime stand-alone tests
-  - |
-    if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then
-      # AArch64 FIXME: don't exclude hanging core.thread.fiber & don't ignore errors
-      ctest -j${PARALLELISM:-3} --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^core.thread.fiber($|-)" || true
-    else
-      ctest -j${PARALLELISM:-3} --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
-    fi
+  - DMD_TESTSUITE_MAKE_ARGS="-j${PARALLELISM:-3} GDB_FLAGS=OFF" ctest -V -R "dmd-testsuite"
+  # Run defaultlib unittests & druntime integration tests
+  # FIXME: don't exclude hanging core.thread.fiber & don't ignore errors
+  - ctest -j${PARALLELISM:-3} --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^core.thread.fiber($|-)" || true
 
 after_success:
   - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 
 variables:
   LLVM_VERSION: 11.0.1
-  CLANG_VERSION: 11.0.0
+  CLANG_VERSION: 11.0.1
   HOST_LDC_VERSION: 1.24.0
 
 trigger:
@@ -58,8 +58,6 @@ jobs:
     # support older user binutils (e.g., Ubuntu 14.04).
     BOOTSTRAP_CMAKE_FLAGS: -DBUILD_LTO_LIBS=ON -DLDC_INSTALL_LTOPLUGIN=ON
     EXTRA_CMAKE_FLAGS: -DMULTILIB=ON -DBUILD_LTO_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ -DJITRT_EXTRA_LDFLAGS=-static-libstdc++ -DRT_CFLAGS=-Wa,-mrelax-relocations=no -DLDC_INSTALL_LTOPLUGIN=ON -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto" -DEXTRA_CXXFLAGS=-flto=full
-    # Official clang 11.0.0 was available for Ubuntu 16.04, but isn't anymore...
-    CLANG_VERSION: 10.0.1
   steps:
     - template: .azure-pipelines/posix.yml
 
@@ -84,8 +82,6 @@ jobs:
   variables:
     CI_OS: android
     ANDROID_NDK_VERSION: r21e
-    # Official clang 11.0.0 was available for Ubuntu 16.04, but isn't anymore...
-    CLANG_VERSION: 10.0.1
   strategy:
     matrix:
       armv7a:


### PR DESCRIPTION
Their open-source engagement is fading, and jobs take a while to get scheduled.

Shippable will die too on ~~March~~ May 3rd; I hope the AArch64 Travis job can last a little while longer for some AArch64 test coverage.

Also add 2 more retry rounds to work around recent OOM regressions.