### PR TITLE
Make sure special struct TypeInfo members are semantically analyzed before emitting the TypeInfo

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -602,7 +602,6 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
     Logger::println("Function is inside a linkonce_odr template, will be "
                     "defined after declaration.");
     if (fdecl->semanticRun < PASSsemantic3done) {
-      // this can e.g. happen for special __xtoHash member functions
       Logger::println("Function hasn't had sema3 run yet, running it now.");
       const bool semaSuccess = fdecl->functionSemantic3();
       (void)semaSuccess;

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -81,6 +81,16 @@ LLConstant *IrStruct::getTypeInfoInit() {
   IF_LOG Logger::println("Defining TypeInfo for struct: %s", sd->toChars());
   LOG_SCOPE;
 
+  // we need (dummy) TypeInfos for opaque structs too
+  const bool isOpaque = !sd->members;
+
+  // make sure xtoHash/xopEquals/xopCmp etc. are semantically analyzed
+  if (!isOpaque && sd->semanticRun < PASSsemantic3done) {
+    Logger::println(
+        "Struct hasn't had semantic3 yet, calling semanticTypeInfoMembers()");
+    sd->semanticTypeInfoMembers();
+  }
+
   TypeStruct *ts = sd->type->isTypeStruct();
 
   // check declaration in object.d
@@ -107,9 +117,6 @@ LLConstant *IrStruct::getTypeInfoInit() {
   }
 
   RTTIBuilder b(structTypeInfoType);
-
-  // we need (dummy) TypeInfos for opaque structs too
-  const bool isOpaque = !sd->members;
 
   // string name
   if (isOpaque) {


### PR DESCRIPTION
As there are apparently cases where the struct hasn't had semantic3 yet, at least with `-linkonce-templates`. This prevents erroneous `xopCmp` etc. (failing to compile) from being referenced in the TypeInfo (=> linker errors) / being analyzed for `-linkonce-templates` codegen. `semanticTypeInfoMembers()` replaces them by `object._xopCmp()` etc. if compilation fails.