### PR TITLE
Fix bad assumption of FuncGenStates stack reflecting lexical parent/child relationships

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1146,6 +1146,13 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     return;
   }
 
+  gIR->funcGenStates.emplace_back(new FuncGenState(*irFunc, *gIR));
+  auto &funcGen = gIR->funcGen();
+  SCOPE_EXIT {
+    assert(&gIR->funcGen() == &funcGen);
+    gIR->funcGenStates.pop_back();
+  };
+
   // if this function is naked, we take over right away! no standard processing!
   if (fd->naked) {
     DtoDefineNakedFunction(fd);
@@ -1162,12 +1169,6 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   gIR->DBuilder.EmitSubProgram(fd);
 
   IF_LOG Logger::println("Doing function body for: %s", fd->toChars());
-  gIR->funcGenStates.emplace_back(new FuncGenState(*irFunc, *gIR));
-  auto &funcGen = gIR->funcGen();
-  SCOPE_EXIT {
-    assert(&gIR->funcGen() == &funcGen);
-    gIR->funcGenStates.pop_back();
-  };
 
   const auto f = static_cast<TypeFunction *>(fd->type->toBasetype());
   IrFuncTy &irFty = irFunc->irFty;

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -147,8 +147,8 @@ public:
   ObjCState objc;
 
   // Stack of currently codegen'd functions (more than one for lambdas or other
-  // nested functions, inlining-only codegen'ing, etc.), and some convenience
-  // accessors for the top-most one.
+  // nested functions, inlining-only codegen'ing, -linkonce-templates etc.),
+  // and some convenience accessors for the top-most one.
   std::vector<std::unique_ptr<FuncGenState>> funcGenStates;
   FuncGenState &funcGen();
   IrFunction *func();

--- a/gen/naked.cpp
+++ b/gen/naked.cpp
@@ -142,8 +142,6 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
   IF_LOG Logger::println("DtoDefineNakedFunction(%s)", mangleExact(fd));
   LOG_SCOPE;
 
-  gIR->funcGenStates.emplace_back(new FuncGenState(*getIrFunc(fd), *gIR));
-
   // we need to do special processing on the body, since we only want
   // to allow actual inline asm blocks to reach the final asm output
 
@@ -247,8 +245,6 @@ void DtoDefineNakedFunction(FuncDeclaration *fd) {
     const auto linkerSwitch = std::string("/EXPORT:") + mangle;
     gIR->addLinkerOption(llvm::StringRef(linkerSwitch));
   }
-
-  gIR->funcGenStates.pop_back();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Found while investigating (but not fixing) #3690.