### PR TITLE
CMake: Install 32-bit LTO versions of druntime & Phobos for multilib builds

### DIFF
--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -31,6 +31,10 @@ runs:
         for mode in thin full; do
           installed/bin/ldc2 hello.d -of=hello_$mode -flto=$mode -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
           ./hello_$mode
+          if [[ '${{ runner.os }}' == Linux ]]; then
+            installed/bin/ldc2 hello.d -m32 -of=hello_$mode-32 -flto=$mode -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
+            ./hello_$mode-32
+          fi
         done
 
     - name: Run dynamic-compile integration test

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -799,6 +799,9 @@ build_jit_runtime("${D_FLAGS};${D_FLAGS_RELEASE}" "${RT_CFLAGS}" "${LD_FLAGS}" "
 # Add the (static- and release-only) bitcode libraries.
 if(BUILD_LTO_LIBS AND (NOT ${BUILD_SHARED_LIBS} STREQUAL "ON"))
     list(APPEND libs_to_install druntime-ldc-lto phobos2-ldc-lto)
+    if(MULTILIB)
+        list(APPEND libs_to_install druntime-ldc-lto_${MULTILIB_SUFFIX} phobos2-ldc-lto_${MULTILIB_SUFFIX})
+    endif()
 endif()
 
 foreach(libname ${libs_to_install})


### PR DESCRIPTION
Resolves #4234.