### PR TITLE
Change `IrTypeAggr::getMemberLocation` to indicate field or byte offest

### DIFF
--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -208,17 +208,16 @@ bool IrTypeAggr::isPacked(AggregateDeclaration *ad) {
   return false;
 }
 
-void IrTypeAggr::getMemberLocation(VarDeclaration *var, unsigned &fieldIndex,
-                                   unsigned &byteOffset) const {
+unsigned IrTypeAggr::getMemberLocation(VarDeclaration *var, bool& isFieldIdx) const {
   // Note: The interface is a bit more general than what we actually return.
   // Specifically, the frontend offset information we use for overlapping
   // fields is always based at the object start.
   auto it = varGEPIndices.find(var);
   if (it != varGEPIndices.end()) {
-    fieldIndex = it->second;
-    byteOffset = 0;
+    isFieldIdx = true;
+    return it->second;
   } else {
-    fieldIndex = 0;
-    byteOffset = var->offset;
+    isFieldIdx = false;
+    return var->offset;
   }
 }

--- a/ir/irtypeaggr.h
+++ b/ir/irtypeaggr.h
@@ -63,8 +63,7 @@ public:
   /// Returns the index of the field in the LLVM struct type that corresponds
   /// to the given member variable, plus the offset to the actual field start
   /// due to overlapping (union) fields, if any.
-  void getMemberLocation(VarDeclaration *var, unsigned &fieldIndex,
-                         unsigned &byteOffset) const;
+  unsigned getMemberLocation(VarDeclaration *var, bool& isFieldIdx) const;
 
   /// true, if the LLVM struct type for the aggregate is declared as packed
   bool packed = false;


### PR DESCRIPTION
The previous API of returning two `unsigned`s was ambiguous when accessing the second member of a union that is the first member of a struct, where both output were set to zero.

It now returns one `unsigned` and an output `bool` to determine if it should be used as either a field or byte offset.