### PR TITLE
CI: Bump Ubuntu 18 jobs to Ubuntu 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,14 +100,14 @@ commonSteps: &commonSteps
 
 version: 2
 jobs:
-  Ubuntu-18.04-multilib-rtSanitizers:
+  Ubuntu-20.04-multilib-rtSanitizers:
     <<: *commonSteps
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:20.04
     environment:
       - PARALLELISM: 2
       - CI_OS: linux
-      - EXTRA_APT_PACKAGES: llvm-9-dev libclang-common-9-dev
+      - EXTRA_APT_PACKAGES: llvm-dev libclang-common-10-dev
       - HOST_LDC_VERSION: 1.24.0
       - EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DRT_SUPPORT_SANITIZERS=ON -DBUILD_LTO_LIBS=ON"
   Ubuntu-20.04-sharedLibsOnly-gdmd:
@@ -147,7 +147,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - Ubuntu-18.04-multilib-rtSanitizers
+      - Ubuntu-20.04-multilib-rtSanitizers
       - Ubuntu-20.04-sharedLibsOnly-gdmd
       - macOS-x64
       - macOS-x64-sharedLibsOnly

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,7 +167,7 @@ packaging_steps_template: &PACKAGING_STEPS_TEMPLATE
       tools/upload-to-github.sh CI ../artifacts/ldc2-*.tar.xz
     fi
 
-# Installs Ubuntu 18.04+ prerequisites.
+# Installs Ubuntu 20.04+ prerequisites.
 # Requires env variables CI_ARCH, HOST_LDC_VERSION, EXTRA_APT_PACKAGES and EXTRA_CMAKE_FLAGS.
 install_ubuntu_prerequisites_template: &INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
   install_prerequisites_script: |
@@ -235,16 +235,16 @@ environment:
   GITHUB_TOKEN: ENCRYPTED[0955bd48c8d4e5391446fc0149d0719ad0b63df27ec9e6c180a5730a5b10dc7f28f09d1383423db158d21380ee2b022a]
 
 task:
-  name: Ubuntu 18.04 x64 multilib rtSanitizers
+  name: Ubuntu 20.04 x64 multilib rtSanitizers
   container:
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     cpu: 8
     memory: 16G
   timeout_in: 20m
   environment:
     CI_ARCH: x86_64
     CI_OS: linux
-    EXTRA_APT_PACKAGES: "llvm-9-dev libclang-common-9-dev"
+    EXTRA_APT_PACKAGES: "llvm-dev libclang-common-10-dev"
     EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DRT_SUPPORT_SANITIZERS=ON -DBUILD_LTO_LIBS=ON"
     PARALLELISM: 8
   << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
@@ -271,9 +271,9 @@ task:
   << : *COMMON_STEPS_TEMPLATE
 
 task:
-  name: Ubuntu 18.04 x64 bootstrap
+  name: Ubuntu 20.04 x64 bootstrap
   container:
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     cpu: 8
     memory: 16G
   timeout_in: 15m
@@ -281,7 +281,7 @@ task:
     CI_ARCH: x86_64
     CI_OS: linux
     HOST_LDC_VERSION: 1.9.0
-    EXTRA_APT_PACKAGES: "llvm-9-dev libclang-common-9-dev"
+    EXTRA_APT_PACKAGES: "llvm-dev libclang-common-10-dev"
     EXTRA_CMAKE_FLAGS: "-DBUILD_LTO_LIBS=ON"
     PARALLELISM: 8
   << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
@@ -318,9 +318,9 @@ task:
   << : *COMMON_STEPS_TEMPLATE
 
 task:
-  name: Ubuntu 18.04 aarch64
+  name: Ubuntu 20.04 aarch64
   arm_container:
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     cpu: 4
     memory: 8G
   timeout_in: 60m
@@ -338,7 +338,7 @@ task:
       -DLLVM_ROOT_DIR=$CIRRUS_WORKING_DIR/../llvm
       -DD_COMPILER=$CIRRUS_WORKING_DIR/../bootstrap-ldc/bin/ldmd2
     PARALLELISM: 4
-    CLANG_VERSION: '14.0.6' # 15.0.6 requires libtinfo.so.6 (but Ubuntu 18 has v5 only)
+    CLANG_VERSION: '15.0.3' # 15.0.6 requires a more recent libstdc++.so.6 than shipped with Ubuntu 20
     CC: $CIRRUS_WORKING_DIR/../clang/bin/clang
     CXX: $CIRRUS_WORKING_DIR/../clang/bin/clang++
   << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -18,11 +18,11 @@ runs:
         export DEBIAN_FRONTEND=noninteractive
         sudo dpkg --add-architecture i386
         sudo apt-get -q update
-        # Don't use latest gdb v10 from Ubuntu toolchain PPA with regressions, use official v8
+        # Don't use latest gdb v10+ from Ubuntu toolchain PPA with regressions, use official v9
         sudo apt-get -yq install \
           git-core cmake g++-multilib \
           libcurl4 libcurl4:i386 \
