### PR TITLE
DI: delegate context pointer should be .ptr instead of .context

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -741,7 +741,7 @@ DIType DIBuilder::CreateDelegateType(TypeDelegate *type) {
   const auto file = CreateFile();
 
   LLMetadata *elems[] = {
-      CreateMemberType(0, Type::tvoidptr, file, "context", 0,
+      CreateMemberType(0, Type::tvoidptr, file, "ptr", 0,
                        Visibility::public_),
       CreateMemberType(0, type->next->pointerTo(), file, "funcptr",
                        target.ptrsize, Visibility::public_)};

--- a/tests/debuginfo/args_cdb.d
+++ b/tests/debuginfo/args_cdb.d
@@ -85,7 +85,7 @@ int byValue(ubyte ub, ushort us, uint ui, ulong ul,
 
 // CDB: ?? dg
 // CHECK: int delegate()
-// CHECK-NEXT: context :
+// CHECK-NEXT: ptr :
 // CHECK-NEXT: funcptr :
 // CHECK-G-SAME: args_cdb.main.__lambda
 // CHECK-GC-SAME: args_cdb::main::__lambda
@@ -188,7 +188,7 @@ int byPtr(ubyte* ub, ushort* us, uint* ui, ulong* ul,
 // CHECK-NEXT: im : 9
 // CDB: ?? *dg
 // CHECK: int delegate()
-// CHECK-NEXT: context :
+// CHECK-NEXT: ptr :
 // CHECK-NEXT: funcptr :
 // CHECK-G-SAME: args_cdb.main.__lambda
 // CHECK-GC-SAME: args_cdb::main::__lambda
@@ -265,7 +265,7 @@ int byRef(ref ubyte ub, ref ushort us, ref uint ui, ref ulong ul,
 // CHECK-NEXT: im : 9
 // CDB: ?? *dg
 // CHECK: int delegate()
-// CHECK-NEXT: context :
+// CHECK-NEXT: ptr :
 // CHECK-NEXT: funcptr : {{0x[0-9a-f`]*}}
 // CHECK-G-SAME: args_cdb.main.__lambda
 // CHECK-GC-SAME: args_cdb::main::__lambda


### PR DESCRIPTION
According to the ABI specification, when describing the delegates memory
layout, the context pointer is named .ptr .

https://dlang.org/spec/abi.html#delegates

Signed-off-by: Luís Ferreira <contact@lsferreira.net>