### PR TITLE
Fix capturing NRVO variables

### DIFF
--- a/tests/codegen/nested_nrvo_gh3883.d
+++ b/tests/codegen/nested_nrvo_gh3883.d
@@ -1,0 +1,21 @@
+// https://github.com/ldc-developers/ldc/issues/3883
+// RUN: %ldc -run %s
+
+struct S {
+    int x;
+    ~this() {}
+}
+
+__gshared S* ptr;
+
+S foo() {
+    auto result = S(123);
+    (() @trusted { result.x++; ptr = &result; })();
+    return result;
+}
+
+void main() {
+    auto r = foo();
+    assert(r.x == 124);
+    assert(&r == ptr);
+}


### PR DESCRIPTION
Fixes #3883 by capturing NRVO vars by ref - unless the nested context is a heap closure.