### PR TITLE
Add an `llvm::Type*` to `DLValue` to hold the pointee type

### DIFF
--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -117,8 +117,23 @@ bool DFuncValue::definedInFuncEntryBB() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+DLValue::DLValue(Type *t, LLValue *v) :
+   DLValue(t, t->toBasetype()->ty == TY::Ttuple ?
+                 nullptr :
+                 DtoMemType(t),
+           v)
+ {}
 
-DLValue::DLValue(Type *t, LLValue *v) : DValue(t, v) {
+DLValue::DLValue(Type *t, LLType *llt, LLValue *v) : DValue(t, v) {
+  lltype = llt;
+
+  if (isSpecialRef())
+    assert(lltype == nullptr ||
+           lltype == val->getType()->getPointerElementType()
+                                   ->getPointerElementType());
+  else
+    assert(lltype == nullptr ||
+           lltype == val->getType()->getPointerElementType());
   // v may be an addrspace qualified pointer so strip it before doing a pointer
   // equality check.
   assert(t->toBasetype()->ty == TY::Ttuple ||

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -152,6 +152,8 @@ public:
 class DLValue : public DValue {
 public:
   DLValue(Type *t, llvm::Value *v);
+  DLValue(Type *t, llvm::Type *llt, llvm::Value *v);
+  llvm::Type *lltype;
 
   DRValue *getRVal() override;
   virtual DLValue *getLVal() { return this; }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2527,7 +2527,7 @@ public:
                  gep);
       }
     }
-    result = new DLValue(e->type, val);
+    result = new DLValue(e->type, nullptr, val);
   }
 
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hmm, right this breaks dcompute.