### PR TITLE
Azure CI: Build and bundle shared libs for iOS too

### DIFF
--- a/.azure-pipelines/4a-mac_x64.yml
+++ b/.azure-pipelines/4a-mac_x64.yml
@@ -20,30 +20,27 @@ steps:
       CMAKE_OSX_ARCHITECTURES=arm64 \
       CMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
       BUILD_LTO_LIBS=ON
-    # TODO: build shared libs too, and look into `-fvisibility=hidden` requirement
     build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
       --buildDir=build-libs-ios-arm64 \
-      --dFlags="-mtriple=$triple_ios_arm64;-fvisibility=hidden" \
+      --dFlags="-mtriple=$triple_ios_arm64" \
       --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
       CMAKE_SYSTEM_NAME=iOS \
       CMAKE_OSX_ARCHITECTURES=arm64 \
       CMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET \
-      BUILD_SHARED_LIBS=OFF \
       BUILD_LTO_LIBS=ON
     build/bin/ldc-build-runtime --ninja -j $PARALLEL_JOBS \
       --buildDir=build-libs-ios-x86_64 \
-      --dFlags="-mtriple=$triple_ios_x64;-fvisibility=hidden" \
+      --dFlags="-mtriple=$triple_ios_x64" \
       --ldcSrcDir=$BUILD_SOURCESDIRECTORY \
       CMAKE_SYSTEM_NAME=iOS \
       CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
       CMAKE_OSX_ARCHITECTURES=x86_64 \
       CMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET \
-      BUILD_SHARED_LIBS=OFF \
       BUILD_LTO_LIBS=ON
     mkdir installed/lib-{arm64,ios-arm64,ios-x86_64}
     cp -a build-libs-arm64/lib/*.{a,dylib} installed/lib-arm64
-    cp build-libs-ios-arm64/lib/*.a installed/lib-ios-arm64
-    cp build-libs-ios-x86_64/lib/*.a installed/lib-ios-x86_64
+    cp -a build-libs-ios-arm64/lib/*.{a,dylib} installed/lib-ios-arm64
+    cp -a build-libs-ios-x86_64/lib/*.{a,dylib} installed/lib-ios-x86_64
     sections="
     \"arm64-apple-macos\":
     {
@@ -64,8 +61,6 @@ steps:
     {
         switches = [
             \"-defaultlib=phobos2-ldc,druntime-ldc\",
-            \"-link-defaultlib-shared=false\",
-            \"-fvisibility=hidden\",
             \"-Xcc=-target\",
             \"-Xcc=$triple_ios_arm64\",
             \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",
@@ -82,8 +77,6 @@ steps:
     {
         switches = [
             \"-defaultlib=phobos2-ldc,druntime-ldc\",
-            \"-link-defaultlib-shared=false\",
-            \"-fvisibility=hidden\",
             \"-Xcc=-target\",
             \"-Xcc=$triple_ios_x64\",
             \"-Xcc=-miphoneos-version-min=$IOS_DEPLOYMENT_TARGET\",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,9 @@ jobs:
         installed/bin/ldc2 -mtriple="arm64-apple-macos" hello.d -of=hello_arm64
         installed/bin/ldc2 -mtriple="arm64-apple-macos" hello.d -of=hello_arm64_shared -link-defaultlib-shared
         installed/bin/ldc2 -mtriple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_arm64
+        installed/bin/ldc2 -mtriple="arm64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_arm64_shared -link-defaultlib-shared
         installed/bin/ldc2 -mtriple="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_x86_64
+        installed/bin/ldc2 -mtriple="x86_64-apple-ios$IOS_DEPLOYMENT_TARGET" hello.d -of=hello_ios_x86_64_shared -link-defaultlib-shared
       displayName: 'Cross-compile & -link hello-world for arm64 and iOS'
     - template: .azure-pipelines/6-package.yml
 


### PR DESCRIPTION
IIRC, I've disabled these because of myriads of linker warnings when trying to use them, and those should be fixed by LLVM 12 now.