### PR TITLE
Travis & Cirrus CI: Do not upload artifacts to GitHub release for tags without `v` prefix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -290,7 +290,7 @@ task:
   pack_artifact_script: |
     cd $CIRRUS_WORKING_DIR/..
     mkdir artifacts
-    if [ -n "$CIRRUS_TAG" ]; then
+    if [[ "${CIRRUS_TAG:-}" == v* ]]; then
       artifactID=${CIRRUS_TAG:1}
     else
       artifactID=${CIRRUS_CHANGE_IN_REPO:0:8}
@@ -302,8 +302,8 @@ task:
   # Upload to GitHub release (only for commits on the master branch and tags)
   upload_to_github_script: |
     cd $CIRRUS_WORKING_DIR
-    if [ -n "$CIRRUS_TAG" ]; then
+    if [[ "${CIRRUS_TAG:-}" == v* ]]; then
       tools/upload-to-github.sh $CIRRUS_TAG ../artifacts/ldc2-*.tar.xz
-    elif [[ "$CIRRUS_PR" = "" && "$CIRRUS_BRANCH" = "master" ]]; then
+    elif [[ "${CIRRUS_TAG:-}" = "" && "$CIRRUS_PR" = "" && "$CIRRUS_BRANCH" = "master" ]]; then
       tools/upload-to-github.sh CI ../artifacts/ldc2-*.tar.xz
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,7 @@ script:
   - installed/bin/reggae --version -b ninja
   # Pack installation dir
   - |
-    if [[ "$TRAVIS_TAG" != "" ]]; then
+    if [[ "${TRAVIS_TAG:-}" == v* ]]; then
       artifactID=${TRAVIS_TAG:1}
     else
       artifactID=${TRAVIS_COMMIT:0:8}
@@ -198,9 +198,9 @@ script:
   # Upload to GitHub release (only for commits on the master branch and tags)
   - |
     if [[ "$TRAVIS_TEST_RESULT" == "0" ]]; then
-      if [[ "$TRAVIS_TAG" != "" ]]; then
+      if [[ "${TRAVIS_TAG:-}" == v* ]]; then
         tools/upload-to-github.sh $TRAVIS_TAG ldc2-*.tar.xz || travis_terminate 1
-      elif [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" = "master" ]]; then
+      elif [[ "${TRAVIS_TAG:-}" = "" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" = "master" ]]; then
         tools/upload-to-github.sh CI ldc2-*.tar.xz || travis_terminate 1
       fi
     fi


### PR DESCRIPTION
GitHub Actions already skips these other tags: https://github.com/ldc-developers/ldc/blob/5c3478c129492acf2201222d5398090a07072f66/.github/workflows/main.yml#L268