### PR TITLE
Remove double `env` from lit tests.

### DIFF
--- a/tests/sanitizers/asan_fakestack_GC.d
+++ b/tests/sanitizers/asan_fakestack_GC.d
@@ -14,7 +14,7 @@
 // RUN: %ldc %s -of=%t1%exe && %t1%exe -O
 // RUN: %ldc -g -fsanitize=address %s -of=%t_asan%exe -O
 // RUN: %t_asan%exe
-// RUN: env %env_asan_opts=detect_stack_use_after_return=true %t_asan%exe 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=detect_stack_use_after_return=true %t_asan%exe 2>&1 | FileCheck %s
 
 import core.memory;
 import core.thread;

--- a/tests/sanitizers/asan_fiber_main.d
+++ b/tests/sanitizers/asan_fiber_main.d
@@ -11,10 +11,10 @@
 // object files from the previous compilation).
 
 // RUN: %ldc -g -fsanitize=address %s -of=%t1%exe  &&  not %t1%exe  2>&1 | FileCheck %s
-// RUN: env %env_asan_opts=detect_stack_use_after_return=true not %t1%exe  2>&1 | FileCheck %s --check-prefix=FAKESTACK
+// RUN: %env_asan_opts=detect_stack_use_after_return=true not %t1%exe  2>&1 | FileCheck %s --check-prefix=FAKESTACK
 
 // RUN: %ldc -g -fsanitize=address %s -of=%t22%exe -d-version=BAD_AFTER_YIELD  &&  not %t22%exe 2>&1 | FileCheck %s
-// RUN: env %env_asan_opts=detect_stack_use_after_return=true not %t22%exe 2>&1 | FileCheck %s --check-prefix=FAKESTACK
+// RUN: %env_asan_opts=detect_stack_use_after_return=true not %t22%exe 2>&1 | FileCheck %s --check-prefix=FAKESTACK
 
 import core.thread;
 

--- a/tests/sanitizers/asan_use_after_return.d
+++ b/tests/sanitizers/asan_use_after_return.d
@@ -7,7 +7,7 @@
 // object files from the previous compilation).
 
 // RUN: %ldc -g -fsanitize=address %s -of=%t%exe
-// RUN: not env %env_asan_opts=detect_stack_use_after_return=true %t%exe 2>&1 | FileCheck %s
+// RUN: not %env_asan_opts=detect_stack_use_after_return=true %t%exe 2>&1 | FileCheck %s
 
 import core.memory;
 import std.stdio;

--- a/tests/sanitizers/lsan_memleak.d
+++ b/tests/sanitizers/lsan_memleak.d
@@ -5,7 +5,7 @@
 // UNSUPPORTED: Windows, FreeBSD
 
 // RUN: %ldc -g -fsanitize=address %s -of=%t_asan%exe
-// RUN: not env %env_asan_opts=detect_leaks=true %t_asan%exe 2>&1 | FileCheck %s
+// RUN: not %env_asan_opts=detect_leaks=true %t_asan%exe 2>&1 | FileCheck %s
 // RUN: %ldc -g -fsanitize=leak %s -of=%t%exe
 // RUN: not %t%exe 2>&1 | FileCheck %s
 


### PR DESCRIPTION
The substitution `%env_asan_opts` already contains the `env` command.