### PR TITLE
CMake: Fix warning when building runtime libs stand-alone

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -103,7 +103,9 @@ if(${BUILD_SHARED_LIBS} STREQUAL "AUTO")
         set(BUILD_SHARED_LIBS OFF)
     endif()
 endif()
-set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS} PARENT_SCOPE) # e.g., for tests/d2/CMakeLists.txt and forwarding to dmd-testsuite
+if(LDC_EXE)
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS} PARENT_SCOPE) # e.g., for tests/d2/CMakeLists.txt and forwarding to dmd-testsuite
+endif()
 
 set(SHARED_LIB_SUFFIX "")
 if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")


### PR DESCRIPTION
E.g., via ldc-build-runtime.