### PR TITLE
Fix lit 12.0.1 installation regression

### DIFF
--- a/.azure-pipelines/1-posix-setup.yml
+++ b/.azure-pipelines/1-posix-setup.yml
@@ -42,7 +42,8 @@ steps:
     fi
     # Install lit
     python3 --version
-    python3 -m pip install --user setuptools wheel lit
+    python3 -m pip install --user setuptools wheel
+    python3 -m pip install --user lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
     # Download & extract host LDC
     HOST_OS="$CI_OS"

--- a/.azure-pipelines/1-posix-setup.yml
+++ b/.azure-pipelines/1-posix-setup.yml
@@ -42,7 +42,7 @@ steps:
     fi
     # Install lit
     python3 --version
-    python3 -m pip install --user lit
+    python3 -m pip install --user setuptools wheel lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
     # Download & extract host LDC
     HOST_OS="$CI_OS"

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -38,7 +38,8 @@ steps:
     7z x ../ninja.zip > nul
     cd ..
     :: Install lit
-    python -m pip install --user setuptools wheel lit
+    python -m pip install --user setuptools wheel
+    python -m pip install --user lit
     python -c "import lit.main; lit.main.main();" --version . | head -n 1
     :: Download & extract host LDC
     curl --max-time 300 --retry 3 -L -o ldc2.7z http://github.com/ldc-developers/ldc/releases/download/v%HOST_LDC_VERSION%/ldc2-%HOST_LDC_VERSION%-windows-multilib.7z 2>&1

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -38,7 +38,7 @@ steps:
     7z x ../ninja.zip > nul
     cd ..
     :: Install lit
-    python -m pip install --user lit
+    python -m pip install --user setuptools wheel lit
     python -c "import lit.main; lit.main.main();" --version . | head -n 1
     :: Download & extract host LDC
     curl --max-time 300 --retry 3 -L -o ldc2.7z http://github.com/ldc-developers/ldc/releases/download/v%HOST_LDC_VERSION%/ldc2-%HOST_LDC_VERSION%-windows-multilib.7z 2>&1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commonSteps: &commonSteps
           fi
           # Install lit
           python3 --version
-          python3 -m pip install --user lit
+          python3 -m pip install --user setuptools wheel lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
           # Download & extract host LDC
           curl --max-time 300 --retry 3 -L -o ldc2.tar.xz https://github.com/ldc-developers/ldc/releases/download/v$HOST_LDC_VERSION/ldc2-$HOST_LDC_VERSION-$CI_OS-x86_64.tar.xz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ commonSteps: &commonSteps
           fi
           # Install lit
           python3 --version
-          python3 -m pip install --user setuptools wheel lit
+          python3 -m pip install --user setuptools wheel
+          python3 -m pip install --user lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
           # Download & extract host LDC
           curl --max-time 300 --retry 3 -L -o ldc2.tar.xz https://github.com/ldc-developers/ldc/releases/download/v$HOST_LDC_VERSION/ldc2-$HOST_LDC_VERSION-$CI_OS-x86_64.tar.xz

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@
 common_steps_template: &COMMON_STEPS_TEMPLATE
   install_lit_script: |
     # Install lit
-    python3 -m pip install --user lit
+    python3 -m pip install --user setuptools wheel lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
   clone_submodules_script: |
     cd $CIRRUS_WORKING_DIR

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,8 @@
 common_steps_template: &COMMON_STEPS_TEMPLATE
   install_lit_script: |
     # Install lit
-    python3 -m pip install --user setuptools wheel lit
+    python3 -m pip install --user setuptools wheel
+    python3 -m pip install --user lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
   clone_submodules_script: |
     cd $CIRRUS_WORKING_DIR

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Install lit
         run: |
           set -euxo pipefail
-          python3 -m pip install --user setuptools wheel lit
+          python3 -m pip install --user setuptools wheel
+          python3 -m pip install --user lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
       - name: "Linux: Install gdb"
         if: runner.os == 'Linux'

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install lit
         run: |
           set -euxo pipefail
-          python3 -m pip install --user lit
+          python3 -m pip install --user setuptools wheel lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
       - name: "Linux: Install gdb"
         if: runner.os == 'Linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ before_install:
 
 install:
   # Install lit
-  - python3 -m pip install --user setuptools wheel lit
+  - python3 -m pip install --user setuptools wheel
+  - python3 -m pip install --user lit
   - |
     set -o pipefail
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 
 install:
   # Install lit
-  - python3 -m pip install --user lit
+  - python3 -m pip install --user setuptools wheel lit
   - |
     set -o pipefail
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1

--- a/shippable.yml
+++ b/shippable.yml
@@ -26,7 +26,7 @@ build:
         git-core cmake ninja-build \
         libcurl3 libcurl4-openssl-dev \
         curl gdb p7zip-full python3-pip tzdata unzip zip
-    - pip install --user lit
+    - pip install --user setuptools wheel lit
     # Download & extract host LDC
     - curl -L -o ldc2.tar.xz https://github.com/ldc-developers/ldc/releases/download/v$HOST_LDC_VERSION/ldc2-$HOST_LDC_VERSION-linux-aarch64.tar.xz
     - mkdir host-ldc

--- a/shippable.yml
+++ b/shippable.yml
@@ -26,7 +26,8 @@ build:
         git-core cmake ninja-build \
         libcurl3 libcurl4-openssl-dev \
         curl gdb p7zip-full python3-pip tzdata unzip zip
-    - pip install --user setuptools wheel lit
+    - pip install --user setuptools wheel
+    - pip install --user lit
     # Download & extract host LDC
     - curl -L -o ldc2.tar.xz https://github.com/ldc-developers/ldc/releases/download/v$HOST_LDC_VERSION/ldc2-$HOST_LDC_VERSION-linux-aarch64.tar.xz
     - mkdir host-ldc


### PR DESCRIPTION
For some Linux images at least, where the lit 12.0.1 upgrade came with some nice `ModuleNotFoundError: No module named 'setuptools'` error from one hour to the next.