### PR TITLE
Add support for control-flow protection

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -538,9 +538,9 @@ cl::opt<CFProtection> cfProtection(
         clEnumValN(CFProtection::none, "none",
                    "Disable CET completely (this is the default)"),
         clEnumValN(CFProtection::branch, "branch",
-                   "Enable indirect branch tracking"),
+                   "Enable branch control flow protection"),
         clEnumValN(CFProtection::return_, "return",
-                   "Enable shadow stack"),
+                   "Enable return control flow protection"),
         clEnumValN(CFProtection::full, "full",
                    "Enable both `branch` and `return`")));
 

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -530,6 +530,20 @@ cl::opt<bool> noPLT(
     "fno-plt", cl::ZeroOrMore,
     cl::desc("Do not use the PLT to make function calls"));
 
+cl::opt<CFProtection> cfProtection(
+    "fcf-protection", cl::ZeroOrMore,
+    cl::desc("instrument control-flow architecture protection"),
+    cl::init(CFProtection::none),
+    cl::values(
+        clEnumValN(CFProtection::none, "none",
+                   "Disable CET completely (this is the default)"),
+        clEnumValN(CFProtection::branch, "branch",
+                   "Enable indirect branch tracking"),
+        clEnumValN(CFProtection::return_, "return",
+                   "Enable shadow stack"),
+        clEnumValN(CFProtection::full, "full",
+                   "Enable both `branch` and `return`")));
+
 // Math options
 bool fFastMath; // Storage for the dynamically created ffast-math option.
 llvm::FastMathFlags defaultFMF;

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -90,6 +90,14 @@ extern cl::opt<bool> noPLT;
 extern cl::opt<bool> useDIP25;
 extern cl::opt<bool> useDIP1000;
 
