### PR TITLE
GH Actions / Cirrus CI: Use lld from host clang (without assertions) as default linker

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -359,8 +359,6 @@ task:
     mkdir -p llvm
     tar -xf llvm.tar.xz --strip 1 -C llvm
     rm llvm.tar.xz
-    # Make lld the default linker (possibly with enabled assertions unfortunately)
-    ln -sf "$PWD/llvm/bin/ld.lld" /usr/bin/ld
   # Download & extract clang
   download_prebuilt_clang_script: |
     cd $CIRRUS_WORKING_DIR/..
@@ -368,6 +366,9 @@ task:
     mkdir clang
     tar -xf clang.tar.xz --strip 1 -C clang
     rm clang.tar.xz
+    # Make lld the default linker
+    ln -sf "$PWD/clang/bin/ld.lld" /usr/bin/ld
+    ld --version
   clone_submodules_early_script: |
     cd $CIRRUS_WORKING_DIR
     git submodule update --init --depth $CIRRUS_CLONE_DEPTH

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -94,12 +94,12 @@ runs:
 
         llvm/bin/llvm-config --version
 
-    - name: 'Linux: Make lld the default linker' # possibly with enabled assertions unfortunately
+    - name: 'Linux: Make lld the default linker'
       if: runner.os == 'Linux'
       shell: bash
       run: |
         set -eux
-        sudo ln -sf "$(dirname "$PWD")/llvm/bin/ld.lld" /usr/bin/ld
+        sudo ln -sf "$(dirname "$PWD")/clang/bin/ld.lld" /usr/bin/ld
         ld --version
 
     - name: Install ninja


### PR DESCRIPTION
Instead of the lld from the prebuilt LDC-LLVM package, with enabled assertions for untagged CI builds. Besides slowing down linking, we also suffer from sporadic failing LLD assertions (since v13) for MSVC targets.