### PR TITLE
Use `Record::getValueAsOptionalString()` when available

### DIFF
--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -85,10 +85,17 @@ StringRef attributes(ListInit* propertyList)
 
 void processRecord(raw_ostream& os, Record& rec, string arch)
 {
+#if LDC_LLVM_VER >= 1200
+    llvm::Optional<StringRef> recval = rec.getValueAsOptionalString();
+    if (!recval)
+        return;
+    const StringRef builtinName = recval.get();
+#else
     if(!rec.getValue("GCCBuiltinName"))
         return;
 
     const StringRef builtinName = rec.getValueAsString("GCCBuiltinName");
+#endif
     string name = rec.getName().str();
 
     if(name.substr(0, 4) != "int_" || name.find(arch) == string::npos)


### PR DESCRIPTION
I get a link error with `getValue` with LLVM truck, not sure exactly when it was changed. `getValueAsOptionalString` was added in
https://github.com/llvm/llvm-project/commit/76419525fba62c93d5c337acdb0b80d6e42b00c9 tagged `llvmorg-12.0.0-rc1`