### PR TITLE
Use new OpenFlags enumeration

### DIFF
--- a/driver/cache.cpp
+++ b/driver/cache.cpp
@@ -480,7 +480,12 @@ void recoverObjectFile(llvm::StringRef cacheObjectHash,
 #if LDC_LLVM_VER >= 700
                                         llvm::sys::fs::CD_OpenExisting,
 #endif
-                                        llvm::sys::fs::F_Append)) {
+#if LDC_LLVM_VER >= 900
+                                        llvm::sys::fs::OF_Append
+#else
+                                        llvm::sys::fs::F_Append
+#endif
+                                        )) {
       error(Loc(), "Failed to open the cached file for writing: %s",
             cacheFile.c_str());
       fatal();

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -347,7 +347,13 @@ void CodeGenerator::writeMLIRModule(mlir::OwningModuleRef *module,
     const auto llpath = replaceExtensionWith(global.mlir_ext, filename);
     Logger::println("Writting MLIR to %s\n", llpath.c_str());
     std::error_code errinfo;
-    llvm::raw_fd_ostream aos(llpath, errinfo, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream aos(llpath, errinfo,
+#if LDC_LLVM_VER >= 900
+                             llvm::sys::fs::OF_None
+#else
+                             llvm::sys::fs::F_None
+#endif
+                             );
 
     if (aos.has_error()) {
       error(Loc(), "Cannot write MLIR file '%s': %s", llpath.c_str(),

--- a/driver/timetrace.cpp
+++ b/driver/timetrace.cpp
@@ -41,7 +41,13 @@ void writeTimeTraceProfile() {
     }
 
     std::error_code err;
-    llvm::raw_fd_ostream outputstream(filename, err, llvm::sys::fs::OF_Text);
+    llvm::raw_fd_ostream outputstream(filename, err,
+#if LDC_LLVM_VER >= 900
+                                      llvm::sys::fs::OF_Text
+#else
+                                      llvm::sys::fs::F_Text
+#endif
+                                      );
     if (err) {
       error(Loc(), "Error writing Time Trace profile: could not open %s",
             filename.c_str());

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -87,7 +87,13 @@ void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
   }
 
   std::error_code errinfo;
-  llvm::raw_fd_ostream out(filename, errinfo, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(filename, errinfo,
+#if LDC_LLVM_VER >= 900
+                           llvm::sys::fs::OF_None
+#else
+                           llvm::sys::fs::F_None
+#endif
+                           );
   if (errinfo) {
     error(Loc(), "cannot write file '%s': %s", filename,
           errinfo.message().c_str());
@@ -359,7 +365,13 @@ void writeModule(llvm::Module *m, const char *filename) {
                              : replaceExtensionWith(global.bc_ext, filename);
     Logger::println("Writing LLVM bitcode to: %s\n", bcpath.c_str());
     std::error_code errinfo;
-    llvm::raw_fd_ostream bos(bcpath.c_str(), errinfo, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream bos(bcpath.c_str(), errinfo,
+#if LDC_LLVM_VER >= 900
+                             llvm::sys::fs::OF_None
+#else
+                             llvm::sys::fs::F_None
+#endif
+                             );
     if (bos.has_error()) {
       error(Loc(), "cannot write LLVM bitcode file '%s': %s", bcpath.c_str(),
             errinfo.message().c_str());
@@ -394,7 +406,13 @@ void writeModule(llvm::Module *m, const char *filename) {
     const auto llpath = replaceExtensionWith(global.ll_ext, filename);
     Logger::println("Writing LLVM IR to: %s\n", llpath.c_str());
     std::error_code errinfo;
-    llvm::raw_fd_ostream aos(llpath.c_str(), errinfo, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream aos(llpath.c_str(), errinfo,
+#if LDC_LLVM_VER >= 900
+                             llvm::sys::fs::OF_None
+#else
+                             llvm::sys::fs::F_None
+#endif
+                             );
     if (aos.has_error()) {
       error(Loc(), "cannot write LLVM IR file '%s': %s", llpath.c_str(),
             errinfo.message().c_str());


### PR DESCRIPTION
[This](https://reviews.llvm.org/D101506) drops old deprecated OpenFlags support.
OF_{Append,None,Text} has been available since LLVM 9.

- https://reviews.llvm.org/rG1f67a3cba9b09636c56e2109d8a35ae96dc15782