### PR TITLE
Remove use of `getPointerElementType` from GC2Stack

### DIFF
--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -93,6 +93,11 @@ void emitTypeInfoMetadata(LLGlobalVariable *typeinfoGlobal, Type *forType) {
       auto val = llvm::UndefValue::get(DtoType(forType));
       meta->addOperand(llvm::MDNode::get(gIR->context(),
                                          llvm::ConstantAsMetadata::get(val)));
+      if (TypeArray *ta = t->isTypeDArray()) {
+        auto val2 = llvm::UndefValue::get(DtoMemType(ta->nextOf()));
+        meta->addOperand(llvm::MDNode::get(gIR->context(),
+                                           llvm::ConstantAsMetadata::get(val2)));
+      }
     }
   }
 }


### PR DESCRIPTION
Augment the type info for arrays to include the element type in addition to the array type as a second type-as-metadata MDNode.

Use this in place of looking up the element type from the array type