### PR TITLE
Travis CI: Use LDC v1.27.1 host compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: bionic
 arch: arm64
 language: d
-d: ldc-beta
+d: ldc-1.27.1
 
 env:
   global:


### PR DESCRIPTION
As Travis issues in the last weeks prevented generating an AArch64 package for v1.28.0.