-          curl gdb=8.1.1-0ubuntu1 p7zip-full tzdata unzip zip python3-pip
+          curl gdb=9.1-0ubuntu1 p7zip-full tzdata unzip zip python3-pip
 
     - name: 'Linux: Download & extract clang' # into ../clang
       if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         include:
 
           - job_name: Linux x86_64 multilib
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             arch: x86_64
             bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
             # To improve portability of the generated binaries, link the C++ standard library statically.
@@ -169,13 +169,13 @@ jobs:
             with_pgo: true
 
           - job_name: Android armv7a
-            host_os: ubuntu-18.04
+            host_os: ubuntu-20.04
             os: android
             arch: armv7a
             android_x86_arch: i686
 
           - job_name: Android aarch64
-            host_os: ubuntu-18.04
+            host_os: ubuntu-20.04
             os: android
             arch: aarch64
             android_x86_arch: x86_64

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -15,28 +15,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job_name: Ubuntu 18.04, LLVM 15, latest LDC beta
-            os: ubuntu-18.04
+          - job_name: Ubuntu 20.04, LLVM 15, latest LDC beta
+            os: ubuntu-20.04
             host_dc: ldc-beta
             llvm_version: 15.0.6
-          - job_name: Ubuntu 18.04, LLVM 14, latest LDC beta
-            os: ubuntu-18.04
+          - job_name: Ubuntu 20.04, LLVM 14, latest LDC beta
+            os: ubuntu-20.04
             host_dc: ldc-beta
             llvm_version: 14.0.0
             # the compiler-rt libs installation is somehow non-standard
             cmake_flags: -DLDC_INSTALL_LLVM_RUNTIME_LIBS_OS=x86_64-unknown-linux-gnu -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=""
-          - job_name: Ubuntu 18.04, LLVM 12, latest LDC beta
-            os: ubuntu-18.04
+          - job_name: Ubuntu 20.04, LLVM 12, latest LDC beta
+            os: ubuntu-20.04
             host_dc: ldc-beta
             llvm_version: 12.0.1
             cmake_flags: -DLIB_SUFFIX=64
-          - job_name: Ubuntu 18.04, LLVM 11, latest LDC beta
-            os: ubuntu-18.04
+          - job_name: Ubuntu 20.04, LLVM 11, latest LDC beta
+            os: ubuntu-20.04
             host_dc: ldc-beta
             llvm_version: 11.1.0
             cmake_flags: -DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON
-          - job_name: Ubuntu 18.04, LLVM 9, latest DMD beta
-            os: ubuntu-18.04
+          - job_name: Ubuntu 20.04, LLVM 9, latest DMD beta
+            os: ubuntu-20.04
             host_dc: dmd-beta
             llvm_version: 9.0.1
             cmake_flags: -DBUILD_SHARED_LIBS=OFF -DRT_SUPPORT_SANITIZERS=ON -DLDC_LINK_MANUALLY=ON
@@ -71,13 +71,13 @@ jobs:
           python3 -m pip install --user setuptools wheel
           python3 -m pip install --user lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
-      - name: 'Linux: Install gdb'
+      - name: 'Linux: Install gdb and llvm-symbolizer'
         if: runner.os == 'Linux'
         run: |
           set -eux
           sudo apt-get update
-          # Don't use latest gdb v10 from Ubuntu toolchain PPA with regressions, use official v8
-          sudo apt-get install gdb=8.1.1-0ubuntu1
+          # Don't use latest gdb v10+ from Ubuntu toolchain PPA with regressions, use official v9
+          sudo apt-get install gdb=9.1-0ubuntu1 llvm
 
       - name: Try to restore cached LLVM
         uses: actions/cache@v2
@@ -140,7 +140,14 @@ jobs:
           if [[ '${{ matrix.llvm_version }}' = 9.* ]]; then
             echo "config.available_features.remove('Fuzzer')" >> tests/sanitizers/lit.local.cfg
           fi
+          # LLVM 14+ on Linux: don't use vanilla llvm-symbolizer (no support for zlib-compressed debug sections => failing ASan tests)
+          if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.llvm_version }}' =~ ^1[4-9]\. ]]; then
+            mv llvm/bin/llvm-symbolizer llvm/bin/llvm-symbolizer.bak
+          fi
           ctest -V -R "lit-tests"
+          if [[ -f llvm/bin/llvm-symbolizer.bak ]]; then
+            mv llvm/bin/llvm-symbolizer.bak llvm/bin/llvm-symbolizer
+          fi
       - name: Run DMD testsuite
         if: success() || failure()
         run: ctest -V -R "dmd-testsuite"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LDC master
 
 #### Big news
+- The prebuilt Linux packages are now generated on a Ubuntu 20.04 box, so the min required `glibc` version has been raised from 2.26 to 2.31. (#4367)
 
 #### Platform support
 


### PR DESCRIPTION
As GitHub Actions eagerly removed support for it (5 years old now).