### PR TITLE
Ignore -enable-cross-module-inlining if inlining is generally disabled

### DIFF
--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -128,7 +128,7 @@ bool willInline() {
 }
 
 bool willCrossModuleInline() {
-  return enableCrossModuleInlining == llvm::cl::BOU_TRUE;
+  return enableCrossModuleInlining == llvm::cl::BOU_TRUE && willInline();
 }
 
 #if LDC_LLVM_VER >= 800 && LDC_LLVM_VER < 1000

--- a/tests/codegen/inlining_disablecross.d
+++ b/tests/codegen/inlining_disablecross.d
@@ -1,21 +1,18 @@
-// Test disabling/enabling of cross-module inlining
+// Test disabling of cross-module inlining
 
-// RUN: %ldc %s -I%S -c -output-ll  -enable-cross-module-inlining -O0 -of=%t.ENA.ll && FileCheck %s --check-prefix ENABLED  < %t.ENA.ll
-// RUN: %ldc %s -I%S -c -output-ll -disable-cross-module-inlining -O3 -of=%t.DIS.ll && FileCheck %s --check-prefix DISABLED < %t.DIS.ll
+// RUN: %ldc %s -I%S -c -output-ll  -enable-cross-module-inlining -O0 -of=%t.ENA.ll && FileCheck %s < %t.ENA.ll
+// RUN: %ldc %s -I%S -c -output-ll -disable-cross-module-inlining -O3 -of=%t.DIS.ll && FileCheck %s < %t.DIS.ll
 
 import inputs.inlinables;
 
 extern (C): // simplify mangling for easier matching
 
-// DISABLED-LABEL: define{{.*}} @call_easily_inlinable(
-// ENABLED-LABEL: define{{.*}} @call_easily_inlinable(
+// CHECK-LABEL: define{{.*}} @call_easily_inlinable(
 int call_easily_inlinable(int i)
 {
-    // DISABLED: call {{.*}} @easily_inlinable(
+    // CHECK: call {{.*}} @easily_inlinable(
     return easily_inlinable(i);
-    // DISABLED: ret
-    // ENABLED: ret
+    // CHECK: ret
 }
 
-// ENABLED-DAG: define {{.*}} @easily_inlinable(
-// DISABLED-DAG: declare {{.*}} @easily_inlinable(
+// CHECK-DAG: declare {{.*}} @easily_inlinable(


### PR DESCRIPTION
People use `dflags "-enable-cross-module-inlining" platform="ldc"` in their `dub.sdl` files; default and debug builds without `-O` thus incur a superfluous compile-time cost (extra `available_externally` emissions) for no benefit.