### PR TITLE
Bit fields

### DIFF
--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -165,3 +165,56 @@ DRValue *DSpecialRefValue::getRVal() {
 }
 
 DLValue *DSpecialRefValue::getLVal() { return new DLValue(type, DtoLoad(val)); }
+
+////////////////////////////////////////////////////////////////////////////////
+
+DBitFieldLValue::DBitFieldLValue(Type *t, LLValue *ptr, BitFieldDeclaration *bf)
+    : DValue(t, ptr), bf(bf),
+      intType(LLIntegerType::get(
+          gIR->context(), (bf->bitOffset + bf->fieldWidth + 7) / 8 * 8)) {
+  assert(ptr->getType()->isPointerTy());
+}
+
+DRValue *DBitFieldLValue::getRVal() {
+  const auto sizeInBits = intType->getBitWidth();
+  const auto ptr = DtoBitCast(val, getPtrToType(intType));
+  LLValue *v = gIR->ir->CreateAlignedLoad(intType, ptr, LLMaybeAlign(1));
+
+  if (bf->type->isunsigned()) {
+    if (auto n = bf->bitOffset)
+      v = gIR->ir->CreateLShr(v, n);
+    const auto mask = llvm::APInt::getLowBitsSet(sizeInBits, bf->fieldWidth);
+    v = gIR->ir->CreateAnd(v, mask);
+    v = gIR->ir->CreateZExtOrTrunc(v, DtoType(bf->type));
+  } else {
+    // shift-left to make the MSB the sign bit
+    if (auto n = sizeInBits - (bf->bitOffset + bf->fieldWidth))
+      v = gIR->ir->CreateShl(v, n);
+    // then arithmetic-shift-right
+    if (auto n = sizeInBits - bf->fieldWidth)
+      v = gIR->ir->CreateAShr(v, n);
+    v = gIR->ir->CreateSExtOrTrunc(v, DtoType(bf->type));
+  }
+
+  return new DImValue(type, v);
+}
+
+void DBitFieldLValue::store(LLValue *value) {
+  assert(value->getType()->isIntegerTy());
+
+  const auto ptr = DtoBitCast(val, getPtrToType(intType));
+
+  const auto mask =
+      llvm::APInt::getLowBitsSet(intType->getBitWidth(), bf->fieldWidth);
+  const auto oldVal = gIR->ir->CreateAlignedLoad(intType, ptr, LLMaybeAlign(1));
+  const auto maskedOldVal =
+      gIR->ir->CreateAnd(oldVal, ~(mask << bf->bitOffset));
+
+  auto bfVal = gIR->ir->CreateZExtOrTrunc(value, intType);
+  bfVal = gIR->ir->CreateAnd(bfVal, mask);
+  if (auto n = bf->bitOffset)
+    bfVal = gIR->ir->CreateShl(bfVal, n);
+
+  const auto newVal = gIR->ir->CreateOr(maskedOldVal, bfVal);
+  gIR->ir->CreateAlignedStore(newVal, ptr, LLMaybeAlign(1));
+}

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1860,8 +1860,8 @@ FuncDeclaration *getParentFunc(Dsymbol *sym) {
   return nullptr;
 }
 
-DValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
-                          VarDeclaration *vd, Type *fieldType) {
+LLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
+                           VarDeclaration *vd) {
   IF_LOG Logger::println("Indexing aggregate field %s:", vd->toPrettyChars());
   LOG_SCOPE;
 
@@ -1869,9 +1869,6 @@ DValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
   // isIrVarCreated(vd). This is a bit of a hack, we don't actually need this
   // ourselves, DtoType below would be enough.
   DtoResolveDsymbol(ad);
-
-  if (!fieldType)
-    fieldType = vd->type;
 
   // Look up field to index or offset to apply.
   unsigned fieldIndex;
@@ -1901,36 +1898,8 @@ DValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
     }
   }
 
