### PR TITLE
DRAFT: Fix issue #2670, support for extern(Objective-C)

### DIFF
--- a/gen/objcgen.cpp
+++ b/gen/objcgen.cpp
@@ -10,7 +10,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "gen/objcgen.h"
-
+#include "dmd/expression.h"
+#include "dmd/identifier.h"
 #include "dmd/mtype.h"
 #include "dmd/objc.h"
 #include "gen/irstate.h"
@@ -40,9 +41,8 @@ bool objc_isSupported(const llvm::Triple &triple) {
   return false;
 }
 
-ObjCState::ObjCState(llvm::Module &module) : module(module)
-{
-  llvm::LLVMContext& c = module.getContext();
+ObjCState::ObjCState(llvm::Module &module) : module(module) {
+  llvm::LLVMContext &c = module.getContext();
   _class_t = llvm::StructType::create(c, "_class_t");
   _objc_cache = llvm::StructType::create(c, "_objc_cache");
   _class_ro_t = llvm::StructType::create(c, "_class_ro_t");
@@ -54,95 +54,64 @@ ObjCState::ObjCState(llvm::Module &module) : module(module)
   _ivar_list_t = llvm::StructType::create(c, "_ivar_list_t");
   _prop_t = llvm::StructType::create(c, "_prop_t");
 
+  _class_t->setBody(
+      {_class_t->getPointerTo(), _class_t->getPointerTo(),
+       _objc_cache->getPointerTo(), _class_t->getPointerTo(),
+       /// i8* (i8*, i8*)**
+       llvm::FunctionType::get(
+           llvm::Type::getInt8PtrTy(c),
+           {llvm::Type::getInt8PtrTy(c), llvm::Type::getInt8PtrTy(c)}, false)
+           ->getPointerTo()
+           ->getPointerTo(),
+       _class_ro_t->getPointerTo()});
 
+  _class_ro_t->setBody(
+      {llvm::Type::getInt32Ty(c), llvm::Type::getInt32Ty(c),
+       llvm::Type::getInt32Ty(c), llvm::Type::getInt8PtrTy(c),
+       llvm::Type::getInt8PtrTy(c), __method_list_t->getPointerTo(),
+       _objc_protocol_list->getPointerTo(), _ivar_list_t->getPointerTo(),
+       llvm::Type::getInt8PtrTy(c), _prop_list_t->getPointerTo()});
 
-  _class_t->setBody({
-    _class_t->getPointerTo(),
-    _class_t->getPointerTo(),
-    _objc_cache->getPointerTo(),
-    _class_t->getPointerTo(),
-    ///i8* (i8*, i8*)**
-    llvm::FunctionType::get(
-      llvm::Type::getInt8PtrTy(c), 
-      {llvm::Type::getInt8PtrTy(c), llvm::Type::getInt8PtrTy(c)},
-      false
-    )->getPointerTo()->getPointerTo(),
-    _class_ro_t->getPointerTo()
-  });
+  __method_list_t->setBody({llvm::Type::getInt32Ty(c),
+                            llvm::Type::getInt32Ty(c),
+                            llvm::ArrayType::get(_objc_method, 0)});
 
-  _class_ro_t->setBody({
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt8PtrTy(c),
-    llvm::Type::getInt8PtrTy(c),
-    __method_list_t->getPointerTo(),
-    _objc_protocol_list->getPointerTo(),
-    _ivar_list_t->getPointerTo(),
-    llvm::Type::getInt8PtrTy(c),
-    _prop_list_t->getPointerTo()
-  });
+  _objc_method->setBody({llvm::Type::getInt8PtrTy(c),
+                         llvm::Type::getInt8PtrTy(c),
+                         llvm::Type::getInt8PtrTy(c)});
 
-  __method_list_t->setBody({
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::ArrayType::get(_objc_method, 0)
-  });
-
-  _objc_method->setBody({
-    llvm::Type::getInt8PtrTy(c), 
-    llvm::Type::getInt8PtrTy(c), 
-    llvm::Type::getInt8PtrTy(c)
-  });
-
-  _objc_protocol_list->setBody({
-    llvm::Type::getInt64Ty(c),
-    llvm::ArrayType::get(_protocol_t->getPointerTo(), 0)
-  });
+  _objc_protocol_list->setBody(
+      {llvm::Type::getInt64Ty(c),
+       llvm::ArrayType::get(_protocol_t->getPointerTo(), 0)});
 
   _protocol_t->setBody({
-    llvm::Type::getInt8PtrTy(c),
-    llvm::Type::getInt8PtrTy(c),
-    _objc_protocol_list->getPointerTo(),
-    __method_list_t->getPointerTo(),
-    __method_list_t->getPointerTo(),
-    __method_list_t->getPointerTo(),
-    __method_list_t->getPointerTo(),
-    _prop_list_t->getPointerTo(),
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt8PtrTy(c)->getPointerTo(),
-    llvm::Type::getInt8PtrTy(c),
-    _prop_list_t->getPointerTo(),
+      llvm::Type::getInt8PtrTy(c),
+      llvm::Type::getInt8PtrTy(c),
+      _objc_protocol_list->getPointerTo(),
+      __method_list_t->getPointerTo(),
+      __method_list_t->getPointerTo(),
+      __method_list_t->getPointerTo(),
+      __method_list_t->getPointerTo(),
+      _prop_list_t->getPointerTo(),
+      llvm::Type::getInt32Ty(c),
+      llvm::Type::getInt32Ty(c),
+      llvm::Type::getInt8PtrTy(c)->getPointerTo(),
+      llvm::Type::getInt8PtrTy(c),
+      _prop_list_t->getPointerTo(),
   });
 
-  _ivar_list_t->setBody({
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::ArrayType::get(_ivar_t, 0)
-  });
+  _ivar_list_t->setBody({llvm::Type::getInt32Ty(c), llvm::Type::getInt32Ty(c),
+                         llvm::ArrayType::get(_ivar_t, 0)});
 
-  _ivar_t->setBody({
-    llvm::Type::getInt64PtrTy(c),
-    llvm::Type::getInt8PtrTy(c),
-    llvm::Type::getInt8PtrTy(c),
-    llvm::Type::getInt32Ty(c),
-    llvm::Type::getInt32Ty(c)
-  });
+  _ivar_t->setBody({llvm::Type::getInt64PtrTy(c), llvm::Type::getInt8PtrTy(c),
+                    llvm::Type::getInt8PtrTy(c), llvm::Type::getInt32Ty(c),
+                    llvm::Type::getInt32Ty(c)});
 
+  _prop_list_t->setBody({llvm::Type::getInt32Ty(c), llvm::Type::getInt32Ty(c),
+                         llvm::ArrayType::get(_prop_t, 0)});
 
-  _prop_list_t->setBody({
-    llvm::Type::getInt32Ty(c), 
-    llvm::Type::getInt32Ty(c),
-    llvm::ArrayType::get(_prop_t, 0)
-  });
-
-  _prop_t->setBody({
-    llvm::Type::getInt8PtrTy(c), 
-    llvm::Type::getInt8PtrTy(c)
-  });
+  _prop_t->setBody({llvm::Type::getInt8PtrTy(c), llvm::Type::getInt8PtrTy(c)});
 }
-
 
 LLGlobalVariable *ObjCState::getCStringVar(const char *symbol,
                                            const llvm::StringRef &str,
@@ -189,6 +158,22 @@ LLGlobalVariable *ObjCState::getMethVarRef(const ObjcSelector &sel) {
           : "__OBJC,__message_refs,literal_pointers,no_dead_strip");
 
   // Save for later lookup and prevent optimizer elimination
+  methVarRefMap[s] = selref;
+  retain(selref);
+
+  return selref;
+}
+
+LLGlobalVariable *ObjCState::classVarRef(const ObjcClassReferenceExp &cre) {
+  llvm::StringRef s(std::string("OBJC_CLASS_$_")
+                    + cre.classDeclaration->objc.identifier->toChars());
+
+  auto it = methVarRefMap.find(s);
+  if (it != methVarRefMap.end()) {
+    return it->second;
+  }
+  auto selref = new LLGlobalVariable(module, _class_t, false, LLGlobalValue::ExternalLinkage, llvm::ConstantPointerNull::get(_class_t->getPointerTo()), s);
+  selref->setSection("__DATA,__objc_classrefs");
   methVarRefMap[s] = selref;
   retain(selref);
 

--- a/gen/objcgen.cpp
+++ b/gen/objcgen.cpp
@@ -80,7 +80,7 @@ ObjCState::ObjCState(llvm::Module &module) : module(module)
 
   _objc_protocol_list = llvm::StructType::Create(
     llvm::Type::getInt64Ty(c),
-    llvm::ArrayType::get(0, _protocol_t)
+    llvm::ArrayType::get(0, llvm::PointerType::get(_protocol_t))
   );
 
   _protocol_t = llvm::StructType::Create(

--- a/gen/objcgen.h
+++ b/gen/objcgen.h
@@ -15,6 +15,7 @@
 
 #include <vector>
 #include "llvm/ADT/StringMap.h"
+#include "llvm/IR/Type.h"
 
 struct ObjcSelector;
 namespace llvm {
@@ -29,13 +30,25 @@ bool objc_isSupported(const llvm::Triple &triple);
 // Objective-C state tied to an LLVM module (object file).
 class ObjCState {
 public:
-  ObjCState(llvm::Module &module) : module(module) {}
+  ObjCState(llvm::Module &module);
 
   llvm::GlobalVariable *getMethVarRef(const ObjcSelector &sel);
   void finalize();
 
 private:
   llvm::Module &module;
+
+  llvm::Type* _class_t;
+  llvm::Type* _objc_cache;
+  llvm::Type* _class_ro_t;
+  llvm::Type* __method_list_t;
+  llvm::Type* _objc_method;
+  llvm::Type* _objc_protocol_list;
+  llvm::Type* _protocol_t;
+  llvm::Type* _ivar_list_t;
+  llvm::Type* _ivar_t;
+  llvm::Type* _prop_list_t;
+  llvm::Type* _prop_t;
 
   // symbols that shouldn't be optimized away
   std::vector<llvm::Constant *> retainedSymbols;

--- a/gen/objcgen.h
+++ b/gen/objcgen.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include "llvm/ADT/StringMap.h"
 #include "llvm/IR/Type.h"
+#include "llvm/IR/DerivedTypes.h"
 
 struct ObjcSelector;
 namespace llvm {
@@ -38,17 +39,17 @@ public:
 private:
   llvm::Module &module;
 
-  llvm::Type* _class_t;
-  llvm::Type* _objc_cache;
-  llvm::Type* _class_ro_t;
-  llvm::Type* __method_list_t;
-  llvm::Type* _objc_method;
-  llvm::Type* _objc_protocol_list;
-  llvm::Type* _protocol_t;
-  llvm::Type* _ivar_list_t;
-  llvm::Type* _ivar_t;
-  llvm::Type* _prop_list_t;
-  llvm::Type* _prop_t;
+  llvm::StructType* _class_t;
+  llvm::StructType* _objc_cache;
+  llvm::StructType* _class_ro_t;
+  llvm::StructType* __method_list_t;
+  llvm::StructType* _objc_method;
+  llvm::StructType* _objc_protocol_list;
+  llvm::StructType* _protocol_t;
+  llvm::StructType* _ivar_list_t;
+  llvm::StructType* _ivar_t;
+  llvm::StructType* _prop_list_t;
+  llvm::StructType* _prop_t;
 
   // symbols that shouldn't be optimized away
   std::vector<llvm::Constant *> retainedSymbols;

--- a/gen/objcgen.h
+++ b/gen/objcgen.h
@@ -25,6 +25,7 @@ class GlobalVariable;
 class Module;
 class Triple;
 }
+class ObjcClassReferenceExp;
 
 bool objc_isSupported(const llvm::Triple &triple);
 
@@ -61,6 +62,7 @@ private:
                                       const llvm::StringRef &str,
                                       const char *section);
   llvm::GlobalVariable *getMethVarName(const llvm::StringRef &name);
+  llvm::GlobalVariable *classVarRef(const ObjcClassReferenceExp& cre);
   void retain(llvm::Constant *sym);
 
   void genImageInfo();

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2809,8 +2809,10 @@ public:
     IF_LOG Logger::print("ObjcClassReferenceExp::toElem() %s\n", e->toChars());
     LOG_SCOPE;
 
-    auto name = e->classDeclaration->objc.identifier->toChars();
-    result = DtoLoad(llvm::StructType::get(gIR->context(), "_class_t")->getPointerTo(), name);
+    auto name = std::string("OBJC_CLASS_$_") + e->classDeclaration->objc.identifier->toChars();
+
+    IF_LOG Logger::print("%s\n", name.data());
+    // result = DtoLoad(llvm::StructType::get(gIR->context(), "_class_t")->getPointerTo(), name);
 
   }
 

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2809,7 +2809,9 @@ public:
     IF_LOG Logger::print("ObjcClassReferenceExp::toElem() %s\n", e->toChars());
     LOG_SCOPE;
 
-    
+    auto name = e->classDeclaration->objc.identifier->toChars();
+    result = DtoLoad(llvm::StructType::get(gIR->context(), "_class_t")->getPointerTo(), name);
+
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2805,6 +2805,13 @@ public:
     llvm_unreachable("Unknown TypeidExp argument kind");
   }
 
+  void visit(ObjcClassReferenceExp *e) override {
+    IF_LOG Logger::print("ObjcClassReferenceExp::toElem() %s\n", e->toChars());
+    LOG_SCOPE;
+
+    
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
 
 #define STUB(x)                                                                \


### PR DESCRIPTION
Most here are obviously WIP, there is a bunch of forwarded things and as I'm only getting started with LLVM I would like you guys to review what I'm doing right now. 

@kinke @thewilsonator @jacob-carlborg 
#2670 

I'm trying to replicate those structs defined by the following objc code:

```objc
#import <objc/runtime.h>
#import <Foundation/Foundation.h>

int main()
{
  [NSObject alloc];
  return 0;
}
```

```ll
; ModuleID = 'test.m'
source_filename = "test.m"
target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-macosx12.0.0"

; Trying to create those strructs
%0 = type opaque
%struct._class_t = type { %struct._class_t*, %struct._class_t*, %struct._objc_cache*, i8* (i8*, i8*)**, %struct._class_ro_t* }
%struct._objc_cache = type opaque
%struct._class_ro_t = type { i32, i32, i32, i8*, i8*, %struct.__method_list_t*, %struct._objc_protocol_list*, %struct._ivar_list_t*, i8*, %struct._prop_list_t* }
%struct.__method_list_t = type { i32, i32, [0 x %struct._objc_method] }
%struct._objc_method = type { i8*, i8*, i8* }
%struct._objc_protocol_list = type { i64, [0 x %struct._protocol_t*] }
%struct._protocol_t = type { i8*, i8*, %struct._objc_protocol_list*, %struct.__method_list_t*, %struct.__method_list_t*, %struct.__method_list_t*, %struct.__method_list_t*, %struct._prop_list_t*, i32, i32, i8**, i8*, %struct._prop_list_t* }
%struct._ivar_list_t = type { i32, i32, [0 x %struct._ivar_t] }
%struct._ivar_t = type { i64*, i8*, i8*, i32, i32 }
%struct._prop_list_t = type { i32, i32, [0 x %struct._prop_t] }
%struct._prop_t = type { i8*, i8* }

@"OBJC_CLASS_$_NSObject" = external global %struct._class_t
@"OBJC_CLASSLIST_REFERENCES_$_" = internal global %struct._class_t* @"OBJC_CLASS_$_NSObject", section "__DATA,__objc_classrefs,regular,no_dead_strip", align 8
@llvm.compiler.used = appending global [1 x i8*] [i8* bitcast (%struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_" to i8*)], section "llvm.metadata"

; Function Attrs: noinline optnone ssp uwtable
define i32 @main() #0 {
  %1 = alloca i32, align 4
  store i32 0, i32* %1, align 4
  %2 = load %struct._class_t*, %struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_", align 8
  %3 = bitcast %struct._class_t* %2 to i8*
  %4 = call i8* @objc_alloc(i8* %3)
  %5 = bitcast i8* %4 to %0*
  ret i32 0
}

declare i8* @objc_alloc(i8*)

attributes #0 = { noinline optnone ssp uwtable "darwin-stkchk-strong-link" "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "probe-stack"="___chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }

!llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10}
!llvm.ident = !{!11}

!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 13, i32 1]}
!1 = !{i32 1, !"Objective-C Version", i32 2}
!2 = !{i32 1, !"Objective-C Image Info Version", i32 0}
!3 = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
!4 = !{i32 1, !"Objective-C Garbage Collection", i8 0}
!5 = !{i32 1, !"Objective-C Class Properties", i32 64}
!6 = !{i32 1, !"Objective-C Enforce ClassRO Pointer Signing", i8 0}
!7 = !{i32 1, !"wchar_size", i32 4}
!8 = !{i32 7, !"PIC Level", i32 2}
!9 = !{i32 7, !"uwtable", i32 1}
!10 = !{i32 7, !"frame-pointer", i32 2}
!11 = !{!"Apple clang version 14.0.0 (clang-1400.0.29.202)"}

```