### PR TITLE
Mark a function or global variable as dso_local if possible

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1386,6 +1386,12 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
       global.params.targetTriple->isWindowsMSVCEnvironment()) {
     emulateWeakAnyLinkageForMSVC(func, fd->linkage);
   }
+
+  // Assume func marked as dso_local, which will resolve to a symbol
+  // within the same linkage unit.
+  if (gTargetMachine->shouldAssumeDSOLocal(gIR->module, func)) {
+    func->setDSOLocal(true);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/PGO/reset_counters.d
+++ b/tests/PGO/reset_counters.d
@@ -8,12 +8,12 @@
 // RUN:   &&  FileCheck %s < %t2.ll
 
 extern(C) void foo(int N) {
-  // CHECK-LABEL: define void @foo(
+  // CHECK-LABEL: define{{( dso_local)?}} void @foo(
   // CHECK: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !prof ![[FOO:[0-9]+]]
   if (N) {}
 }
 
-// CHECK-LABEL: define i32 @_Dmain(
+// CHECK-LABEL: define{{( dso_local)?}} i32 @_Dmain(
 void main() {
   import ldc.profile;
   foo(0);

--- a/tests/PGO/unrolledloopstatement_gh3375.d
+++ b/tests/PGO/unrolledloopstatement_gh3375.d
@@ -14,7 +14,7 @@ void main() {
         foofoofoo(i);
 }
 
-// PROFUSE-LABEL: define void @foofoofoo(
+// PROFUSE-LABEL: define{{( dso_local)?}} void @foofoofoo(
 // PROFUSE-SAME: !prof ![[FUNCENTRY:[0-9]+]]
 extern(C) void foofoofoo(int i)
 {
@@ -81,4 +81,3 @@ extern(C) void foofoofoo(int i)
 // PROFUSE-DAG: ![[IF2_2]] = !{!"branch_weights", i32 51, i32 26}
 // PROFUSE-DAG: ![[IF2_3]] = !{!"branch_weights", i32 2, i32 25}
 // PROFUSE-DAG: ![[IFEXIT]] = !{!"branch_weights", i32 399, i32 1}
-

--- a/tests/codegen/align.d
+++ b/tests/codegen/align.d
@@ -4,9 +4,9 @@
 // XFAIL: Windows_x86
 
 align(32) struct Outer { int a = 1; }
-// CHECK-DAG: _D5align5Outer6__initZ = constant %align.Outer {{.*}}, align 32
+// CHECK-DAG: _D5align5Outer6__initZ ={{( dso_local)?}} constant %align.Outer {{.*}}, align 32
 struct Inner { align(32) int a = 1; }
-// CHECK-DAG: _D5align5Inner6__initZ = constant %align.Inner {{.*}}, align 32
+// CHECK-DAG: _D5align5Inner6__initZ ={{( dso_local)?}} constant %align.Inner {{.*}}, align 32
 
 align(1) ubyte globalByte1;
 // CHECK-DAG: _D5align11globalByte1h = {{.*}} align 1

--- a/tests/codegen/avr.d
+++ b/tests/codegen/avr.d
@@ -7,7 +7,7 @@ version (D_SoftFloat) {} else static assert(0);
 
 // make sure TLS globals are emitted as regular __gshared globals:
 
-// CHECK: @_D3avr13definedGlobali = global i32 123
+// CHECK: @_D3avr13definedGlobali ={{( dso_local)?}} global i32 123
 int definedGlobal = 123;
 // CHECK: @_D3avr14declaredGlobali = external global i32
 extern int declaredGlobal;

--- a/tests/codegen/dso_local.d
+++ b/tests/codegen/dso_local.d
@@ -1,0 +1,46 @@
+// RUN: %ldc -mtriple=x86_64-linux-gnu --relocation-model=static --output-ll -of=%t.ll %s && FileCheck --check-prefix=ELF_STATIC_RELOC %s < %t.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu --relocation-model=pic --output-ll -of=%t.ll %s && FileCheck --check-prefix=ELF_PIC_DEFAULT %s < %t.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu -fvisibility=hidden --relocation-model=pic --output-ll -of=%t.ll %s && FileCheck --check-prefix=ELF_PIC_HIDDEN %s < %t.ll
+// RUN: %ldc -mtriple=x86_64-apple-darwin --relocation-model=static --output-ll -of=%t.ll %s && FileCheck --check-prefix=MACHO_STATIC_RELOC %s < %t.ll
+// RUN: %ldc -mtriple=x86_64-apple-darwin --relocation-model=pic --output-ll -of=%t.ll %s && FileCheck --check-prefix=MACHO_PIC %s < %t.ll
+// RUN: %ldc -mtriple=x86_64-windows-coff -output-ll -of=%t.ll %s && FileCheck --check-prefix=COFF %s < %t.ll
+
+import ldc.attributes : weak;
+
+// ELF_STATIC_RELOC: define{{( dso_local)?}} i32 @{{.*}}3foo
+// ELF_PIC_DEFAULT: define i32 @{{.*}}3foo
+// ELF_PIC_HIDDEN: define{{( dso_local)?}} hidden i32 @{{.*}}3foo
+// MACHO_STATIC_RELOC: define dso_local i32 @{{.*}}3foo
+// MACHO_PIC: define dso_local i32 @{{.*}}3foo
+// COFF: define dso_local {{.*}} i32 @{{.*}}3foo
+private int foo() { return 42; }
+
+
+// ELF_STATIC_RELOC: define{{( dso_local)?}} i32 @{{.*}}3bar
+// ELF_PIC_DEFAULT: define i32 @{{.*}}3bar
+// ELF_PIC_HIDDEN: define hidden i32 @{{.*}}3bar
+// MACHO_STATIC_RELOC: define dso_local i32 @{{.*}}3bar
+// MACHO_PIC: define dso_local i32 @{{.*}}3bar
+// COFF: define dso_local {{.*}} i32 @{{.*}}3bar
+public int bar() { return foo(); }
+
+
+// ELF_STATIC_RELOC: define weak{{( dso_local)?}} i32 @{{.*}}3baz
+// ELF_PIC_DEFAULT: define weak i32 @{{.*}}3baz
+// ELF_PIC_HIDDEN: define weak hidden i32 @{{.*}}3baz
+// MACHO_STATIC_RELOC: define weak i32 @{{.*}}3baz
+// MACHO_PIC: define weak i32 @{{.*}}3baz
+// COFF: define x86_vectorcallcc i32 @{{.*}}3baz
+@weak int baz() { return 42; }
+
+
+version(Windows)
+{
+// COFF: declare extern_weak void @weakreffunction
+pragma(LDC_extern_weak) extern(C) void weakreffunction();
+
+void piyo()
+{
+    auto a = &weakreffunction;
+}
+}

--- a/tests/codegen/export.d
+++ b/tests/codegen/export.d
@@ -11,7 +11,7 @@ export
     // CHECK-DAG: @{{.*}}importedGlobal{{.*}} = external dllimport
     extern(C) extern __gshared void* importedGlobal;
 
-    // CHECK-DAG: define dllexport {{.*}}_D6export11exportedFooFZv
+    // CHECK-DAG: define{{( dso_local)?}} dllexport {{.*}}_D6export11exportedFooFZv
     void exportedFoo() {}
 
     // CHECK-DAG: declare dllimport {{.*}}_D6export11importedFooFZv

--- a/tests/codegen/gh3221.d
+++ b/tests/codegen/gh3221.d
@@ -8,7 +8,7 @@ union U
     uint b;
 }
 
-// CHECK: @{{.*}}_D6gh32211uSQk1U{{.*}} = global { i32 } { i32 12345 }
+// CHECK: @{{.*}}_D6gh32211uSQk1U{{.*}} ={{( dso_local)?}} global { i32 } { i32 12345 }
 // CHECK: @llvm.used = appending global
 // CHECK-SAME: _D6gh32211uSQk1U
 @assumeUsed __gshared U u = { b: 12345 };

--- a/tests/codegen/lambdas_gh3648.d
+++ b/tests/codegen/lambdas_gh3648.d
@@ -26,9 +26,9 @@ void foo()
 }
 
 // the global variables should be defined as linkonce_odr:
-// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr thread_local global
-// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr global
-// CHECK: _D14lambdas_gh36483fooFZ__T9__lambda1TiZQnFiZ12lambda_templi{{.*}} = linkonce_odr global
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} ={{( dso_local)?}} linkonce_odr thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} ={{( dso_local)?}} linkonce_odr global
+// CHECK: _D14lambdas_gh36483fooFZ__T9__lambda1TiZQnFiZ12lambda_templi{{.*}} ={{( dso_local)?}} linkonce_odr global
 
 // foo() should only call two lambdas:
 // CHECK: define {{.*}}_D14lambdas_gh36483fooFZv