-  // special case for bit fields: return a (shifted & masked) rvalue
-  if (auto bf = vd->isBitFieldDeclaration()) {
-    const auto sizeInBytes = (bf->bitOffset + bf->fieldWidth + 7) / 8;
-    const auto sizeInBits = sizeInBytes * 8;
-    const auto intType = LLIntegerType::get(gIR->context(), sizeInBits);
-    ptr = DtoBitCast(ptr, getPtrToType(intType));
-    LLValue *val = gIR->ir->CreateAlignedLoad(intType, ptr, LLMaybeAlign(1));
-    if (bf->type->isunsigned()) {
-      if (auto n = bf->bitOffset)
-        val = gIR->ir->CreateLShr(val, n);
-      const auto mask = llvm::APInt::getLowBitsSet(sizeInBits, bf->fieldWidth);
-      val = gIR->ir->CreateAnd(val, mask);
-      val = gIR->ir->CreateZExtOrTrunc(val, DtoType(fieldType));
-    } else {
-      // shift-left to make the MSB the sign bit
-      if (auto n = sizeInBits - (bf->bitOffset + bf->fieldWidth))
-        val = gIR->ir->CreateShl(val, n);
-      // then arithmetic-shift-right
-      if (auto n = sizeInBits - bf->fieldWidth)
-        val = gIR->ir->CreateAShr(val, n);
-      val = gIR->ir->CreateSExtOrTrunc(val, DtoType(fieldType));
-    }
-    return new DImValue(fieldType, val);
-  }
-
-  // Cast the (possibly void*) pointer to the canonical variable type.
-  ptr = DtoBitCast(ptr, DtoPtrToType(fieldType));
-
   IF_LOG Logger::cout() << "Pointer: " << *ptr << '\n';
