### PR TITLE
Fix miscompilation when adding a 64-bit constant to a symbol

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -847,7 +847,7 @@ public:
         uint64_t elemSize = gDataLayout->getTypeAllocSize(elemType);
         if (e->offset % elemSize == 0) {
           // We can turn this into a "nice" GEP.
-          offsetValue = DtoGEP1(DtoType(base->type), baseValue, e->offset / elemSize);
+          offsetValue = DtoGEP1u64(DtoType(base->type), baseValue, e->offset / elemSize);
         }
       }
 
@@ -855,7 +855,7 @@ public:
         // Offset isn't a multiple of base type size, just cast to i8* and
         // apply the byte offset.
         offsetValue =
-            DtoGEP1(LLType::getInt8Ty(gIR->context()),
+            DtoGEP1u64(LLType::getInt8Ty(gIR->context()),
                     DtoBitCast(baseValue, getVoidPtrType()), e->offset);
       }
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -847,7 +847,12 @@ public:
         uint64_t elemSize = gDataLayout->getTypeAllocSize(elemType);
         if (e->offset % elemSize == 0) {
           // We can turn this into a "nice" GEP.
-          offsetValue = DtoGEP1i64(DtoType(base->type), baseValue, e->offset / elemSize);
+          if (elemType->isStructTy()) {
+            // LLVM requires that struct offsets are 32-bit.
+            offsetValue = DtoGEP1(DtoType(base->type), baseValue, e->offset / elemSize);
+          } else {
+            offsetValue = DtoGEP1i64(DtoType(base->type), baseValue, e->offset / elemSize);
+          }
         }
       }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -847,7 +847,7 @@ public:
         uint64_t elemSize = gDataLayout->getTypeAllocSize(elemType);
         if (e->offset % elemSize == 0) {
           // We can turn this into a "nice" GEP.
-          offsetValue = DtoGEP1u64(DtoType(base->type), baseValue, e->offset / elemSize);
+          offsetValue = DtoGEP1i64(DtoType(base->type), baseValue, e->offset / elemSize);
         }
       }
 
@@ -855,7 +855,7 @@ public:
         // Offset isn't a multiple of base type size, just cast to i8* and
         // apply the byte offset.
         offsetValue =
-            DtoGEP1u64(LLType::getInt8Ty(gIR->context()),
+            DtoGEP1i64(LLType::getInt8Ty(gIR->context()),
                     DtoBitCast(baseValue, getVoidPtrType()), e->offset);
       }
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -848,7 +848,8 @@ public:
         if (e->offset % elemSize == 0) {
           // We can turn this into a "nice" GEP.
           if (elemType->isStructTy()) {
-            // LLVM requires that struct offsets are 32-bit.
+            // LLVM getelementptr requires that offsets are 32-bit constants
+            // when the base type is a struct.
             offsetValue = DtoGEP1(DtoType(base->type), baseValue, e->offset / elemSize);
           } else {
             offsetValue = DtoGEP1i64(DtoType(base->type), baseValue, e->offset / elemSize);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -385,22 +385,13 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                                               /* InBounds = */ true);
 }
 
-LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0, const char *name,
                     llvm::BasicBlock *bb) {
+  // Use a 32-bit offset if i0 can fit, otherwise use a 64-bit offset.
+  if (i0 <= INT32_MAX && i0 >= INT32_MIN) {
+    return DtoGEP(pointeeTy, ptr, DtoConstUint(i0), name, bb);
+  }
   return DtoGEP(pointeeTy, ptr, DtoConstSize_t(i0), name, bb);
-}
-
-LLValue *DtoGEPi64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
-                   const char *name, llvm::BasicBlock *bb) {
-  LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
-  return DtoGEP(pointeeTy, ptr, indices, name, bb);
-}
-
-LLConstant *DtoGEPi64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
-                      uint64_t i1) {
-  LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
-  return llvm::ConstantExpr::getGetElementPtr(pointeeTy, ptr, indices,
-                                              /* InBounds = */ true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -387,11 +387,7 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
 
 LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0, const char *name,
                     llvm::BasicBlock *bb) {
-  // Use a 32-bit offset if i0 can fit, otherwise use a 64-bit offset.
-  if (i0 <= INT32_MAX && i0 >= INT32_MIN) {
-    return DtoGEP(pointeeTy, ptr, DtoConstUint(i0), name, bb);
-  }
-  return DtoGEP(pointeeTy, ptr, DtoConstSize_t(i0), name, bb);
+  return DtoGEP(pointeeTy, ptr, DtoConstUlong(i0), name, bb);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -458,6 +454,12 @@ LLValue *DtoMemCmp(LLValue *lhs, LLValue *rhs, LLValue *nbytes) {
 
 llvm::ConstantInt *DtoConstSize_t(uint64_t i) {
   return LLConstantInt::get(DtoSize_t(), i, false);
+}
+llvm::ConstantInt *DtoConstUlong(uint64_t i) {
+  return LLConstantInt::get(LLType::getInt64Ty(gIR->context()), i, false);
+}
+llvm::ConstantInt *DtoConstLong(int64_t i) {
+  return LLConstantInt::get(LLType::getInt64Ty(gIR->context()), i, true);
 }
 llvm::ConstantInt *DtoConstUint(unsigned i) {
   return LLConstantInt::get(LLType::getInt32Ty(gIR->context()), i, false);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -386,18 +386,18 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
 }
 
 LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
-                 llvm::BasicBlock *bb) {
+                    llvm::BasicBlock *bb) {
   return DtoGEP(pointeeTy, ptr, DtoConstSize_t(i0), name, bb);
 }
 
 LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
-                const char *name, llvm::BasicBlock *bb) {
+                   const char *name, llvm::BasicBlock *bb) {
   LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
   return DtoGEP(pointeeTy, ptr, indices, name, bb);
 }
 
 LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
-                   uint64_t i1) {
+                      uint64_t i1) {
   LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
   return llvm::ConstantExpr::getGetElementPtr(pointeeTy, ptr, indices,
                                               /* InBounds = */ true);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -385,18 +385,18 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                                               /* InBounds = */ true);
 }
 
-LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
                     llvm::BasicBlock *bb) {
   return DtoGEP(pointeeTy, ptr, DtoConstSize_t(i0), name, bb);
 }
 
-LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
+LLValue *DtoGEPi64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
                    const char *name, llvm::BasicBlock *bb) {
   LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
   return DtoGEP(pointeeTy, ptr, indices, name, bb);
 }
 
-LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
+LLConstant *DtoGEPi64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
                       uint64_t i1) {
   LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
   return llvm::ConstantExpr::getGetElementPtr(pointeeTy, ptr, indices,

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -385,7 +385,7 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                                               /* InBounds = */ true);
 }
 
-LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0, const char *name,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
                     llvm::BasicBlock *bb) {
   return DtoGEP(pointeeTy, ptr, DtoConstUlong(i0), name, bb);
 }

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -385,6 +385,24 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                                               /* InBounds = */ true);
 }
 
+LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
+                 llvm::BasicBlock *bb) {
+  return DtoGEP(pointeeTy, ptr, DtoConstSize_t(i0), name, bb);
+}
+
+LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
+                const char *name, llvm::BasicBlock *bb) {
+  LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
+  return DtoGEP(pointeeTy, ptr, indices, name, bb);
+}
+
+LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
+                   uint64_t i1) {
+  LLValue *indices[] = {DtoConstSize_t(i0), DtoConstSize_t(i1)};
+  return llvm::ConstantExpr::getGetElementPtr(pointeeTy, ptr, indices,
+                                              /* InBounds = */ true);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void DtoMemSet(LLValue *dst, LLValue *val, LLValue *nbytes, unsigned align) {

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -95,7 +95,7 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
-LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
                     const char *name = "", llvm::BasicBlock *bb = nullptr);
 
 // to constant helpers

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -100,6 +100,8 @@ LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0,
 
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);
+LLConstantInt *DtoConstUlong(uint64_t i);
+LLConstantInt *DtoConstLong(int64_t i);
 LLConstantInt *DtoConstUint(unsigned i);
 LLConstantInt *DtoConstInt(int i);
 LLConstantInt *DtoConstUbyte(unsigned char i);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -95,12 +95,8 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
-LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, int64_t i0,
                     const char *name = "", llvm::BasicBlock *bb = nullptr);
-LLValue *DtoGEPi64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
-                   const char *name = "", llvm::BasicBlock *bb = nullptr);
-LLConstant *DtoGEPi64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
-                      uint64_t i1);
 
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -95,6 +95,13 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
+LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
+                 const char *name = "", llvm::BasicBlock *bb = nullptr);
+LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
+                const char *name = "", llvm::BasicBlock *bb = nullptr);
+LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
+                   uint64_t i1);
+
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);
 LLConstantInt *DtoConstUint(unsigned i);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -96,11 +96,11 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
 LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
-                 const char *name = "", llvm::BasicBlock *bb = nullptr);
+                    const char *name = "", llvm::BasicBlock *bb = nullptr);
 LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
-                const char *name = "", llvm::BasicBlock *bb = nullptr);
+                   const char *name = "", llvm::BasicBlock *bb = nullptr);
 LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
-                   uint64_t i1);
+                      uint64_t i1);
 
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -95,11 +95,11 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
-LLValue *DtoGEP1u64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
+LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
                     const char *name = "", llvm::BasicBlock *bb = nullptr);
-LLValue *DtoGEPu64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
+LLValue *DtoGEPi64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, uint64_t i1,
                    const char *name = "", llvm::BasicBlock *bb = nullptr);
-LLConstant *DtoGEPu64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
+LLConstant *DtoGEPi64(LLType *pointeeTy, LLConstant *ptr, uint64_t i0,
                       uint64_t i1);
 
 // to constant helpers

--- a/tests/codegen/gh2865.d
+++ b/tests/codegen/gh2865.d
@@ -2,7 +2,7 @@
 
 void foo()
 {
-    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_D6gh28653fooFZv{{.*}}, i32 -10
+    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_D6gh28653fooFZv{{.*}}, i64 -10
     // CHECK-NEXT: %2 = ptrtoint {{i8\*|ptr}} %1 to i{{32|64}}
     auto addr = (cast(size_t) &foo) - 10;
 }

--- a/tests/codegen/gh2865.d
+++ b/tests/codegen/gh2865.d
@@ -2,7 +2,7 @@
 
 void foo()
 {
-    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_D6gh28653fooFZv{{.*}}, i64 -10
+    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_D6gh28653fooFZv{{.*}}, i32 -10
     // CHECK-NEXT: %2 = ptrtoint {{i8\*|ptr}} %1 to i{{32|64}}
     auto addr = (cast(size_t) &foo) - 10;
 }

--- a/tests/codegen/gh4264.d
+++ b/tests/codegen/gh4264.d
@@ -1,0 +1,6 @@
+// RUN: %ldc -run %s
+
+enum offset = 0xFFFF_FFFF_0000_0000UL;
+void main() {
+    assert((cast(ulong)&main) != (cast(ulong)&main + offset));
+}

--- a/tests/codegen/gh4264.d
+++ b/tests/codegen/gh4264.d
@@ -1,6 +1,7 @@
-// RUN: %ldc -run %s
+// RUN: %ldc -run %s && %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 enum offset = 0xFFFF_FFFF_0000_0000UL;
 void main() {
+    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_Dmain{{.*}}, i64 -4294967296
     assert((cast(ulong)&main) != (cast(ulong)&main + offset));
 }

--- a/tests/codegen/gh4264.d
+++ b/tests/codegen/gh4264.d
@@ -1,7 +1,6 @@
-// RUN: %ldc -run %s && %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -run %s
 
 enum offset = 0xFFFF_FFFF_0000_0000UL;
 void main() {
-    // CHECK: %1 = getelementptr inbounds i8,{{.*}}_Dmain{{.*}}, i64 -4294967296
     assert((cast(ulong)&main) != (cast(ulong)&main + offset));
 }


### PR DESCRIPTION
The `DtoGEP` functions assume the offset is a 32-bit value, but when used with a `SymOffExp`, the offset may be 64-bit. In that case, the GEP should use an i64 for the offset.

Fixes #4264.

Let me know if I should make any changes. Thanks!