### PR TITLE
Fix some lit tests for typed pointer LLVM15.

### DIFF
--- a/tests/codegen/gh3692_llvm15.d
+++ b/tests/codegen/gh3692_llvm15.d
@@ -7,40 +7,39 @@
 
 
 // D `int[3]` rewritten to LL `{ i64, i32 }` for SysV ABI - mismatching size and alignment
-// CHECK: define void @_D13gh3692_llvm154takeFG3iZv({ i64, i32 } %a_arg)
+// CHECK-LABEL: define void @_D13gh3692_llvm154takeFG3iZv({ i64, i32 } %a_arg)
 void take(int[3] a)
 {
     // the `{ i64, i32 }` size is 16 bytes, so we need a padded alloca (with 8-bytes alignment)
-    // CHECK-NEXT: %a = alloca { i64, i32 }, align 8
-    // CHECK-NEXT: store { i64, i32 } %a_arg, ptr %a
+    // CHECK-NEXT: = alloca { i64, i32 }, align 8
 }
 
-// CHECK: define void @_D13gh3692_llvm154passFZv()
+// CHECK-LABEL: define void @_D13gh3692_llvm154passFZv()
 void pass()
 {
     // CHECK-NEXT: %arrayliteral = alloca [3 x i32], align 4
     // we need an extra padded alloca with proper alignment
     // CHECK-NEXT: %.BaseBitcastABIRewrite_padded_arg_storage = alloca { i64, i32 }, align 8
-    // CHECK:      %.BaseBitcastABIRewrite_arg = load { i64, i32 }, ptr %.BaseBitcastABIRewrite_padded_arg_storage
+    // CHECK:      %.BaseBitcastABIRewrite_arg = load { i64, i32 }, {{\{ i64, i32 \}\*|ptr}} %.BaseBitcastABIRewrite_padded_arg_storage
     take([1, 2, 3]);
 }
 
 
 // D `int[4]` rewritten to LL `{ i64, i64 }` for SysV ABI - mismatching alignment only
-// CHECK: define void @_D13gh3692_llvm155take4FG4iZv({ i64, i64 } %a_arg)
+// CHECK-LABEL: define void @_D13gh3692_llvm155take4FG4iZv({ i64, i64 } %a_arg)
 void take4(int[4] a)
 {
     // the alloca should have 8-bytes alignment, even though a.alignof == 4
     // CHECK-NEXT: %a = alloca [4 x i32], align 8
-    // CHECK-NEXT: store { i64, i64 } %a_arg, ptr %a
+    // CHECK: store { i64, i64 } %a_arg, {{\{ i64, i64 \}\*|ptr}} %
 }
 
-// CHECK: define void @_D13gh3692_llvm155pass4FZv()
+// CHECK-LABEL: define void @_D13gh3692_llvm155pass4FZv()
 void pass4()
 {
     // CHECK-NEXT: %arrayliteral = alloca [4 x i32], align 4
     // we need an extra alloca with 8-bytes alignment
     // CHECK-NEXT: %.BaseBitcastABIRewrite_padded_arg_storage = alloca { i64, i64 }, align 8
-    // CHECK:      %.BaseBitcastABIRewrite_arg = load { i64, i64 }, ptr %.BaseBitcastABIRewrite_padded_arg_storage
+    // CHECK:      %.BaseBitcastABIRewrite_arg = load { i64, i64 }, {{\{ i64, i64 \}\*|ptr}} %.BaseBitcastABIRewrite_padded_arg_storage
     take4([1, 2, 3, 4]);
 }

--- a/tests/codegen/inline_ir.d
+++ b/tests/codegen/inline_ir.d
@@ -2,7 +2,7 @@
 
 import ldc.llvmasm;
 import ldc.intrinsics;
-static if (LLVM_atleast!15)
+version (LDC_LLVM_OpaquePointers)
 {
   alias __irEx!("", "store i32 %1, ptr %0, !nontemporal !0", "!0 = !{i32 1}", void, int*, int) nontemporalStore;
   alias __irEx!("!0 = !{i32 1}", "%i = load i32, ptr %0, !nontemporal !0\nret i32 %i", "", int, const int*) nontemporalLoad;


### PR DESCRIPTION
Now the tests support opaque and typed ptr output.