### PR TITLE
Add -fno-delete-null-pointer-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Big news
 - Bit fields support. (#4015)
 - macOS on Apple M1: linking with `-g` is working again without unaligned pointer warnings/errors. This fixes file:line debug information in exception backtraces (requiring `atos`, a macOS development tool installed with Xcode), without the need to set MACOSX_DEPLOYMENT_TARGET=11 and using a modified LLVM. (#4291)
+- New commandline option `-fno-delete-null-pointer-checks`, mimicking the same commandline option of GCC and Clang. (#4297)
 
 #### Platform support
 - Initial ABI support for 64-bit RISC-V. (#4007)

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -554,6 +554,14 @@ cl::opt<bool>
     fNoDiscardValueNames("fno-discard-value-names", cl::ZeroOrMore,
                          cl::desc("Do not discard value names in LLVM IR"));
 
+cl::opt<bool> fNullPointerIsValid(
+    "fno-delete-null-pointer-checks", cl::ZeroOrMore,
+    cl::desc(
+        "Treat null pointer dereference as defined behavior when optimizing "
+        "(instead of _un_defined behavior). This prevents the optimizer from "
+        "assuming that any dereferenced pointer must not have been null and "
+        "optimize away the branches accordingly."));
+
 cl::opt<bool, true>
     allinst("allinst", cl::ZeroOrMore, cl::location(global.params.allInst),
             cl::desc("Generate code for all template instantiations"));

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -98,6 +98,7 @@ extern llvm::FastMathFlags defaultFMF;
 void setDefaultMathOptions(llvm::TargetOptions &targetOptions);
 
 extern cl::opt<bool> fNoDiscardValueNames;
+extern cl::opt<bool> fNullPointerIsValid;
 
 // Arguments to -d-debug
 extern std::vector<std::string> debugArgs;

--- a/tests/codegen/fno_delete_null_pointer_checks.d
+++ b/tests/codegen/fno_delete_null_pointer_checks.d
@@ -1,0 +1,50 @@
+// Test -fno-delete-null-pointer-checks
+
+// RUN: %ldc -c -output-ll -of=%t_ub.ll %s && FileCheck -check-prefix=NULL_UB -check-prefix=BOTH %s < %t_ub.ll
+// RUN: %ldc -fno-delete-null-pointer-checks -c -output-ll -of=%t.ll %s && FileCheck -check-prefix=NULL_OK -check-prefix=BOTH %s < %t.ll
+
+// BOTH-LABEL: define{{.*}} @foo
+// BOTH-SAME: #[[ATTR:[0-9]+]]
+extern (C) double foo(double a, double b)
+{
+    double c;
+
+    return a * b + c;
+
+// BOTH-LABEL: define{{.*}} @{{.*}}nested_func
+// NULL_UB-SAME: nonnull
+// NULL_OK-NOT: nonnull
+    void nested_func()
+    {
+        c = 1;
+    }
+}
+
+struct S
+{
+// BOTH-LABEL: define{{.*}} @{{.*}}member_func
+// NULL_UB-SAME: nonnull
+// NULL_OK-NOT: nonnull
+    void member_func() {}
+}
+
+class C
+{
+// BOTH-LABEL: define{{.*}} @{{.*}}member_2_func
+// NULL_UB-SAME: nonnull
+// NULL_OK-NOT: nonnull
+    void member_2_func() {}
+}
+
+// BOTH-LABEL: define{{.*}} @{{.*}}some_other_function
+// NULL_UB-SAME: nonnull
+// NULL_OK-NOT: nonnull
+struct Opaque;
+void some_other_function(ref Opaque b)
+{
+
+}
+
+// NULL_OK-DAG: attributes #[[ATTR]] ={{.*null.pointer.is.valid}}
+// NULL_UB-NOT: null-pointer-is-valid
+// NULL_UB-NOT: null_pointer_is_valid


### PR DESCRIPTION
The commandline option name stems from GCC and Clang.