### PR TITLE
Place __minfo global variables in llvm.used

### DIFF
--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -325,6 +325,8 @@ void emitModuleRefToSection(RegistryStyle style, std::string moduleMangle,
   auto thismref = defineDSOGlobal(thismrefIRMangle,
                                   DtoBitCast(thisModuleInfo, moduleInfoPtrTy));
   thismref->setSection(moduleInfoRefsSectionName);
+  // Ensure __minfo will not be discarded by ld -z start-stop-gc.
+  appendToUsed(gIR->module, {thismref});
   gIR->usedArray.push_back(thismref);
 
   if (!isFirst || style == RegistryStyle::sectionSimple) {


### PR DESCRIPTION
This removes an abuse of ELF linker behaviors while keeping
Mach-O/COFF/WebAssembly linker behaviors unchanged.

LLD 13.0.0 (default) and GNU ld 2.37 support `-z start-stop-gc` which enables
the linker to linker to garbage collect unreferenced C identifier name sections
in the presence of `__start_/__stop_`. The `__minfo` section is otherwise
unreferenced and may be garbage collected.

Add the global variables to `llvm.used` can prevent garbage collection.

Fixes #3861

---

I don't know how to add test and I may not have enough time following up. If this needs larger changes, please just take over.