### PR TITLE
Fix v1.31 regression wrt. unresolved `IrAggr`

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -39,6 +39,7 @@
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
 #include "ir/irtypeaggr.h"
+#include "ir/irtypeclass.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ManagedStatic.h"
@@ -1895,16 +1896,12 @@ DLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
       // Cast the pointer we got to the canonical struct type the indices are
       // based on.
       LLType *st = nullptr;
-      LLType *pst = nullptr;
-      if (ad->isClassDeclaration()) {
-        st = getIrAggr(ad)->getLLStructType();
-        pst = DtoType(ad->type);
+      if (auto irtc = irTypeAggr->isClass()) {
+        st = irtc->getMemoryLLType();
+      } else {
+        st = irTypeAggr->getLLType();
       }
-      else {
-        st = DtoType(ad->type);
-        pst = getPtrToType(st);
-      }
-      ptr = DtoBitCast(ptr, pst);
+      ptr = DtoBitCast(ptr, st->getPointerTo());
       ptr = DtoGEP(st, ptr, 0, off);
       ty = isaStruct(st)->getElementType(off);
     }

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -46,7 +46,8 @@ LLValue *loadThisPtr(AggregateDeclaration *ad, IrFunction &irfunc) {
 }
 
 LLValue *indexVThis(AggregateDeclaration *ad,  LLValue* val) {
-  llvm::StructType *st = getIrAggr(ad, true)->getLLStructType();
+  DtoResolveDsymbol(ad);
+  llvm::StructType *st = getIrAggr(ad)->getLLStructType();
   unsigned idx = getVthisIdx(ad);
   return DtoLoad(st->getElementType(idx),
                  DtoGEP(st, val, 0, idx, ".vthis"));
@@ -226,7 +227,7 @@ void DtoResolveNestedContext(const Loc &loc, AggregateDeclaration *decl,
     DtoResolveDsymbol(decl);
 
     unsigned idx = getVthisIdx(decl);
-    llvm::StructType *st = getIrAggr(decl, true)->getLLStructType();
+    llvm::StructType *st = getIrAggr(decl)->getLLStructType();
     LLValue *gep = DtoGEP(st, value, 0, idx, ".vthis");
     DtoStore(DtoBitCast(nest, st->getElementType(idx)), gep);
   }

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -441,9 +441,8 @@ void buildTypeInfo(TypeInfoDeclaration *decl) {
     assert(isBuiltin && "existing global expected to be the init symbol of a "
                         "built-in TypeInfo");
   } else {
-    DtoType(decl->type);
-    TypeClass *tclass = decl->type->isTypeClass();
-    LLType *type = getIrType(tclass)->isClass()->getMemoryLLType();
+    TypeClass *tc = decl->type->isTypeClass();
+    LLType *type = getIrType(tc->sym->type, true)->isClass()->getMemoryLLType();
     // We need to keep the symbol mutable as the type is not declared as
     // immutable on the D side, and e.g. synchronized() can be used on the
     // implicit monitor.


### PR DESCRIPTION
And use `IrTypeClass::getVtblType()` to get the vtable LLVM array type, instead of deriving it from the `IrClass::getVtblSymbol()` global (invoking that function may define the vtable!).

I've hit some compiler crashes for the Symmetry code base, on Windows only. I guess the problem surfaced due to `-link-defaultlib-shared`, which on Windows causes some vtables of instantiated classes to be defined whenever accessing the vtable symbol. I don't have a reduced test case unfortunately.