### PR TITLE
CMake: Drop macOS fat multilib support

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -787,139 +787,55 @@ include(jit-rt/DefineBuildJitRT.cmake)
 # Set up build and install targets
 #
 
-if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
-    # On OS X, build "fat" libraries containing code for both architectures.
-
-    # Some suffix for the target/file names of the host-native arch so
-    # that they don't collide with the final combined ones.
-    set(hostsuffix "${LIB_SUFFIX}${HOST_BITNESS}")
-
-    set(libtargets)
-    build_runtime_variants("" "${RT_CFLAGS}" "${LD_FLAGS}" "${hostsuffix}" libtargets)
-    build_runtime_variants("-m${MULTILIB_SUFFIX}" "-m${MULTILIB_SUFFIX} ${RT_CFLAGS}" "-m${MULTILIB_SUFFIX} ${LD_FLAGS}" "${MULTILIB_SUFFIX}" libtargets)
-
-    # Only build the host version of the jit runtime due to LLVM dependency.
-    set(libtargets_jit)
-    build_jit_runtime("${D_FLAGS};${D_FLAGS_RELEASE}" "${RT_CFLAGS}" "${LD_FLAGS}" "${LIB_SUFFIX}" libtargets_jit)
-    # Install separately; also manually copy libldc-jit-rt.a to prevent ranlib from
-    # potentially corrupting the file during installation.
-    if(LDC_DYNAMIC_COMPILE)
-        install(FILES       $<TARGET_FILE:ldc-jit-rt>
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-        list(REMOVE_ITEM libtargets_jit ldc-jit-rt)
-    endif()
-    install(TARGETS     ${libtargets_jit}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-
-    # KLUDGE: Cannot use `$<TARGET_LINKER_FILE:target>` in custom command.
-    # Set up the list of generated libs (without 'lib' prefix) to be merged manually.
-    set(libs_to_merge)
-    if(NOT ${BUILD_SHARED_LIBS} STREQUAL "ON")
-        list(APPEND libs_to_merge druntime-ldc.a druntime-ldc-debug.a
-                                  phobos2-ldc.a  phobos2-ldc-debug.a
-        )
-        if(BUILD_LTO_LIBS)
-            list(APPEND libs_to_merge druntime-ldc-lto.a phobos2-ldc-lto.a)
-        endif()
-    endif()
-    if(NOT ${BUILD_SHARED_LIBS} STREQUAL "OFF")
-        set(suffix ${SHARED_LIB_SUFFIX}.dylib)
-        list(APPEND libs_to_merge druntime-ldc${suffix} druntime-ldc-debug${suffix}
-                                  phobos2-ldc${suffix}  phobos2-ldc-debug${suffix}
-        )
-    endif()
-
-    foreach(lib ${libs_to_merge})
-        set(target_name "")
-        set(lib_extension "")
-        get_filename_component(target_name ${lib} NAME_WE)
-        get_filename_component(lib_extension ${lib} EXT)
-
-        set(host_path  ${CMAKE_BINARY_DIR}/lib${hostsuffix}/lib${lib})
-        set(multi_path ${CMAKE_BINARY_DIR}/lib${MULTILIB_SUFFIX}/lib${lib})
-
-        # Create (& later install) symbolic links for merged dylibs.
-        set(final_files_to_install)
-        if(${lib_extension} STREQUAL ".dylib")
-            set(final_path     ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/lib${target_name}.${DMDFE_VERSION}.dylib)
-            set(dylib_symlink1 ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/lib${target_name}.${DMDFE_PATCH_VERSION}.dylib)
-            set(dylib_symlink2 ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/lib${target_name}.dylib)
-            set(final_files_to_install ${final_path} ${dylib_symlink1} ${dylib_symlink2})
-            add_custom_command(
-                OUTPUT  ${final_files_to_install}
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}
-                COMMAND lipo ${multi_path} ${host_path} -create -output ${final_path}
-                COMMAND ln -s lib${target_name}.${DMDFE_VERSION}.dylib ${dylib_symlink1}
-                COMMAND ln -s lib${target_name}.${DMDFE_PATCH_VERSION}.dylib ${dylib_symlink2}
-                DEPENDS ${libtargets}
-            )
-        else()
-            set(final_path ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}/lib${lib})
-            set(final_files_to_install ${final_path})
-            add_custom_command(
-                OUTPUT  ${final_path}
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}
-                COMMAND lipo ${multi_path} ${host_path} -create -output ${final_path}
-                DEPENDS ${libtargets}
-            )
-        endif()
-
-        add_custom_target(${target_name} ALL DEPENDS ${final_files_to_install})
-
-        install(FILES       ${final_files_to_install}
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-    endforeach()
-else()
-    set(libs_to_install)
-    # build host versions
-    build_runtime_variants("" "${RT_CFLAGS}" "${LD_FLAGS}" "${LIB_SUFFIX}" libs_to_install)
-    if(MULTILIB)
-        # build multi versions
-        build_runtime_variants("-m${MULTILIB_SUFFIX}" "-m${MULTILIB_SUFFIX} ${RT_CFLAGS}" "-m${MULTILIB_SUFFIX} ${LD_FLAGS}" "${MULTILIB_SUFFIX}" libs_to_install)
-    endif()
-
-    # Only build the host version of the jit runtime due to LLVM dependency.
-    build_jit_runtime("${D_FLAGS};${D_FLAGS_RELEASE}" "${RT_CFLAGS}" "${LD_FLAGS}" "${LIB_SUFFIX}" libs_to_install)
-
-    # Add the (static- and release-only) bitcode libraries.
-    if(BUILD_LTO_LIBS AND (NOT ${BUILD_SHARED_LIBS} STREQUAL "ON"))
-        list(APPEND libs_to_install druntime-ldc-lto phobos2-ldc-lto)
-    endif()
-
-    foreach(libname ${libs_to_install})
-        set(target_type)
-        get_target_property(target_type ${libname} TYPE)
-
-        set(destination_dir ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-        if(${libname} MATCHES "_${MULTILIB_SUFFIX}$")
-            set(destination_dir ${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX})
-        endif()
-
-        # On Mac, manually copy static libraries to prevent ranlib from
-        # potentially corrupting the file during installation.
-        # See https://bugs.llvm.org/show_bug.cgi?id=34808.
-        if("${TARGET_SYSTEM}" MATCHES "APPLE" AND "${target_type}" STREQUAL "STATIC_LIBRARY")
-            install(FILES       $<TARGET_FILE:${libname}>
-                    DESTINATION ${destination_dir})
-        # Windows DLLs:
-        elseif("${TARGET_SYSTEM}" MATCHES "MSVC" AND "${target_type}" STREQUAL "SHARED_LIBRARY")
-            # import .lib in regular lib dir
-            install(FILES       $<TARGET_LINKER_FILE:${libname}>
-                    DESTINATION ${destination_dir})
-            # .dll in bin dir
-            install(FILES       $<TARGET_FILE:${libname}>
-                    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-            # .pdb of debug DLLs in bin dir
-            if(${libname} MATCHES "-debug")
-                install(FILES       $<TARGET_PDB_FILE:${libname}>
-                        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-            endif()
-        else()
-            install(TARGETS     ${libname}
-                    DESTINATION ${destination_dir})
-        endif()
-    endforeach()
+set(libs_to_install)
+# build host versions
+build_runtime_variants("" "${RT_CFLAGS}" "${LD_FLAGS}" "${LIB_SUFFIX}" libs_to_install)
+if(MULTILIB)
+    # build multi versions
+    build_runtime_variants("-m${MULTILIB_SUFFIX}" "-m${MULTILIB_SUFFIX} ${RT_CFLAGS}" "-m${MULTILIB_SUFFIX} ${LD_FLAGS}" "${MULTILIB_SUFFIX}" libs_to_install)
 endif()
+
+# Only build the host version of the jit runtime due to LLVM dependency.
+build_jit_runtime("${D_FLAGS};${D_FLAGS_RELEASE}" "${RT_CFLAGS}" "${LD_FLAGS}" "${LIB_SUFFIX}" libs_to_install)
+
+# Add the (static- and release-only) bitcode libraries.
+if(BUILD_LTO_LIBS AND (NOT ${BUILD_SHARED_LIBS} STREQUAL "ON"))
+    list(APPEND libs_to_install druntime-ldc-lto phobos2-ldc-lto)
+endif()
+
+foreach(libname ${libs_to_install})
+    set(target_type)
+    get_target_property(target_type ${libname} TYPE)
+
+    set(destination_dir ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
+    if(${libname} MATCHES "_${MULTILIB_SUFFIX}$")
+        set(destination_dir ${CMAKE_INSTALL_PREFIX}/lib${MULTILIB_SUFFIX})
+    endif()
+
+    # On Mac, manually copy static libraries to prevent ranlib from
+    # potentially corrupting the file during installation.
+    # See https://bugs.llvm.org/show_bug.cgi?id=34808.
+    if("${TARGET_SYSTEM}" MATCHES "APPLE" AND "${target_type}" STREQUAL "STATIC_LIBRARY")
+        install(FILES       $<TARGET_FILE:${libname}>
+                DESTINATION ${destination_dir})
+    # Windows DLLs:
+    elseif("${TARGET_SYSTEM}" MATCHES "MSVC" AND "${target_type}" STREQUAL "SHARED_LIBRARY")
+        # import .lib in regular lib dir
+        install(FILES       $<TARGET_LINKER_FILE:${libname}>
+                DESTINATION ${destination_dir})
+        # .dll in bin dir
+        install(FILES       $<TARGET_FILE:${libname}>
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+        # .pdb of debug DLLs in bin dir
+        if(${libname} MATCHES "-debug")
+            install(FILES       $<TARGET_PDB_FILE:${libname}>
+                    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+        endif()
+    else()
+        install(TARGETS     ${libname}
+                DESTINATION ${destination_dir})
+    endif()
+endforeach()
 
 set(DRUNTIME_PACKAGES core etc ldc)
 


### PR DESCRIPTION
It's been dead for a while, since i686 support was dropped. Merging x86_64 and arm64 installations manually in e.g. bash (see the macOS_universal Azure CI job) seems much simpler and flexible to me.