### PR TITLE
Fix issue #3802 - Fix size_t size for 32bit ABI on 64bit architectures.

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -728,6 +728,8 @@ void registerPredefinedTargetVersions() {
   // Set versions for arch bitwidth
   if (gDataLayout->getPointerSizeInBits() == 64) {
     VersionCondition::addPredefinedGlobalIdent("D_LP64");
+  } else if (triple.isArch64Bit()) {
+    VersionCondition::addPredefinedGlobalIdent("D_X32");
   } else if (triple.isArch16Bit()) {
     VersionCondition::addPredefinedGlobalIdent("D_P16");
   }

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -90,7 +90,7 @@ void Target::_init(const Param &params) {
   classinfosize = 0; // unused
   maxStaticDataSize = std::numeric_limits<unsigned long long>::max();
 
-  c.longsize = triple.isArch64Bit() && !isMSVC ? 8 : 4;
+  c.longsize = (ptrsize == 8) && !isMSVC ? 8 : 4;
   c.long_doublesize = realsize;
   c.wchar_tsize = triple.isOSWindows() ? 2 : 4;
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -16,6 +16,7 @@
 #include "dmd/id.h"
 #include "dmd/init.h"
 #include "dmd/module.h"
+#include "dmd/target.h"
 #include "driver/cl_options.h"
 #include "gen/abi.h"
 #include "gen/arrays.h"
@@ -298,13 +299,11 @@ LLIntegerType *DtoSize_t() {
   // the type of size_t does not change once set
   static LLIntegerType *t = nullptr;
   if (t == nullptr) {
-    auto triple = global.params.targetTriple;
-
-    if (triple->isArch64Bit()) {
+    if (target.ptrsize == 8) {
       t = LLType::getInt64Ty(gIR->context());
-    } else if (triple->isArch32Bit()) {
+    } else if (target.ptrsize == 4) {
       t = LLType::getInt32Ty(gIR->context());
-    } else if (triple->isArch16Bit()) {
+    } else if (target.ptrsize == 2) {
       t = LLType::getInt16Ty(gIR->context());
     } else {
       llvm_unreachable("Unsupported size_t width");

--- a/tests/compilable/arch64bit_abi32bit_gh3802.d
+++ b/tests/compilable/arch64bit_abi32bit_gh3802.d
@@ -1,0 +1,12 @@
+// Tests compilation for 64-bit architecture with 32-bit word size ABI.
+// Triple examples: mips64el-linux, x86_64-linux-gnux32, aarch64-linux-gnu_ilp32
+// Targeting x86 because that's the most widely available target in our CI/developer systems.
+
+// REQUIRES: target_X86
+// RUN: %ldc -mtriple=x86_64-linux-gnux32 -c %s
+
+bool equals(string lhs, string rhs)
+{
+    foreach (const i; 0 .. lhs.length) {}
+    return false;
+}

--- a/tests/compilable/arch64bit_abi32bit_gh3802.d
+++ b/tests/compilable/arch64bit_abi32bit_gh3802.d
@@ -1,12 +1,31 @@
 // Tests compilation for 64-bit architecture with 32-bit word size ABI.
-// Triple examples: mips64el-linux, x86_64-linux-gnux32, aarch64-linux-gnu_ilp32
+// Triple examples: mips64el-linux-gnuabin32, x86_64-linux-gnux32
 // Targeting x86 because that's the most widely available target in our CI/developer systems.
 
 // REQUIRES: target_X86
-// RUN: %ldc -mtriple=x86_64-linux-gnux32 -c %s
+// RUN: %ldc -mtriple=x86_64-linux-gnux32 -O -c %s
+
+static assert(size_t.sizeof == 4);
+static assert(ptrdiff_t.sizeof == 4);
+
+version (D_LP64) static assert(0);
 
 bool equals(string lhs, string rhs)
 {
     foreach (const i; 0 .. lhs.length) {}
     return false;
+}
+
+// test _d_array_slice_copy optimization IR pass (requires -O)
+auto test_ArraySliceCopyOpt()
+{
+    static void copy(int[] a, int[] b)
+    {
+        a[] = b[];
+    }
+
+    int[2] a = [1, 2];
+    int[2] b = [3, 4];
+    copy(a, b);
+    return a;
 }

--- a/tests/compilable/arch64bit_abi32bit_gh3802.d
+++ b/tests/compilable/arch64bit_abi32bit_gh3802.d
@@ -9,6 +9,7 @@ static assert(size_t.sizeof == 4);
 static assert(ptrdiff_t.sizeof == 4);
 
 version (D_LP64) static assert(0);
+version (D_X32) { /* expected */ } else static assert(0);
 
 bool equals(string lhs, string rhs)
 {

--- a/tests/compilable/arch64bit_abi32bit_gh3802.d
+++ b/tests/compilable/arch64bit_abi32bit_gh3802.d
@@ -5,6 +5,7 @@
 // REQUIRES: target_X86
 // RUN: %ldc -mtriple=x86_64-linux-gnux32 -O -c %s
 
+static assert((void*).sizeof == 4);
 static assert(size_t.sizeof == 4);
 static assert(ptrdiff_t.sizeof == 4);
 


### PR DESCRIPTION
I don't know how to trigger the `_d_array_slice_copy` simplification by SimplifyDRuntimeCalls, so can't test that part of the PR.