### PR TITLE
Fix segmentation fault when compiling va_arg intrinsic

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1046,6 +1046,8 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   }
 
   if (fd->ir->isDefined()) {
+    if (fd->llvmInternal == LLVMva_arg)
+      return;
     llvm::Function *func = getIrFunc(fd)->getLLVMFunc();
     assert(func);
     if (!linkageAvailableExternally &&

--- a/tests/compilable/va_arg.d
+++ b/tests/compilable/va_arg.d
@@ -1,0 +1,9 @@
+// RUN: %ldc -c %s
+
+alias va_list = void*;
+
+pragma(LDC_va_arg) T va_arg(T)(va_list ap);
+
+int foo(va_list ap) {
+    return va_arg!(int)(ap);
+}


### PR DESCRIPTION
The following code currently causes a segmentation fault in LDC when compiled:

```d
alias va_list = void*;

pragma(LDC_va_arg) T va_arg(T)(va_list ap);

int foo(va_list ap) {
    return va_arg!(int)(ap);
}
```

This PR fixes that.

Note: the following code still causes a segfault during compilation, but I think this is a bug in LLVM, not LDC.

```d
alias va_list = void*;

pragma(LDC_va_arg) T va_arg(T)(va_list ap);

string foo(va_list ap) {
    return va_arg!(string)(ap);
}
```

I will report that separately to the LLVM project.