### PR TITLE
Windows: Make -fvisibility=public export all defined symbols and import external data

### DIFF
--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -361,6 +361,10 @@ version (IN_LLVM)
     bool outputSourceLocations; // if true, output line tables.
 
     bool linkonceTemplates; // -linkonce-templates
+
+    // Windows-specific:
+    bool dllexport; // dllexport ~all defined symbols?
+    bool dllimport; // dllimport data symbols not defined in any root module?
 } // IN_LLVM
 }
 

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -323,6 +323,10 @@ struct Param
     bool outputSourceLocations; // if true, output line tables.
 
     bool linkonceTemplates; // -linkonce-templates
+
+    // Windows-specific:
+    bool dllexport; // dllexport ~all defined symbols?
+    bool dllimport; // dllimport data symbols not defined in any root module?
 #endif
 };
 

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -60,12 +60,15 @@ static cl::opt<bool, true>
     createSharedLib("shared", cl::desc("Create shared library (DLL)"),
                     cl::ZeroOrMore, cl::location(global.params.dll));
 
-cl::opt<unsigned char> defaultToHiddenVisibility(
-    "fvisibility", cl::ZeroOrMore,
-    cl::desc("Default visibility of symbols (not relevant for Windows)"),
-    cl::values(clEnumValN(0, "default", "Export all symbols"),
-               clEnumValN(1, "hidden",
-                          "Only export symbols marked with 'export'")));
+cl::opt<SymbolVisibility> symbolVisibility(
+    "fvisibility", cl::ZeroOrMore, cl::desc("Default visibility of symbols"),
+    cl::init(SymbolVisibility::default_),
+    cl::values(clEnumValN(SymbolVisibility::default_, "default",
+                          "Hidden for Windows targets, otherwise public"),
+               clEnumValN(SymbolVisibility::hidden, "hidden",
+                          "Only export symbols marked with 'export'"),
+               clEnumValN(SymbolVisibility::public_, "public",
+                          "Export all symbols")));
 
 static cl::opt<bool, true> verbose("v", cl::desc("Verbose"), cl::ZeroOrMore,
                                    cl::location(global.params.verbose));

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -63,12 +63,13 @@ static cl::opt<bool, true>
 cl::opt<SymbolVisibility> symbolVisibility(
     "fvisibility", cl::ZeroOrMore, cl::desc("Default visibility of symbols"),
     cl::init(SymbolVisibility::default_),
-    cl::values(clEnumValN(SymbolVisibility::default_, "default",
-                          "Hidden for Windows targets, otherwise public"),
-               clEnumValN(SymbolVisibility::hidden, "hidden",
-                          "Only export symbols marked with 'export'"),
-               clEnumValN(SymbolVisibility::public_, "public",
-                          "Export all symbols")));
+    cl::values(
+        clEnumValN(
+            SymbolVisibility::default_, "default",
+            "Hidden for Windows targets without -shared, otherwise public"),
+        clEnumValN(SymbolVisibility::hidden, "hidden",
+                   "Only export symbols marked with 'export'"),
+        clEnumValN(SymbolVisibility::public_, "public", "Export all symbols")));
 
 static cl::opt<bool, true> verbose("v", cl::desc("Verbose"), cl::ZeroOrMore,
                                    cl::location(global.params.verbose));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -83,7 +83,8 @@ extern cl::opt<std::string> mTargetTriple;
 extern cl::opt<std::string> mABI;
 extern FloatABI::Type floatABI;
 extern cl::opt<bool> disableLinkerStripDead;
-extern cl::opt<unsigned char> defaultToHiddenVisibility;
+enum class SymbolVisibility { default_, hidden, public_ };
+extern cl::opt<SymbolVisibility> symbolVisibility;
 extern cl::opt<bool> noPLT;
 extern cl::opt<bool> useDIP25;
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1110,6 +1110,18 @@ int cppmain() {
     global.params.symdebug = 1;
   }
 
+  if (global.params.targetTriple->isOSWindows()) {
+    const auto v = opts::symbolVisibility.getValue();
+    global.params.dllexport =
+        v == opts::SymbolVisibility::public_ ||
+        // default with -shared
+        (v == opts::SymbolVisibility::default_ && global.params.dll);
+    global.params.dllimport =
+        v == opts::SymbolVisibility::public_ ||
+        // enforced when linking against shared default libs
+        linkAgainstSharedDefaultLibs();
+  }
+
   // allocate the target abi
   gABI = TargetABI::getTarget();
 

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -667,12 +667,6 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
 
   func->setCallingConv(gABI->callingConv(link, f, fdecl));
 
-  if (global.params.targetTriple->isOSWindows() && fdecl->isExport()) {
-    func->setDLLStorageClass(fdecl->isImportedSymbol()
-                                 ? LLGlobalValue::DLLImportStorageClass
-                                 : LLGlobalValue::DLLExportStorageClass);
-  }
-
   IF_LOG Logger::cout() << "func = " << *func << std::endl;
 
   // add func to IRFunc
@@ -1151,9 +1145,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     return;
   }
 
-  if (opts::defaultToHiddenVisibility && !fd->isExport()) {
-    func->setVisibility(LLGlobalValue::HiddenVisibility);
-  }
+  setVisibility(fd, func);
 
   // if this function is naked, we take over right away! no standard processing!
   if (fd->naked) {
@@ -1192,8 +1184,6 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   } else {
     setLinkage(lwc, func);
   }
-
-  assert(!func->hasDLLImportStorageClass());
 
   // function attributes
   if (gABI->needsUnwindTables()) {

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1023,9 +1023,10 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     assert(func);
     if (!linkageAvailableExternally &&
         (func->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage)) {
-      // Fix linkage
+      // Fix linkage and visibility
       const auto lwc = lowerFuncLinkage(fd);
       setLinkage(lwc, func);
+      setVisibility(fd, func);
     }
     return;
   }