-  return new DLValue(fieldType, ptr);
+  return ptr;
 }
 
 unsigned getFieldGEPIndex(AggregateDeclaration *ad, VarDeclaration *vd) {

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1321,24 +1321,6 @@ void DtoSetFuncDeclIntrinsicName(TemplateInstance *ti, TemplateDeclaration *td,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-size_t getMemberSize(Type *type) {
-  const dinteger_t dSize = type->size();
-  llvm::Type *const llType = DtoType(type);
-  if (!llType->isSized()) {
-    // Forward reference in a cycle or similar, we need to trust the D type.
-    return dSize;
-  }
-
-  const uint64_t llSize = gDataLayout->getTypeAllocSize(llType);
-  assert(llSize <= dSize &&
-         "LLVM type is bigger than the corresponding D type, "
-         "might lead to aggregate layout mismatch.");
-
-  return llSize;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 Type *stripModifiers(Type *type, bool transitive) {
   if (type->ty == TY::Tfunction) {
     return type;

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -397,6 +397,11 @@ void DtoAssign(const Loc &loc, DValue *lhs, DValue *rhs, EXP op,
     return;
   }
 
+  if (auto bfLVal = lhs->isBitFieldLVal()) {
+    bfLVal->store(DtoRVal(rhs));
+    return;
+  }
+
   if (t->ty == TY::Tbool) {
     DtoStoreZextI8(DtoRVal(rhs), DtoLVal(lhs));
   } else if (t->ty == TY::Tstruct) {

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -152,10 +152,6 @@ llvm::CallInst *DtoInlineAsmExpr(const Loc &loc, llvm::StringRef code,
                                  llvm::ArrayRef<llvm::Value *> operands,
                                  llvm::Type *returnType);
 
-/// Returns the size the LLVM type for a member variable of the given type will
-/// take up in a struct (in bytes). This does not include padding in any way.
-size_t getMemberSize(Type *type);
-
 /// Returns the llvm::Value of the passed DValue, making sure that it is an
 /// lvalue (has a memory address), so it can be passed to the D runtime
 /// functions without problems.

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -132,8 +132,8 @@ void findDefaultTarget();
 /// Returns a pointer to the given member field of an aggregate.
 ///
 /// 'src' is a pointer to the start of the memory of an 'ad' instance.
-DValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
-                          VarDeclaration *vd, Type *fieldType = nullptr);
+LLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
+                           VarDeclaration *vd);
 
 /// Returns the index of a given member variable in the resulting LLVM type of
 /// an aggregate.

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -132,8 +132,8 @@ void findDefaultTarget();
 /// Returns a pointer to the given member field of an aggregate.
 ///
 /// 'src' is a pointer to the start of the memory of an 'ad' instance.
-LLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
-                           VarDeclaration *vd);
+DValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
+                          VarDeclaration *vd, Type *fieldType = nullptr);
 
 /// Returns the index of a given member variable in the resulting LLVM type of
 /// an aggregate.

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -381,46 +381,50 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
   IF_LOG Logger::cout() << "Function " << fd->toChars() << " has depth "
                         << depth << '\n';
 
-  AggrTypeBuilder builder(false);
+  AggrTypeBuilder builder;
 
   if (depth != 0) {
     assert(innerFrameType);
-    unsigned ptrSize = gDataLayout->getPointerSize();
     // Add frame pointer types for all but last frame
     for (unsigned i = 0; i < (depth - 1); ++i) {
-      builder.addType(innerFrameType->getElementType(i), ptrSize);
+      builder.addType(innerFrameType->getElementType(i), target.ptrsize);
     }
     // Add frame pointer type for last frame
-    builder.addType(LLPointerType::getUnqual(innerFrameType), ptrSize);
+    builder.addType(LLPointerType::getUnqual(innerFrameType), target.ptrsize);
   }
 
   // Add the direct nested variables of this function, and update their
   // indices to match.
   // TODO: optimize ordering for minimal space usage?
+  unsigned maxAlignment = 1;
   for (auto vd : fd->closureVars) {
-    unsigned alignment = DtoAlignment(vd);
-    if (alignment > 1) {
-      builder.alignCurrentOffset(alignment);
-    }
-
     const bool isParam = vd->isParameter();
 
-    IrLocal &irLocal =
-        *(isParam ? getIrParameter(vd, true) : getIrLocal(vd, true));
-    irLocal.nestedIndex = builder.currentFieldIndex();
-    irLocal.nestedDepth = depth;
-
     LLType *t = nullptr;
+    unsigned alignment = 0;
     if (captureByRef(vd)) {
       t = DtoType(vd->type->pointerTo());
+      alignment = target.ptrsize;
     } else if (isParam && (vd->storage_class & STClazy)) {
       // the type is a delegate (LL struct)
       auto tf = TypeFunction::create(nullptr, vd->type, VARARGnone, LINK::d);
       auto td = TypeDelegate::create(tf);
       t = DtoType(td);
+      alignment = target.ptrsize;
     } else {
       t = DtoMemType(vd->type);
+      alignment = DtoAlignment(vd);
     }
+
+    if (alignment > 1) {
+      builder.alignCurrentOffset(alignment);
+      maxAlignment = std::max(maxAlignment, alignment);
+    }
+
+    IrLocal &irLocal =
+        *(isParam ? getIrParameter(vd, true) : getIrLocal(vd, true));
+    irLocal.nestedIndex = builder.currentFieldIndex();
+    irLocal.nestedDepth = depth;
 
     builder.addType(t, getTypeAllocSize(t));
 
@@ -428,15 +432,15 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
                           << *t << "\n";
   }
 
-  LLStructType *frameType =
-      LLStructType::create(gIR->context(), builder.defaultTypes(),
-                           std::string("nest.") + fd->toChars());
+  LLStructType *frameType = LLStructType::create(
+      gIR->context(), builder.defaultTypes(),
+      std::string("nest.") + fd->toChars(), builder.isPacked());
 
   IF_LOG Logger::cout() << "frameType = " << *frameType << '\n';
 
   // Store type in IrFunction
   irFunc.frameType = frameType;
-  irFunc.frameTypeAlignment = builder.overallAlignment();
+  irFunc.frameTypeAlignment = maxAlignment;
 }
 
 void DtoCreateNestedContext(FuncGenState &funcGen) {

--- a/gen/structs.cpp
+++ b/gen/structs.cpp
@@ -145,16 +145,17 @@ LLValue *DtoUnpaddedStruct(Type *dty, LLValue *v) {
   LLValue *newval = llvm::UndefValue::get(DtoUnpaddedStructType(dty));
 
   for (unsigned i = 0; i < fields.length; i++) {
-    DValue *field = DtoIndexAggregate(v, sty->sym, fields[i]);
+    LLValue *fieldptr = DtoIndexAggregate(v, sty->sym, fields[i]);
     LLValue *fieldval;
     if (fields[i]->type->ty == TY::Tstruct) {
       // Nested structs are the only members that can contain padding
-      fieldval = DtoUnpaddedStruct(fields[i]->type, DtoLVal(field));
+      fieldval = DtoUnpaddedStruct(fields[i]->type, fieldptr);
     } else {
-      fieldval = DtoRVal(field);
+      assert(!fields[i]->isBitFieldDeclaration());
+      fieldptr = DtoBitCast(fieldptr, DtoPtrToType(fields[i]->type));
+      fieldval = DtoLoad(fieldptr);
     }
     newval = DtoInsertValue(newval, fieldval, i);
-    delete field;
   }
   return newval;
 }
@@ -166,14 +167,15 @@ void DtoPaddedStruct(Type *dty, LLValue *v, LLValue *lval) {
   VarDeclarations &fields = sty->sym->fields;
 
   for (unsigned i = 0; i < fields.length; i++) {
-    DValue *field = DtoIndexAggregate(lval, sty->sym, fields[i]);
+    LLValue *fieldptr = DtoIndexAggregate(lval, sty->sym, fields[i]);
     LLValue *fieldval = DtoExtractValue(v, i);
     if (fields[i]->type->ty == TY::Tstruct) {
       // Nested structs are the only members that can contain padding
-      DtoPaddedStruct(fields[i]->type, fieldval, DtoLVal(field));
+      DtoPaddedStruct(fields[i]->type, fieldval, fieldptr);
     } else {
-      DtoStoreZextI8(fieldval, DtoLVal(field));
+      assert(!fields[i]->isBitFieldDeclaration());
+      fieldptr = DtoBitCast(fieldptr, DtoPtrToType(fields[i]->type));
+      DtoStoreZextI8(fieldval, fieldptr);
     }
-    delete field;
   }
 }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -126,42 +126,29 @@ static void write_struct_literal(Loc loc, LLValue *mem, StructDeclaration *sd,
     }
 
     if (vd->isBitFieldDeclaration()) {
-      // collect all bit fields at the current byte offset
-      size_t j; // endIndex
-      unsigned maxSizeInBytes = 0;
-      for (j = i; j < data.size(); ++j) {
-        if (auto bf = data[j].field->isBitFieldDeclaration()) {
-          if (bf->offset == vd->offset) {
-            const auto sizeInBytes = (bf->bitOffset + bf->fieldWidth + 7) / 8;
-            if (sizeInBytes > maxSizeInBytes)
-              maxSizeInBytes = sizeInBytes;
-            continue;
-          }
-        }
-        break;
-      }
+      const auto group = BitFieldGroup::startingFrom(
+          i, data.size(), [&data](size_t i) { return data[i].field; });
 
       IF_LOG Logger::println("initializing bit field group: (+%u, %u bytes)",
-                             vd->offset, maxSizeInBytes);
+                             group.byteOffset, group.sizeInBytes);
       LOG_SCOPE
 
-      // get a pointer to this field
+      // get a pointer to this group's IR field
       const auto ptr = DtoIndexAggregate(mem, sd, vd);
 
       // merge all initializers to a single value
       const auto intType =
-          LLIntegerType::get(gIR->context(), maxSizeInBytes * 8);
+          LLIntegerType::get(gIR->context(), group.sizeInBytes * 8);
       LLValue *val = LLConstant::getNullValue(intType);
-      for (size_t k = i; k < j; ++k) {
-        const auto bf = data[k].field->isBitFieldDeclaration();
-        assert(bf);
-        const auto bfExpr = data[k].expr;
+      for (size_t j = 0; j < group.bitFields.size(); ++j) {
+        const auto bf = group.bitFields[j];
+        const auto bfExpr = data[i + j].expr;
         assert(bfExpr);
 
+        const unsigned bitOffset = group.getBitOffset(bf);
         IF_LOG Logger::println("bit field: %s %s (bit offset %u, width %u): %s",
-                               bf->type->toChars(), bf->toChars(),
-                               bf->bitOffset, bf->fieldWidth,
-                               bfExpr->toChars());
+                               bf->type->toChars(), bf->toChars(), bitOffset,
+                               bf->fieldWidth, bfExpr->toChars());
         LOG_SCOPE
 
         auto bfVal = DtoRVal(bfExpr);
@@ -169,17 +156,17 @@ static void write_struct_literal(Loc loc, LLValue *mem, StructDeclaration *sd,
         const auto mask =
             llvm::APInt::getLowBitsSet(intType->getBitWidth(), bf->fieldWidth);
         bfVal = gIR->ir->CreateAnd(bfVal, mask);
-        if (auto n = bf->bitOffset)
-          bfVal = gIR->ir->CreateShl(bfVal, n);
+        if (bitOffset)
+          bfVal = gIR->ir->CreateShl(bfVal, bitOffset);
         val = gIR->ir->CreateOr(val, bfVal);
       }
 
       IF_LOG Logger::cout() << "merged IR value: " << *val << '\n';
       gIR->ir->CreateAlignedStore(val, DtoBitCast(ptr, getPtrToType(intType)),
                                   LLMaybeAlign(1));
-      offset += maxSizeInBytes;
+      offset += group.sizeInBytes;
 
-      i = j - 1; // skip the other bit fields of the group
+      i += group.bitFields.size() - 1; // skip the other bit fields of the group
     } else {
       IF_LOG Logger::println("initializing field: %s %s (+%u)",
                              vd->type->toChars(), vd->toChars(), vd->offset);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -478,51 +478,6 @@ public:
       }
     }
 
-    // Handle assignments to bit fields (no lvalues).
-    if (auto dve = e->e1->isDotVarExp()) {
-      if (auto bf = dve->var->isBitFieldDeclaration()) {
-        const auto aggr = dve->e1;
-
-        AggregateDeclaration *ad;
-        const auto at = aggr->type->toBasetype();
-        if (auto ts = at->isTypeStruct()) {
-          ad = ts->sym;
-        } else if (auto tc = at->isTypeClass()) {
-          ad = tc->sym;
-        } else {
-          llvm_unreachable("Unknown aggregate type being indexed.");
-        }
-
-        const auto sizeInBits = (bf->bitOffset + bf->fieldWidth + 7) / 8 * 8;
-        const auto intType = LLIntegerType::get(gIR->context(), sizeInBits);
-
-        const auto aggrPtr = DtoLVal(aggr);
-        const auto val = DtoRVal(e->e2);
-
-        const auto ptr = DtoBitCast(DtoIndexAggregate(aggrPtr, ad, bf),
-                                    getPtrToType(intType));
-
-        const auto mask =
-            llvm::APInt::getLowBitsSet(sizeInBits, bf->fieldWidth);
-        const auto oldVal =
-            gIR->ir->CreateAlignedLoad(intType, ptr, LLMaybeAlign(1));
-        const auto maskedOldVal =
-            gIR->ir->CreateAnd(oldVal, ~(mask << bf->bitOffset));
-
-        auto bfVal = gIR->ir->CreateZExtOrTrunc(val, intType);
-        bfVal = gIR->ir->CreateAnd(bfVal, mask);
-        if (auto n = bf->bitOffset)
-          bfVal = gIR->ir->CreateShl(bfVal, n);
-
-        const auto newVal = gIR->ir->CreateOr(maskedOldVal, bfVal);
-        gIR->ir->CreateAlignedStore(newVal, ptr, LLMaybeAlign(1));
-
-        // return the untainted rhs rvalue
-        result = new DImValue(e->type, val);
-        return;
-      }
-    }
-
     // The front-end sometimes rewrites a static-array-lhs to a slice, e.g.,
     // when initializing a static array with an array literal.
     // Use the static array as lhs in that case.
@@ -672,8 +627,6 @@ public:
 
   template <BinOpFunc binOpFunc, bool useLValTypeForBinOp>
   static DValue *binAssign(BinAssignExp *e) {
-    // TODO: bit fields?!
-
     Expression *lvalExp = getLValExp(e->e1);
     DValue *lhsLVal = toElem(lvalExp);
 
@@ -1026,29 +979,9 @@ public:
 
       LLValue *ptr = DtoIndexAggregate(aggrPtr, ad, vd);
 
-      // special case for bit fields: return a (shifted & masked) rvalue
+      // special case for bit fields (no real lvalues)
       if (auto bf = vd->isBitFieldDeclaration()) {
-        const auto sizeInBytes = (bf->bitOffset + bf->fieldWidth + 7) / 8;
-        const auto sizeInBits = sizeInBytes * 8;
-        const auto intType = LLIntegerType::get(gIR->context(), sizeInBits);
-        ptr = DtoBitCast(ptr, getPtrToType(intType));
-        LLValue *val = gIR->ir->CreateAlignedLoad(intType, ptr, LLMaybeAlign(1));
-        if (bf->type->isunsigned()) {
-          if (auto n = bf->bitOffset)
-            val = gIR->ir->CreateLShr(val, n);
-          const auto mask = llvm::APInt::getLowBitsSet(sizeInBits, bf->fieldWidth);
-          val = gIR->ir->CreateAnd(val, mask);
-          val = gIR->ir->CreateZExtOrTrunc(val, DtoType(bf->type));
-        } else {
-          // shift-left to make the MSB the sign bit
-          if (auto n = sizeInBits - (bf->bitOffset + bf->fieldWidth))
-            val = gIR->ir->CreateShl(val, n);
-          // then arithmetic-shift-right
-          if (auto n = sizeInBits - bf->fieldWidth)
-            val = gIR->ir->CreateAShr(val, n);
-          val = gIR->ir->CreateSExtOrTrunc(val, DtoType(bf->type));
-        }
-        result = new DImValue(e->type, val);
+        result = new DBitFieldLValue(e->type, ptr, bf);
       } else {
         // Cast the (possibly void*) pointer to the canonical variable type.
         ptr = DtoBitCast(ptr, DtoPtrToType(e->type));

--- a/ir/iraggr.cpp
+++ b/ir/iraggr.cpp
@@ -281,6 +281,8 @@ void IrAggr::addFieldInitializers(
   const size_t numNewLLFields = b.defaultTypes().size();
   constants.resize(constants.size() + numNewLLFields, nullptr);
 
+  // TODO: bit fields! (possibly overlapping and missing in varGEPIndices)
+
   // add explicit and non-overlapping implicit initializers
   for (const auto &pair : b.varGEPIndices()) {
     const auto field = pair.first;

--- a/ir/iraggr.h
+++ b/ir/iraggr.h
@@ -106,7 +106,7 @@ private:
   void addFieldInitializers(llvm::SmallVectorImpl<llvm::Constant *> &constants,
                             const VarInitMap &explicitInitializers,
                             AggregateDeclaration *decl, unsigned &offset,
-                            unsigned &interfaceVtblIndex);
+                            unsigned &interfaceVtblIndex, bool &isPacked);
 };
 
 /// Represents a struct.

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -86,7 +86,7 @@ void AggrTypeBuilder::addAggregate(
   LLSmallVector<BitFieldDeclaration *, 16> allBitFieldDecls;
   for (VarDeclaration *field : ad->fields) {
     if (auto bf = field->isBitFieldDeclaration()) {
-      printf(".: %s: byte offset %d, bit offset %d, type size %d\n", bf->toChars(), bf->offset, bf->bitOffset, (int) bf->type->size());
+      //printf(".: %s: byte offset %d, bit offset %d, type size %d\n", bf->toChars(), bf->offset, bf->bitOffset, (int) bf->type->size());
       allBitFieldDecls.push_back(bf);
     }
   }
@@ -188,7 +188,12 @@ void AggrTypeBuilder::addAggregate(
     m_defaultTypes.push_back(fieldType);
 
     // advance offset to right past this field
-    m_offset += getTypeAllocSize(fieldType); //getMemberSize(vd->type);
+    if (!fieldType->isSized()) {
+      // forward reference in a cycle or similar, we need to trust the D type
+      m_offset += vd->type->size();
+    } else {
+      m_offset += getTypeAllocSize(fieldType);
+    }
 
     // set the field index
     m_varGEPIndices[vd] = m_fieldIndex;

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -223,6 +223,8 @@ void AggrTypeBuilder::alignCurrentOffset(unsigned alignment) {
 }
 
 void AggrTypeBuilder::addTailPadding(unsigned aggregateSize) {
+  assert(m_offset <= aggregateSize &&
+         "IR aggregate type is larger than the corresponding D type");
   if (m_offset < aggregateSize)
     add_zeros(m_defaultTypes, m_offset, aggregateSize);
 }

--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -276,8 +276,6 @@ bool IrTypeAggr::isPacked(AggregateDeclaration *ad) {
 
 void IrTypeAggr::getMemberLocation(VarDeclaration *var, unsigned &fieldIndex,
                                    unsigned &byteOffset) const {
-  assert(!var->isBitFieldDeclaration());
-
   // Note: The interface is a bit more general than what we actually return.
   // Specifically, the frontend offset information we use for overlapping
   // fields is always based at the object start.

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -30,7 +30,7 @@ public:
   using VarInitMap = std::map<VarDeclaration *, llvm::Constant *>;
   enum class Aliases { Skip, AddToVarGEPIndices };
 
-  explicit AggrTypeBuilder(bool packed, unsigned offset = 0);
+  explicit AggrTypeBuilder(unsigned offset = 0);
   void addType(llvm::Type *type, unsigned size);
   void addAggregate(AggregateDeclaration *ad);
   void addAggregate(AggregateDeclaration *ad, const VarInitMap *explicitInits,
@@ -42,7 +42,7 @@ public:
     return m_defaultTypes;
   }
   const VarGEPIndices &varGEPIndices() const { return m_varGEPIndices; }
-  unsigned overallAlignment() const { return m_overallAlignment; }
+  bool isPacked() const { return m_packed; }
   unsigned currentOffset() const { return m_offset; }
 
 protected:
@@ -50,8 +50,8 @@ protected:
   VarGEPIndices m_varGEPIndices;
   unsigned m_offset = 0;
   unsigned m_fieldIndex = 0;
-  unsigned m_overallAlignment = 0;
-  bool m_packed = false;
+  unsigned m_maxFieldIRAlignment = 1;
+  bool m_packed = false; // in IR terms
 };
 
 /// Base class of IrTypes for aggregate types.
@@ -66,16 +66,9 @@ public:
   void getMemberLocation(VarDeclaration *var, unsigned &fieldIndex,
                          unsigned &byteOffset) const;
 
-  /// true, if the LLVM struct type for the aggregate is declared as packed
-  bool packed = false;
-
 protected:
   ///
   explicit IrTypeAggr(AggregateDeclaration *ad);
-
-  /// Returns true, if the LLVM struct type for the aggregate must be declared
-  /// as packed.
-  static bool isPacked(AggregateDeclaration *ad);
 
   /// AggregateDeclaration this type represents.
   AggregateDeclaration *aggr = nullptr;

--- a/ir/irtypeclass.cpp
+++ b/ir/irtypeclass.cpp
@@ -67,7 +67,8 @@ IrTypeClass *IrTypeClass::get(ClassDeclaration *cd) {
   const auto t = new IrTypeClass(cd);
   getIrType(cd->type) = t;
 
-  IF_LOG Logger::println("Instance size: %u", cd->structsize);
+  const unsigned instanceSize = cd->structsize;
+  IF_LOG Logger::println("Instance size: %u", instanceSize);
 
   // This class may contain an align declaration. See GitHub #726.
   t->packed = false;
@@ -97,7 +98,8 @@ IrTypeClass *IrTypeClass::get(ClassDeclaration *cd) {
     t->addClassData(builder, cd);
 
     // add tail padding
-    builder.addTailPadding(cd->structsize);
+    if (instanceSize) // can be 0 for opaque classes
+      builder.addTailPadding(instanceSize);
   }
 
   // set struct body and copy GEP indices

--- a/ir/irtypestruct.cpp
+++ b/ir/irtypestruct.cpp
@@ -65,8 +65,6 @@ IrTypeStruct *IrTypeStruct::get(StructDeclaration *sd) {
     return t;
   }
 
-  t->packed = isPacked(sd);
-
   if(isFromLDC_DCompute(sd)) {
     dcomputeTypes.push_back(t);
   }
@@ -83,15 +81,15 @@ IrTypeStruct *IrTypeStruct::get(StructDeclaration *sd) {
     llvm::SmallVector<LLType *, 1> body;
     body.push_back(DtoMemType(p->type)->getPointerTo(realAS));
 
-    isaStruct(t->type)->setBody(body, t->packed);
+    isaStruct(t->type)->setBody(body, false);
     VarGEPIndices v;
     v[sd->fields[0]] = 0;
     t->varGEPIndices = v;
   } else {
-    AggrTypeBuilder builder(t->packed);
+    AggrTypeBuilder builder;
     builder.addAggregate(sd);
     builder.addTailPadding(sd->structsize);
-    isaStruct(t->type)->setBody(builder.defaultTypes(), t->packed);
+    isaStruct(t->type)->setBody(builder.defaultTypes(), builder.isPacked());
     t->varGEPIndices = builder.varGEPIndices();
   }
 

--- a/tests/codegen/align_class.d
+++ b/tests/codegen/align_class.d
@@ -1,17 +1,17 @@
 // RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 // RUN: %ldc -run %s
 
-struct S16 { align(16) int a; }
+struct S16 { align(16) short a; }
 
-class D     { align(32) int d = 0xDD; }
-// CHECK: %align_class.D = type { [5 x i8*]*, i8*, [{{(16|24)}} x i8], i32 }
+class D     { align(32) short d = 0xDD; }
+// CHECK: %align_class.D = type <{ [5 x i8*]*, i8*, [{{(16|24)}} x i8], i16 }>
 class E : D { S16 s16 = S16(0xEE); }
-// CHECK: %align_class.E = type { [5 x i8*]*, i8*, [{{(16|24)}} x i8], i32, [12 x i8], %align_class.S16 }
-class F : D { align(64) int f = 0xFF; }
-// CHECK: %align_class.F = type { [5 x i8*]*, i8*, [{{(16|24)}} x i8], i32, [28 x i8], i32 }
+// CHECK: %align_class.E = type { [5 x i8*]*, i8*, [{{(16|24)}} x i8], i16, [14 x i8], %align_class.S16 }
+class F : D { align(64) short f = 0xFF; }
+// CHECK: %align_class.F = type <{ [5 x i8*]*, i8*, [{{(16|24)}} x i8], i16, [30 x i8], i16 }>
 
-extern(C++) class CppClass { align(32) int a = 0xAA; }
-// CHECK: %align_class.CppClass = type { [0 x i8*]*, [{{(24|28)}} x i8], i32 }
+extern(C++) class CppClass { align(32) short a = 0xAA; }
+// CHECK: %align_class.CppClass = type <{ [0 x i8*]*, [{{(24|28)}} x i8], i16 }>
 
 void main()
 {

--- a/tests/codegen/gh2346.d
+++ b/tests/codegen/gh2346.d
@@ -1,15 +1,14 @@
 // RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
-// Make sure the LL struct is packed due to an unnatural overall alignment of 1.
-// CHECK-DAG: %gh2346.UnalignedUInt = type <{ i32 }>
+// Make sure the LL struct isn't packed.
+// CHECK-DAG: %gh2346.UnalignedUInt = type { i32 }
 struct UnalignedUInt {
     align(1) uint a;
 }
 static assert(UnalignedUInt.alignof == 1);
 static assert(UnalignedUInt.sizeof == 4);
 
-// Then there's no need to pack naturally aligned containers.
-// CHECK-DAG: %gh2346.Container = type { i8, %gh2346.UnalignedUInt }
+// CHECK-DAG: %gh2346.Container = type <{ i8, %gh2346.UnalignedUInt }>
 struct Container {
     ubyte one;
     UnalignedUInt two;
@@ -18,14 +17,14 @@ static assert(Container.alignof == 1);
 static assert(Container.sizeof == 5);
 static assert(Container.two.offsetof == 1);
 
-// CHECK-DAG: %gh2346.UnalignedUInt2 = type <{ i32 }>
+// CHECK-DAG: %gh2346.UnalignedUInt2 = type { i32 }
 struct UnalignedUInt2 {
     align(2) uint a;
 }
 static assert(UnalignedUInt2.alignof == 2);
 static assert(UnalignedUInt2.sizeof == 4);
 
-// CHECK-DAG: %gh2346.Container2 = type { i8, [1 x i8], %gh2346.UnalignedUInt2 }
+// CHECK-DAG: %gh2346.Container2 = type <{ i8, [1 x i8], %gh2346.UnalignedUInt2 }>
 struct Container2 {
     ubyte one;
     UnalignedUInt2 two;
@@ -43,7 +42,7 @@ static assert(PackedContainer2.alignof == 1);
 static assert(PackedContainer2.sizeof == 5);
 static assert(PackedContainer2.two.offsetof == 1);
 
-// CHECK-DAG: %gh2346.WeirdContainer = type { i8, [1 x i8], %gh2346.UnalignedUInt, [2 x i8] }
+// CHECK-DAG: %gh2346.WeirdContainer = type <{ i8, [1 x i8], %gh2346.UnalignedUInt, [2 x i8] }>
 align(4) struct WeirdContainer {
     ubyte one;
     align(2) UnalignedUInt two;
@@ -52,14 +51,14 @@ static assert(WeirdContainer.alignof == 4);
 static assert(WeirdContainer.sizeof == 8);
 static assert(WeirdContainer.two.offsetof == 2);
 
-// CHECK-DAG: %gh2346.ExplicitlyUnalignedUInt2 = type <{ i32 }>
+// CHECK-DAG: %gh2346.ExplicitlyUnalignedUInt2 = type { i32 }
 align(2) struct ExplicitlyUnalignedUInt2 {
     uint a;
 }
 static assert(ExplicitlyUnalignedUInt2.alignof == 2);
 static assert(ExplicitlyUnalignedUInt2.sizeof == 4);
 
-// CHECK-DAG: %gh2346.AnotherContainer = type { i8, [1 x i8], %gh2346.ExplicitlyUnalignedUInt2 }
+// CHECK-DAG: %gh2346.AnotherContainer = type <{ i8, [1 x i8], %gh2346.ExplicitlyUnalignedUInt2 }>
 struct AnotherContainer {
     ubyte one;
     ExplicitlyUnalignedUInt2 two;


### PR DESCRIPTION
I hoped this day would never come, but we need crappy bit fields for ImportC - and D 2.101 (FWIW, I was very much against that decision). They mess up a bunch of assumptions (every member aligned at a byte boundary and of an integral size in bytes, so directly addressable) and come with no LLVM support AFAICT, so... much fun.