### PR TITLE
wasm: Add new default lld switches to protect from stackoverflow overwriting global memory

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -250,14 +250,15 @@ elseif(${BUILD_SHARED_LIBS} STREQUAL "OFF")
     set(ADDITIONAL_DEFAULT_LDC_SWITCHES "${ADDITIONAL_DEFAULT_LDC_SWITCHES}\n        \"-link-defaultlib-shared=false\",")
 endif()
 
+
+# Default wasm stack is only 64kb, this is rather small, let's bump it to 1mb
+set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L-z\", \"-Lstack-size=1048576\",")
+
+# Protect from stack overflow overwriting global memory
+set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--stack-first\",")
+
 if(LDC_WITH_LLD)
     set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-link-internally\",")
-
-    # Default wasm stack is only 64kb, this is rather small, let's bump it to 1mb
-    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L-z\", \"-Lstack-size=1048576\",")
-
-    # Protect from stack overflow overwriting global memory
-    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--stack-first\",")
 endif()
 # LLD 8+ requires (new) `--export-dynamic` for WebAssembly (https://github.com/ldc-developers/ldc/issues/3023).
 if(NOT (LDC_LLVM_VER LESS 800))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -254,10 +254,10 @@ if(LDC_WITH_LLD)
     set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-link-internally\",")
 
     # Default wasm stack is only 64kb, this is rather small, let's bump it to 1mb
-    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-z\", \"stack-size=1048576\",")
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L-z\", \"-Lstack-size=1048576\",")
 
     # Protect from stack overflow overwriting global memory
-    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"--stack-first\",")
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--stack-first\",")
 endif()
 # LLD 8+ requires (new) `--export-dynamic` for WebAssembly (https://github.com/ldc-developers/ldc/issues/3023).
 if(NOT (LDC_LLVM_VER LESS 800))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -252,6 +252,12 @@ endif()
 
 if(LDC_WITH_LLD)
     set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-link-internally\",")
+
+    # Default wasm stack is only 64kb, this is rather small, let's bump it to 1mb
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-z\", \"stack-size=1048576\",")
+
+    # Protect from stack overflow overwriting global memory
+    set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"--stack-first\",")
 endif()
 # LLD 8+ requires (new) `--export-dynamic` for WebAssembly (https://github.com/ldc-developers/ldc/issues/3023).
 if(NOT (LDC_LLVM_VER LESS 800))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -250,13 +250,10 @@ elseif(${BUILD_SHARED_LIBS} STREQUAL "OFF")
     set(ADDITIONAL_DEFAULT_LDC_SWITCHES "${ADDITIONAL_DEFAULT_LDC_SWITCHES}\n        \"-link-defaultlib-shared=false\",")
 endif()
 
-
 # Default wasm stack is only 64kb, this is rather small, let's bump it to 1mb
 set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L-z\", \"-Lstack-size=1048576\",")
-
 # Protect from stack overflow overwriting global memory
 set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-L--stack-first\",")
-
 if(LDC_WITH_LLD)
     set(WASM_DEFAULT_LDC_SWITCHES "${WASM_DEFAULT_LDC_SWITCHES}\n        \"-link-internally\",")
 endif()


### PR DESCRIPTION
I was stuck on trying to fix a bug on my code, whenever i was manipulating around large stucts, it'd change global data

I first thought of a memory corruption somewhere, but it turns out it was a stackoverflow issue!

Increasing the default stack (from 64kb) to 1mb fixed the issue... temporarily! as i was playing with more data, i hit the issue again.. so i looked around and found this PR on the zig repo: https://github.com/ziglang/zig/issues/4496

Tada! now instead of overwritting my global memory, it throws a runtime error! that's better! i can now debug the issue properly!

Let's save people days of headache and make these options the default!

Zig/Rust also bumped the default stack size to 1mb (emscripten has a stack size of 5mb)