@@ -1145,8 +1146,6 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     return;
   }
 
-  setVisibility(fd, func);
-
   // if this function is naked, we take over right away! no standard processing!
   if (fd->naked) {
     DtoDefineNakedFunction(fd);
@@ -1183,6 +1182,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
            lwc.first != llvm::GlobalValue::LinkOnceAnyLinkage);
   } else {
     setLinkage(lwc, func);
+    setVisibility(fd, func);
   }
 
   // function attributes

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1373,6 +1373,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   }
 
   if (func->getLinkage() == LLGlobalValue::WeakAnyLinkage &&
+      !func->hasDLLExportStorageClass() &&
       global.params.targetTriple->isWindowsMSVCEnvironment()) {
     emulateWeakAnyLinkageForMSVC(func, fd->linkage);
   }

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -253,8 +253,8 @@ llvm::Constant *buildStringLiteralConstant(StringExp *se, bool zeroTerm);
 llvm::GlobalVariable *declareGlobal(const Loc &loc, llvm::Module &module,
                                     llvm::Type *type,
                                     llvm::StringRef mangledName,
-                                    bool isConstant,
-                                    bool isThreadLocal = false);
+                                    bool isConstant, bool isThreadLocal,
+                                    bool useDLLImport);
 
 /// Defines an existing LLVM global, i.e., sets the initial value and finalizes
 /// its linkage and visibility.

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -12,6 +12,7 @@
 #include "dmd/errors.h"
 #include "dmd/mangle.h"
 #include "dmd/module.h"
+#include "driver/cl_options.h"
 #include "gen/abi.h"
 #include "gen/classes.h"
 #include "gen/irstate.h"
@@ -312,5 +313,9 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
   LLGlobalVariable *moduleInfoSym = getIrModule(m)->moduleInfoSymbol();
   b.finalize(moduleInfoSym);
   setLinkage({LLGlobalValue::ExternalLinkage, needsCOMDAT()}, moduleInfoSym);
+  if (global.params.targetTriple->isOSWindows() &&
+      opts::symbolVisibility == opts::SymbolVisibility::public_) {
+    moduleInfoSym->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
+  }
   return moduleInfoSym;
 }

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -12,7 +12,6 @@
 #include "dmd/errors.h"
 #include "dmd/mangle.h"
 #include "dmd/module.h"
-#include "driver/cl_options.h"
 #include "gen/abi.h"
 #include "gen/classes.h"
 #include "gen/irstate.h"
@@ -313,8 +312,7 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
   LLGlobalVariable *moduleInfoSym = getIrModule(m)->moduleInfoSymbol();
   b.finalize(moduleInfoSym);
   setLinkage({LLGlobalValue::ExternalLinkage, needsCOMDAT()}, moduleInfoSym);
