### PR TITLE
accept i1 types as dlang bool

### DIFF
--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -52,7 +52,9 @@ string dtype(Record* rec, bool readOnlyMem)
         type = type.substr(i);
     }
 
-    if(type == "i8")
+    if(type == "i1" && vec.empty())
+        return "bool";
+    else if(type == "i8")
         return "byte" + vec;
     else if(type == "i16")
         return "short" + vec;


### PR DESCRIPTION
This updates the gen_gccbuiltins utility to handle 'i1' types as dlang bool.

The 'vec' substring concatentation against "bool" seems innocuous but should be reviewed.
