### PR TITLE
Added support for newlib

### DIFF
--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -316,6 +316,7 @@ version (IN_LLVM)
     // target stuff
     const(void)* targetTriple; // const llvm::Triple*
     bool isUClibcEnvironment;
+    bool isNewlibEnvironment;
 
     // Codegen cl options
     bool disableRedZone;

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -284,6 +284,7 @@ struct Param
 
     const llvm::Triple *targetTriple;
     bool isUClibcEnvironment; // not directly supported by LLVM
+    bool isNewlibEnvironment; // not directly supported by LLVM
 
     // Codegen cl options
     bool disableRedZone;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -595,20 +595,16 @@ void fixupUClibcEnv() {
   global.params.isUClibcEnvironment = true;
 }
 
-// Check for -newlib and strip out (supports -newlib and -eabi-newlib)
+// Strip out newlib
 void fixupNewlibEnv() {
-  llvm::Triple triple(mTargetTriple);
-  std::string envName(triple.getEnvironmentName());
-  size_t pos = envName.find("newlib");
-
+  std::string fullTriple(mTargetTriple);
+  size_t pos = fullTriple.find("newlib");
   if (pos == std::string::npos)
     return;
 
-  envName.replace(pos, 6, "");
-  if (envName[envName.length() - 1] == '-') {
-      envName.replace(envName.length() - 1, 1, "");
-  }
-  triple.setEnvironmentName(envName);
+  fullTriple.replace(pos, 6, "");
+
+  llvm::Triple triple(fullTriple);
   mTargetTriple = triple.normalize();
   global.params.isNewlibEnvironment = true;
 }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -585,22 +585,14 @@ static void registerMipsABI() {
 
 // Handle target environments not directly supported by LLVM.
 void fixupTripleEnv(std::string &tripleString) {
-  llvm::Triple triple(tripleString);
-  llvm::StringRef env = triple.getEnvironmentName();
-  std::string newEnv;
-
-  if (env.startswith("uclibc")) {
+  size_t i;
+  if ((i = tripleString.find("-uclibc")) != std::string::npos) {
     global.params.isUClibcEnvironment = true;
-    newEnv = ("gnu" + env.substr(6)).str(); // uclibceabihf => gnueabihf
-  } else if (env.startswith("newlib")) {
+    tripleString.replace(i + 1, 6, "gnu"); // -uclibceabihf => -gnueabihf
+  } else if ((i = tripleString.find("-newlib")) != std::string::npos) {
     global.params.isNewlibEnvironment = true;
-    newEnv = env.substr(6).str(); // newlibeabi => eabi
-  } else {
-    return;
+    tripleString.replace(i + 1, 6, ""); // -newlibeabi => -eabi
   }
-
-  triple.setEnvironmentName(newEnv);
-  tripleString = triple.normalize();
 }
 
 /// Register the float ABI.


### PR DESCRIPTION
Fixes #3945 by handling newlib like uclibc.

Implemented similar to fixupUClibc. newlib will be removed from the
environment part of the triple, if present. The rest of the environment
is preserved (such as eabi). For example, the triple
arm-none-eabi-newlib will be converted to arm-none-eabi and 
CRuntime_Newlib will be set.