### PR TITLE
Fix gccbuiltins_*.di generation for LLVM >= 15.

### DIFF
--- a/runtime/druntime/src/core/simd.d
+++ b/runtime/druntime/src/core/simd.d
@@ -39,6 +39,14 @@ template Vector(T)
 
 /* Handy aliases
  */
+version (LDC)
+{
+static if (is(Vector!(void[4])))    alias Vector!(void[4])    void4;        ///
+static if (is(Vector!(byte[4])))    alias Vector!(byte[4])    byte4;        ///
+static if (is(Vector!(ubyte[4])))   alias Vector!(ubyte[4])   ubyte4;       ///
+static if (is(Vector!(short[2])))   alias Vector!(short[2])   short2;       ///
+static if (is(Vector!(ushort[2])))  alias Vector!(ushort[2])  ushort2;      ///
+}
 static if (is(Vector!(void[8])))    alias Vector!(void[8])    void8;        ///
 static if (is(Vector!(double[1])))  alias Vector!(double[1])  double1;      ///
 static if (is(Vector!(float[2])))   alias Vector!(float[2])   float2;       ///

--- a/tests/compilable/intrinsics_imports.d
+++ b/tests/compilable/intrinsics_imports.d
@@ -1,0 +1,34 @@
+// Very basic test to check that instrinsics include file is made correctly.
+// Related to https://github.com/ldc-developers/ldc/issues/4347
+
+// Just do SemA, no codegen, such that it works on all CI systems.
+// RUN: %ldc -o- %s
+
+import core.simd;
+static import ldc.gccbuiltins_aarch64;
+static import ldc.gccbuiltins_arm;
+static import ldc.gccbuiltins_mips;
+static import ldc.gccbuiltins_nvvm;
+static import ldc.gccbuiltins_ppc;
+static import ldc.gccbuiltins_x86;
+
+short2 s2;
+short8 s8;
+double2 d2;
+void* ptr;
+
+void main()
+{
+    ldc.gccbuiltins_aarch64.__builtin_arm_isb(1);
+
+    ldc.gccbuiltins_arm.__builtin_arm_dmb(2);
+
+    short2 mips = ldc.gccbuiltins_mips.__builtin_mips_addq_s_ph(s2, s2);
+
+    long nvvm = ldc.gccbuiltins_nvvm.__nvvm_mbarrier_arrive(ptr);
+
+    short8 ppc8 = ldc.gccbuiltins_ppc.__builtin_altivec_crypto_vpmsumh(s8, s8);
+
+    ldc.gccbuiltins_x86.__builtin_ia32_lfence();
+    double2 x86 = ldc.gccbuiltins_x86.__builtin_ia32_maxpd(d2, d2);
+}

--- a/tests/compilable/intrinsics_imports.d
+++ b/tests/compilable/intrinsics_imports.d
@@ -25,10 +25,11 @@ void main()
 
     short2 mips = ldc.gccbuiltins_mips.__builtin_mips_addq_s_ph(s2, s2);
 
-    long nvvm = ldc.gccbuiltins_nvvm.__nvvm_mbarrier_arrive(ptr);
+    double nvvm = ldc.gccbuiltins_nvvm.__nvvm_fma_rz_d(1.0, 2.0, 3.0);
 
     short8 ppc8 = ldc.gccbuiltins_ppc.__builtin_altivec_crypto_vpmsumh(s8, s8);
 
     ldc.gccbuiltins_x86.__builtin_ia32_lfence();
+    ldc.gccbuiltins_x86.__builtin_ia32_umonitor(ptr);
     double2 x86 = ldc.gccbuiltins_x86.__builtin_ia32_maxpd(d2, d2);
 }

--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -29,6 +29,12 @@
 using namespace std;
 using namespace llvm;
 
+#if LDC_LLVM_VER >= 1500
+#define BUILTIN_NAME_STRING "ClangBuiltinName"
+#else
+#define BUILTIN_NAME_STRING "GCCBuiltinName"
+#endif
+
 string dtype(Record* rec, bool readOnlyMem)
 {
     Init* typeInit = rec->getValueInit("VT");
@@ -85,10 +91,10 @@ StringRef attributes(ListInit* propertyList)
 
 void processRecord(raw_ostream& os, Record& rec, string arch)
 {
-    if(!rec.getValue("GCCBuiltinName"))
+    if(!rec.getValue(BUILTIN_NAME_STRING))
         return;
 
-    const StringRef builtinName = rec.getValueAsString("GCCBuiltinName");
+    const StringRef builtinName = rec.getValueAsString(BUILTIN_NAME_STRING);
     string name = rec.getName().str();
 
     if(name.substr(0, 4) != "int_" || name.find(arch) == string::npos)


### PR DESCRIPTION
Adds simple testcase to test that generation of intrinsics import files is indeed happening. This uncovered missing vector type aliases for MIPS, fixed that too. Resolves issue #4347