### PR TITLE
Add druntime support for AddressSanitizer stack-use-after-return, fakestack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On Linux, LDC doesn't default to the `ld.gold` linker anymore. The combination of LLVM 13 and older gold linkers can apparently cause problems. We recommend using LLD, e.g., via `-linker=lld` or by setting your default `/usr/bin/ld` symlink; it's significantly faster too.
 - `-linkonce-templates` is less aggressive by default now and IMHO production-ready. (#3924)
 - When linking manually (not via LDC) against *shared* druntime, it is now required to link the bundled `lib/ldc_rt.dso.o[bj]` object file into each binary. It replaces the previously Windows-specific `dso_windows.obj`. (#3850)
+- AddressSanitizer's stack-use-after-return (e.g. catches `scope` variable use outside the defining function) is now supported by druntime when it is built with sanitizer support (pass `RT_SUPPORT_SANITIZERS=ON` when using `ldc-build-runtime`). AddressSanitizer support is disabled by default because of its runtime cost. (#3888)
 
 #### Bug fixes
 - Linux: Make LTO work with LLD. (#3786, #3850)

--- a/tests/sanitizers/asan_fakestack_GC.d
+++ b/tests/sanitizers/asan_fakestack_GC.d
@@ -1,0 +1,93 @@
+// AddressSanitizer: Test that the GC properly scans ASan's fakestack when enabled. Requires runtime support.
+
+// REQUIRES: ASan, RTSupportsSanitizers
+
+// Test without and with fake stack enabled.
+
+// Note on debug lineinfo: on macOS the executable contains a link back to the
+// object files for debug info. Therefore the order of text execution is important,
+// i.e. we should finish all testing on one compiled executable before recompiling
+// with different conditional compilation settings (because it will overwrite the
+// object files from the previous compilation).
+
+// RUN: %ldc %s -of=%t1%exe && %t1%exe -O
+// RUN: %ldc -g -fsanitize=address %s -of=%t_asan%exe -O
+// RUN: %t_asan%exe
+// RUN: env %env_asan_opts=detect_stack_use_after_return=true %t_asan%exe 2>&1 | FileCheck %s
+
+import core.memory;
+import core.thread;
+import std.stdio;
+
+import ldc.attributes;
+@weak
+pragma(inline, false)
+void doNotOptimizeParameter(T)(ref T)
+{
+}
+
+void test_nulling_triggers_collection()
+{
+    void*[100] a; // Large enough so it will be on fakestack heap (not inlined in local stack frame)
+    GC.collect();
+    auto initialSize = GC.stats.usedSize;
+    //writeln(__LINE__, " ", GC.stats.usedSize);
+    a[50] = GC.malloc(100);
+    //writeln(__LINE__, " ", GC.stats.usedSize);
+    auto allocatedSize = GC.stats.usedSize - initialSize;
+    assert(allocatedSize >= 100);
+    a[50] = null;
+    doNotOptimizeParameter(a);
+    //writeln(__LINE__, " ", GC.stats.usedSize);
+    GC.collect();
+    //writeln(__LINE__, " ", GC.stats.usedSize);
+    assert(GC.stats.usedSize == initialSize);
+    doNotOptimizeParameter(a);
+}
+
+void test_non_null_does_not_trigger_collection(uint index)
+{
+    void*[100] a; // Large enough so it will be on fakestack heap (not inlined in local stack frame)
+    //writefln("Address range a, line %u: 0x%x - 0x%x", __LINE__, cast(size_t)&a[0], cast(size_t)&a[$-1]);
+
+    GC.collect();
+    auto initialSize = GC.stats.usedSize;
+    //writeln("GC.stats.usedSize, line ", __LINE__, ": ", GC.stats.usedSize);
+    a[index] = GC.malloc(100);
+    //writeln("GC.stats.usedSize, line ", __LINE__, ": ", GC.stats.usedSize);
+    //writefln("Address a[index], line %u: 0x%x", __LINE__, cast(size_t) a[index]);
+    auto allocatedSize = GC.stats.usedSize - initialSize;
+    assert(allocatedSize >= 100);
+    doNotOptimizeParameter(a);
+    //writeln("GC.stats.usedSize, line ", __LINE__, ": ", GC.stats.usedSize);
+    GC.collect();
+    writeln("GC.stats.usedSize, line ", __LINE__, ": ", GC.stats.usedSize);
+    assert(GC.stats.usedSize == initialSize + allocatedSize); // This fails if GC scanning does not support ASan's fakestack.
+    GC.collect();
+    doNotOptimizeParameter(a);
+}
+
+void main()
+{
+    test_nulling_triggers_collection();
+    test_non_null_does_not_trigger_collection(0);
+    test_non_null_does_not_trigger_collection(50);
+    test_non_null_does_not_trigger_collection(99);
+
+    // Also test threading
+    auto t = new Thread({
+                            test_non_null_does_not_trigger_collection(0);
+                            test_non_null_does_not_trigger_collection(50);
+                            test_non_null_does_not_trigger_collection(99);
+                        });
+    t.start();
+    t.join();
+}
+
+// Make sure that the function calls did indeed happen.
+// CHECK: GC.stats.usedSize
+// CHECK: GC.stats.usedSize
+// CHECK: GC.stats.usedSize
+// CHECK: GC.stats.usedSize
+// CHECK: GC.stats.usedSize
+// CHECK: GC.stats.usedSize

--- a/tests/sanitizers/asan_use_after_return.d
+++ b/tests/sanitizers/asan_use_after_return.d
@@ -28,7 +28,7 @@ auto invoker(Dlg)(scope Dlg dlg) { return S!Dlg(dlg); }
 void main()
 {
     auto inv = f(2);
-// CHECK-NEXT: #1 {{.*}} in {{.*}}asan_use_after_return.d:[[@LINE+1]]
+// CHECK-NEXT: #1 {{.*}} in {{.*}}asan_use_after_return.d
     inv.dlg();
 }
 

--- a/tests/sanitizers/asan_use_after_return.d
+++ b/tests/sanitizers/asan_use_after_return.d
@@ -1,0 +1,36 @@
+// REQUIRES: ASan, RTSupportsSanitizers
+
+// Note on debug lineinfo: on macOS the executable contains a link back to the
+// object files for debug info. Therefore the order of text execution is important,
+// i.e. we should finish all testing on one compiled executable before recompiling
+// with different conditional compilation settings (because it will overwrite the
+// object files from the previous compilation).
+
+// RUN: %ldc -g -fsanitize=address %s -of=%t%exe
+// RUN: not env %env_asan_opts=detect_stack_use_after_return=true %t%exe 2>&1 | FileCheck %s
+
+import core.memory;
+import std.stdio;
+
+// CHECK: ERROR: AddressSanitizer: stack-use-after-return
+// CHECK-NEXT: READ of size 4
+
+struct S(Dlg) { Dlg dlg; }
+auto invoker(Dlg)(scope Dlg dlg) { return S!Dlg(dlg); }
+@nogc auto f(int x) {
+    scope dlg = delegate() {
+// CHECK-NEXT: #0 {{.*}} in {{.*}}asan_use_after_return.d:[[@LINE+1]]
+                    x++;
+                };
+    return invoker(dlg);
+}
+
+void main()
+{
+    auto inv = f(2);
+// CHECK-NEXT: #1 {{.*}} in {{.*}}asan_use_after_return.d:[[@LINE+1]]
+    inv.dlg();
+}
+
+// CHECK: Address {{.*}} is located in stack of
+// CHECK-NEXT: #0 {{.*}} in {{.*}}asan_use_after_return.d:[[@LINE-16]]


### PR DESCRIPTION
See https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterReturn for an explanation of what bugs can be caught with ASan's fakestack enabled.

Apologies for the mess in git on master :(