-  if (global.params.targetTriple->isOSWindows() &&
-      opts::symbolVisibility == opts::SymbolVisibility::public_) {
+  if (global.params.dllexport) {
     moduleInfoSym->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
   }
   return moduleInfoSym;

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -22,6 +22,7 @@
 #include "dmd/statement.h"
 #include "dmd/target.h"
 #include "dmd/template.h"
+#include "driver/cl_options.h"
 #include "driver/cl_options_instrumentation.h"
 #include "driver/timetrace.h"
 #include "gen/abi.h"
@@ -128,7 +129,7 @@ RegistryStyle getModuleRegistryStyle() {
 LLGlobalVariable *declareDSOGlobal(llvm::StringRef mangledName, LLType *type,
                                    bool isThreadLocal = false) {
   auto global = declareGlobal(Loc(), gIR->module, type, mangledName, false,
-                              isThreadLocal);
+                              isThreadLocal, false);
   global->setVisibility(LLGlobalValue::HiddenVisibility);
   return global;
 }
@@ -190,7 +191,10 @@ LLFunction *build_module_reference_and_ctor(const char *moduleMangle,
   LLConstant *mref = gIR->module.getNamedGlobal(mrefIRMangle);
   LLType *modulerefPtrTy = getPtrToType(modulerefTy);
   if (!mref) {
-    mref = declareGlobal(Loc(), gIR->module, modulerefPtrTy, mrefIRMangle, false);
+    const bool useDLLImport =
+        opts::symbolVisibility == opts::SymbolVisibility::public_;
+    mref = declareGlobal(Loc(), gIR->module, modulerefPtrTy, mrefIRMangle,
+                         false, false, useDLLImport);
   }
   mref = DtoBitCast(mref, getPtrToType(modulerefPtrTy));
 

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -22,7 +22,6 @@
 #include "dmd/statement.h"
 #include "dmd/target.h"
 #include "dmd/template.h"
-#include "driver/cl_options.h"
 #include "driver/cl_options_instrumentation.h"
 #include "driver/timetrace.h"
 #include "gen/abi.h"
@@ -191,10 +190,8 @@ LLFunction *build_module_reference_and_ctor(const char *moduleMangle,
   LLConstant *mref = gIR->module.getNamedGlobal(mrefIRMangle);
   LLType *modulerefPtrTy = getPtrToType(modulerefTy);
   if (!mref) {
-    const bool useDLLImport =
-        opts::symbolVisibility == opts::SymbolVisibility::public_;
     mref = declareGlobal(Loc(), gIR->module, modulerefPtrTy, mrefIRMangle,
-                         false, false, useDLLImport);
+                         false, false, global.params.dllimport);
   }
   mref = DtoBitCast(mref, getPtrToType(modulerefPtrTy));
 

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -160,7 +160,8 @@ llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
   if (cd->isCPPclass()) {
     const char *name = target.cpp.typeInfoMangle(cd);
     return declareGlobal(cd->loc, irs.module, getVoidPtrType(), name,
-                         /*isConstant=*/true);
+                         /*isConstant*/ true, false,
+                         /*useDLLImport*/ cd->isExport());
   }
 
   llvm::GlobalVariable *&Var = irs.TypeDescriptorMap[cd];

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -14,6 +14,7 @@
 #include "dmd/mangle.h"
 #include "dmd/statement.h"
 #include "dmd/template.h"
+#include "driver/cl_options.h"
 #include "gen/dvalue.h"
 #include "gen/funcgenstate.h"
 #include "gen/irstate.h"
@@ -240,8 +241,9 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
   gIR->module.appendModuleInlineAsm(asmstr.str());
   asmstr.str("");
 
-  if (global.params.targetTriple->isWindowsMSVCEnvironment() &&
-      fd->isExport()) {
+  if (global.params.targetTriple->isOSWindows() &&
+      (opts::symbolVisibility == opts::SymbolVisibility::public_ ||
+       fd->isExport())) {
     // Embed a linker switch telling the MS linker to export the naked function.
     // This mimics the effect of the dllexport attribute for regular functions.
     const auto linkerSwitch = std::string("/EXPORT:") + mangle;

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -14,7 +14,6 @@
 #include "dmd/mangle.h"
 #include "dmd/statement.h"
 #include "dmd/template.h"
-#include "driver/cl_options.h"
 #include "gen/dvalue.h"
 #include "gen/funcgenstate.h"
 #include "gen/irstate.h"
@@ -241,9 +240,8 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
   gIR->module.appendModuleInlineAsm(asmstr.str());
   asmstr.str("");
 
-  if (global.params.targetTriple->isOSWindows() &&
-      (opts::symbolVisibility == opts::SymbolVisibility::public_ ||
-       fd->isExport())) {
+  if (global.params.dllexport ||
+      (global.params.targetTriple->isOSWindows() && fd->isExport())) {
     // Embed a linker switch telling the MS linker to export the naked function.
     // This mimics the effect of the dllexport attribute for regular functions.
     const auto linkerSwitch = std::string("/EXPORT:") + mangle;

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -412,8 +412,7 @@ bool ldc_optimize_module(llvm::Module *M) {
 
   addOptimizationPasses(mpm, fpm, optLevel(), sizeLevel());
 
-  if (global.params.targetTriple->isOSWindows() &&
-      opts::symbolVisibility == opts::SymbolVisibility::public_) {
+  if (global.params.dllimport) {
     mpm.add(createDLLImportRelocationPass());
   }
 

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -412,6 +412,11 @@ bool ldc_optimize_module(llvm::Module *M) {
 
   addOptimizationPasses(mpm, fpm, optLevel(), sizeLevel());
 
+  if (global.params.targetTriple->isOSWindows() &&
+      opts::symbolVisibility == opts::SymbolVisibility::public_) {
+    mpm.add(createDLLImportRelocationPass());
+  }
+
   // Run per-function passes.
   fpm.doInitialization();
   for (auto &F : *M) {

--- a/gen/passes/DLLImportRelocation.cpp
+++ b/gen/passes/DLLImportRelocation.cpp
@@ -1,0 +1,234 @@
+//===-- DLLImportRelocation.cpp -------------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This transform scans the initializers of global variables for references to
+// dllimported globals. Such references need to be 'relocated' manually on
+// Windows to prevent undefined-symbol linker errors. This is done by
+// 1) nullifying the pointers in the static initializer, and
+// 2) initializing these fields at runtime via a CRT constructor.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "dllimport-relocation"
+#if LDC_LLVM_VER < 700
+#define LLVM_DEBUG DEBUG
+#endif
+
+#include "gen/passes/Passes.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+
+using namespace llvm;
+
+STATISTIC(NumPatchedGlobals,
+          "Number of global variables with patched initializer");
+STATISTIC(NumRelocations,
+          "Total number of patched references to dllimported globals");
+
+namespace {
+struct LLVM_LIBRARY_VISIBILITY DLLImportRelocation : public ModulePass {
+  static char ID; // Pass identification, replacement for typeid
+  DLLImportRelocation() : ModulePass(ID) {}
+
+  // Returns true if the module has been changed.
+  bool runOnModule(Module &m) override;
+};
+
+struct Impl {
+  Module &m;
+
+  // the global variable whose initializer is being fixed up
+  GlobalVariable *currentGlobal = nullptr;
+  // the GEP indices from the global to the currently inspected field
+  SmallVector<uint64_t, 4> currentGepPath;
+
+  Impl(Module &m) : m(m) {}
+
+  ~Impl() {
+    if (ctor) {
+      // append a `ret void` instruction
+      ReturnInst::Create(m.getContext(), &ctor->getEntryBlock());
+    }
+  }
+
+  // Recursively walks over each field of an initializer and checks for
+  // references to dllimported globals.
+  // Returns true if a fixup was necessary.
+  bool fixup(Constant *initializer) {
+    if (!initializer)
+      return false;
+
+    // set i to the initializer, skipping over an optional cast
+    auto i = initializer;
+    if (auto ce = dyn_cast<ConstantExpr>(i)) {
+      if (ce->isCast())
+        i = ce->getOperand(0);
+    }
+
+    // check if i is a reference to a dllimport global
+    if (auto globalRef = dyn_cast<GlobalVariable>(i)) {
+      if (globalRef->hasDLLImportStorageClass()) {
+        onDLLImportReference(globalRef);
+        return true;
+      }
+      return false;
+    }
+
+    const Type *t = initializer->getType();
+    auto st = dyn_cast<StructType>(t);
+    auto at = dyn_cast<ArrayType>(t);
+    if (st || at) {
+      // descend recursively into each field/element
+      const uint64_t N = st ? st->getNumElements() : at->getNumElements();
+      bool hasChanged = false;
+      for (uint64_t i = 0; i < N; ++i) {
+        currentGepPath.push_back(i);
+        if (fixup(initializer->getAggregateElement(i)))
+          hasChanged = true;
+        currentGepPath.pop_back();
+      }
+      return hasChanged;
+    }
+
+    return false;
+  }
+
+private:
+  void onDLLImportReference(GlobalVariable *importedVar) {
+    ++NumRelocations;
+
+    // initialize at runtime:
+    currentGlobal->setConstant(false);
+    appendToCRTConstructor(importedVar);
+
+    const auto pathLength = currentGepPath.size();
+    if (pathLength == 0) {
+      currentGlobal->setInitializer(
+          Constant::getNullValue(currentGlobal->getValueType()));
+      return;
+    }
+
+    // We cannot mutate a llvm::Constant, so need to replace all parent
+    // aggregate initializers.
+    SmallVector<Constant *, 4> initializers;
+    initializers.reserve(pathLength + 1);
+    initializers.push_back(currentGlobal->getInitializer());
+    for (uint64_t i = 0; i < pathLength - 1; ++i) {
+      initializers.push_back(
+          initializers.back()->getAggregateElement(currentGepPath[i]));
+    }
+
+    // Nullify the field referencing the dllimported global.
+    const auto fieldIndex = currentGepPath.back();
+    auto fieldType =
+        initializers.back()->getAggregateElement(fieldIndex)->getType();
+    initializers.push_back(Constant::getNullValue(fieldType));
+
+    // Replace all parent aggregate initializers, bottom-up.
+    for (ptrdiff_t i = pathLength - 1; i >= 0; --i) {
+      initializers[i] =
+          replaceField(initializers[i], currentGepPath[i], initializers[i + 1]);
+    }
+
+    currentGlobal->setInitializer(initializers[0]);
+  }
+
+  static Constant *replaceField(Constant *aggregate, uint64_t fieldIndex,
+                                Constant *newFieldValue) {
+    const auto t = aggregate->getType();
+    const auto st = dyn_cast<StructType>(t);
+    const auto at = dyn_cast<ArrayType>(t);
+
+    if (!st && !at) {
+      llvm_unreachable("Only expecting IR structs or arrays here");
+      return aggregate;
+    }
+
+    const auto N = st ? st->getNumElements() : at->getNumElements();
+    std::vector<Constant *> elements;
+    elements.reserve(N);
+    for (uint64_t i = 0; i < N; ++i)
+      elements.push_back(aggregate->getAggregateElement(i));
+    elements[fieldIndex] = newFieldValue;
+    return st ? ConstantStruct::get(st, elements)
+              : ConstantArray::get(at, elements);
+  }
+
+  Function *ctor = nullptr;
+
+  void createCRTConstructor() {
+    ctor = Function::Create(
+        FunctionType::get(Type::getVoidTy(m.getContext()), false),
+        GlobalValue::PrivateLinkage, "ldc.dllimport_relocation", &m);
+    llvm::BasicBlock::Create(m.getContext(), "", ctor);
+
+    llvm::appendToGlobalCtors(m, ctor, 0);
+  }
+
+  void appendToCRTConstructor(GlobalVariable *importedVar) {
+    if (!ctor)
+      createCRTConstructor();
+
+    IRBuilder<> b(&ctor->getEntryBlock());
+
+    Value *address = currentGlobal;
+    for (auto i : currentGepPath) {
+      if (i <= 0xFFFFFFFFu) {
+        address = b.CreateConstInBoundsGEP2_32(
+            address->getType()->getPointerElementType(), address, 0,
+            static_cast<unsigned>(i));
+      } else {
+        address = b.CreateConstInBoundsGEP2_64(address, 0, i);
+      }
+    }
+
+    Value *value = importedVar;
+    auto t = address->getType()->getPointerElementType();
+    if (value->getType() != t)
+      value = b.CreatePointerCast(value, t);
+
+    b.CreateStore(value, address);
+  }
+};
+}
+
+char DLLImportRelocation::ID = 0;
+static RegisterPass<DLLImportRelocation>
+    X("dllimport-relocation",
+      "Patch references to dllimported globals in static initializers");
+
+ModulePass *createDLLImportRelocationPass() {
+  return new DLLImportRelocation();
+}
+
+bool DLLImportRelocation::runOnModule(Module &m) {
+  Impl impl(m);
+  bool hasChanged = false;
+
+  for (GlobalVariable &global : m.getGlobalList()) {
+    // TODO: thread-local globals would need to be initialized in a separate TLS
+    // ctor
+    if (!global.hasInitializer() || global.isThreadLocal())
+      continue;
+
+    impl.currentGlobal = &global;
+    impl.currentGepPath.clear();
+    if (impl.fixup(global.getInitializer())) {
+      ++NumPatchedGlobals;
+      hasChanged = true;
+    }
+  }
+
+  return hasChanged;
+}

--- a/gen/passes/Passes.h
+++ b/gen/passes/Passes.h
@@ -24,3 +24,5 @@ llvm::FunctionPass *createSimplifyDRuntimeCalls();
 llvm::FunctionPass *createGarbageCollect2Stack();
 
 llvm::ModulePass *createStripExternalsPass();
+
+llvm::ModulePass *createDLLImportRelocationPass();

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -276,8 +276,7 @@ void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
 void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
   if (global.params.targetTriple->isOSWindows()) {
     bool isExported = sym->isExport();
-    if (!isExported &&
-        opts::symbolVisibility == opts::SymbolVisibility::public_) {
+    if (!isExported && global.params.dllexport) {
       const auto l = obj->getLinkage();
       isExported = l == LLGlobalValue::ExternalLinkage ||
                    l == LLGlobalValue::WeakODRLinkage ||

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -274,8 +274,17 @@ void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
 }
 
 void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
-  if (opts::defaultToHiddenVisibility && !sym->isExport())
-    obj->setVisibility(LLGlobalValue::HiddenVisibility);
+  if (global.params.targetTriple->isOSWindows()) {
+    if (opts::symbolVisibility == opts::SymbolVisibility::public_ ||
+        sym->isExport()) {
+      obj->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
+    }
+  } else {
+    if (opts::symbolVisibility == opts::SymbolVisibility::hidden &&
+        !sym->isExport()) {
+      obj->setVisibility(LLGlobalValue::HiddenVisibility);
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -275,9 +275,13 @@ void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
 
 void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
   if (global.params.targetTriple->isOSWindows()) {
-    const bool isExported =
-        opts::symbolVisibility == opts::SymbolVisibility::public_ ||
-        sym->isExport();
+    bool isExported = sym->isExport();
+    if (!isExported &&
+        opts::symbolVisibility == opts::SymbolVisibility::public_) {
+      const auto l = obj->getLinkage();
+      isExported = l == LLGlobalValue::ExternalLinkage ||
+                   l == LLGlobalValue::WeakODRLinkage;
+    }
     obj->setDLLStorageClass(isExported ? LLGlobalValue::DLLExportStorageClass
                                        : LLGlobalValue::DefaultStorageClass);
   } else {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -275,10 +275,11 @@ void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
 
 void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
   if (global.params.targetTriple->isOSWindows()) {
-    if (opts::symbolVisibility == opts::SymbolVisibility::public_ ||
-        sym->isExport()) {
-      obj->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
-    }
+    const bool isExported =
+        opts::symbolVisibility == opts::SymbolVisibility::public_ ||
+        sym->isExport();
+    obj->setDLLStorageClass(isExported ? LLGlobalValue::DLLExportStorageClass
+                                       : LLGlobalValue::DefaultStorageClass);
   } else {
     if (opts::symbolVisibility == opts::SymbolVisibility::hidden &&
         !sym->isExport()) {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -280,7 +280,8 @@ void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
         opts::symbolVisibility == opts::SymbolVisibility::public_) {
       const auto l = obj->getLinkage();
       isExported = l == LLGlobalValue::ExternalLinkage ||
-                   l == LLGlobalValue::WeakODRLinkage;
+                   l == LLGlobalValue::WeakODRLinkage ||
+                   l == LLGlobalValue::WeakAnyLinkage;
     }
     obj->setDLLStorageClass(isExported ? LLGlobalValue::DLLExportStorageClass
                                        : LLGlobalValue::DefaultStorageClass);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -71,11 +71,11 @@ LinkageWithCOMDAT DtoLinkage(Dsymbol *sym);
 
 bool needsCOMDAT();
 void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj);
-// Sets the linkage of the specified IR global and possibly hides it, both based
-// on the specified D symbol.
+// Sets linkage and visibility of the specified IR symbol based on the specified
+// D symbol.
 void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
-// Hides the specified IR global if using `-fvisibility=hidden` and the
-// specified D symbol is not exported.
+// Hides or exports the specified IR symbol depending on its linkage,
+// `-fvisibility` and the specified D symbol's visibility.
 void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
 
 // some types

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -170,9 +170,9 @@ void TryCatchScope::emitCatchBodies(IRState &irs, llvm::Value *ehPtrSlot) {
       ci = irs.module.getGlobalVariable(wrapperMangle);
       if (!ci) {
         const char *name = target.cpp.typeInfoMangle(p.cd);
-        auto cpp_ti =
-            declareGlobal(p.cd->loc, irs.module, getVoidPtrType(), name,
-                          /*isConstant=*/true);
+        auto cpp_ti = declareGlobal(
+            p.cd->loc, irs.module, getVoidPtrType(), name,
+            /*isConstant*/ true, false, /*useDLLImport*/ p.cd->isExport());
 
         const auto cppTypeInfoPtrType = getCppTypeInfoPtrType();
         RTTIBuilder b(cppTypeInfoPtrType);

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -36,7 +36,6 @@
 #include "dmd/mtype.h"
 #include "dmd/scope.h"
 #include "dmd/template.h"
-#include "driver/cl_options.h"
 #include "gen/arrays.h"
 #include "gen/classes.h"
 #include "gen/irstate.h"
@@ -441,8 +440,7 @@ void buildTypeInfo(TypeInfoDeclaration *decl) {
     // implicit monitor.
     const bool isConstant = false;
     // TODO: no dllimport when compiling druntime itself
-    const bool useDLLImport =
-        isBuiltin && opts::symbolVisibility == opts::SymbolVisibility::public_;
+    const bool useDLLImport = isBuiltin && global.params.dllimport;
     gvar = declareGlobal(decl->loc, gIR->module, type, irMangle, isConstant,
                          false, useDLLImport);
   }

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -16,7 +16,6 @@
 #include "dmd/init.h"
 #include "dmd/mtype.h"
 #include "dmd/target.h"
-#include "driver/cl_options.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
@@ -57,8 +56,7 @@ bool IrAggr::useDLLImport() const {
   if (!global.params.targetTriple->isOSWindows())
     return false;
 
-  if (aggrdecl->isExport() ||
-      opts::symbolVisibility == opts::SymbolVisibility::public_) {
+  if (global.params.dllimport || aggrdecl->isExport()) {
     // dllimport, unless defined in a root module (=> no extra indirection for
     // other root modules, assuming *all* root modules will be linked together
     // to one or more binaries).

--- a/ir/iraggr.h
+++ b/ir/iraggr.h
@@ -93,6 +93,9 @@ protected:
   explicit IrAggr(AggregateDeclaration *aggr)
       : aggrdecl(aggr), type(aggr->type) {}
 
+  // Use dllimport for *declared* init symbol, TypeInfo and vtable?
+  bool useDLLImport() const;
+
 private:
   llvm::StructType *llStructType = nullptr;
 

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -70,7 +70,7 @@ LLGlobalVariable *IrClass::getVtblSymbol(bool define) {
     LLType *vtblTy = getIrType(type)->isClass()->getVtblType();
 
     vtbl = declareGlobal(aggrdecl->loc, gIR->module, vtblTy, irMangle,
-                         /*isConstant=*/true);
+                         /*isConstant=*/true, false, useDLLImport());
 
     if (!define)
       define = defineOnDeclare(aggrdecl);
@@ -101,7 +101,7 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
     // immutable on the D side, and e.g. synchronized() can be used on the
     // implicit monitor.
     typeInfo = declareGlobal(aggrdecl->loc, gIR->module, tc->getMemoryLLType(),
-                             irMangle, /*isConstant=*/false);
+                             irMangle, /*isConstant=*/false, false, useDLLImport());
 
     // Generate some metadata on this ClassInfo if it's for a class.
     if (!aggrdecl->isInterfaceDeclaration()) {
@@ -167,8 +167,9 @@ LLGlobalVariable *IrClass::getInterfaceArraySymbol() {
 
   LLArrayType *array_type = llvm::ArrayType::get(InterfaceTy, n);
 
-  classInterfacesArray = declareGlobal(cd->loc, gIR->module, array_type,
-                                       irMangle, /*isConstant=*/true);
+  classInterfacesArray =
+      declareGlobal(cd->loc, gIR->module, array_type, irMangle,
+                    /*isConstant=*/true, false, false);
 
   return classInterfacesArray;
 }
@@ -466,7 +467,7 @@ llvm::GlobalVariable *IrClass::getInterfaceVtblSymbol(BaseClass *b,
     const auto irMangle = getIRMangledVarName(mangledName.peekChars(), LINK::d);
 
     gvar = declareGlobal(aggrdecl->loc, gIR->module, vtblType, irMangle,
-                         /*isConstant=*/true);
+                         /*isConstant=*/true, false, false);
 
     // insert into the vtbl map
     interfaceVtblMap.insert({{b->sym, interfaces_index}, gvar});

--- a/ir/irmodule.cpp
+++ b/ir/irmodule.cpp
@@ -10,6 +10,7 @@
 #include "ir/irmodule.h"
 
 #include "dmd/module.h"
+#include "driver/cl_options.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
@@ -27,9 +28,12 @@ llvm::GlobalVariable *IrModule::moduleInfoSymbol() {
 
   const auto irMangle = getIRMangledModuleInfoSymbolName(M);
 
-  moduleInfoVar =
-      declareGlobal(Loc(), gIR->module,
-                    llvm::StructType::create(gIR->context()), irMangle, false);
+  const bool useDLLImport =
+      opts::symbolVisibility == opts::SymbolVisibility::public_ && !M->isRoot();
+
+  moduleInfoVar = declareGlobal(Loc(), gIR->module,
+                                llvm::StructType::create(gIR->context()),
+                                irMangle, false, false, useDLLImport);
 
   return moduleInfoVar;
 }

--- a/ir/irmodule.cpp
+++ b/ir/irmodule.cpp
@@ -10,7 +10,6 @@
 #include "ir/irmodule.h"
 
 #include "dmd/module.h"
-#include "driver/cl_options.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/llvmhelpers.h"
@@ -28,8 +27,7 @@ llvm::GlobalVariable *IrModule::moduleInfoSymbol() {
 
   const auto irMangle = getIRMangledModuleInfoSymbolName(M);
 
-  const bool useDLLImport =
-      opts::symbolVisibility == opts::SymbolVisibility::public_ && !M->isRoot();
+  const bool useDLLImport = global.params.dllimport && !M->isRoot();
 
   moduleInfoVar = declareGlobal(Loc(), gIR->module,
                                 llvm::StructType::create(gIR->context()),

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -47,9 +47,12 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
     // We need to keep the symbol mutable as the type is not declared as
     // immutable on the D side, and e.g. synchronized() can be used on the
     // implicit monitor.
+    const bool isConstant = false;
+    // Struct TypeInfos are emitted into each referencing CU.
+    const bool useDLLImport = false;
     typeInfo =
         declareGlobal(aggrdecl->loc, gIR->module, getTypeInfoStructMemType(),
-                      irMangle, /*isConstant=*/false);
+                      irMangle, isConstant, false, useDLLImport);
 
     emitTypeInfoMetadata(typeInfo, aggrdecl->type);
 

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -12,7 +12,6 @@
 #include "dmd/declaration.h"
 #include "dmd/errors.h"
 #include "dmd/init.h"
-#include "driver/cl_options.h"
 #include "gen/dynamiccompile.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
@@ -86,10 +85,9 @@ void IrGlobal::declare() {
   if (global.params.targetTriple->isOSWindows()) {
     // dllimport isn't supported for thread-local globals (MSVC++ neither)
     if (!V->isThreadlocal()) {
-      // with -fvisibility=public, also include all extern(D) globals
-      if (V->isExport() ||
-          (opts::symbolVisibility == opts::SymbolVisibility::public_ &&
-           V->linkage == LINK::d)) {
+      // with -fvisibility=public / -link-defaultlib-shared, also include all
+      // extern(D) globals
+      if (V->isExport() || (global.params.dllimport && V->linkage == LINK::d)) {
         const bool isDefinedInRootModule =
             !(V->storage_class & STCextern) && !V->inNonRoot();
         if (!isDefinedInRootModule)

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -102,15 +102,14 @@ void IrGlobal::declare() {
   if (global.params.targetTriple->isOSWindows()) {
     // dllimport isn't supported for thread-local globals (MSVC++ neither)
     if (!V->isThreadlocal()) {
-      const bool isDefinedInRootModule =
-          !(V->storage_class & STCextern) && !V->inNonRoot();
-      if (!isDefinedInRootModule) {
-        // with -fvisibility=public, also include all extern(D) globals
-        if (V->isExport() ||
-            (opts::symbolVisibility == opts::SymbolVisibility::public_ &&
-             V->linkage == LINK::d)) {
+      // with -fvisibility=public, also include all extern(D) globals
+      if (V->isExport() ||
+          (opts::symbolVisibility == opts::SymbolVisibility::public_ &&
+           V->linkage == LINK::d)) {
+        const bool isDefinedInRootModule =
+            !(V->storage_class & STCextern) && !V->inNonRoot();
+        if (!isDefinedInRootModule)
           gvar->setDLLStorageClass(LLGlobalValue::DLLImportStorageClass);
-        }
       }
     }
   }

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -98,12 +98,6 @@ void IrGlobal::declare() {
   // as well).
   gvar->setAlignment(LLMaybeAlign(DtoAlignment(V)));
 
-  // Windows: initialize DLL storage class with `dllimport` for `export`ed
-  // symbols
-  if (global.params.targetTriple->isOSWindows() && V->isExport()) {
-    gvar->setDLLStorageClass(LLGlobalValue::DLLImportStorageClass);
-  }
-
   applyVarDeclUDAs(V, gvar);
 
   if (dynamicCompileConst)
@@ -127,11 +121,6 @@ void IrGlobal::define() {
   // match.
   auto gvar = llvm::cast<LLGlobalVariable>(value);
   value = gIR->setGlobalVarInitializer(gvar, initVal, V);
-
-  // Finalize DLL storage class.
-  if (gvar->hasDLLImportStorageClass()) {
-    gvar->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
-  }
 
   // If this global is used from a naked function, we need to create an
   // artificial "use" for it, or it could be removed by the optimizer if

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -5,11 +5,27 @@
 
 export
 {
-    // CHECK: @{{.*}}exportedGlobal{{.*}} = dllexport
-    extern(C) __gshared void* exportedGlobal;
+    // non-TLS:
+    __gshared
+    {
+        // CHECK: @{{.*}}exportedGlobal{{.*}} = dllexport
+        void* exportedGlobal;
 
-    // CHECK: @{{.*}}importedGlobal{{.*}} = external dllimport
-    extern(C) extern __gshared void* importedGlobal;
+        // CHECK: @{{.*}}importedGlobal{{.*}} = external dllimport
+        extern void* importedGlobal;
+    }
+
+    // TLS: unsupported => linker errors
+    version (all)
+    {
+        // CHECK: @{{.*}}exportedTlsGlobal{{.*}} = thread_local
+        // CHECK-NOT: dllexport
+        void* exportedTlsGlobal;
+
+        // CHECK: @{{.*}}importedTlsGlobal{{.*}} = external thread_local
+        // CHECK-NOT: dllimport
+        extern void* importedTlsGlobal;
+    }
 
     // CHECK: define dllexport {{.*}}_D6export11exportedFooFZv
     void exportedFoo() {}

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -5,16 +5,19 @@
 
 export
 {
-    // CHECK-DAG: @{{.*}}exportedGlobal{{.*}} = dllexport
+    // CHECK: @{{.*}}exportedGlobal{{.*}} = dllexport
     extern(C) __gshared void* exportedGlobal;
 
-    // CHECK-DAG: @{{.*}}importedGlobal{{.*}} = external dllimport
+    // CHECK: @{{.*}}importedGlobal{{.*}} = external
+    // CHECK-NOT: dllimport
     extern(C) extern __gshared void* importedGlobal;
 
-    // CHECK-DAG: define dllexport {{.*}}_D6export11exportedFooFZv
+    // CHECK: define dllexport {{.*}}_D6export11exportedFooFZv
     void exportedFoo() {}
 
-    // CHECK-DAG: declare dllimport {{.*}}_D6export11importedFooFZv
+    // CHECK: declare
+    // CHECK-NOT: dllimport
+    // CHECK-SAME: _D6export11importedFooFZv
     void importedFoo();
 }
 

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -8,8 +8,7 @@ export
     // CHECK: @{{.*}}exportedGlobal{{.*}} = dllexport
     extern(C) __gshared void* exportedGlobal;
 
-    // CHECK: @{{.*}}importedGlobal{{.*}} = external
-    // CHECK-NOT: dllimport
+    // CHECK: @{{.*}}importedGlobal{{.*}} = external dllimport
     extern(C) extern __gshared void* importedGlobal;
 
     // CHECK: define dllexport {{.*}}_D6export11exportedFooFZv

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -1,0 +1,21 @@
+// Tests that -fvisibility=public for Windows targets exports defined symbols
+// (dllexport) without explicit `export` visibility, and that linking an app
+// against such a DLL via import library works as expected.
+
+// REQUIRES: Windows
+
+// generate DLL and import lib
+// RUN: %ldc %S/inputs/fvisibility_dll_lib.d -betterC -shared -fvisibility=public -of=%t_lib.dll
+
+// compile, link and run the app
+// RUN: %ldc %s -I%S/inputs -betterC %t_lib.lib -of=%t.exe
+// RUN: %t.exe
+
+import fvisibility_dll_lib;
+
+extern(C) void main()
+{
+    //assert(dllGlobal == 123);
+    const x = dllSum(1, 2);
+    assert(x == 3);
+}

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -16,6 +16,9 @@ import fvisibility_dll_lib;
 extern(C) void main()
 {
     assert(dllGlobal == 123);
+
     const x = dllSum(1, 2);
     assert(x == 3);
+
+    dllWeakFoo();
 }

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -13,6 +13,16 @@
 
 import fvisibility_dll_lib;
 
+// test manual 'relocation' of references to dllimported globals in static data initializers:
+__gshared int* dllimportRef = &dllGlobal;
+__gshared void* castDllimportRef = &dllGlobal;
+immutable void*[2] arrayOfRefs = [ null, cast(immutable) &dllGlobal ];
+
+struct MyStruct
+{
+    int* dllimportRef = &dllGlobal; // init symbol references dllimported global
+}
+
 extern(C) void main()
 {
     assert(dllGlobal == 123);
@@ -24,4 +34,9 @@ extern(C) void main()
 
     scope c = new MyClass;
     assert(c.myInt == 456);
+
+    assert(dllimportRef == &dllGlobal);
+    assert(castDllimportRef == &dllGlobal);
+    assert(arrayOfRefs[1] == &dllGlobal);
+    assert(MyStruct.init.dllimportRef == &dllGlobal);
 }

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -5,10 +5,10 @@
 // REQUIRES: Windows
 
 // generate DLL and import lib
-// RUN: %ldc %S/inputs/fvisibility_dll_lib.d -betterC -shared -fvisibility=public -of=%t_lib.dll
+// RUN: %ldc %S/inputs/fvisibility_dll_lib.d -betterC -shared -of=%t_lib.dll
 
-// compile, link and run the app; -fvisibility=public for importing data symbols as dllimport
-// RUN: %ldc %s -fvisibility=public -I%S/inputs -betterC %t_lib.lib -of=%t.exe
+// compile, link and run the app; -link-defaultlib-shared for importing data symbols as dllimport
+// RUN: %ldc %s -I%S/inputs -betterC -link-defaultlib-shared %t_lib.lib -of=%t.exe
 // RUN: %t.exe
 
 import fvisibility_dll_lib;

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -7,15 +7,15 @@
 // generate DLL and import lib
 // RUN: %ldc %S/inputs/fvisibility_dll_lib.d -betterC -shared -fvisibility=public -of=%t_lib.dll
 
-// compile, link and run the app
-// RUN: %ldc %s -I%S/inputs -betterC %t_lib.lib -of=%t.exe
+// compile, link and run the app; -fvisibility=public for importing data symbols as dllimport
+// RUN: %ldc %s -fvisibility=public -I%S/inputs -betterC %t_lib.lib -of=%t.exe
 // RUN: %t.exe
 
 import fvisibility_dll_lib;
 
 extern(C) void main()
 {
-    //assert(dllGlobal == 123);
+    assert(dllGlobal == 123);
     const x = dllSum(1, 2);
     assert(x == 3);
 }

--- a/tests/codegen/fvisibility_dll.d
+++ b/tests/codegen/fvisibility_dll.d
@@ -21,4 +21,7 @@ extern(C) void main()
     assert(x == 3);
 
     dllWeakFoo();
+
+    scope c = new MyClass;
+    assert(c.myInt == 456);
 }

--- a/tests/codegen/inputs/fvisibility_dll_lib.d
+++ b/tests/codegen/inputs/fvisibility_dll_lib.d
@@ -1,6 +1,10 @@
+import ldc.attributes;
+
 __gshared int dllGlobal = 123;
 
 double dllSum(double a, double b)
 {
     return a + b;
 }
+
+void dllWeakFoo() @weak {}

--- a/tests/codegen/inputs/fvisibility_dll_lib.d
+++ b/tests/codegen/inputs/fvisibility_dll_lib.d
@@ -9,7 +9,7 @@ double dllSum(double a, double b)
 
 void dllWeakFoo() @weak {}
 
-// extern(C++) for no vtable; that requires an explicit `export` (contrary to extern(D))
+// extern(C++) for -betterC; that requires an explicit `export` (contrary to extern(D))
 export extern(C++) class MyClass
 {
     int myInt = 456;

--- a/tests/codegen/inputs/fvisibility_dll_lib.d
+++ b/tests/codegen/inputs/fvisibility_dll_lib.d
@@ -8,3 +8,9 @@ double dllSum(double a, double b)
 }
 
 void dllWeakFoo() @weak {}
+
+// extern(C++) for no vtable; that requires an explicit `export` (contrary to extern(D))
+export extern(C++) class MyClass
+{
+    int myInt = 456;
+}

--- a/tests/codegen/inputs/fvisibility_dll_lib.d
+++ b/tests/codegen/inputs/fvisibility_dll_lib.d
@@ -9,8 +9,8 @@ double dllSum(double a, double b)
 
 void dllWeakFoo() @weak {}
 
-// extern(C++) for -betterC; that requires an explicit `export` (contrary to extern(D))
-export extern(C++) class MyClass
+// extern(C++) for -betterC
+extern(C++) class MyClass
 {
     int myInt = 456;
 }

--- a/tests/codegen/inputs/fvisibility_dll_lib.d
+++ b/tests/codegen/inputs/fvisibility_dll_lib.d
@@ -1,0 +1,6 @@
+__gshared int dllGlobal = 123;
+
+double dllSum(double a, double b)
+{
+    return a + b;
+}


### PR DESCRIPTION
To pave the way for simple DLL generation (end goal: `druntime-ldc-shared.dll`).

The `dllexport` storage class for functions definitions is enough; the automatically generated import .lib seems to resolve the regular symbol name to the actual symbol (`__imp_*`), so `dllimport` for declarations seems superfluous.

For global variables, things are apparently different unfortunately.