### PR TITLE
Travis CI: Revert to latest LDC (beta) as host compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: bionic
 arch: arm64
 language: d
-d: ldc-1.26.0
+d: ldc-beta
 
 env:
   global:


### PR DESCRIPTION
Now that we have AArch64 packages again.