### PR TITLE
Add --fno-discard-value-names : Do not discard value names in LLVM IR

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -541,6 +541,10 @@ void setDefaultMathOptions(llvm::TargetOptions &targetOptions) {
   }
 }
 
+cl::opt<bool>
+    fNoDiscardValueNames("fno-discard-value-names", cl::ZeroOrMore,
+                         cl::desc("Do not discard value names in LLVM IR"));
+
 cl::opt<bool, true>
     allinst("allinst", cl::ZeroOrMore, cl::location(global.params.allInst),
             cl::desc("Generate code for all template instantiations"));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -95,6 +95,8 @@ extern bool fFastMath;
 extern llvm::FastMathFlags defaultFMF;
 void setDefaultMathOptions(llvm::TargetOptions &targetOptions);
 
+extern cl::opt<bool> fNoDiscardValueNames;
+
 // Arguments to -d-debug
 extern std::vector<std::string> debugArgs;
 // Arguments to -run

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -198,7 +198,7 @@ CodeGenerator::CodeGenerator(llvm::LLVMContext &context,
       moduleCount_(0), singleObj_(singleObj), ir_(nullptr) {
   // Set the context to discard value names when not generating textual IR and
   // when ASan or MSan are not enabled.
-  if (!global.params.output_ll &&
+  if (!global.params.output_ll && !opts::fNoDiscardValueNames &&
       !opts::isSanitizerEnabled(opts::AddressSanitizer |
                                 opts::MemorySanitizer)) {
     context_.setDiscardValueNames(true);

--- a/tests/codegen/fno_discard_value_names.d
+++ b/tests/codegen/fno_discard_value_names.d
@@ -1,0 +1,9 @@
+// RUN: %ldc -c --print-after-all %s 2>&1 | FileCheck %s --check-prefix=DISCARD_CHECK
+// RUN: %ldc -c --print-after-all --fno-discard-value-names %s 2>&1 | FileCheck %s --check-prefix=NO_DISCARD_CHECK
+
+// DISCARD_CHECK-NOT: %first_argument_name
+// DISCARD_CHECK-NOT: %a_second_argument
+// NO_DISCARD_CHECK: %first_argument_name
+// NO_DISCARD_CHECK: %a_second_argument
+
+void foofoo(int first_argument_name, int a_second_argument) {}


### PR DESCRIPTION
This option has effect when outputting LLVM IR through LLVM option `--print-after=...` and similar cmdline options. It is needed to show variable names in IR in Godbolt's CE optimization pipeline view: https://d.godbolt.org/z/rjbEPaehn

See: https://github.com/compiler-explorer/compiler-explorer/pull/3838/files#diff-791e27601ad6c45c8712671c7e401aefe6d736159523745bc18b991bedcb4442R49
