### PR TITLE
Use d_size_t in dibuilder.cpp

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -19,6 +19,7 @@
 #include "dmd/module.h"
 #include "dmd/mtype.h"
 #include "dmd/nspace.h"
+#include "dmd/root/dcompat.h"
 #include "dmd/target.h"
 #include "dmd/template.h"
 #include "driver/cl_options.h"
@@ -51,7 +52,8 @@ static cl::opt<cl::boolOrDefault> emitColumnInfo(
 namespace ldc {
 
 // in gen/cpp-imitating-naming.d
-const char *convertDIdentifierToCPlusPlus(const char *name, size_t nameLength);
+const char *convertDIdentifierToCPlusPlus(const char *name,
+                                          d_size_t nameLength);
 
 namespace {
 llvm::StringRef uniqueIdent(Type *t) {


### PR DESCRIPTION
Add a special case for size_t compat on 32-bit OpenBSD, which fixes linker errors when building LDC on 32-bit OpenBSD.