### PR TITLE
Default to POSITION_INDEPENDENT_CODE on OpenBSD

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -620,7 +620,8 @@ function(set_common_library_properties target name output_dir c_flags ld_flags i
     # linker default on Ubuntu 16.10 and above. As we might be building on an
     # older system (e.g. binary packages), we need to make sure the C parts are
     # built as PIC as well.
-    if("${TARGET_SYSTEM}" MATCHES "Linux")
+    # Same on OpenBSD.
+    if("${TARGET_SYSTEM}" MATCHES "Linux|OpenBSD")
         set_target_properties(${target} PROPERTIES
             POSITION_INDEPENDENT_CODE ON)
     endif()


### PR DESCRIPTION
OpenBSD defaults to PIC. Everything is built as PIC.