### PR TITLE
RISCV64: Initial support

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -421,6 +421,7 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
   }
 
   if (triple.getArch() == llvm::Triple::riscv64 && !hasFeature("d")) {
+    // Support Double-Precision Floating-Point by default.
     features.push_back("+d");
   }
 

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -102,6 +102,8 @@ static const char *getABI(const llvm::Triple &triple) {
     return "elfv1";
   case llvm::Triple::ppc64le:
     return "elfv2";
+  case llvm::Triple::riscv64:
+    return "lp64d";
   default:
     return "";
   }
@@ -416,6 +418,10 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
   // if the user did not make an explicit choice.
   if (cpu == "x86-64" && !hasFeature("cx16")) {
     features.push_back("+cx16");
+  }
+
+  if (triple.getArch() == llvm::Triple::riscv64 && !hasFeature("d")) {
+    features.push_back("+d");
   }
 
   // Handle cases where LLVM picks wrong default relocModel

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -120,6 +120,11 @@ void appendTargetArgsForGcc(std::vector<std::string> &args) {
     }
     return;
 
+  case Triple::riscv64:
+      args.push_back("-march=rv64gc");
+      args.push_back("-mabi=lp64d");
+    return;
+
   default:
     break;
   }

--- a/gen/abi-riscv64.cpp
+++ b/gen/abi-riscv64.cpp
@@ -23,21 +23,21 @@ struct Integer2Rewrite : BaseBitcastABIRewrite {
   }
 };
 
