### PR TITLE
Replace `sprintf` with safer `snprintf`

### DIFF
--- a/dmd/root/ctfloat.d
+++ b/dmd/root/ctfloat.d
@@ -208,6 +208,8 @@ extern (C++) struct CTFloat
     static real_t parse(const(char)* literal, bool* isOutOfRange = null);
     @system
     static int sprint(char* str, char fmt, real_t x);
+    @system
+    static int snprint(char* str, size_t str_buf_length, char fmt, real_t x);
   }
   else
   {

--- a/dmd/root/ctfloat.h
+++ b/dmd/root/ctfloat.h
@@ -70,6 +70,9 @@ struct CTFloat
 
     static real_t parse(const char *literal, bool *isOutOfRange = NULL);
     static int sprint(char *str, char fmt, real_t x);
+#if IN_LLVM
+    static int snprint(char *str, size_t str_buf_length, char fmt, real_t x);
+#endif
 
     static size_t hash(real_t a);
 

--- a/dmd/root/longdouble.h
+++ b/dmd/root/longdouble.h
@@ -26,6 +26,7 @@ typedef volatile long double volatile_longdouble;
 #define sprintf __mingw_sprintf
 #endif
 
+#if !IN_LLVM // warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.
 inline size_t ld_sprint(char* str, int fmt, longdouble x)
 {
     if (((longdouble)(unsigned long long)x) == x)
@@ -43,6 +44,7 @@ inline size_t ld_sprint(char* str, int fmt, longdouble x)
         return sprintf(str, sfmt, x);
     }
 }
+#endif
 
 #if __MINGW32__
 #undef sprintf

--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -434,7 +434,7 @@ static void remap_args(std::string &insnt, size_t nargs, size_t idx,
     needle = prefix + digits[i] + suffix;
     size_t pos = insnt.find(needle);
     if (std::string::npos != pos) {
-      sprintf(buf, "%llu", static_cast<unsigned long long>(idx++));
+      snprintf(buf, 10, "%llu", static_cast<unsigned long long>(idx++));
     }
     while (std::string::npos != (pos = insnt.find(needle))) {
       insnt.replace(pos, needle.size(), buf);

--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -172,7 +172,7 @@ LDCPragma DtoGetPragma(Scope *sc, PragmaDeclaration *decl,
       priority = 65535;
     }
     char buf[8];
-    sprintf(buf, "%llu", static_cast<unsigned long long>(priority));
+    snprintf(buf, 8, "%llu", static_cast<unsigned long long>(priority));
     arg1str = strdup(buf);
     return ident == Id::LDC_global_crt_ctor || ident == Id::crt_constructor
                ? LLVMglobal_crt_ctor

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -448,9 +448,9 @@ llvm::GlobalVariable *IrClass::getInterfaceVtblSymbol(BaseClass *b,
 
     // Thunk prefix
     char thunkPrefix[16];
-    int thunkLen = sprintf(thunkPrefix, "Thn%d_", b->offset);
+    int thunkLen = snprintf(thunkPrefix, 16, "Thn%d_", b->offset);
     char thunkPrefixLen[16];
-    sprintf(thunkPrefixLen, "%d", thunkLen);
+    snprintf(thunkPrefixLen, 16, "%d", thunkLen);
 
     OutBuffer mangledName;
     mangledName.writestring("_D");
@@ -499,7 +499,7 @@ LLConstant *IrClass::getInterfaceVtblInit(BaseClass *b,
   constants.reserve(vtbl_array.length);
 
   char thunkPrefix[16];
-  sprintf(thunkPrefix, "Thn%d_", b->offset);
+  snprintf(thunkPrefix, 16, "Thn%d_", b->offset);
 
   const auto voidPtrTy = getVoidPtrType();
 


### PR DESCRIPTION
fixes compilation warning on newer clang versions.

See https://issues.dlang.org/show_bug.cgi?id=23648 for frontend.