### PR TITLE
Don't enforce the frame pointer for functions with GCC-style inline asm

### DIFF
--- a/dmd/declaration.h
+++ b/dmd/declaration.h
@@ -568,6 +568,7 @@ public:
     // 4 if there's an assert(0)
     // 8 if there's inline asm
     // 16 if there are multiple return statements
+    // IN_LLVM: 32 if there's DMD-style inline asm
     int hasReturnExp;
 
     // Support for NRVO (named return value optimization)

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -109,6 +109,9 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
     return gccAsmSemantic(gas, sc);
   }
 
+  // this is DMD-style asm
+  sc->func->hasReturnExp |= 32;
+
   auto ias = createInlineAsmStatement(s->loc, s->tokens);
   s = ias;
 
@@ -156,7 +159,7 @@ void AsmStatement_toIR(InlineAsmStatement *stmt, IRState *irs) {
   LOG_SCOPE;
 
   // sanity check
-  assert(irs->func()->decl->hasReturnExp & 8);
+  assert((irs->func()->decl->hasReturnExp & 40) == 40);
 
   // get asm block
   IRAsmBlock *asmblock = irs->asmBlock;

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1232,8 +1232,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     emitDMDStyleFunctionTrace(*gIR, fd, funcGen);
   }
 
-  // disable frame-pointer-elimination for functions with inline asm
-  if (fd->hasReturnExp & 8) // has inline asm
+  // disable frame-pointer-elimination for functions with DMD-style inline asm
+  if (fd->hasReturnExp & 32)
   {
 #if LDC_LLVM_VER >= 800
     func->addFnAttr(

--- a/tests/codegen/asm_gcc_no_fp.d
+++ b/tests/codegen/asm_gcc_no_fp.d
@@ -1,0 +1,21 @@
+// Makes sure the frame pointer isn't enforced for GCC-style asm.
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -mattr=avx -O -output-s -of=%t.s %s
+// RUN: FileCheck %s < %t.s
+
+alias byte32 = __vector(byte[32]);
+
+// CHECK: _D13asm_gcc_no_fp3xorFNhG32gQgZQj:
+byte32 xor(byte32 a, byte32 b)
+{
+    // CHECK-NEXT: .cfi_startproc
+    byte32 r;
+    // CHECK-NEXT: #APP
+    // CHECK-NEXT: vxorps %ymm0, %ymm1, %ymm0
+    // CHECK-NEXT: #NO_APP
+    asm { "vxorps %0, %1, %2" : "=v" (r) : "v" (a), "v" (b); }
+    // CHECK-NEXT: retq
+    return r;
+}


### PR DESCRIPTION
As GDC doesn't either (see https://d.godbolt.org/z/6qMG76).