--- a/tests/codegen/lambdas_gh3648b.d
+++ b/tests/codegen/lambdas_gh3648b.d
@@ -11,8 +11,8 @@ void foo()
 }
 
 // the global variables should be defined as linkonce_odr:
-// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr thread_local global
-// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr global
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} ={{( dso_local)?}} linkonce_odr thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} ={{( dso_local)?}} linkonce_odr global
 
 // foo() should only call one lambda:
 // CHECK: define {{.*}}_D15lambdas_gh3648b3fooFZv

--- a/tests/codegen/simd_alignment.d
+++ b/tests/codegen/simd_alignment.d
@@ -17,7 +17,7 @@ int4 globalIntFour;
 S17237 globalStruct;
 // CHECK-DAG: @{{.*}}globalStruct{{.*}}S17237{{\"?}} = {{.*}} zeroinitializer{{(, comdat)?}}, align 32
 
-// CHECK-LABEL: define <8 x i32> @foo(
+// CHECK-LABEL: define{{( dso_local)?}} <8 x i32> @foo(
 extern(C) int8 foo(S17237* s)
 {
     // CHECK: %[[GEP:[0-9]]] = getelementptr {{.*}}S17237* %s_arg

--- a/tests/codegen/static_typeid_gh1540.d
+++ b/tests/codegen/static_typeid_gh1540.d
@@ -16,13 +16,13 @@ struct S
 }
 
 // CHECK-DAG: _D{{.*}}1C7__ClassZ{{\"?}} = global %object.TypeInfo_Class
