### PR TITLE
Fix little compilability regression

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -152,26 +152,26 @@ void emitLLVMUsedArray(IRState &irs) {
   llvmUsed->setSection("llvm.metadata");
 }
 
-bool inlineAsmDiagnostic(IRState* irs,const llvm::SMDiagnostic &d, unsigned locCookie)
-{
-    if (!locCookie) {
-      d.print(nullptr, llvm::errs());
-      return true;
-    }
-
-    // replace the `<inline asm>` dummy filename by the LOC of the actual D
-    // expression/statement (`myfile.d(123)`)
-    const Loc &loc = irs->getInlineAsmSrcLoc(locCookie);
-    const char *filename = loc.toChars(/*showColumns*/ false);
-
-    // keep on using llvm::SMDiagnostic::print() for nice, colorful output
-    llvm::SMDiagnostic d2(*d.getSourceMgr(), d.getLoc(), filename, d.getLineNo(),
-                          d.getColumnNo(), d.getKind(), d.getMessage(),
-                          d.getLineContents(), d.getRanges(), d.getFixIts());
-    d2.print(nullptr, llvm::errs());
+bool inlineAsmDiagnostic(IRState *irs, const llvm::SMDiagnostic &d,
+                         unsigned locCookie) {
+  if (!locCookie) {
+    d.print(nullptr, llvm::errs());
     return true;
+  }
+
+  // replace the `<inline asm>` dummy filename by the LOC of the actual D
+  // expression/statement (`myfile.d(123)`)
+  const Loc &loc = irs->getInlineAsmSrcLoc(locCookie);
+  const char *filename = loc.toChars(/*showColumns*/ false);
+
+  // keep on using llvm::SMDiagnostic::print() for nice, colorful output
+  llvm::SMDiagnostic d2(*d.getSourceMgr(), d.getLoc(), filename, d.getLineNo(),
+                        d.getColumnNo(), d.getKind(), d.getMessage(),
+                        d.getLineContents(), d.getRanges(), d.getFixIts());
+  d2.print(nullptr, llvm::errs());
+  return true;
 }
-                                           
+
 #if LDC_LLVM_VER < 1300
 void inlineAsmDiagnosticHandler(const llvm::SMDiagnostic &d, void *context,
                                 unsigned locCookie) {

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -29,26 +29,14 @@ IrFunction::IrFunction(FuncDeclaration *fd)
 }
 
 void IrFunction::setNeverInline() {
-  assert(!func->getAttributes()
-#if LDC_LLVM_VER < 1400
-                .hasAttribute(LLAttributeList::FunctionIndex,
-#else
-                .hasFnAttr(
-#endif
-                           llvm::Attribute::AlwaysInline) &&
-            "function can't be never- and always-inline at the same time");
+  assert(!func->hasFnAttribute(llvm::Attribute::AlwaysInline) &&
+         "function can't be never- and always-inline at the same time");
   func->addFnAttr(llvm::Attribute::NoInline);
 }
 
 void IrFunction::setAlwaysInline() {
-  assert(!func->getAttributes()
-#if LDC_LLVM_VER < 1400
-                .hasAttribute(LLAttributeList::FunctionIndex,
-#else
-                .hasFnAttr(
-#endif
-                           llvm::Attribute::NoInline) &&
-            "function can't be never- and always-inline at the same time");
+  assert(!func->hasFnAttribute(llvm::Attribute::NoInline) &&
+         "function can't be never- and always-inline at the same time");
   func->addFnAttr(llvm::Attribute::AlwaysInline);
 }
 


### PR DESCRIPTION
Encountered with the MSVC++ compiler and an LLVM 12 with disabled assertions, complaining about an `assert` macro expansion.