### PR TITLE
CMake: Run the druntime integration tests in debug mode too

### DIFF
--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -130,4 +130,11 @@ jobs:
           fi
           ctest -V -R "dmd-testsuite"
       - name: Run defaultlib unittests & druntime integration tests
-        run: ctest -j2 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest"
+        run: |
+          set -euxo pipefail
+          excludes='dmd-testsuite|lit-tests|ldc2-unittest'
+          if [[ '${{ runner.os }}' == 'macOS' ]]; then
+            # https://github.com/ldc-developers/ldc/issues/3280
+            excludes+='|druntime-test-exceptions-debug'
+          fi
+          ctest -j2 --output-on-failure -E "$excludes"

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -206,27 +206,38 @@ void DIBuilder::SetValue(const Loc &loc, llvm::Value *value,
                                    IR->scopebb());
 }
 
-DIFile DIBuilder::CreateFile(const Loc &loc) {
-  const char *filename = loc.filename;
+DIFile DIBuilder::CreateFile(const char *filename) {
   if (!filename)
     filename = IR->dmodule->srcfile.toChars();
-  llvm::SmallString<128> path(filename);
-  llvm::sys::fs::make_absolute(path);
 
-  return DBuilder.createFile(llvm::sys::path::filename(path),
-                             llvm::sys::path::parent_path(path));
+  // clang appears to use the curent working dir as 'directory' for relative
+  // source paths, and the root path for absolute ones:
+  // clang -g -emit-llvm -S ..\blub.c =>
+  //   !DIFile(filename: "..\\blub.c", directory: "C:\\LDC\\ninja-ldc", ...)
+  //   !DIFile(filename: "Program
+  //   Files\\LLVM\\lib\\clang\\11.0.1\\include\\stddef.h", directory: "C:\\",
+  //   ...)
+
+  if (llvm::sys::path::is_absolute(filename)) {
+    return DBuilder.createFile(llvm::sys::path::relative_path(filename),
+                               llvm::sys::path::root_path(filename));
+  }
+
+  llvm::SmallString<128> cwd;
+  llvm::sys::fs::current_path(cwd);
+
+  return DBuilder.createFile(filename, cwd);
 }
 
-DIFile DIBuilder::CreateFile() {
-  Loc loc(IR->dmodule->srcfile.toChars(), 0, 0);
-  return CreateFile(loc);
+DIFile DIBuilder::CreateFile(const Loc &loc) {
+  return CreateFile(loc.filename);
 }
 
 DIFile DIBuilder::CreateFile(Dsymbol *decl) {
-  Loc loc;
-  for (Dsymbol *sym = decl; sym && !loc.filename; sym = sym->parent)
-    loc = sym->loc;
-  return loc.filename ? CreateFile(loc) : CreateFile();
+  const char *filename = nullptr;
+  for (Dsymbol *sym = decl; sym && !filename; sym = sym->parent)
+    filename = sym->loc.filename;
+  return CreateFile(filename);
 }
 
 DIType DIBuilder::CreateBasicType(Type *type) {
@@ -827,10 +838,6 @@ void DIBuilder::EmitCompileUnit(Module *m) {
 
   assert(!CUNode && "Already created compile unit for this DIBuilder instance");
 
-  // prepare srcpath
-  llvm::SmallString<128> srcpath(m->srcfile.toChars());
-  llvm::sys::fs::make_absolute(srcpath);
-
   // prepare producer name string
   auto producerName =
       std::string("LDC ") + ldc_version + " (LLVM " + llvm_version + ")";
@@ -858,9 +865,7 @@ void DIBuilder::EmitCompileUnit(Module *m) {
   CUNode = DBuilder.createCompileUnit(
       global.params.symdebug == 2 ? llvm::dwarf::DW_LANG_C_plus_plus
                                   : llvm::dwarf::DW_LANG_D,
-      DBuilder.createFile(llvm::sys::path::filename(srcpath),
-                          llvm::sys::path::parent_path(srcpath)),
-      producerName,
+      CreateFile(m->srcfile.toChars()), producerName,
       isOptimizationEnabled(), // isOptimized
       llvm::StringRef(),       // Flags TODO
       1,                       // Runtime Version TODO

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -163,9 +163,9 @@ private:
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);
   void AddStaticMembers(AggregateDeclaration *sd, ldc::DIFile file,
                  llvm::SmallVector<llvm::Metadata *, 16> &elems);
+  DIFile CreateFile(const char *filename = nullptr);
   DIFile CreateFile(const Loc &loc);
-  DIFile CreateFile();
-  DIFile CreateFile(Dsymbol* decl);
+  DIFile CreateFile(Dsymbol *decl);
   DIType CreateBasicType(Type *type);
   DIType CreateEnumType(TypeEnum *type);
   DIType CreatePointerType(TypePointer *type);

--- a/runtime/DRuntimeIntegrationTests.cmake
+++ b/runtime/DRuntimeIntegrationTests.cmake
@@ -55,17 +55,18 @@ endif()
 list(REMOVE_ITEM testnames uuid) # MSVC only, custom Makefile (win64.mak)
 
 foreach(name ${testnames})
-    set(outdir ${PROJECT_BINARY_DIR}/druntime-test-${name})
-    add_test(NAME clean-druntime-test-${name}
-        COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir}
-    )
-    add_test(NAME druntime-test-${name}
-        COMMAND ${GNU_MAKE_BIN} -C ${PROJECT_SOURCE_DIR}/druntime/test/${name}
-            ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default
-            DRUNTIME=${druntime_path} DRUNTIMESO=${shared_druntime_path}
-            ${cflags_base} ${linkdl}
-    )
-    set_tests_properties(druntime-test-${name}
-        PROPERTIES DEPENDS clean-druntime-test-${name}
-    )
+    foreach(build debug release)
+        set(fullname druntime-test-${name}-${build})
+        set(outdir ${PROJECT_BINARY_DIR}/${fullname})
+        add_test(NAME clean-${fullname}
+            COMMAND ${CMAKE_COMMAND} -E remove_directory ${outdir}
+        )
+        add_test(NAME ${fullname}
+            COMMAND ${GNU_MAKE_BIN} -C ${PROJECT_SOURCE_DIR}/druntime/test/${name}
+                ROOT=${outdir} DMD=${LDMD_EXE_FULL} MODEL=default BUILD=${build}
+                DRUNTIME=${druntime_path} DRUNTIMESO=${shared_druntime_path}
+                ${cflags_base} ${linkdl}
+        )
+        set_tests_properties(${fullname} PROPERTIES DEPENDS clean-${fullname})
+    endforeach()
 endforeach()

--- a/runtime/DRuntimeIntegrationTests.cmake
+++ b/runtime/DRuntimeIntegrationTests.cmake
@@ -70,3 +70,7 @@ foreach(name ${testnames})
         set_tests_properties(${fullname} PROPERTIES DEPENDS clean-${fullname})
     endforeach()
 endforeach()
+
+# HACK: there's a race condition for the debug/release coverage tests
+#       (temporary in-place modification of source file)
+set_tests_properties(druntime-test-coverage-release PROPERTIES DEPENDS druntime-test-coverage-debug)

--- a/tests/driver/save_optimization_record.d
+++ b/tests/driver/save_optimization_record.d
@@ -12,7 +12,7 @@ int alwaysInlined(int a) { return a; }
 int foo()
 {
     // LLVM: 8329424
-    // YAML: File: save_optimization_record.d, Line: [[@LINE+1]]
+    // YAML: File: {{.*}}save_optimization_record.d{{.*[[:space:]]?.*}}Line: [[@LINE+1]]
     return 8329423 + alwaysInlined(1);
 }
 


### PR DESCRIPTION
As I've seen that we run them in (default) release mode, which includes `-release` and so disables assertions etc.