### PR TITLE
Prepare for LLVM15: Headers, attributes

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -24,6 +24,9 @@
 #include "gen/modules.h"
 #include "gen/runtime.h"
 #include "ir/irdsymbol.h"
+#if LDC_LLVM_VER >= 1500
+#include "llvm/IR/DiagnosticInfo.h"
+#endif
 #if LDC_LLVM_VER >= 1100
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #elif LDC_LLVM_VER >= 900

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -31,6 +31,10 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
+#if LDC_LLVM_VER >= 1500
+#include "llvm/Support/AArch64TargetParser.h"
+#include "llvm/Support/ARMTargetParser.h"
+#endif
 
 #if LDC_LLVM_VER >= 700
 #include "gen/optimizer.h"

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -1167,7 +1167,12 @@ void DIBuilder::EmitValue(llvm::Value *val, VarDeclaration *vd) {
 void DIBuilder::EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd,
                                   Type *type, bool isThisPtr, bool forceAsLocal,
                                   bool isRefRVal,
-                                  llvm::ArrayRef<int64_t> addr) {
+#if LDC_LLVM_VER >= 1500
+                                  llvm::ArrayRef<uint64_t> addr
+#else
+                                  llvm::ArrayRef<int64_t> addr
+#endif
+                                  ) {
   if (!mustEmitFullDebugInfo())
     return;
 

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -140,7 +140,12 @@ public:
   EmitLocalVariable(llvm::Value *ll, VarDeclaration *vd, Type *type = nullptr,
                     bool isThisPtr = false, bool forceAsLocal = false,
                     bool isRefRVal = false,
-                    llvm::ArrayRef<int64_t> addr = llvm::ArrayRef<int64_t>());
+#if LDC_LLVM_VER >= 1500
+                    llvm::ArrayRef<uint64_t> addr = llvm::ArrayRef<uint64_t>()
+#else
+                    llvm::ArrayRef<int64_t> addr = llvm::ArrayRef<int64_t>()
+#endif
+                    );
 
   /// \brief Emits all things necessary for making debug info for a global
   /// variable vd.

