### PR TITLE
Add -fsanitize-address-use-after-return

### DIFF
--- a/driver/cl_options_sanitizers.h
+++ b/driver/cl_options_sanitizers.h
@@ -20,6 +20,7 @@ class FuncDeclaration;
 namespace llvm {
 class raw_ostream;
 class StringRef;
+enum class AsanDetectStackUseAfterReturnMode;
 }
 
 namespace opts {
@@ -36,6 +37,8 @@ enum SanitizerCheck : SanitizerBits {
   LeakSanitizer = 1 << 5,
 };
 extern SanitizerBits enabledSanitizers;
+
+extern cl::opt<llvm::AsanDetectStackUseAfterReturnMode> fSanitizeAddressUseAfterReturn;
 
 inline bool isAnySanitizerEnabled() { return enabledSanitizers; }
 inline bool isSanitizerEnabled(SanitizerBits san) {

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -454,7 +454,7 @@ static void addAddressSanitizerPasses(ModulePassManager &mpm,
   aso.CompileKernel = false;
   aso.Recover = false;
   aso.UseAfterScope = true;
-  aso.UseAfterReturn = AsanDetectStackUseAfterReturnMode::Runtime;
+  aso.UseAfterReturn = opts::fSanitizeAddressUseAfterReturn;
 
 #if LDC_LLVM_VER >= 1600
   mpm.addPass(AddressSanitizerPass(aso));

--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -3,7 +3,8 @@
 // REQUIRES: Fuzzer, ASan
 
 // See https://github.com/ldc-developers/ldc/issues/2222 for %disable_fp_elim
-// RUN: %ldc -g -fsanitize=address,fuzzer %disable_fp_elim %s -of=%t%exe
+// See https://github.com/ldc-developers/ldc/pull/4328 for -fsanitize-address-use-after-return=never
+// RUN: %ldc -g -fsanitize=address,fuzzer -fsanitize-address-use-after-return=never %disable_fp_elim %s -of=%t%exe
 // RUN: not %t%exe 2>&1 | FileCheck %s
 
 bool FuzzMe(ubyte* data, size_t dataSize)
@@ -12,7 +13,7 @@ bool FuzzMe(ubyte* data, size_t dataSize)
            data[0] == 'F' &&
            data[1] == 'U' &&
            data[2] == 'Z' &&
-    // CHECK: ERROR: AddressSanitizer: {{stack-buffer-overflow|stack-use-after-return}}
+    // CHECK: ERROR: AddressSanitizer: stack-buffer-overflow
     // CHECK-NEXT: READ of size 1
     // CHECK-NEXT: #0 {{.*}} in {{.*fuzz_asan6FuzzMe.*}} {{.*}}fuzz_asan.d:
     // FIXME, debug line info is wrong (Github issue #2090). Once fixed, add [[@LINE+1]]


### PR DESCRIPTION
Make this optional for users, especially on Linux. Because LLVM's default has changed, and using UAR requires runtime support.
relates to https://github.com/ldc-developers/ldc/pull/4328