### PR TITLE
Add -cov-increment option to specify the type of increment instruction

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -588,6 +588,18 @@ static cl::opt<DummyDataType, false, CoverageParser> coverageAnalysis(
              "Use -cov=<n> for n% minimum required coverage\n"
              "Use -cov=ctfe to include code executed during CTFE"));
 
+cl::opt<CoverageIncrement> coverageIncrement(
+    "cov-increment", cl::ZeroOrMore,
+    cl::desc("Set the type of coverage line count increment instruction"),
+    cl::init(CoverageIncrement::_default),
+    cl::values(clEnumValN(CoverageIncrement::_default, "default",
+                          "Use the default (atomic)"),
+               clEnumValN(CoverageIncrement::atomic, "atomic", "Atomic increment"),
+               clEnumValN(CoverageIncrement::nonatomic, "non-atomic",
+                          "Non-atomic increment (not thread safe)"),
+               clEnumValN(CoverageIncrement::boolean, "boolean",
+                          "Don't read, just set counter to 1")));
+
 // Compilation time tracing options
 cl::opt<bool> fTimeTrace(
     "ftime-trace", cl::ZeroOrMore,

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -100,6 +100,15 @@ extern std::vector<std::string> debugArgs;
 void createClashingOptions();
 void hideLLVMOptions();
 
+enum class CoverageIncrement
+{
+    _default,
+    atomic,
+    nonatomic,
+    boolean
+};
+extern cl::opt<CoverageIncrement> coverageIncrement;
+
 // Compilation time tracing options
 extern cl::opt<bool> fTimeTrace;
 extern cl::opt<std::string> fTimeTraceFile;

--- a/gen/coverage.cpp
+++ b/gen/coverage.cpp
@@ -10,6 +10,7 @@
 #include "gen/coverage.h"
 
 #include "dmd/module.h"
+#include "driver/cl_options.h"
 #include "gen/irstate.h"
 #include "gen/logger.h"
 
@@ -30,21 +31,52 @@ void emitCoverageLinecountInc(const Loc &loc) {
   IF_LOG Logger::println("Coverage: increment _d_cover_data[%d]", line);
   LOG_SCOPE;
 
-  // Get GEP into _d_cover_data array
+  // Increment the line counter:
+  // Get GEP into _d_cover_data array...
   LLConstant *idxs[] = {DtoConstUint(0), DtoConstUint(line)};
   LLValue *ptr = llvm::ConstantExpr::getGetElementPtr(
       LLArrayType::get(LLType::getInt32Ty(gIR->context()), m->numlines),
       m->d_cover_data, idxs, true);
+  // ...and generate the "increment" instruction(s)
+  switch (opts::coverageIncrement) {
+  case opts::CoverageIncrement::_default: // fallthrough
+  case opts::CoverageIncrement::atomic:
+    // Do an atomic increment, so this works when multiple threads are executed.
+    gIR->ir->CreateAtomicRMW(llvm::AtomicRMWInst::Add, ptr, DtoConstUint(1),
+                             llvm::AtomicOrdering::Monotonic);
+    break;
+  case opts::CoverageIncrement::nonatomic: {
+    // Do a non-atomic increment, user is responsible for correct results with
+    // multithreaded execution
+    llvm::LoadInst *load = gIR->ir->CreateAlignedLoad(ptr, LLAlign(4));
+    llvm::StoreInst *store = gIR->ir->CreateAlignedStore(
+        gIR->ir->CreateAdd(load, DtoConstUint(1)), ptr, LLAlign(4));
+    // add !nontemporal attribute, to inform the optimizer that caching is not
+    // needed
+    llvm::MDNode *node = llvm::MDNode::get(
+        gIR->context(), llvm::ConstantAsMetadata::get(DtoConstInt(1)));
+    load->setMetadata("nontemporal", node);
+    store->setMetadata("nontemporal", node);
+    break;
+  }
+  case opts::CoverageIncrement::boolean: {
+    // Do a boolean set, avoiding a memory read (blocking) and threading issues
+    // at the cost of not "counting"
+    llvm::StoreInst *store =
+        gIR->ir->CreateAlignedStore(DtoConstUint(1), ptr, LLAlign(4));
+    // add !nontemporal attribute, to inform the optimizer that caching is not
+    // needed
+    llvm::MDNode *node = llvm::MDNode::get(
+        gIR->context(), llvm::ConstantAsMetadata::get(DtoConstInt(1)));
+    store->setMetadata("nontemporal", node);
+    break;
+  }
+  }
 
-  // Do an atomic increment, so this works when multiple threads are executed.
-  gIR->ir->CreateAtomicRMW(llvm::AtomicRMWInst::Add, ptr, DtoConstUint(1),
-                           llvm::AtomicOrdering::Monotonic);
-
+  // Set the 'counter valid' bit to 1 for this line of code
   unsigned num_sizet_bits = gDataLayout->getTypeSizeInBits(DtoSize_t());
   unsigned idx = line / num_sizet_bits;
   unsigned bitidx = line % num_sizet_bits;
-
   IF_LOG Logger::println("_d_cover_valid[%d] |= (1 << %d)", idx, bitidx);
-
   m->d_cover_valid_init[idx] |= (size_t(1) << bitidx);
 }

--- a/tests/codegen/cov_modes.d
+++ b/tests/codegen/cov_modes.d
@@ -1,0 +1,44 @@
+// Test the different modes of -cov instrumentation code
+
+// RUN: %ldc --cov                                                 --output-ll -of=%t.ll         %s && FileCheck --check-prefix=ALL --check-prefix=DEFAULT %s < %t.ll
+// RUN: %ldc --cov --cov-increment=boolean --cov-increment=default --output-ll -of=%t.default.ll %s && FileCheck --check-prefix=ALL --check-prefix=DEFAULT %s < %t.default.ll
+
+// RUN: %ldc --cov --cov-increment=atomic     --output-ll -of=%t.atomic.ll    %s && FileCheck --check-prefix=ALL --check-prefix=ATOMIC    %s < %t.atomic.ll
+// RUN: %ldc --cov --cov-increment=non-atomic --output-ll -of=%t.nonatomic.ll %s && FileCheck --check-prefix=ALL --check-prefix=NONATOMIC %s < %t.nonatomic.ll
+// RUN: %ldc --cov --cov-increment=boolean    --output-ll -of=%t.boolean.ll   %s && FileCheck --check-prefix=ALL --check-prefix=BOOLEAN   %s < %t.boolean.ll
+
+
+// REQUIRES: Linux
+// RUN: mkdir %t
+// RUN: mkdir %t/atomic    && %ldc --cov --cov-increment=atomic     --run %s --DRT-covopt="dstpath:%t/atomic"
+// RUN: mkdir %t/nonatomic && %ldc --cov --cov-increment=non-atomic --run %s --DRT-covopt="dstpath:%t/nonatomic"
+// RUN: mkdir %t/boolean   && %ldc --cov --cov-increment=boolean    --run %s --DRT-covopt="dstpath:%t/boolean"
+// Some sed xargs magic to replace '/' with '-' in the filename, and replace the extension '.d' with '.lst'
+// RUN: echo %s | sed -e "s,/,-,g" -e "s,\(.*\).d,\1.lst," | xargs printf "%%s%%s" "%t/atomic/"    | xargs cat | FileCheck --check-prefix=ATOMIC_LST %s
+// RUN: echo %s | sed -e "s,/,-,g" -e "s,\(.*\).d,\1.lst," | xargs printf "%%s%%s" "%t/nonatomic/" | xargs cat | FileCheck --check-prefix=NONATOMIC_LST %s
+// RUN: echo %s | sed -e "s,/,-,g" -e "s,\(.*\).d,\1.lst," | xargs printf "%%s%%s" "%t/boolean/"   | xargs cat | FileCheck --check-prefix=BOOLEAN_LST %s
+
+void f2()
+{
+}
+
+// ALL-LABEL: define{{.*}} void @{{.*}}f1
+void f1()
+{
+    // DEFAULT: atomicrmw add {{.*}}@_d_cover_data, {{.*}} monotonic
+    // ATOMIC: atomicrmw add {{.*}}@_d_cover_data, {{.*}} monotonic
+    // NONATOMIC: load {{.*}}@_d_cover_data, {{.*}} !nontemporal
+    // NONATOMIC: store {{.*}}@_d_cover_data, {{.*}} !nontemporal
+    // BOOLEAN: store {{.*}}@_d_cover_data, {{.*}} !nontemporal
+    // ALL-LABEL: call{{.*}} @{{.*}}f2
+    f2();
+}
+
+void main()
+{
+    foreach (i; 0..10)
+        f1();
+    // ATOMIC_LST: {{^ *}}10|        f1();
+    // NONATOMIC_LST: {{^ *}}10|        f1();
+    // BOOLEAN_LST: {{^ *}}1|        f1();
+}


### PR DESCRIPTION
This gives the user the ability to get a more performant coverage count execution, at the cost of thread-safety or just boolean true/false on a line (no more counting).

I restricted the testing to Linux, due to the test commandline crazyness (the coverage output filename is very annoying and cannot be set by the user).