### PR TITLE
Adapt to Windows-specific LLVM 12 API change

### DIFF
--- a/driver/args.cpp
+++ b/driver/args.cpp
@@ -118,8 +118,17 @@ struct ResponseFile {
       return true; // nothing to do
 
 #if defined(_WIN32) && LDC_LLVM_VER >= 700
+#if LDC_LLVM_VER >= 1200
+    const llvm::ErrorOr<std::wstring> wcontent =
+        llvm::sys::flattenWindowsCommandLine(toRefsVector(args));
+
+    std::string content;
+    if (!wcontent || !llvm::convertWideToUTF8(*wcontent, content))
+      return false;
+#else
     const std::string content =
         llvm::sys::flattenWindowsCommandLine(toRefsVector(args));
+#endif
 #else
     std::string content;
     content.reserve(65536);


### PR DESCRIPTION
I've missed this in #3663 (only tested manually on Linux back then).