### PR TITLE
Add Void Linux to package manager list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ the full feature set of official packages from GitHub**):
 | Nix/NixOS    | `nix-env -i ldc`                             |
 | Snap         | `snap install --classic --channel=edge ldc2` |
 | Ubuntu       | `apt install ldc`                            |
+| Void         | `xbps-install -S ldc`                        |
 
 ### Building from source
 


### PR DESCRIPTION
Maintained at https://github.com/void-linux/void-packages/blob/master/srcpkgs/ldc/template