### PR TITLE
Fix for optnone not being respected with new passmanager

### DIFF
--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -122,7 +122,7 @@ static cl::opt<int> fSanitizeMemoryTrackOrigins(
         "Enable origins tracking in MemorySanitizer (0=disabled, default)"));
 
 static cl::opt<signed char> passmanager("passmanager",
-    cl::desc("Setting the passmanager (new,legacy):"), cl::ZeroOrMore, cl::init(1),
+    cl::desc("Setting the passmanager (new,legacy):"), cl::ZeroOrMore, cl::init(0),
     cl::values(
         clEnumValN(0, "legacy", "Use the legacy passmanager (available for LLVM14 and below) "),
         clEnumValN(1, "new", "Use the new passmanager (available for LLVM14 and above)")));

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -641,22 +641,25 @@ void runOptimizationPasses(llvm::Module *M) {
 //  } else {
 //    builder.Inliner = createAlwaysInlinerLegacyPass();
 //  }
-
-   llvm::PassInstrumentationCallbacks passInstrumentationCallbacks;
-
-   llvm::OptNoneInstrumentation optNoneInstrumentation(false);
-
-   optNoneInstrumentation.registerCallbacks(passInstrumentationCallbacks);
-
-
-
-  PassBuilder pb(gTargetMachine, getPipelineTuningOptions(optLevelVal, sizeLevelVal),
-                 getPGOOptions(), &passInstrumentationCallbacks);
-
   LoopAnalysisManager lam;
   FunctionAnalysisManager fam;
   CGSCCAnalysisManager cgam;
   ModuleAnalysisManager mam;
+
+
+  PassInstrumentationCallbacks pic;
+  PrintPassOptions ppo;
+  //FIXME: Where should these come from
+  bool debugLogging = false;
+  ppo.Indent = false; 
+  ppo.SkipAnalyses = false;
+  StandardInstrumentations si(debugLogging, verifyEach, ppo);
+
+  si.registerCallbacks(pic, &fam);
+
+  PassBuilder pb(gTargetMachine, getPipelineTuningOptions(optLevelVal, sizeLevelVal),
+                 getPGOOptions(), &pic);
+
 
   pb.registerModuleAnalyses(mam);
   pb.registerCGSCCAnalyses(cgam);

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -37,6 +37,7 @@
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #if LDC_LLVM_VER >= 1400
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizerOptions.h"
 #include "llvm/Transforms/Instrumentation/InstrProfiling.h"
 #include "llvm/Transforms/Instrumentation/PGOInstrumentation.h"
@@ -121,7 +122,7 @@ static cl::opt<int> fSanitizeMemoryTrackOrigins(
         "Enable origins tracking in MemorySanitizer (0=disabled, default)"));
 
 static cl::opt<signed char> passmanager("passmanager",
-    cl::desc("Setting the passmanager (new,legacy):"), cl::ZeroOrMore, cl::init(0),
+    cl::desc("Setting the passmanager (new,legacy):"), cl::ZeroOrMore, cl::init(1),
     cl::values(
         clEnumValN(0, "legacy", "Use the legacy passmanager (available for LLVM14 and below) "),
         clEnumValN(1, "new", "Use the new passmanager (available for LLVM14 and above)")));
@@ -641,8 +642,16 @@ void runOptimizationPasses(llvm::Module *M) {
 //    builder.Inliner = createAlwaysInlinerLegacyPass();
 //  }
 
+   llvm::PassInstrumentationCallbacks passInstrumentationCallbacks;
+
+   llvm::OptNoneInstrumentation optNoneInstrumentation(false);
+
+   optNoneInstrumentation.registerCallbacks(passInstrumentationCallbacks);
+
+
+
   PassBuilder pb(gTargetMachine, getPipelineTuningOptions(optLevelVal, sizeLevelVal),
-                 getPGOOptions());
+                 getPGOOptions(), &passInstrumentationCallbacks);
 
   LoopAnalysisManager lam;
   FunctionAnalysisManager fam;

--- a/tests/codegen/attr_optstrat.d
+++ b/tests/codegen/attr_optstrat.d
@@ -61,6 +61,6 @@ void foo2()
 {
 }
 
-// CHECK-DAG: attributes #[[OPTNONE]] = {{.*}} noinline {{.*}} optnone
+// CHECK-DAG: attributes #[[OPTNONE]] = {{.*}} noinline{{.*}} optnone
 // CHECK-DAG: attributes #[[OPTSIZE]] = {{.*}} optsize
 // CHECK-DAG: attributes #[[MINSIZE]] = {{.*}} minsize


### PR DESCRIPTION
Found an explanation of what was happening with optnone attribute being ignored here: https://www.duskborn.com/posts/llvm-new-pass-manager/#the-curious-case-of-the-optimized-optnone-functions
I made the change suggested there.