### PR TITLE
Use LLVM's SPIRV backend for LLVM 16

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -72,12 +72,12 @@ void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
     std::ofstream out(filename, std::ofstream::binary);
     llvm::createSPIRVWriterPass(out)->runOnModule(m);
     IF_LOG Logger::println("Success.");
+    return;
 #endif
 #else
     error(Loc(), "Trying to target SPIRV, but LDC is not built to do so!");
-#endif
-
     return;
+#endif
   }
 
   std::error_code errinfo;

--- a/tests/codegen/dcompute_cl_addrspaces_new.d
+++ b/tests/codegen/dcompute_cl_addrspaces_new.d
@@ -1,0 +1,49 @@
+// See GH issue #2709
+
+// REQUIRES: target_SPIRV && llvm_atleast1600
+// RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace_new -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_new_ocl220_64.ll \
+// RUN: && %llc addrspace_new_ocl220_64.ll -mtriple=spirv64-unknown-unknown -O0 -o - | FileCheck %s --check-prefix=SPT
+@compute(CompileFor.deviceOnly) module dcompute_cl_addrspaces_new;
+import ldc.dcompute;
+
+// LL: %"ldc.dcompute.Pointer!(AddrSpace.Private, float).Pointer" = type { ptr }
+// LL: %"ldc.dcompute.Pointer!(AddrSpace.Global, float).Pointer" = type { ptr addrspace(1) }
+// LL: %"ldc.dcompute.Pointer!(AddrSpace.Shared, float).Pointer" = type { ptr addrspace(2) }
+// LL: %"ldc.dcompute.Pointer!(AddrSpace.Constant, immutable(float)).Pointer" = type { ptr addrspace(3) }
+// LL: %"ldc.dcompute.Pointer!(AddrSpace.Generic, float).Pointer" = type { ptr addrspace(4) }
+
+// SPT-DAG: %{{[0-9]+}} = OpTypeVoid
+// SPT-DAG: %{{[0-9]+}} = OpTypeFloat 32
+
+//See section 3.7 of the SPIR-V Specification for the numbers in the 4th column.
+// SPT-DAG: %{{[0-9]+}} = OpTypePointer CrossWorkgroup %{{[0-9]+}}
+// SPT-DAG: %{{[0-9]+}} = OpTypePointer UniformConstant %{{[0-9]+}}
+// SPT-DAG: %{{[0-9]+}} = OpTypePointer Workgroup %{{[0-9]+}}
+// SPT-DAG: %{{[0-9]+}} = OpTypePointer Generic %{{[0-9]+}}
+
+//void function({ T addrspace(n)* })
+
+void foo(PrivatePointer!float f) {
+    // LL: load float, ptr
+    float g = *f;
+}
+
+void foo(GlobalPointer!float f) {
+    // LL: load float, ptr addrspace(1)
+    float g = *f;
+}
+
+void foo(SharedPointer!float f) {
+    // LL: load float, ptr addrspace(2)
+    float g = *f;
+}
+
+void foo(ConstantPointer!float f) {
+    // LL: load float, ptr addrspace(3)
+    float g = *f;
+}
+
+void foo(GenericPointer!float f) {
+    // LL: load float, ptr addrspace(4)
+    float g = *f;
+}

--- a/tests/codegen/dcompute_cl_addrspaces_old.d
+++ b/tests/codegen/dcompute_cl_addrspaces_old.d
@@ -1,9 +1,9 @@
 // See GH issue #2709
 
-// REQUIRES: target_SPIRV
-// RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_ocl220_64.ll \
-// RUN: && %llvm-spirv -to-text addrspace_ocl220_64.spv && FileCheck %s --check-prefix=SPT < addrspace_ocl220_64.spt
-@compute(CompileFor.deviceOnly) module dcompute_cl_addrspaces;
+// REQUIRES: target_SPIRV && llvm_atmost1500
+// RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace_old -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_ocl220_64.ll \
+// RUN: && %llvm-spirv -to-text addrspace_old_ocl220_64.spv && FileCheck %s --check-prefix=SPT < addrspace_ocl220_64.spt
+@compute(CompileFor.deviceOnly) module dcompute_cl_addrspaces_old;
 import ldc.dcompute;
 
 // LL: %"ldc.dcompute.Pointer!(AddrSpace.Private, float).Pointer" = type { float* }

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -156,6 +156,7 @@ config.substitutions.append( ('%gnu_make', config.gnu_make_bin) )
 config.substitutions.append( ('%profdata', config.ldcprofdata_bin) )
 config.substitutions.append( ('%prunecache', config.ldcprunecache_bin) )
 config.substitutions.append( ('%llvm-spirv', os.path.join(config.llvm_tools_dir, 'llvm-spirv')) )
+config.substitutions.append( ('%llc', os.path.join(config.llvm_tools_dir, 'llc')) )
 config.substitutions.append( ('%runtimedir', config.ldc2_runtime_dir ) )
 
 # Add platform-dependent file extension substitutions


### PR DESCRIPTION
The test has this at the top of it.
```
// REQUIRES: target_SPIRV
// RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -mdcompute-file-prefix=addrspace -output-ll -output-o %s && FileCheck %s --check-prefix=LL < addrspace_ocl220_64.ll \
// RUN: && %llvm-spirv -to-text addrspace_ocl220_64.spv && FileCheck %s --check-prefix=SPT < addrspace_ocl220_64.spt
```

judging by e.g. https://github.com/llvm/llvm-project/blob/main/llvm/test/CodeGen/SPIRV/ExecutionMode.ll it seems we should be able to use `llc` to then get text that we can verify. How do I `//RUN:` a different set of commands based on the LLVM version that LDC was built against?
