### PR TITLE
Fix `getValueOr`-> `value_or` deprecation

### DIFF
--- a/gen/abi-x86.cpp
+++ b/gen/abi-x86.cpp
@@ -267,7 +267,13 @@ struct X86TargetABI : TargetABI {
           // Keep alignment for LLVM 13+, to prevent invalid `movaps` etc.,
           // but limit to 4 (required according to runnable/ldc_cabi1.d).
           auto align4 = LLAlign(4);
-          if (arg->attrs.getAlignment().getValueOr(align4) > align4)
+          if (arg->attrs.getAlignment().
+#if LDC_LLVM_VER >= 1500
+              value_or
+#else
+              getValueOr
+#endif
+              (align4) > align4)
             arg->attrs.addAlignmentAttr(align4);
 #endif
         }


### PR DESCRIPTION
`value_or` added in https://github.com/llvm/llvm-project/commit/3c49576417bab1b07764aa0b22664cbc8d3c3f53

`getValueOr` deprecated in
https://github.com/llvm/llvm-project/commit/5512f398a039e3ed7df502a0c263a8f366a84a4c