### PR TITLE
Rename `DtoAggrPaint` to `DtoSlicePaint`

### DIFF
--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -827,7 +827,7 @@ DSliceValue *DtoCatAssignArray(const Loc &loc, DValue *arr, Expression *exp) {
   LLValue *newArray = gIR->CreateCallOrInvoke(
       fn, DtoTypeInfoOf(loc, arrayType),
       DtoBitCast(DtoLVal(arr), fn->getFunctionType()->getParamType(1)),
-      DtoAggrPaint(DtoSlice(exp), fn->getFunctionType()->getParamType(2)),
+      DtoSlicePaint(DtoSlice(exp), fn->getFunctionType()->getParamType(2)),
       ".appendedArray");
 
   return getSlice(arrayType, newArray);
@@ -920,7 +920,7 @@ DSliceValue *DtoCatArrays(const Loc &loc, Type *arrayType, Expression *exp1,
     auto loadArray = [fn](Expression* e, int paramTypeIdx) {
       DValue * dval = toElem(e);
       LLValue *val = DtoLoad(DtoSlicePtrType(dval), DtoSlicePtr(dval));
-      return DtoAggrPaint(val, fn->getFunctionType()->getParamType(paramTypeIdx));
+      return DtoSlicePaint(val, fn->getFunctionType()->getParamType(paramTypeIdx));
     };
     // byte[] x
     args.push_back(loadArray(exp1,1));
@@ -988,9 +988,9 @@ LLValue *DtoArrayEqCmp_impl(const Loc &loc, const char *func, DValue *l,
   LLSmallVector<LLValue *, 3> args;
 
   // get values, reinterpret cast to void[]
-  args.push_back(DtoAggrPaint(DtoRVal(l),
+  args.push_back(DtoSlicePaint(DtoRVal(l),
                               DtoArrayType(LLType::getInt8Ty(gIR->context()))));
-  args.push_back(DtoAggrPaint(DtoRVal(r),
+  args.push_back(DtoSlicePaint(DtoRVal(r),
                               DtoArrayType(LLType::getInt8Ty(gIR->context()))));
 
   // pass array typeinfo ?

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -188,7 +188,7 @@ static void addExplicitArguments(std::vector<LLValue *> &args, AttrSet &attrs,
         Logger::cout() << "expects: " << *paramType << '\n';
       }
       if (isaStruct(llVal)) {
-        llVal = DtoAggrPaint(llVal, paramType);
+        llVal = DtoSlicePaint(llVal, paramType);
       } else {
         llVal = DtoBitCast(llVal, paramType);
       }
@@ -956,7 +956,7 @@ DValue *DtoCallFunction(const Loc &loc, Type *resulttype, DValue *fnval,
       if (tf->isref()) {
         retllval = DtoBitCast(retllval, DtoType(rbase->pointerTo()));
       } else {
-        retllval = DtoAggrPaint(retllval, DtoType(rbase));
+        retllval = DtoSlicePaint(retllval, DtoType(rbase));
       }
       break;
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2475,7 +2475,7 @@ public:
           LLGlobalValue::InternalLinkage, initval, ".aaKeysStorage");
       LLConstant *slice = DtoGEP(initval->getType(), globalstore, 0u, 0u);
       slice = DtoConstSlice(DtoConstSize_t(e->keys->length), slice);
-      LLValue *keysArray = DtoAggrPaint(slice, funcTy->getParamType(1));
+      LLValue *keysArray = DtoSlicePaint(slice, funcTy->getParamType(1));
 
       initval = arrayConst(valuesInits, vtype);
       globalstore = new LLGlobalVariable(gIR->module, initval->getType(), false,
@@ -2483,7 +2483,7 @@ public:
                                          initval, ".aaValuesStorage");
       slice = DtoGEP(initval->getType(), globalstore, 0u, 0u);
       slice = DtoConstSlice(DtoConstSize_t(e->keys->length), slice);
-      LLValue *valuesArray = DtoAggrPaint(slice, funcTy->getParamType(2));
+      LLValue *valuesArray = DtoSlicePaint(slice, funcTy->getParamType(2));
 
       LLValue *aa = gIR->CreateCallOrInvoke(func, aaTypeInfo, keysArray,
                                             valuesArray, "aa");

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -765,7 +765,7 @@ LLValue *DtoAggrPair(LLValue *V1, LLValue *V2, const char *name) {
   return DtoAggrPair(t, V1, V2, name);
 }
 
-LLValue *DtoAggrPaint(LLValue *aggr, LLType *as) {
+LLValue *DtoSlicePaint(LLValue *aggr, LLType *as) {
   if (aggr->getType() == as) {
     return aggr;
   }

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -161,7 +161,7 @@ unsigned int getABITypeAlign(LLType *t);
 LLValue *DtoAggrPair(LLType *type, LLValue *V1, LLValue *V2,
                      const char *name = "");
 LLValue *DtoAggrPair(LLValue *V1, LLValue *V2, const char *name = "");
-LLValue *DtoAggrPaint(LLValue *aggr, LLType *as);
+LLValue *DtoSlicePaint(LLValue *aggr, LLType *as);
 
 /**
  * Generates a call to llvm.memset.i32 (or i64 depending on architecture).


### PR DESCRIPTION
It only does two elements and is exclusively used for slices

fixes #4137