### PR TITLE
Cherry-pick upstream support for enforcing ANSI colors for redirected stderr on Windows

### DIFF
--- a/dmd/console.d
+++ b/dmd/console.d
@@ -15,6 +15,20 @@ module dmd.console;
 import core.stdc.stdio;
 extern (C) int isatty(int) nothrow;
 
+version (Windows)
+{
+    import core.sys.windows.winbase;
+    import core.sys.windows.wincon;
+    import core.sys.windows.windef;
+}
+else version (Posix)
+{
+    import core.sys.posix.unistd;
+}
+else
+{
+    static assert(0);
+}
 
 enum Color : int
 {
@@ -37,216 +51,195 @@ enum Color : int
     white         = bright | lightGray,
 }
 
-struct Console
+interface Console
+{
+  nothrow:
+    @property FILE* fp();
+
+    /**
+     * Turn on/off intensity.
+     * Params:
+     *      bright = turn it on
+     */
+    void setColorBright(bool bright);
+
+    /**
+     * Set color and intensity.
+     * Params:
+     *      color = the color
+     */
+    void setColor(Color color);
+
+    /**
+     * Reset console attributes to what they were
+     * when create() was called.
+     */
+    void resetColor();
+}
+
+version (Windows)
+private final class WindowsConsole : Console
 {
   nothrow:
 
+  private:
+    CONSOLE_SCREEN_BUFFER_INFO sbi;
+    HANDLE handle;
+    FILE* _fp;
+
+    static HANDLE getStdHandle(FILE *fp)
+    {
+        /* Determine if stream fp is a console
+         */
+        version (CRuntime_DigitalMars)
+        {
+            if (!isatty(fp._file))
+                return null;
+        }
+        else version (CRuntime_Microsoft)
+        {
+            if (!isatty(fileno(fp)))
+                return null;
+        }
+        else
+        {
+            static assert(0, "Unsupported Windows runtime.");
+        }
+
+        if (fp == stdout)
+            return GetStdHandle(STD_OUTPUT_HANDLE);
+        else if (fp == stderr)
+            return GetStdHandle(STD_ERROR_HANDLE);
+        else
+            return null;
+    }
+
+  public:
+
+    @property FILE* fp() { return _fp; }
+
+    static WindowsConsole create(FILE* fp)
+    {
+        auto h = getStdHandle(fp);
+        if (h is null)
+            return null;
+
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
+            return null;
+
+        auto c = new WindowsConsole();
+        c._fp = fp;
+        c.handle = h;
+        c.sbi = sbi;
+        return c;
+    }
+
+    void setColorBright(bool bright)
+    {
+        SetConsoleTextAttribute(handle, sbi.wAttributes | (bright ? FOREGROUND_INTENSITY : 0));
+    }
+
+    void setColor(Color color)
+    {
+        enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+        WORD attr = sbi.wAttributes;
+        attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
+                ((color & Color.red)    ? FOREGROUND_RED   : 0) |
+                ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
+                ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
+                ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
+        SetConsoleTextAttribute(handle, attr);
+    }
+
+    void resetColor()
+    {
+        SetConsoleTextAttribute(handle, sbi.wAttributes);
+    }
+}
+
+/* Uses the ANSI escape codes.
+ * https://en.wikipedia.org/wiki/ANSI_escape_code
+ * Foreground colors: 30..37
+ * Background colors: 40..47
+ * Attributes:
+ *  0: reset all attributes
+ *  1: high intensity
+ *  2: low intensity
+ *  3: italic
+ *  4: single line underscore
+ *  5: slow blink
+ *  6: fast blink
+ *  7: reverse video
+ *  8: hidden
+ */
+private final class ANSIConsole : Console
+{
+  nothrow:
+
+  private:
+    FILE* _fp;
+
+  public:
+
+    this(FILE* fp) { _fp = fp; }
+
+    @property FILE* fp() { return _fp; }
+
+    void setColorBright(bool bright)
+    {
+        fprintf(_fp, "\033[%dm", bright);
+    }
+
+    void setColor(Color color)
+    {
+        fprintf(_fp, "\033[%d;%dm", color & Color.bright ? 1 : 0, 30 + (color & ~Color.bright));
+    }
+
+    void resetColor()
+    {
+        fputs("\033[m", _fp);
+    }
+}
+
+/**
+ Tries to detect whether DMD has been invoked from a terminal.
+ Returns: `true` if a terminal has been detected, `false` otherwise
+ */
+bool detectTerminal() nothrow
+{
+    version (Posix)
+    {
+        import core.stdc.stdlib : getenv;
+        const(char)* term = getenv("TERM");
+        import core.stdc.string : strcmp;
+        return isatty(STDERR_FILENO) && term && term[0] && strcmp(term, "dumb") != 0;
+    }
+    else version (Windows)
+    {
+        auto h = WindowsConsole.getStdHandle(stderr);
+        if (h is null)
+            return false;
+
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        return GetConsoleScreenBufferInfo(h, &sbi) != 0;
+    }
+}
+
+/**
+ * Creates an instance of Console connected to stream fp.
+ * Params:
+ *      fp = io stream
+ * Returns:
+ *      reference to created Console
+ */
+Console createConsole(FILE* fp) nothrow
+{
     version (Windows)
     {
-        import core.sys.windows.winbase;
-        import core.sys.windows.wincon;
-        import core.sys.windows.windef;
-
-      private:
-        CONSOLE_SCREEN_BUFFER_INFO sbi;
-        HANDLE handle;
-        FILE* _fp;
-
-      public:
-
-        @property FILE* fp() { return _fp; }
-
-        /**
-         Tries to detect whether DMD has been invoked from a terminal.
-         Returns: `true` if a terminal has been detected, `false` otherwise
-         */
-        static bool detectTerminal()
-        {
-            auto h = GetStdHandle(STD_OUTPUT_HANDLE);
-            CONSOLE_SCREEN_BUFFER_INFO sbi;
-            if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-                return false; // no terminal detected
-
-            version (CRuntime_DigitalMars)
-            {
-                return isatty(stdout._file) != 0;
-            }
-            else version (CRuntime_Microsoft)
-            {
-                return isatty(fileno(stdout)) != 0;
-            }
-            else
-            {
-                static assert(0, "Unsupported Windows runtime.");
-            }
-        }
-
-        /*********************************
-         * Create an instance of Console connected to stream fp.
-         * Params:
-         *      fp = io stream
-         * Returns:
-         *      pointer to created Console
-         *      null if failed
-         */
-        static Console* create(FILE* fp)
-        {
-            /* Determine if stream fp is a console
-             */
-            version (CRuntime_DigitalMars)
-            {
-                if (!isatty(fp._file))
-                    return null;
-            }
-            else version (CRuntime_Microsoft)
-            {
-                if (!isatty(fileno(fp)))
-                    return null;
-            }
-            else
-            {
-                return null;
-            }
-
-            DWORD nStdHandle;
-            if (fp == stdout)
-                nStdHandle = STD_OUTPUT_HANDLE;
-            else if (fp == stderr)
-                nStdHandle = STD_ERROR_HANDLE;
-            else
-                return null;
-
-            auto h = GetStdHandle(nStdHandle);
-            CONSOLE_SCREEN_BUFFER_INFO sbi;
-            if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-                return null;
-
-            auto c = new Console();
-            c._fp = fp;
-            c.handle = h;
-            c.sbi = sbi;
+        if (auto c = WindowsConsole.create(fp))
             return c;
-        }
-
-        /*******************
-         * Turn on/off intensity.
-         * Params:
-         *      bright = turn it on
-         */
-        void setColorBright(bool bright)
-        {
-            SetConsoleTextAttribute(handle, sbi.wAttributes | (bright ? FOREGROUND_INTENSITY : 0));
-        }
-
-        /***************************
-         * Set color and intensity.
-         * Params:
-         *      color = the color
-         */
-        void setColor(Color color)
-        {
-            enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
-            WORD attr = sbi.wAttributes;
-            attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
-                   ((color & Color.red)    ? FOREGROUND_RED   : 0) |
-                   ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
-                   ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
-                   ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
-            SetConsoleTextAttribute(handle, attr);
-        }
-
-        /******************
-         * Reset console attributes to what they were
-         * when create() was called.
-         */
-        void resetColor()
-        {
-            SetConsoleTextAttribute(handle, sbi.wAttributes);
-        }
-    }
-    else version (Posix)
-    {
-        /* The ANSI escape codes are used.
-         * https://en.wikipedia.org/wiki/ANSI_escape_code
-         * Foreground colors: 30..37
-         * Background colors: 40..47
-         * Attributes:
-         *  0: reset all attributes
-         *  1: high intensity
-         *  2: low intensity
-         *  3: italic
-         *  4: single line underscore
-         *  5: slow blink
-         *  6: fast blink
-         *  7: reverse video
-         *  8: hidden
-         */
-
-        import core.sys.posix.unistd;
-
-      private:
-        FILE* _fp;
-
-      public:
-
-        @property FILE* fp() { return _fp; }
-        /**
-         Tries to detect whether DMD has been invoked from a terminal.
-         Returns: `true` if a terminal has been detect, `false` otherwise
-         */
-        static bool detectTerminal()
-        {
-            import core.stdc.stdlib : getenv;
-            const(char)* term = getenv("TERM");
-            import core.stdc.string : strcmp;
-            return isatty(STDERR_FILENO) && term && term[0] && strcmp(term, "dumb") != 0;
-        }
-
-        static Console* create(FILE* fp)
-        {
-            auto c = new Console();
-            c._fp = fp;
-            return c;
-        }
-
-        void setColorBright(bool bright)
-        {
-            fprintf(_fp, "\033[%dm", bright);
-        }
-
-        void setColor(Color color)
-        {
-            fprintf(_fp, "\033[%d;%dm", color & Color.bright ? 1 : 0, 30 + (color & ~Color.bright));
-        }
-
-        void resetColor()
-        {
-            fputs("\033[m", _fp);
-        }
-    }
-    else
-    {
-        @property FILE* fp() { assert(0); }
-
-        static Console* create(FILE* fp)
-        {
-            return null;
-        }
-
-        void setColorBright(bool bright)
-        {
-            assert(0);
-        }
-
-        void setColor(Color color)
-        {
-            assert(0);
-        }
-
-        void resetColor()
-        {
-            assert(0);
-        }
     }
 
+    return new ANSIConsole(fp);
 }

