### PR TITLE
Fix ABI build for FreeBSD on PowerPC64

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -75,10 +75,12 @@ static const char *getABI(const llvm::Triple &triple) {
         return "eabi";
       break;
     case llvm::Triple::ppc64:
-    case llvm::Triple::ppc64le:
       if (ABIName.startswith("elfv1"))
         return "elfv1";
       if (ABIName.startswith("elfv2"))
+        return "elfv2";
+      break;
+    case llvm::Triple::ppc64le:
         return "elfv2";
       break;
     default:
@@ -93,7 +95,10 @@ static const char *getABI(const llvm::Triple &triple) {
   case llvm::Triple::mips64el:
     return "n32";
   case llvm::Triple::ppc64:
-    return "elfv1";
+    if (ABIName.startswith("elfv1"))
+      return "elfv1";
+    if (ABIName.startswith("elfv2"))
+      return "elfv2";
   case llvm::Triple::ppc64le:
     return "elfv2";
   default:


### PR DESCRIPTION
This fixes an issue when building on PowerPC64 BE on FreeBSD.  FreeBSD version 12 uses elfv1 but version 13 uses elfv2.  Changes allow LDC to build against the appropriate ABI for PowerPC.