-struct flattenedFields {
-  struct flattenedField {
+struct FlattenedFields {
+  struct FlattenedField {
     Type *ty = nullptr;
     unsigned offset = 0;
   };
-  flattenedField fields[2];
+  FlattenedField fields[2];
   int length = 0; // use -1 to represent "no need to rewrite" condition
 };
 
-flattenedFields visitStructFields(Type *ty, unsigned baseOffset) {
+FlattenedFields visitStructFields(Type *ty, unsigned baseOffset) {
   // recursively visit a POD struct to flatten it
   // FIXME: may cause low performance
   // dmd may cache argtypes in some other architectures as a TypeTuple, but we
   // need to additionally store field offsets to realign later
-  flattenedFields result;
+  FlattenedFields result;
   if (auto ts = ty->toBasetype()->isTypeStruct()) {
     for (auto fi : ts->sym->fields) {
       auto sub = visitStructFields(fi->type, baseOffset + fi->offset);
@@ -126,7 +126,7 @@ struct HardfloatRewrite : ABIRewrite {
     }
     return ret;
   }
-  LLType *type(Type *ty, const flattenedFields &flat) {
+  LLType *type(Type *ty, const FlattenedFields &flat) {
     if (flat.length == 1) {
       return LLStructType::get(gIR->context(), {DtoType(flat.fields[0].ty)},
                                false);

--- a/gen/abi-riscv64.cpp
+++ b/gen/abi-riscv64.cpp
@@ -1,0 +1,234 @@
+//===-- gen/abi-riscv64.cpp - RISCV64 ABI description -----------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/abi.h"
+#include "gen/abi-generic.h"
+#include "gen/abi-riscv64.h"
+#include "gen/dvalue.h"
+#include "gen/irstate.h"
+#include "gen/llvmhelpers.h"
+#include "gen/tollvm.h"
+
+namespace {
+struct Integer2Rewrite : BaseBitcastABIRewrite {
+  LLType *type(Type *t) override {
+    return LLStructType::get(gIR->context(),
+                             {DtoType(Type::tint64), DtoType(Type::tint64)});
+  }
+};
+
+struct flattenedFields {
+  struct flattenedField {
+    Type *ty = nullptr;
+    unsigned offset = 0;
+  };
+  flattenedField fields[2];
+  int length = 0; // use -1 to represent "no need to rewrite" condition
+};
+
+flattenedFields visitStructFields(Type *ty, unsigned baseOffset) {
+  // recursively visit a POD struct to flatten it
+  // FIXME: may cause low performance
+  // dmd may cache argtypes in some other architectures as a TypeTuple, but we
+  // need to additionally store field offsets to realign later
+  flattenedFields result;
+  if (auto ts = ty->toBasetype()->isTypeStruct()) {
+    for (auto fi : ts->sym->fields) {
+      auto sub = visitStructFields(fi->type, baseOffset + fi->offset);
+      if (sub.length == -1 || result.length + sub.length > 2) {
+        result.length = -1;
+        return result;
+      }
+      for (unsigned i = 0; i < (unsigned)sub.length; ++i) {
+        result.fields[result.length++] = sub.fields[i];
+      }
+    }
+    return result;
+  }
+  switch (ty->toBasetype()->ty) {
+  case TY::Tcomplex32: // treat it as {float32, float32}
+    result.fields[0].ty = Type::tfloat32->pointerTo();
+    result.fields[1].ty = Type::tfloat32->pointerTo();
+    result.fields[0].offset = baseOffset;
+    result.fields[1].offset = baseOffset + 4;
+    result.length = 2;
+    break;
+  case TY::Tcomplex64: // treat it as {float64, float64}
+    result.fields[0].ty = Type::tfloat64->pointerTo();
+    result.fields[1].ty = Type::tfloat64->pointerTo();
+    result.fields[0].offset = baseOffset;
+    result.fields[1].offset = baseOffset + 8;
+    result.length = 2;
+    break;
+  default:
+    if (ty->toBasetype()->size() > 8) {
+      // field larger than XLEN and FLEN
+      result.length = -1;
+      break;
+    }
+    result.fields[0].ty = ty->toBasetype();
+    result.fields[0].offset = baseOffset;
+    result.length = 1;
+    break;
+  }
+  return result;
+}
+
+bool requireHardfloatRewrite(Type *ty) {
+  if (!ty->toBasetype()->isTypeStruct())
+    return false;
+  auto result = visitStructFields(ty, 0);
+  if (result.length <= 0)
+    return false;
+  if (result.length == 1)
+    return result.fields[0].ty->isfloating();
+  return result.fields[0].ty->isfloating() || result.fields[1].ty->isfloating();
+}
+
+struct HardfloatRewrite : ABIRewrite {
+  LLValue *put(DValue *dv, bool, bool) override {
+    // realign fields
+    // FIXME: no need to alloc an extra buffer in many conditions
+    const auto flat = visitStructFields(dv->type, 0);
+    LLType *asType = type(dv->type, flat);
+    const unsigned alignment = getABITypeAlign(asType);
+    assert(dv->isLVal());
+    LLValue *address = DtoLVal(dv);
+    LLValue *buffer =
+        DtoRawAlloca(asType, alignment, ".HardfloatRewrite_arg_storage");
+    for (unsigned i = 0; i < (unsigned)flat.length; ++i) {
+      DtoMemCpy(
+          DtoGEP(buffer, 0, i),
+          DtoGEP1(DtoBitCast(address, getVoidPtrType()), flat.fields[i].offset),
+          DtoConstSize_t(flat.fields[i].ty->size()));
+    }
+    return DtoLoad(buffer, ".HardfloatRewrite_arg");
+  }
+  LLValue *getLVal(Type *dty, LLValue *v) override {
+    // inverse operation of method "put"
+    const auto flat = visitStructFields(dty, 0);
+    LLType *asType = type(dty, flat);
+    const unsigned alignment = DtoAlignment(dty);
+    LLValue *buffer = DtoAllocaDump(v, asType, getABITypeAlign(asType),
+                                    ".HardfloatRewrite_param");
+    LLValue *ret = DtoRawAlloca(DtoType(dty), alignment,
+                                ".HardfloatRewrite_param_storage");
+    for (unsigned i = 0; i < (unsigned)flat.length; ++i) {
+      DtoMemCpy(
+          DtoGEP1(DtoBitCast(ret, getVoidPtrType()), flat.fields[i].offset),
+          DtoGEP(buffer, 0, i), DtoConstSize_t(flat.fields[i].ty->size()));
+    }
+    return ret;
+  }
+  LLType *type(Type *ty, const flattenedFields &flat) {
+    if (flat.length == 1) {
+      return LLStructType::get(gIR->context(), {DtoType(flat.fields[0].ty)},
+                               false);
+    }
+    assert(flat.length == 2);
+    LLType *t[2];
+    for (unsigned i = 0; i < 2; ++i) {
+      t[i] = flat.fields[i].ty->isfloating()
+                 ? DtoType(flat.fields[i].ty)
+                 : LLIntegerType::get(gIR->context(),
+                                      flat.fields[i].ty->size() * 8);
+    }
+    return LLStructType::get(gIR->context(), {t[0], t[1]}, false);
+  }
+  LLType *type(Type *ty) override { return type(ty, visitStructFields(ty, 0)); }
+};
+} // anonymous namespace
+
+struct RISCV64TargetABI : TargetABI {
+private:
+  HardfloatRewrite hardfloatRewrite;
+  IndirectByvalRewrite indirectByvalRewrite;
+  Integer2Rewrite integer2Rewrite;
+  IntegerRewrite integerRewrite;
+
+public:
+  Type *vaListType() override {
+    // va_list is void*
+    return Type::tvoid->pointerTo();
+  }
+  bool returnInArg(TypeFunction *tf, bool) override {
+    if (tf->isref()) {
+      return false;
+    }
+    Type *rt = tf->next->toBasetype();
+    if (!rt->size())
+      return false;
+    if (!isPOD(rt))
+      return true;
+    return rt->size() > 16;
+  }
+  bool passByVal(TypeFunction *, Type *t) override {
+    if (!t->size())
+      return false;
+    if (t->toBasetype()->ty == TY::Tcomplex80) {
+      // rewrite it later to bypass the RVal problem
+      return false;
+    }
+    return t->size() > 16;
+  }
+  void rewriteFunctionType(IrFuncTy &fty) override {
+    if (!fty.ret->byref) {
+      if (!skipReturnValueRewrite(fty)) {
+        if (!fty.ret->byref && isPOD(fty.ret->type) &&
+            requireHardfloatRewrite(fty.ret->type)) {
+          // rewrite here because we should not apply this to variadic arguments
+          hardfloatRewrite.applyTo(*fty.ret);
+        } else {
+          rewriteArgument(fty, *fty.ret);
+        }
+      }
+    }
+
+    for (auto arg : fty.args) {
+      if (!arg->byref && isPOD(arg->type) &&
+          requireHardfloatRewrite(arg->type)) {
+        // rewrite here because we should not apply this to variadic arguments
+        hardfloatRewrite.applyTo(*arg);
+      } else {
+        rewriteArgument(fty, *arg);
+      }
+    }
+  }
+
+  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
+    if (arg.byref) {
+      return;
+    }
+
+    Type *ty = arg.type->toBasetype();
+    if (ty->ty == TY::Tcomplex80) {
+      // {real, real} should be passed in memory
+      indirectByvalRewrite.applyTo(arg);
+      return;
+    }
+
+    if (!isPOD(arg.type)) {
+      // non-PODs should be passed in memory
+      indirectByvalRewrite.applyTo(arg);
+      return;
+    }
+
+    if (isAggregate(ty) && ty->size() && ty->size() <= 16) {
+      if (ty->size() > 8 && DtoAlignment(ty) < 16) {
+        // pass the aggregate as {int64, int64} to avoid wrong alignment
+        integer2Rewrite.applyToIfNotObsolete(arg);
+      } else {
+        integerRewrite.applyToIfNotObsolete(arg);
+      }
+    }
+  }
+};
+
+// The public getter for abi.cpp
+TargetABI *getRISCV64TargetABI() { return new RISCV64TargetABI(); }

--- a/gen/abi-riscv64.h
+++ b/gen/abi-riscv64.h
@@ -1,0 +1,18 @@
+//===-- gen/abi-riscv64.h - RISCV64 ABI description ------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// The ABI implementation used for RISCV64 targets.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+struct TargetABI;
+
+TargetABI *getRISCV64TargetABI();

--- a/gen/abi.cpp
+++ b/gen/abi.cpp
@@ -17,6 +17,7 @@
 #include "gen/abi-arm.h"
 #include "gen/abi-generic.h"
 #include "gen/abi-mips64.h"
+#include "gen/abi-riscv64.h"
 #include "gen/abi-ppc.h"
 #include "gen/abi-ppc64le.h"
 #include "gen/abi-win64.h"
@@ -275,6 +276,8 @@ TargetABI *TargetABI::getTarget() {
   case llvm::Triple::mips64:
   case llvm::Triple::mips64el:
     return getMIPS64TargetABI(global.params.targetTriple->isArch64Bit());
+  case llvm::Triple::riscv64:
+    return getRISCV64TargetABI();
   case llvm::Triple::ppc:
   case llvm::Triple::ppc64:
     return getPPCTargetABI(global.params.targetTriple->isArch64Bit());

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -341,8 +341,8 @@ if(TARGET gen_gccbuiltins)
     )
   endfunction()
 
-  set(target_arch "AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;SystemZ;X86")
-  set(target_name "aarch64;amdgcn;arm;mips;nvvm;ppc;s390;x86")
+  set(target_arch "AArch64;AMDGPU;ARM;Mips;RISCV;NVPTX;PowerPC;SystemZ;X86")
+  set(target_name "aarch64;amdgcn;arm;mips;riscv;nvvm;ppc;s390;x86")
 
   foreach(target ${LLVM_TARGETS_TO_BUILD})
     list(FIND target_arch ${target} idx)


### PR DESCRIPTION
This adds support for riscv64gc with the default LP64D ABI.
This work with https://github.com/ldc-developers/druntime/pull/204 and https://github.com/ldc-developers/phobos/pull/71.
Enable attribute `+d` by default to support riscv64gc D standard extension.
ABI is implemented according to RISCV Calling Convention.

Currently it is not able to pass all tests.

Most failed tests are related to NaN payload issue. But this maybe a issue related to the platform. e.g., after `atan` calculation, NaN payload will be cleared. This behavior is the same with GDC. C codes compiled with GCC and Clang act the same.

The `zlib-debug` and `zlib-debug-shared` test failure is probably caused by a wrong signed/unsigned compiler optimization. This needs further investigation.

The `druntime-test-gc-*` test also fails on x86-64 according to my test. Failing assertion is the same one.

Many GDB tests and profdata tests fail. This needs further investigation.
Sanitizers seem to be unusable.
LTO should not be enabled because of soft-float and double-float merging issue. This error may be triggered with Clang too. This seems to be a common issue for LLVM-based compilers.

In `dmd-testsuite*`, `runnable/argufilem.d` fails with a comment inside explaining this may be a known issue. `dshell/dll_cxx.d` fails because `c++` on riscv64 do not accept argument `-m64`. `fail_compilation/test15703.d` seem to output some extra unexpected explanations for compilation error.