--- a/dmd/errors.d
+++ b/dmd/errors.d
@@ -316,7 +316,7 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
 
     if (global.params.showGaggedErrors && global.gag)
         fprintf(stderr, "(spec:%d) ", global.gag);
-    Console* con = cast(Console*)global.console;
+    Console con = cast(Console) global.console;
     const p = loc.toChars();
     if (con)
         con.setColorBright(true);
@@ -771,7 +771,7 @@ private void colorHighlightCode(ref OutBuffer buf)
  * Params:
  *      buf = highlighted text
  */
-private void writeHighlights(Console* con, ref const OutBuffer buf)
+private void writeHighlights(Console con, ref const OutBuffer buf)
 {
     bool colors;
     scope (exit)

--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -540,8 +540,8 @@ else
             }
 
             // -color=auto is the default value
-            import dmd.console : Console;
-            params.color = Console.detectTerminal();
+            import dmd.console : detectTerminal;
+            params.color = detectTerminal();
         }
         else version (IN_GCC)
         {
@@ -560,8 +560,8 @@ else
             bc_ext  = "bc";
             s_ext   = "s";
 
-            import dmd.console : Console;
-            params.color = Console.detectTerminal();
+            import dmd.console : detectTerminal;
+            params.color = detectTerminal();
         }
     }
 

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -386,7 +386,7 @@ version (IN_LLVM) {} else
 } // !IN_LLVM
 
     if (params.color)
-        global.console = Console.create(core.stdc.stdio.stderr);
+        global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
 version (IN_LLVM) {} else
 {


### PR DESCRIPTION
dlang/dmd#12541 will land in 2.098; I want it in LDC v1.27 already because colors come in handy in GitLab CI logs etc.