-// CHECK-DAG: _D{{.*}}classvarC14TypeInfo_Class{{\"?}} = thread_local global %object.TypeInfo_Class* {{.*}}1C7__ClassZ
+// CHECK-DAG: _D{{.*}}classvarC14TypeInfo_Class{{\"?}} ={{( dso_local)?}} thread_local global %object.TypeInfo_Class* {{.*}}1C7__ClassZ
 auto classvar = typeid(C);
 
 // CHECK-DAG: _D{{.*}}TypeInfo_C{{.*}}1I6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Interface
-// CHECK-DAG: _D{{.*}}interfacevarC18TypeInfo_Interface{{\"?}} = thread_local global %object.TypeInfo_Interface* {{.*}}TypeInfo_C{{.*}}1I6__initZ
+// CHECK-DAG: _D{{.*}}interfacevarC18TypeInfo_Interface{{\"?}} ={{( dso_local)?}} thread_local global %object.TypeInfo_Interface* {{.*}}TypeInfo_C{{.*}}1I6__initZ
 auto interfacevar = typeid(I);
 
 // CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Struct
-// CHECK-DAG: _D{{.*}}structvarC15TypeInfo_Struct{{\"?}} = thread_local global %object.TypeInfo_Struct* {{.*}}TypeInfo_S{{.*}}1S6__initZ
+// CHECK-DAG: _D{{.*}}structvarC15TypeInfo_Struct{{\"?}} ={{( dso_local)?}} thread_local global %object.TypeInfo_Struct* {{.*}}TypeInfo_S{{.*}}1S6__initZ
 auto structvar = typeid(S);

--- a/tests/codegen/union.d
+++ b/tests/codegen/union.d
@@ -13,12 +13,12 @@ struct S
     char[2][1] multidim; // multidimensional init based on a single 0xff char
 }
 // CHECK-DAG: %union.S                              = type { i8, [3 x i8], i32, [2 x i8], i8, [1 x [2 x i8]], [3 x i8] }
-// CHECK-DAG: @{{.*}}_D5union1S6__initZ{{\"?}}      = constant %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
+// CHECK-DAG: @{{.*}}_D5union1S6__initZ{{\"?}}      ={{( dso_local)?}} constant %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
 
-// CHECK-DAG: @{{.*}}_D5union8defaultSSQq1S{{\"?}}  = global   %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
+// CHECK-DAG: @{{.*}}_D5union8defaultSSQq1S{{\"?}}  ={{( dso_local)?}} global   %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
 __gshared S defaultS;
 
-// CHECK-DAG: @{{.*}}_D5union9explicitSSQr1S{{\"?}} = global   %union.S { i8 3, [3 x i8] zeroinitializer, i32 56, [2 x i8] c"\00\01", i8 0, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
+// CHECK-DAG: @{{.*}}_D5union9explicitSSQr1S{{\"?}} ={{( dso_local)?}} global   %union.S { i8 3, [3 x i8] zeroinitializer, i32 56, [2 x i8] c"\00\01", i8 0, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }
 __gshared S explicitS = { 3, 56, [false, true], false /* implicit multidim */ };
 
 
