### PR TITLE
gen/target: refactor function to discover real type

### DIFF
--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -35,20 +35,17 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
   auto &ctx = getGlobalContext();
 
   const auto a = triple.getArch();
-  const bool anyX86 = (a == llvm::Triple::x86) || (a == llvm::Triple::x86_64);
-  const bool anyAarch64 =
-      (a == llvm::Triple::aarch64) || (a == llvm::Triple::aarch64_be);
   const bool isAndroid = triple.getEnvironment() == llvm::Triple::Android;
 
   // Only x86 has 80-bit extended precision.
   // MSVC and Android/x86 use double precision, Android/x64 quadruple.
-  if (anyX86 && !triple.isWindowsMSVCEnvironment() && !isAndroid) {
+  if (triple.isX86() && !triple.isWindowsMSVCEnvironment() && !isAndroid) {
     return llvm::Type::getX86_FP80Ty(ctx);
   }
 
   // AArch64 targets except Darwin (64-bit) use 128-bit quadruple precision.
   // FIXME: PowerPC, SystemZ, ...
-  if ((anyAarch64 && !triple.isOSDarwin()) ||
+  if ((triple.isAArch64() && !triple.isOSDarwin()) ||
       (isAndroid && a == llvm::Triple::x86_64)) {
     return llvm::Type::getFP128Ty(ctx);
   }


### PR DESCRIPTION
This patch refactors the real type discover function to use triple methods
instead of reinventing them.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>