### PR TITLE
Fix regression with LLVM 13+: some errors in inline assembly don't stop compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Supports LLVM 9.0 - 15.0.
 
 #### Bug fixes
+- Fix regression with LLVM 13+: some errors in inline assembly don't stop compilation. (#4293, #4331)
 
 # LDC 1.31.0 (2022-02-11)
 

--- a/tests/fail_compilation/asm_error_gh4293.d
+++ b/tests/fail_compilation/asm_error_gh4293.d
@@ -1,0 +1,11 @@
+// Make sure an invalid asm instruction causes a non-zero exit code.
+
+// RUN: not %ldc -c %s 2> %t.stderr
+// RUN: FileCheck %s < %t.stderr
+
+void main()
+{
+    asm { "some_garbage"; }
+}
+
+// CHECK: error:


### PR DESCRIPTION
Based on Luís' #4302.