@@ -35,17 +35,17 @@ struct SWithUnion
     }
 }
 // CHECK-DAG: %union.SWithUnion                                                      = type { i8, [3 x i8], %union.S, [4 x i8], i8, [1 x i8], i16, i32, i64, i64 }
-// CHECK-DAG: @{{.*}}_D5union10SWithUnion6__initZ{{\"?}}                             = constant %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 666, i64 123 }
+// CHECK-DAG: @{{.*}}_D5union10SWithUnion6__initZ{{\"?}}                             ={{( dso_local)?}} constant %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 666, i64 123 }
 
-// CHECK-DAG: @{{.*}}_D5union17defaultSWithUnionSQBa10SWithUnion{{\"?}}              = global   %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 666, i64 123 }
+// CHECK-DAG: @{{.*}}_D5union17defaultSWithUnionSQBa10SWithUnion{{\"?}}              ={{( dso_local)?}} global   %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 666, i64 123 }
 __gshared SWithUnion defaultSWithUnion;
 
-// CHECK-DAG: @{{.*}}_D5union28explicitCompatibleSWithUnionSQBl10SWithUnion{{\"?}}   = global   %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 53, i64 123 }
+// CHECK-DAG: @{{.*}}_D5union28explicitCompatibleSWithUnionSQBl10SWithUnion{{\"?}}   ={{( dso_local)?}} global   %union.SWithUnion { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i8 6, [1 x i8] zeroinitializer, i16 33, i32 84, i64 53, i64 123 }
 __gshared SWithUnion explicitCompatibleSWithUnion = { ul_dummy: 53 }; // ul_dummy is an alias for dominant ul
 
 // If a dominated union field is initialized and it isn't an alias for a dominant field,
 // the regular LL type cannot be used, and an anonymous one is used instead.
-// CHECK-DAG: @{{.*}}_D5union30explicitIncompatibleSWithUnionSQBn10SWithUnion{{\"?}} = global   { i8, [3 x i8], %union.S, [4 x i8], i32, i32, i64, i64 } { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i32 23, i32 84, i64 666, i64 123 }
+// CHECK-DAG: @{{.*}}_D5union30explicitIncompatibleSWithUnionSQBn10SWithUnion{{\"?}} ={{( dso_local)?}} global   { i8, [3 x i8], %union.S, [4 x i8], i32, i32, i64, i64 } { i8 -1, [3 x i8] zeroinitializer, %union.S { i8 -1, [3 x i8] zeroinitializer, i32 0, [2 x i8] zeroinitializer, i8 1, [1 x [2 x i8]] {{\[}}[2 x i8] c"\FF\FF"], [3 x i8] zeroinitializer }, [4 x i8] zeroinitializer, i32 23, i32 84, i64 666, i64 123 }
 __gshared SWithUnion explicitIncompatibleSWithUnion = { ui1: 23 }; // // ui1 dominated by ub and us
 
 
@@ -70,7 +70,7 @@ struct Quat
 
 // T.init may feature explicit initializers for dominated members in nested unions (GitHub issue #2108).
 // In that case, the init constant has an anonymous LL type as well.
-// CHECK-DAG: @{{.*}}_D5union33QuatContainerWithIncompatibleInit6__initZ{{\"?}} = constant { { float } } { { float } { float 1.000000e+00 } }
+// CHECK-DAG: @{{.*}}_D5union33QuatContainerWithIncompatibleInit6__initZ{{\"?}} ={{( dso_local)?}} constant { { float } } { { float } { float 1.000000e+00 } }
 struct QuatContainerWithIncompatibleInit
 {
     Quat q = Quat.identity;

--- a/tests/codegen/wasi.d
+++ b/tests/codegen/wasi.d
@@ -13,7 +13,7 @@ version (CRuntime_WASI) {} else static assert(0);
 
 // make sure TLS globals are emitted as regular __gshared globals:
 
-// CHECK: @_D4wasi13definedGlobali = global i32 123
+// CHECK: @_D4wasi13definedGlobali ={{( dso_local)?}} global i32 123
 int definedGlobal = 123;
 // CHECK: @_D4wasi14declaredGlobali = external global i32
 extern int declaredGlobal;


### PR DESCRIPTION
dso_local allows the compiler to assume a function or global variable will resolve to a symbol within the same linkage unit.

reference: https://llvm.org/docs/LangRef.html#runtime-preemption-specifiers