### PR TITLE
Remove usage of `getPointerElementType` and `getPointeeType`

### DIFF
--- a/gen/abi-generic.h
+++ b/gen/abi-generic.h
@@ -132,14 +132,15 @@ struct BaseBitcastABIRewrite : ABIRewrite {
     const unsigned alignment = getMaxAlignment(asType, dv->type);
     const char *name = ".BaseBitcastABIRewrite_arg";
 
-    if (!dv->isLVal()) {
+    DLValue * ldv = dv->isLVal();
+    if (!ldv) {
       LLValue *dump = DtoAllocaDump(dv, asType, alignment,
                                     ".BaseBitcastABIRewrite_arg_storage");
       return DtoLoad(dump, name);
     }
 
-    LLValue *address = DtoLVal(dv);
-    LLType *pointeeType = address->getType()->getPointerElementType();
+    LLValue *address = DtoLVal(ldv);
+    LLType *pointeeType = ldv->memoryType();
 
     if (getTypeStoreSize(asType) > getTypeAllocSize(pointeeType) ||
         alignment > DtoAlignment(dv->type)) {

--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -877,7 +877,7 @@ DSliceValue *DtoCatArrays(const Loc &loc, Type *arrayType, Expression *exp1,
     // Create static array from slices
     LLPointerType *ptrarraytype = isaPointer(arrs[0]);
     assert(ptrarraytype && "Expected pointer type");
-    LLStructType *arraytype = isaStruct(ptrarraytype->getPointerElementType());
+    LLStructType *arraytype = isaStruct(DtoType(arrayType));
     assert(arraytype && "Expected struct type");
     LLArrayType *type = LLArrayType::get(arraytype, arrs.size());
     LLValue *array = DtoRawAlloca(type, 0, ".slicearray");

--- a/gen/asm-gcc.cpp
+++ b/gen/asm-gcc.cpp
@@ -209,12 +209,13 @@ void GccAsmStatement_toIR(GccAsmStatement *stmt, IRState *irs) {
 
       if (isOutput) {
         assert(e->isLvalue() && "should have been caught by front-end");
-        LLValue *lval = DtoLVal(e);
+        DLValue * dlval = static_cast<DLValue*>(toElem(e));
+        LLValue *lval = DtoLVal(dlval);
         if (isIndirect) {
           operands.push_back(lval);
         } else {
           outputLVals.push_back(lval);
-          outputTypes.push_back(lval->getType()->getPointerElementType());
+          outputTypes.push_back(dlval->memoryType());
         }
       } else {
         if (isIndirect && !e->isLvalue()) {

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -545,10 +545,8 @@ DIType DIBuilder::CreateCompositeType(Type *t) {
 
   // Use the actual type associated with the declaration, ignoring any
   // const/wrappers.
-  LLType *T = DtoType(ad->type);
-  if (t->ty == TY::Tclass)
-    T = T->getPointerElementType();
   IrAggr *irAggr = getIrAggr(ad, true);
+  LLType *T = irAggr->getLLStructType();
 
   if (irAggr->diCompositeType) {
     return irAggr->diCompositeType;

--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -125,6 +125,10 @@ DLValue::DLValue(Type *t, LLValue *v) : DValue(t, v) {
          stripAddrSpaces(v->getType()) == DtoPtrToType(t));
 }
 
+llvm::Type *DLValue::memoryType() {
+    return DtoMemType(type);
+}
+
 DRValue *DLValue::getRVal() {
   if (DtoIsInMemoryOnly(type)) {
     llvm_unreachable("getRVal() for memory-only type");

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -158,6 +158,7 @@ public:
 
   DLValue *isLVal() override { return this; }
 
+  llvm::Type *memoryType();
 protected:
   DLValue(llvm::Value *v, Type *t) : DValue(t, v) {}
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -205,7 +205,7 @@ TypeFunction *DtoTypeFunction(DValue *fnval);
 LLValue *DtoCallableValue(DValue *fn);
 
 ///
-LLFunctionType *DtoExtractFunctionType(LLType *type);
+LLFunctionType *DtoCallableType(DValue *val);
 
 /// Checks whether fndecl is an intrinsic that requires special lowering. If so,
 /// emits the code for it and returns true, settings result to the resulting

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -568,6 +568,11 @@ LLType *stripAddrSpaces(LLType *t)
   if(gIR->dcomputetarget == nullptr)
     return t;
 
+#if LDC_LLVM_VER >= 1500
+   // Opqaue pointers only
+   if (t->isPointerTy())
+       return llvm::PointerType::get(gIR->context(), 0);
+#else
   int indirections = 0;
   while (t->isPointerTy()) {
     indirections++;
@@ -575,6 +580,7 @@ LLType *stripAddrSpaces(LLType *t)
   }
   while (indirections-- != 0)
      t = t->getPointerTo(0);
+#endif
 
   return t;
 }

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -435,7 +435,7 @@ void buildTypeInfo(TypeInfoDeclaration *decl) {
     assert(isBuiltin && "existing global expected to be the init symbol of a "
                         "built-in TypeInfo");
   } else {
-    LLType *type = DtoType(decl->type)->getPointerElementType();
+      LLType *type = DtoType(decl->type)->getPointerElementType();
     // We need to keep the symbol mutable as the type is not declared as
     // immutable on the D side, and e.g. synchronized() can be used on the
     // implicit monitor.

--- a/ir/iraggr.h
+++ b/ir/iraggr.h
@@ -96,11 +96,12 @@ protected:
   // Use dllimport for *declared* init symbol, TypeInfo and vtable?
   bool useDLLImport() const;
 
-private:
   llvm::StructType *llStructType = nullptr;
 
+public:
   llvm::StructType *getLLStructType();
 
+private:
   /// Recursively adds all the initializers for the given aggregate and, in
   /// case of a class type, all its base classes.
   void addFieldInitializers(llvm::SmallVectorImpl<llvm::Constant *> &constants,

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -110,8 +110,7 @@ LLGlobalVariable *IrClass::getClassInfoSymbol(bool define) {
       emitTypeInfoMetadata(typeInfo, aggrdecl->type);
 
       // Gather information
-      LLType *type = DtoType(aggrdecl->type);
-      LLType *bodyType = type->getPointerElementType();
+      LLType *bodyType = llStructType;
       bool hasDestructor = (aggrdecl->dtor != nullptr);
       // Construct the fields
       llvm::Metadata *mdVals[CD_NumFields];
@@ -512,7 +511,7 @@ LLConstant *IrClass::getInterfaceVtblInit(BaseClass *b,
 
       llvm::GlobalVariable *interfaceInfosZ = getInterfaceArraySymbol();
       llvm::Constant *c = llvm::ConstantExpr::getGetElementPtr(
-          getPointeeType(interfaceInfosZ), interfaceInfosZ, idxs, true);
+          interfaceInfosZ->getValueType(), interfaceInfosZ, idxs, true);
 
       constants.push_back(DtoBitCast(c, voidPtrTy));
     } else {


### PR DESCRIPTION
These no longer exist in LLVM15 as part of the opaque pointer migration.