+enum class CFProtection {
+    none,
+    branch,
+    return_,
+    full,
+};
+extern cl::opt<CFProtection> cfProtection;
+
 // Math options
 extern bool fFastMath;
 extern llvm::FastMathFlags defaultFMF;

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -237,14 +237,20 @@ void CodeGenerator::prepareLLModule(Module *m) {
 
   // Currently, controll-flow architecture protection is x86 only.
   auto arch = global.params.targetTriple->getArch();
-  if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
-    if (opts::cfProtection == opts::CFProtection::branch || opts::cfProtection == opts::CFProtection::full) {
+  if (opts::cfProtection == opts::CFProtection::branch || opts::cfProtection == opts::CFProtection::full) {
+    if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
       // Indicate that we want to instrument branch control flow protection.
       ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-branch", 1);
+    } else {
+      warning(Loc(), "Ignoring -fcf-protection options: branch control flow protection is not supported this architecture");
     }
-    if (opts::cfProtection == opts::CFProtection::return_ || opts::cfProtection == opts::CFProtection::full) {
+  }
+  if (opts::cfProtection == opts::CFProtection::return_ || opts::cfProtection == opts::CFProtection::full) {
+    if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
       // Indicate that we want to instrument return control flow protection.
       ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-return", 1);
+    } else {
+      warning(Loc(), "Ignoring -fcf-protection options: return control flow protection is not supported this architecture");
     }
   }
 

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -235,6 +235,19 @@ void CodeGenerator::prepareLLModule(Module *m) {
   ir_->module.setTargetTriple(global.params.targetTriple->str());
   ir_->module.setDataLayout(*gDataLayout);
 
+  // Currently, controll-flow architecture protection is x86 only.
+  auto arch = global.params.targetTriple->getArch();
+  if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
+    if (opts::cfProtection == opts::CFProtection::branch || opts::cfProtection == opts::CFProtection::full) {
+      // Indicate that we want to instrument branch control flow protection.
+      ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-branch", 1);
+    }
+    if (opts::cfProtection == opts::CFProtection::return_ || opts::cfProtection == opts::CFProtection::full) {
+      // Indicate that we want to instrument return control flow protection.
+      ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-return", 1);
+    }
+  }
+
   // TODO: Make ldc::DIBuilder per-Module to be able to emit several CUs for
   // single-object compilations?
   ir_->DBuilder.EmitCompileUnit(m);

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -243,10 +243,10 @@ void CodeGenerator::prepareLLModule(Module *m) {
 #if LDC_LLVM_VER >= 1500
       ir_->module.addModuleFlag(llvm::Module::Min, "cf-protection-branch", 1);
 #else
-      ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-branch", 1);
+      warning(Loc(), "Ignoring -fcf-protection options: branch control flow protection is not supported in this LLVM version");
 #endif
     } else {
-      warning(Loc(), "Ignoring -fcf-protection options: branch control flow protection is not supported this architecture");
+      warning(Loc(), "Ignoring -fcf-protection options: branch control flow protection is not supported in this architecture");
     }
   }
   if (opts::cfProtection == opts::CFProtection::return_ || opts::cfProtection == opts::CFProtection::full) {
@@ -255,10 +255,10 @@ void CodeGenerator::prepareLLModule(Module *m) {
 #if LDC_LLVM_VER >= 1500
       ir_->module.addModuleFlag(llvm::Module::Min, "cf-protection-return", 1);
 #else
-      ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-return", 1);
+      warning(Loc(), "Ignoring -fcf-protection options: return control flow protection is not supported in this LLVM version");
 #endif
     } else {
-      warning(Loc(), "Ignoring -fcf-protection options: return control flow protection is not supported this architecture");
+      warning(Loc(), "Ignoring -fcf-protection options: return control flow protection is not supported in this architecture");
     }
   }
 

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -240,7 +240,11 @@ void CodeGenerator::prepareLLModule(Module *m) {
   if (opts::cfProtection == opts::CFProtection::branch || opts::cfProtection == opts::CFProtection::full) {
     if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
       // Indicate that we want to instrument branch control flow protection.
+#if LDC_LLVM_VER >= 1500
+      ir_->module.addModuleFlag(llvm::Module::Min, "cf-protection-branch", 1);
+#else
       ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-branch", 1);
+#endif
     } else {
       warning(Loc(), "Ignoring -fcf-protection options: branch control flow protection is not supported this architecture");
     }
@@ -248,7 +252,11 @@ void CodeGenerator::prepareLLModule(Module *m) {
   if (opts::cfProtection == opts::CFProtection::return_ || opts::cfProtection == opts::CFProtection::full) {
     if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64) {
       // Indicate that we want to instrument return control flow protection.
+#if LDC_LLVM_VER >= 1500
+      ir_->module.addModuleFlag(llvm::Module::Min, "cf-protection-return", 1);
+#else
       ir_->module.addModuleFlag(llvm::Module::Override, "cf-protection-return", 1);
+#endif
     } else {
       warning(Loc(), "Ignoring -fcf-protection options: return control flow protection is not supported this architecture");
     }

--- a/tests/codegen/cfprotection.d
+++ b/tests/codegen/cfprotection.d
@@ -1,0 +1,30 @@
+// REQUIRES: target_X86
+
+// RUN: %ldc -output-ll -of=%t_undefined.ll %s
+// RUN : FileCheck %s --check-prefix=UNDEFINED < %t_undefined.ll
+
+// RUN: %ldc -fcf-protection=none -output-ll -of=%t_none.ll %s
+// RUN: FileCheck %s --check-prefix=NONE < %t_none.ll
+
+// RUN: %ldc -fcf-protection=branch -output-ll -of=%t_branch.ll %s
+// RUN: FileCheck %s --check-prefix=BRANCH < %t_branch.ll
+
+// RUN: %ldc -fcf-protection=return -output-ll -of=%t_return.ll %s
+// RUN: FileCheck %s --check-prefix=RETURN < %t_return.ll
+
+// RUN: %ldc -fcf-protection=full -output-ll -of=%t_full.ll %s
+// RUN: FileCheck %s --check-prefix=FULL < %t_full.ll
+
+void foo() {}
+
+// UNDEFINED-NOT: !"cf-protection-branch"
+// NONE-NOT: !"cf-protection-branch"
+// BRANCH: !"cf-protection-branch", i32 1
+// RETURN-NOT: !"cf-protection-branch"
+// FULL: !"cf-protection-branch", i32 1
+
+// UNDEFINED-NOT: !"cf-protection-return"
+// NONE-NOT: !"cf-protection-return"
+// BRANCH-NOT: !"cf-protection-return"
+// RETURN: !"cf-protection-return", i32 1
+// FULL: !"cf-protection-return", i32 1

--- a/tests/codegen/cfprotection.d
+++ b/tests/codegen/cfprotection.d
@@ -18,13 +18,16 @@
 void foo() {}
 
 // UNDEFINED-NOT: !"cf-protection-branch"
-// NONE-NOT: !"cf-protection-branch"
-// BRANCH: !"cf-protection-branch", i32 1
-// RETURN-NOT: !"cf-protection-branch"
-// FULL: !"cf-protection-branch", i32 1
-
 // UNDEFINED-NOT: !"cf-protection-return"
+
+// NONE-NOT: !"cf-protection-branch"
 // NONE-NOT: !"cf-protection-return"
+
+// BRANCH: !"cf-protection-branch", i32 1
 // BRANCH-NOT: !"cf-protection-return"
+
+// RETURN-NOT: !"cf-protection-branch"
 // RETURN: !"cf-protection-return", i32 1
+
+// FULL: !"cf-protection-branch", i32 1
 // FULL: !"cf-protection-return", i32 1

--- a/tests/codegen/cfprotection.d
+++ b/tests/codegen/cfprotection.d
@@ -1,18 +1,18 @@
 // REQUIRES: target_X86
 
-// RUN: %ldc -output-ll -of=%t_undefined.ll %s
+// RUN: %ldc -mtriple=x86_64 -output-ll -of=%t_undefined.ll %s
 // RUN : FileCheck %s --check-prefix=UNDEFINED < %t_undefined.ll
 
-// RUN: %ldc -fcf-protection=none -output-ll -of=%t_none.ll %s
+// RUN: %ldc -mtriple=x86_64 -fcf-protection=none -output-ll -of=%t_none.ll %s
 // RUN: FileCheck %s --check-prefix=NONE < %t_none.ll
 
-// RUN: %ldc -fcf-protection=branch -output-ll -of=%t_branch.ll %s
+// RUN: %ldc -mtriple=x86_64 -fcf-protection=branch -output-ll -of=%t_branch.ll %s
 // RUN: FileCheck %s --check-prefix=BRANCH < %t_branch.ll
 
-// RUN: %ldc -fcf-protection=return -output-ll -of=%t_return.ll %s
+// RUN: %ldc -mtriple=x86_64 -fcf-protection=return -output-ll -of=%t_return.ll %s
 // RUN: FileCheck %s --check-prefix=RETURN < %t_return.ll
 
-// RUN: %ldc -fcf-protection=full -output-ll -of=%t_full.ll %s
+// RUN: %ldc -mtriple=x86_64 -fcf-protection=full -output-ll -of=%t_full.ll %s
 // RUN: FileCheck %s --check-prefix=FULL < %t_full.ll
 
 void foo() {}

--- a/tests/codegen/cfprotection.d
+++ b/tests/codegen/cfprotection.d
@@ -1,3 +1,4 @@
+// REQUIRES: atleast_llvm1500
 // REQUIRES: target_X86
 
 // RUN: %ldc -mtriple=x86_64 -output-ll -of=%t_undefined.ll %s


### PR DESCRIPTION
This implementation is fully inspired by `-fcf-protection` in Clang, with options `none|branch|return|full`.

- related: #2511
- LLVM side: https://reviews.llvm.org/D40478