### PR TITLE
Opaque pointer fix and LDC_LLVM_OpaquePointers

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -993,6 +993,13 @@ void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("LDC_ThreadSanitizer");
   }
 
+#if LDC_LLVM_VER >= 1400
+  // A version identifier for whether opaque pointers are enabled or not. (needed e.g. for intrinsic mangling)
+  if (!getGlobalContext().supportsTypedPointers()) {
+    VersionCondition::addPredefinedGlobalIdent("LDC_LLVM_OpaquePointers");
+  }
+#endif
+
 // Expose LLVM version to runtime
 #define STR(x) #x
 #define XSTR(x) STR(x)

--- a/gen/arrays.cpp
+++ b/gen/arrays.cpp
@@ -238,7 +238,7 @@ void DtoArrayAssign(const Loc &loc, DValue *lhs, DValue *rhs, EXP op,
   LLValue *realRhsArrayPtr = (t2->ty == TY::Tarray || t2->ty == TY::Tsarray)
                                  ? DtoArrayPtr(rhs)
                                  : nullptr;
-  if (realRhsArrayPtr && realRhsArrayPtr->getType() == realLhsPtr->getType()) {
+  if (realRhsArrayPtr && DtoMemType(t2->nextOf()) == DtoMemType(t->nextOf())) {
     // T[]  = T[]      T[]  = T[n]
     // T[n] = T[n]     T[n] = T[]
     LLValue *rhsPtr = DtoBitCast(realRhsArrayPtr, getVoidPtrType());

--- a/tests/codegen/vastart_vaend_gh1744.d
+++ b/tests/codegen/vastart_vaend_gh1744.d
@@ -12,7 +12,7 @@ module mod;
 // OPT3-LABEL: define {{.*}} @{{.*}}void_three_return_paths
 void void_three_return_paths(int a, ...)
 {
-    // OPT3: call void @llvm.va_start({{.*}} %[[VA:([0-9]+|_argptr_mem)]])
+    // OPT3: call void @llvm.va_start({{.*}} %[[VA:[_0-9a-zA-Z]+]])
     // OPT3-NOT: return_two
     return_two();
 


### PR DESCRIPTION
Separate out the code fixes from https://github.com/ldc-developers/ldc/pull/4257

This adds LDC_LLVM_OpaquePointers version identifier, needed for supporting druntime with opaque and typed pointers. This is needed for testing with `--opaque-pointers=false/true`.