### PR TITLE
Enable output of variable names in ASan and MSan error reporting.

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -17,6 +17,7 @@
 #include "dmd/scope.h"
 #include "driver/cl_options.h"
 #include "driver/cl_options_instrumentation.h"
+#include "driver/cl_options_sanitizers.h"
 #include "driver/linker.h"
 #include "driver/toobj.h"
 #include "gen/dynamiccompile.h"
@@ -195,8 +196,11 @@ CodeGenerator::CodeGenerator(llvm::LLVMContext &context,
       mlirContext_(mlirContext),
 #endif
       moduleCount_(0), singleObj_(singleObj), ir_(nullptr) {
-  // Set the context to discard value names when not generating textual IR.
-  if (!global.params.output_ll) {
+  // Set the context to discard value names when not generating textual IR and
+  // when ASan or MSan are not enabled.
+  if (!global.params.output_ll &&
+      !opts::isSanitizerEnabled(opts::AddressSanitizer |
+                                opts::MemorySanitizer)) {
     context_.setDiscardValueNames(true);
   }
 }

--- a/tests/sanitizers/asan_fiber.d
+++ b/tests/sanitizers/asan_fiber.d
@@ -27,8 +27,9 @@ void foo(int* ptr)
 // CHECK-NEXT: #0 {{.*}} in {{.*prefoo.*}} {{.*}}asan_fiber.d:[[@LINE+1]]
 void prefoo()
 {
-    int[10] a;
-    foo(&a[0]);
+    // CHECK: 'aiaiaiaiaiaiaiaiaiai'{{.*}} <== {{.*}} overflows this variable
+    int[10] aiaiaiaiaiaiaiaiaiai;
+    foo(&aiaiaiaiaiaiaiaiaiai[0]);
 }
 
 void main()

--- a/tests/sanitizers/asan_fiber_main.d
+++ b/tests/sanitizers/asan_fiber_main.d
@@ -36,13 +36,14 @@ void foo(int* arr)
 // FAKESTACK: #0 {{.*}} in {{.*main.*}} {{.*}}asan_fiber_main.d:[[@LINE+1]]
 void main()
 {
-    int[10] a;
+    // FAKESTACK: 'abcdabcdabcd'{{.*}} <== {{.*}} overflows this variable
+    int[10] abcdabcdabcd;
     int b;
 
     // Use an extra variable instead of passing `&a[0]` directly to `foo`.
     // This is to keep `a` on the stack: `ptr` may be heap allocated because
     // it is used in the lambda (delegate).
-    int* ptr = &a[0];
+    int* ptr = &abcdabcdabcd[0];
     auto fib = new Fiber(() => foo(ptr));
     fib.call();
     version (BAD_AFTER_YIELD)

--- a/tests/sanitizers/asan_stackoverflow.d
+++ b/tests/sanitizers/asan_stackoverflow.d
@@ -17,10 +17,9 @@ void foo(int* arr)
 // CHECK-NEXT: #0 {{.*}} in {{.*main.*}} {{.*}}asan_stackoverflow.d:[[@LINE+1]]
 void main()
 {
-    // TODO: add test for the name of the variable that is overflown. Right now we get this message:
-    //[32, 72) '' <== Memory access at offset 72 overflows this variable
-    // C HECK: 'a'{{.*}} <== {{.*}} overflows this variable
-    int[10] a;
+    // Test for the name of the variable that is overflown.
+    // CHECK: 'aiaiaiaiaiaiai'{{.*}} <== {{.*}} overflows this variable
+    int[10] aiaiaiaiaiaiai;
     int b;
-    foo(&a[0]);
+    foo(&aiaiaiaiaiaiai[0]);
 }


### PR DESCRIPTION
I've finally found what was the problem! Now the user will see the variable name that is overflown (close to the address read), e.g.:
```
=================================================================
==73095==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x000101507f08 at pc 0x000100c7ece8 bp 0x000101507e70 sp 0x000101507e68
WRITE of size 4 at 0x000101507f08 thread T0
    #0 0x100c7ece4 in _D10asan_fiber3fooFPiZv asan_fiber.d:21
    #1 0x100c7ee1c in _D10asan_fiber6prefooFZv asan_fiber.d:31
    #2 0x100de8ecc in fiber_entryPoint+0x4c (asan_fiber.d.tmp:arm64+0x10016cecc)

Address 0x000101507f08 is located in stack of thread T0 at offset 72 in frame
    #0 0x100c7ed0c in _D10asan_fiber6prefooFZv asan_fiber.d:28

  This frame has 1 object(s):
    [32, 72) 'aiaiaiaiaiaiaiaiaiai' <== Memory access at offset 72 overflows this variable
```