### PR TITLE
-dllimport=defaultLibsOnly: Avoid -linkonce-templates requirement

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -80,9 +80,7 @@ cl::opt<DLLImport, true> dllimport(
                    "None (default with -link-defaultlib-shared=false)"),
         clEnumValN(DLLImport::defaultLibsOnly, "defaultLibsOnly",
                    "Only druntime/Phobos symbols (default with "
-                   "-link-defaultlib-shared and -fvisibility=hidden). May "
-                   "likely need to be coupled with -linkonce-templates to "
-                   "overcome linker errors wrt. instantiated symbols."),
+                   "-link-defaultlib-shared and -fvisibility=hidden)."),
         clEnumValN(DLLImport::all, "all",
                    "All (default with -link-defaultlib-shared and "
                    "-fvisibility=public)")));

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -598,7 +598,7 @@ void DtoDeclareFunction(FuncDeclaration *fdecl, const bool willDefine) {
   bool defineAsAvailableExternally = false;
   if (willDefine) {
     // will be defined anyway after declaration
-  } else if (defineOnDeclare(fdecl)) {
+  } else if (defineOnDeclare(fdecl, /*isFunction=*/true)) {
     Logger::println("Function is inside a linkonce_odr template, will be "
                     "defined after declaration.");
     if (fdecl->semanticRun < PASSsemantic3done) {

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -101,10 +101,6 @@ DValue *DtoCast(const Loc &loc, DValue *val, Type *to);
 // otherwise returns a new DValue
 DValue *DtoPaintType(const Loc &loc, DValue *val, Type *to);
 
-/// Returns true if the specified symbol is to be defined on declaration, for
-/// -linkonce-templates.
-bool defineOnDeclare(Dsymbol *s);
-
 /// Makes sure the declarations corresponding to the given D symbol have been
 /// emitted to the currently processed LLVM module.
 ///
@@ -245,8 +241,13 @@ LLConstant *toConstantArray(LLType *ct, LLArrayType *at, T *str, size_t len,
 
 llvm::Constant *buildStringLiteralConstant(StringExp *se, bool zeroTerm);
 
-/// Indicates whether the specified symbol is a general dllimport candidate.
-bool dllimportSymbol(Dsymbol *sym);
+/// Returns true if the specified symbol is to be defined on declaration,
+/// primarily for -linkonce-templates.
+bool defineOnDeclare(Dsymbol *sym, bool isFunction);
+
+/// Indicates whether the specified data symbol is a general dllimport
+/// candidate.
+bool dllimportDataSymbol(Dsymbol *sym);
 
 /// Tries to declare an LLVM global. If a variable with the same mangled name
 /// already exists, checks if the types match and returns it instead.

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -56,7 +56,7 @@ bool IrAggr::useDLLImport() const {
   if (!global.params.targetTriple->isOSWindows())
     return false;
 
-  if (dllimportSymbol(aggrdecl)) {
+  if (dllimportDataSymbol(aggrdecl)) {
     // dllimport, unless defined in a root module (=> no extra indirection for
     // other root modules, assuming *all* root modules will be linked together
     // to one or more binaries).
@@ -103,7 +103,7 @@ LLConstant *IrAggr::getInitSymbol(bool define) {
     init = initGlobal;
 
     if (!define)
-      define = defineOnDeclare(aggrdecl);
+      define = defineOnDeclare(aggrdecl, /*isFunction=*/false);
   }
 
   if (define) {

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -73,7 +73,7 @@ LLGlobalVariable *IrClass::getVtblSymbol(bool define) {
                          /*isConstant=*/true, false, useDLLImport());
 
     if (!define)
-      define = defineOnDeclare(aggrdecl);
+      define = defineOnDeclare(aggrdecl, /*isFunction=*/false);
   }
 
   if (define) {
@@ -130,7 +130,7 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
     }
 
     if (!define)
-      define = defineOnDeclare(aggrdecl);
+      define = defineOnDeclare(aggrdecl, /*isFunction=*/false);
   }
 
   if (define) {
@@ -473,7 +473,7 @@ llvm::GlobalVariable *IrClass::getInterfaceVtblSymbol(BaseClass *b,
     interfaceVtblMap.insert({{b->sym, interfaces_index}, gvar});
 
     if (!define)
-      define = defineOnDeclare(aggrdecl);
+      define = defineOnDeclare(aggrdecl, /*isFunction=*/false);
   }
 
   if (define && !gvar->hasInitializer()) {

--- a/ir/irmodule.cpp
+++ b/ir/irmodule.cpp
@@ -27,7 +27,7 @@ llvm::GlobalVariable *IrModule::moduleInfoSymbol() {
 
   const auto irMangle = getIRMangledModuleInfoSymbolName(M);
 
-  const bool useDLLImport = !M->isRoot() && dllimportSymbol(M);
+  const bool useDLLImport = !M->isRoot() && dllimportDataSymbol(M);
 
   moduleInfoVar = declareGlobal(Loc(), gIR->module,
                                 llvm::StructType::create(gIR->context()),

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -57,7 +57,7 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
     emitTypeInfoMetadata(typeInfo, aggrdecl->type);
 
     if (!define)
-      define = defineOnDeclare(aggrdecl);
+      define = defineOnDeclare(aggrdecl, /*isFunction=*/false);
   }
 
   if (define) {

--- a/ir/irvar.cpp
+++ b/ir/irvar.cpp
@@ -29,7 +29,7 @@ LLValue *IrGlobal::getValue(bool define) {
     declare();
 
     if (!define)
-      define = defineOnDeclare(V);
+      define = defineOnDeclare(V, /*isFunction=*/false);
   }
 
   if (define) {
@@ -86,7 +86,7 @@ void IrGlobal::declare() {
     // dllimport isn't supported for thread-local globals (MSVC++ neither)
     if (!V->isThreadlocal()) {
       // implicitly include extern(D) globals with -dllimport
-      if (V->isExport() || (V->linkage == LINK::d && dllimportSymbol(V))) {
+      if (V->isExport() || (V->linkage == LINK::d && dllimportDataSymbol(V))) {
         const bool isDefinedInRootModule =
             !(V->storage_class & STCextern) && !V->inNonRoot();
         if (!isDefinedInRootModule)


### PR DESCRIPTION
Via a sorts-of '-linkonce-templates light', only defining all *data* symbols instantiated from druntime/Phobos templates in each referencing CU (as `weak_odr`).