### PR TITLE
CI: Use `-k0` for ninja cmdlines potentially running into out-of-memory errors

### DIFF
--- a/.azure-pipelines/1-posix-setup.yml
+++ b/.azure-pipelines/1-posix-setup.yml
@@ -40,7 +40,7 @@ steps:
       tar -xf clang.tar.xz --strip 1 -C clang
     fi
     # Install lit
-    curl -OL https://bootstrap.pypa.io/2.7/get-pip.py
+    curl -OL https://bootstrap.pypa.io/pip/2.7/get-pip.py
     python get-pip.py --user
     python -m pip install --user lit
     python -c "import lit.main; lit.main.main();" --version . | head -n 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,10 @@ commonSteps: &commonSteps
             -DD_COMPILER=$PWD/../host-ldc/bin/ldmd2 \
             -DLDC_LINK_MANUALLY=OFF \
             $EXTRA_CMAKE_FLAGS
-          # Work around out-of-memory errors - retry twice with parallelization and one last time serially
+          # Work around out-of-memory errors - retry once with parallelization and one last time serially
           targets='all ldc2-unittest all-test-runners'
-          for i in {1..3}; do
-            ninja -j$PARALLELISM $targets && break || true
+          for i in {1..2}; do
+            ninja -j$PARALLELISM -k0 $targets && break || true
           done
           ninja -j1 $targets
           bin/ldc2 -version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commonSteps: &commonSteps
             echo "export PATH=$PWD/cmake/bin:$PWD/ninja:$PWD/llvm/bin:$PATH" >> $BASH_ENV
           fi
           # Install pip
-          curl --max-time 300 --retry 3 -OL https://bootstrap.pypa.io/2.7/get-pip.py
+          curl --max-time 300 --retry 3 -OL https://bootstrap.pypa.io/pip/2.7/get-pip.py
           python get-pip.py --user
           rm get-pip.py
           # Install lit

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@
 common_steps_template: &COMMON_STEPS_TEMPLATE
   install_pip_and_lit_script: |
     # Install pip
-    curl --max-time 300 --retry 3 -OL https://bootstrap.pypa.io/2.7/get-pip.py
+    curl --max-time 300 --retry 3 -OL https://bootstrap.pypa.io/pip/2.7/get-pip.py
     python get-pip.py --user
     rm get-pip.py
     # Install lit

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install lit
         run: |
           set -euxo pipefail
-          curl -OL https://bootstrap.pypa.io/2.7/get-pip.py
+          curl -OL https://bootstrap.pypa.io/pip/2.7/get-pip.py
           python get-pip.py --user
           python -m pip install --user lit
           python -c "import lit.main; lit.main.main();" --version . | head -n 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - os: linux
       arch: arm64
       d: ldc-beta
-      env: LLVM_VERSION=11.0.1 PARALLELISM=8 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
+      env: LLVM_VERSION=11.0.1 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
 
 cache:
   directories:
@@ -55,14 +55,12 @@ script:
       $OPTS
   # Build LDC & LDC D unittests & defaultlib unittest runners
   - |
-    numJobs=${PARALLELISM:-3}
     # Work around out-of-memory errors - retry with decreasing jobs
     targets='all ldc2-unittest all-test-runners'
-    currentNumJobs=$numJobs
-    for i in {1..5}; do
-      ninja -j$currentNumJobs $targets && break || true
-      currentNumJobs=$(( ($numJobs + $i - 1) / $i ))
-    done
+    ninja -j8 -k0 $targets || \
+      ninja -j8 -k0 $targets || \
+      ninja -j2 -k0 $targets || \
+      ninja -j1 $targets
   - bin/ldc2 -version || exit 1
   # Run LDC D unittests
   - ctest --output-on-failure -R "ldc2-unittest"
@@ -73,10 +71,10 @@ script:
   # FIXME: don't ignore errors
   - ctest -V -R "lit-tests" || true
   # Run DMD testsuite
-  - DMD_TESTSUITE_MAKE_ARGS="-j${PARALLELISM:-3} GDB_FLAGS=OFF" ctest -V -R "dmd-testsuite"
+  - DMD_TESTSUITE_MAKE_ARGS="-j8 GDB_FLAGS=OFF" ctest -V -R "dmd-testsuite"
   # Run defaultlib unittests & druntime integration tests
   # FIXME: don't exclude hanging core.thread.fiber & don't ignore errors
-  - ctest -j${PARALLELISM:-3} --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^core.thread.fiber($|-)" || true
+  - ctest -j8 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^core.thread.fiber($|-)" || true
 
 after_success:
   - |

--- a/shippable.yml
+++ b/shippable.yml
@@ -81,7 +81,7 @@ build:
     - |
       # Work around out-of-memory errors - retry once with halved jobs
       targets='all ldc2-unittest all-test-runners'
-      ninja -j32 $targets || ninja -j16 $targets
+      ninja -j32 -k0 $targets || ninja -j16 $targets
     - bin/ldc2 --version
     # Run LDC D unittests
     - ctest --output-on-failure -R "ldc2-unittest"


### PR DESCRIPTION
This can significantly improve throughput, because ninja keeps on going after a child process dies and tries to build as many targets as it can in the current pass.