### PR TITLE
GH Actions: Bump macOS 10.15 jobs to macOS 11

### DIFF
--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -40,16 +40,16 @@ jobs:
             host_dc: dmd-beta
             llvm_version: 9.0.1
             cmake_flags: -DBUILD_SHARED_LIBS=OFF -DRT_SUPPORT_SANITIZERS=ON -DLDC_LINK_MANUALLY=ON
-          - job_name: macOS 10.15, LLVM 10, latest DMD beta
-            os: macos-10.15
+          - job_name: macOS 11, LLVM 10, latest DMD beta
+            os: macos-11
             host_dc: dmd-beta
             llvm_version: 10.0.1
-            cmake_flags: -DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON -DLDC_LINK_MANUALLY=ON
-          - job_name: macOS 10.15, LLVM 13, latest LDC beta
-            os: macos-10.15
+            cmake_flags: -DBUILD_SHARED_LIBS=ON -DRT_SUPPORT_SANITIZERS=ON -DLDC_LINK_MANUALLY=ON -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+          - job_name: macOS 11, LLVM 13, latest LDC beta
+            os: macos-11
             host_dc: ldc-beta
             llvm_version: 13.0.1
-            cmake_flags: -DBUILD_SHARED_LIBS=OFF
+            cmake_flags: -DBUILD_SHARED_LIBS=OFF -DD_COMPILER_FLAGS=-gcc=/usr/bin/c++ -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
     name: ${{ matrix.job_name }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
As the 10.x images aren't available anymore.