### PR TITLE
Travis CI: Pin host compiler to v1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - os: linux
       arch: arm64
-      d: ldc-beta
+      d: ldc-1.26.0
       env: LLVM_VERSION=12.0.0 CC=gcc-8 CXX=g++-8 OPTS="-DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64 -DADDITIONAL_DEFAULT_LDC_SWITCHES='\"-linker=bfd\",' -DCOMPILE_ALL_D_FILES_AT_ONCE=OFF"
 
 cache:


### PR DESCRIPTION
We don't have AArch64 packages at the moment, so downloading v1.27.0-beta1 fails.