### PR TITLE
LLVM 16 fix build

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -569,11 +569,15 @@ void initializePasses() {
   initializeCore(Registry);
   initializeTransformUtils(Registry);
   initializeScalarOpts(Registry);
+#if LDC_LLVM_VER < 1600
   initializeObjCARCOpts(Registry);
+#endif
   initializeVectorization(Registry);
   initializeInstCombine(Registry);
   initializeIPO(Registry);
+#if LDC_LLVM_VER < 1600
   initializeInstrumentation(Registry);
+#endif
   initializeAnalysis(Registry);
   initializeCodeGen(Registry);
   initializeGlobalISel(Registry);

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -574,6 +574,7 @@ void initializePasses() {
 #endif
   initializeVectorization(Registry);
   initializeInstCombine(Registry);
+  initializeAggressiveInstCombine(Registry);
   initializeIPO(Registry);
 #if LDC_LLVM_VER < 1600
   initializeInstrumentation(Registry);


### PR DESCRIPTION
- remove initialization of removed legacy passes
- add initialization of AggressiveInstCombine pass
- Fix build for new MemoryEffects attributes (memory(read) instead of `readonly`)