### PR TITLE
Implement --cppstdlib

### DIFF
--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -351,6 +351,7 @@ version (IN_LLVM)
     // target stuff
     const(void)* targetTriple; // const llvm::Triple*
     bool isUClibcEnvironment;
+    const(char)[] cppstdlib; // Cpp runtime library
 
     // Codegen cl options
     bool disableRedZone;

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -313,6 +313,7 @@ struct Param
 
     const llvm::Triple *targetTriple;
     bool isUClibcEnvironment; // not directly supported by LLVM
+    DString cppstdlib; // Cpp runtime library
 
     // Codegen cl options
     bool disableRedZone;

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -83,6 +83,7 @@ version (IN_LLVM)
     const(char)* getPathToProducedBinary();
     void deleteExeFile();
     int runProgram();
+    const (char)* getExplicitCppRuntimeName();
 }
 else
 {
@@ -431,6 +432,8 @@ else
 
 version (IN_LLVM)
 {
+    import dmd.root.string : toDString;
+    global.params.cppstdlib = toDString(getExplicitCppRuntimeName());
     registerPredefinedVersions();
 }
 else

--- a/dmd/root/dcompat.h
+++ b/dmd/root/dcompat.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <string>
+#include <cstring>
 #include "dsystem.h"
 
 /// Represents a D [ ] array
@@ -33,6 +35,12 @@ struct DString : public DArray<const char>
 
     DString(size_t length, const char *ptr)
         : DArray<const char>(length, ptr) { }
+
+    int compare (std::string str)
+    {
+        return this->length >= str.length() ?
+            strncmp(this->ptr, str.c_str(), this->length) : -1;
+    }
 };
 
 /// Corresponding C++ type that maps to D size_t

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -81,6 +81,12 @@ static llvm::cl::opt<std::string>
              llvm::cl::value_desc("libcmt[d]|msvcrt[d]"),
              llvm::cl::cat(opts::linkingCategory));
 
+static llvm::cl::opt<std::string>
+    cppstdlib("cppstdlib", llvm::cl::Optional ,
+             llvm::cl::desc("C++ runtime library to link with"),
+             llvm::cl::value_desc("libstd++|libc++"),
+             llvm::cl::cat(opts::linkingCategory));
+
 //////////////////////////////////////////////////////////////////////////////
 
 // linker-gcc.cpp
@@ -335,3 +341,7 @@ int runProgram() {
   }
   return status;
 }
+
+//////////////////////////////////////////////////////////////////////////////
+
+const char * getExplicitCppRuntimeName() { return cppstdlib.c_str(); }

--- a/driver/linker.h
+++ b/driver/linker.h
@@ -81,3 +81,8 @@ void deleteExeFile();
  * @return the return status of the executable.
  */
 int runProgram();
+
+/**
+ * Returns the name of the C++ runtime library to link with.
+ */
+const char *getExplicitCppRuntimeName();

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -784,7 +784,10 @@ void registerPredefinedTargetVersions() {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_UClibc");
     } else {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Glibc");
-      VersionCondition::addPredefinedGlobalIdent("CppRuntime_Gcc");
+      if (global.params.cppstdlib.compare("libc++") == 0)
+        VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
+      else
+        VersionCondition::addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
     break;
   case llvm::Triple::Haiku:


### PR DESCRIPTION
This flag allows user to select from GCC/Clang C++ runtimes
on Linux similar to `--stdlib` on `clang`.