### PR TITLE
Driver: Use CppRuntime_Gcc by default with Musl

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -778,6 +778,7 @@ void registerPredefinedTargetVersions() {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
     } else if (triple.isMusl()) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
+      VersionCondition::addPredefinedGlobalIdent("CppRuntime_Gcc");
       // use libunwind for backtraces
       VersionCondition::addPredefinedGlobalIdent("DRuntime_Use_Libunwind");
     } else if (global.params.isUClibcEnvironment) {


### PR DESCRIPTION
While CppRuntime should ideally be moved out of the compiler,
it is currently reserved by the compiler and can't be defined
in user code. The most used Musl platform is Alpine Linux,
which doesn't have an alternative for CppRuntime_Clang,
so just define it to use Gcc for now.