### PR TITLE
Fix -main regression when used for linking only, without source module

### DIFF
--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -689,7 +689,22 @@ version (IN_LLVM)
     }
 
     if (params.addMain && !global.hasMainFunction)
+    {
+version (IN_LLVM)
+{
+        auto mainModule = moduleWithEmptyMain();
+        modules.push(mainModule);
+
+        if (!params.oneobj)
+            params.objfiles.push(mainModule.objfile.toChars());
+        else if (modules.length == 1)
+            params.objfiles.insert(0, mainModule.objfile.toChars());
+}
+else
+{
         modules.push(moduleWithEmptyMain());
+}
+    }
 
 version (IN_LLVM)
 {

--- a/tests/driver/inputs/include_imports2.d
+++ b/tests/driver/inputs/include_imports2.d
@@ -1,1 +1,3 @@
+module inputs.include_imports2;
+
 void bar() {}

--- a/tests/driver/main.d
+++ b/tests/driver/main.d
@@ -1,0 +1,20 @@
+// compile & link at once with -main:
+// RUN: %ldc -main %s %S/inputs/include_imports2.d -of=%t1%exe
+// RUN: %t1%exe | FileCheck %s
+
+// compile separately, then link with -main:
+// RUN: %ldc -c %s %S/inputs/include_imports2.d -od=%t.obj
+// RUN: %ldc -main %t.obj/main%obj %t.obj/include_imports2%obj -of=%t2%exe
+// RUN: %t2%exe | FileCheck %s
+
+module main_;
+
+import core.stdc.stdio : printf;
+import inputs.include_imports2 : bar;
+
+shared static this()
+{
+    bar();
+    // CHECK: module ctor
+    printf("module ctor\n");
+}


### PR DESCRIPTION
This is a pretty wild one. `-main` handling was changed in v2.099 - the module is now optionally appended *after* full semantic for the source modules, so that it can be skipped if a `main` was already encountered.

Unlike regular source modules, it didn't get an entry in `global.params.objfiles` anymore this way though. So in non-singleobj
mode, its object file was ignored for archiving/linking. In singleobj mode, the problem was the case with no regular source
modules at all, the main module being the only module to be compiled (in singleobj mode) - where we assume `global.params.objfile[0]` to be the path to that object file.

Some meson build at Symmetry uses `-main` for linking separately compiled object files. The compiler then overwrote the first given object file with the compiled main module, and the linker later luckily complained about an undefined symbol, defined in the original first object file...