--- a/gen/inlineir.cpp
+++ b/gen/inlineir.cpp
@@ -37,7 +37,10 @@ struct TempDisableDiscardValueNames {
 /// Note: don't add function _parameter_ attributes
 void copyFnAttributes(llvm::Function *wannabe, llvm::Function *idol) {
   auto attrSet = idol->getAttributes();
-#if LDC_LLVM_VER >= 1400
+#if   LDC_LLVM_VER >= 1500
+  auto fnAttrSet = attrSet.getFnAttrs();
+  wannabe->addFnAttrs(llvm::AttrBuilder(getGlobalContext(), fnAttrSet));
+#elif LDC_LLVM_VER >= 1400
   auto fnAttrSet = attrSet.getFnAttrs();
   wannabe->addFnAttrs(fnAttrSet);
 #else

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -125,7 +125,11 @@ DValue *DtoNestedVariable(const Loc &loc, Type *astype, VarDeclaration *vd,
   // Make the DWARF variable address relative to the context pointer (ctx);
   // register all ops (offsetting, dereferencing) required to get there in the
   // following list.
+#if LDC_LLVM_VER >= 1500
+  LLSmallVector<uint64_t, 4> dwarfAddrOps;
+#else
   LLSmallVector<int64_t, 4> dwarfAddrOps;
+#endif
 
   const auto offsetToNthField = [&val, &dwarfAddrOps](unsigned fieldIndex,
                                                       const char *name = "") {

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -12,11 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "dgc2stack"
-#if LDC_LLVM_VER < 700
-#define LLVM_DEBUG DEBUG
-#endif
-
 #include "gen/attributes.h"
 #include "metadata.h"
 #include "gen/passes/Passes.h"
@@ -41,6 +36,11 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+
+#define DEBUG_TYPE "dgc2stack"
+#if LDC_LLVM_VER < 700
+#define LLVM_DEBUG DEBUG
+#endif
 
 using namespace llvm;
 

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -215,7 +215,11 @@ void applyAttrAllocSize(StructLiteralExp *sle, IrFunction *irFunc) {
   llvmSizeIdx += offset;
   llvmNumIdx += offset;
 
+#if LDC_LLVM_VER >= 1500
+  llvm::AttrBuilder builder(getGlobalContext());
+#else
   llvm::AttrBuilder builder;
+#endif
   if (numArgIdx >= 0) {
     builder.addAllocSizeAttr(llvmSizeIdx, llvmNumIdx);
   } else {
@@ -446,7 +450,11 @@ void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc) {
       if (ident == Id::udaAllocSize) {
         applyAttrAllocSize(sle, irFunc);
       } else if (ident == Id::udaLLVMAttr) {
+#if LDC_LLVM_VER >= 1500
+        llvm::AttrBuilder attrs(getGlobalContext());
+#else
         llvm::AttrBuilder attrs;
+#endif
         applyAttrLLVMAttr(sle, attrs);
 #if LDC_LLVM_VER >= 1400
         func->addFnAttrs(attrs);

--- a/ir/irfuncty.cpp
+++ b/ir/irfuncty.cpp
@@ -17,10 +17,26 @@
 #include "gen/logger.h"
 #include "gen/tollvm.h"
 
+IrFuncTyArg::IrFuncTyArg(Type *t, bool bref)
+    : type(t),
+      ltype(t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t)),
+      attrs(
+#if LDC_LLVM_VER < 1500
+        llvm::AttrBuilder {}
+#else
+        llvm::AttrBuilder(getGlobalContext())
+#endif
+      ),
+      byref(bref)
+{
+  mem.addRange(&type, sizeof(type));
+}
+
 IrFuncTyArg::IrFuncTyArg(Type *t, bool bref, llvm::AttrBuilder a)
     : type(t),
       ltype(t != Type::tvoid && bref ? DtoType(t->pointerTo()) : DtoType(t)),
       attrs(std::move(a)), byref(bref) {
+
   mem.addRange(&type, sizeof(type));
 }
 

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -15,11 +15,6 @@
 #pragma once
 
 #include "gen/attributes.h"
-
-// "gen/llvmhelpers.h" declares `getGlobalContext`, but includes this header
-// so we can't #include it to rely on its definitions
-llvm::LLVMContext& getGlobalContext();
-
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -81,13 +81,8 @@ struct IrFuncTyArg {
    *  @param byref Initial value for the 'byref' field. If true the initial
    *               LLVM Type will be of DtoType(type->pointerTo()), instead
    *               of just DtoType(type) */
-  IrFuncTyArg(Type *t, bool byref,
-#if LDC_LLVM_VER < 1500
-              llvm::AttrBuilder attrs = llvm::AttrBuilder {}
-#else
-              llvm::AttrBuilder attrs = llvm::AttrBuilder(getGlobalContext())
-#endif
-              );
+  IrFuncTyArg(Type *t, bool byref);
+  IrFuncTyArg(Type *t, bool byref, llvm::AttrBuilder);
   IrFuncTyArg(const IrFuncTyArg &) = delete;
 
   ~IrFuncTyArg();

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -15,6 +15,11 @@
 #pragma once
 
 #include "gen/attributes.h"
+
+// "gen/llvmhelpers.h" declares `getGlobalContext`, but includes this header
+// so we can't #include it to rely on its definitions
+llvm::LLVMContext& getGlobalContext();
+
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 
@@ -76,7 +81,13 @@ struct IrFuncTyArg {
    *  @param byref Initial value for the 'byref' field. If true the initial
    *               LLVM Type will be of DtoType(type->pointerTo()), instead
    *               of just DtoType(type) */
-  IrFuncTyArg(Type *t, bool byref, llvm::AttrBuilder attrs = {});
+  IrFuncTyArg(Type *t, bool byref,
+#if LDC_LLVM_VER < 1500
+              llvm::AttrBuilder attrs = llvm::AttrBuilder {}
+#else
+              llvm::AttrBuilder attrs = llvm::AttrBuilder(getGlobalContext())
+#endif
+              );
   IrFuncTyArg(const IrFuncTyArg &) = delete;
 
   ~IrFuncTyArg();


### PR DESCRIPTION
`llvm::AttrBuilder` was changed to require an LLVMContext in its constructor, and can no longer be copied.

declare `DEBUG_TYPE` after includes for the GC2Stack pass as `llvm/Support/GenericDomTreeConstruction.h `(included from `llvm/IR/Dominators.h` `#define`s and `#undef`s it.

`llvm::DIBuilder::createExpression` now takes an `ArrayRef<uint64_t>` instead of `int64_t`. EmitLocalVariable has similarly changed

There is still to go the changing of load instructions to specify a type when loading, but that is significantly larger and more complicated. Will do that in a follow up PR.