### PR TITLE
`gen/cl_helpers.h`: Allow `MultiSetter` to be default constucted

### DIFF
--- a/gen/cl_helpers.h
+++ b/gen/cl_helpers.h
@@ -157,6 +157,7 @@ class MultiSetter {
 public:
   // end with a nullptr
   MultiSetter(bool invert, CHECKENABLE *p, ...);
+  MultiSetter() = default;
 
   void operator=(bool val);
 };


### PR DESCRIPTION
Fixes compilation broken by https://github.com/llvm/llvm-project/commit/fcd9fa416d0d3585f9d6c68302df8ba39889608a

I've no idea if this the proper thing to do, but it fixes compilation