### PR TITLE
Revert "Add D types to `IRAsmStmt::Operands` (#4138)"

### DIFF
--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -267,12 +267,10 @@ void AsmStatement_toIR(InlineAsmStatement *stmt, IRState *irs) {
       arg_map[i] = --input_idx;
       asmStmt->in.ops.push_back(arg_val);
       input_constraints.push_back(cns);
-      asmStmt->in.dTypes.push_back(arg->expr->type);
     } else {
       arg_map[i] = n_outputs++;
       asmStmt->out.ops.push_back(arg_val);
       output_constraints.push_back(cns);
-      asmStmt->out.dTypes.push_back(arg->expr->type);
     }
   }
 

--- a/gen/irstate.h
+++ b/gen/irstate.h
@@ -78,10 +78,8 @@ struct IRAsmStmt {
 
   std::string code;
   struct Operands {
-    Operands() = default;
     std::string c; // contraint
     std::vector<LLValue *> ops;
-    std::vector<Type *> dTypes;
   };
   Operands out, in;
 


### PR DESCRIPTION
This reverts commit f4a4f76b8988c5ebd9733c579a87ec74eaca85de.