### PR TITLE
Fix #4354 - Huge compile slowdown with -g and the new LLVM pass manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Platform support
 
 #### Bug fixes
+- Fix potentially huge compile slowdowns with `-g` and LLVM 15+. (#4354, #4393)
 
 # LDC 1.32.1 (2023-04-17)
 

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -322,7 +322,7 @@ void writeModule(llvm::Module *m, const char *filename) {
     }
   }
 
-  // run optimizer
+  // run LLVM passes (optimizer + codegen)
   {
     ::TimeTraceScope timeScope("Optimize", filename);
     ldc_optimize_module(m);

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -618,6 +618,8 @@ static PipelineTuningOptions getPipelineTuningOptions(unsigned optLevelVal, unsi
  */
 //Run optimization passes using the new pass manager
 void runOptimizationPasses(llvm::Module *M) {
+  TimeTraceScope timeScope("Optimization passes");
+
   // Create a ModulePassManager to hold and optimize the collection of
   // per-module passes we are about to build.
 
@@ -660,7 +662,7 @@ void runOptimizationPasses(llvm::Module *M) {
   if (!noVerify) {
     pb.registerPipelineStartEPCallback([&](ModulePassManager &mpm,
                                           OptimizationLevel level) {
-      mpm.addPass(createModuleToFunctionPassAdaptor(VerifierPass()));
+      mpm.addPass(VerifierPass());
     });
   }
 
@@ -752,6 +754,8 @@ void runOptimizationPasses(llvm::Module *M) {
 }
 //Run codgen passes using the legacy pass manager
 void runCodegenPasses(llvm::Module* M) {
+  TimeTraceScope timeScope("Codegen passes");
+
   legacy::PassManager mpm;
 
   // Add an appropriate TargetLibraryInfo pass for the module's triple.


### PR DESCRIPTION
Tested manually with the Symmetry project, and LLVM 14. The `-g` compile times with both legacy and new pass managers are on par again.