### PR TITLE
Implement -femit-local-var-lifetime which adds local (stack) variable…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Big news
 - Frontend, druntime and Phobos are at version [2.103.1](https://dlang.org/changelog/2.103.0.html), incl. new command-line option `-verror-supplements`. (#4345)
+- New commandline option `-femit-local-var-lifetime` that enables variable lifetime (scope) annotation to LLVM IR codegen. Lifetime annotation enables stack memory reuse for local variables with non-overlapping scope. (#4395)
 
 #### Platform support
 

--- a/gen/funcgenstate.cpp
+++ b/gen/funcgenstate.cpp
@@ -100,8 +100,8 @@ llvm::BasicBlock *SwitchCaseTargets::getOrCreate(Statement *stmt,
 }
 
 FuncGenState::FuncGenState(IrFunction &irFunc, IRState &irs)
-    : irFunc(irFunc), scopes(irs), jumpTargets(scopes), switchTargets(),
-      irs(irs) {}
+    : irFunc(irFunc), scopes(irs), localVariableLifetimeAnnotator(irs),
+      jumpTargets(scopes), switchTargets(), irs(irs) {}
 
 LLCallBasePtr FuncGenState::callOrInvoke(llvm::Value *callee,
                                          llvm::FunctionType *calleeType,

--- a/gen/funcgenstate.h
+++ b/gen/funcgenstate.h
@@ -17,6 +17,7 @@
 #include "gen/irstate.h"
 #include "gen/pgo_ASTbased.h"
 #include "gen/trycatchfinally.h"
+#include "gen/variable_lifetime.h"
 #include "llvm/ADT/DenseMap.h"
 #include <vector>
 
@@ -175,6 +176,8 @@ public:
   IrFunction &irFunc;
 
   TryCatchFinallyScopes scopes;
+
+  LocalVariableLifetimeAnnotator localVariableLifetimeAnnotator;
 
   JumpTargets jumpTargets;
 

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -294,3 +294,6 @@ DValue *makeVarDValue(Type *type, VarDeclaration *vd,
 bool toInPlaceConstruction(DLValue *lhs, Expression *rhs);
 
 std::string llvmTypeToString(LLType *type);
+
+void emitLifetimeStart(llvm::Value *size, llvm::Value *addr);
+void emitLifetimeEnd(llvm::Value *size, llvm::Value *addr);

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -203,8 +203,10 @@ static void legacyAddGarbageCollect2StackPass(const PassManagerBuilder &builder,
 }
 
 static void legacyAddAddressSanitizerPasses(const PassManagerBuilder &Builder,
-                                      PassManagerBase &PM) {
-  PM.add(createAddressSanitizerFunctionPass());
+                                            PassManagerBase &PM) {
+  PM.add(createAddressSanitizerFunctionPass(/*CompileKernel = */ false,
+                                            /*Recover = */ false,
+                                            /*UseAfterScope = */ true));
   PM.add(createModuleAddressSanitizerLegacyPassPass());
 }
 

--- a/gen/variable_lifetime.cpp
+++ b/gen/variable_lifetime.cpp
@@ -1,0 +1,97 @@
+//===-- gen/variable_lifetime.cpp - -----------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Codegen for local variable lifetime: llvm.lifetime.start abd
+// llvm.lifetime.end.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/variable_lifetime.h"
+
+#include "driver/cl_options.h"
+#include "gen/irstate.h"
+
+#include <vector>
+#include <utility>
+
+// TODO: make this option depend on -O and -fsanitize settings.
+static llvm::cl::opt<bool> fEmitLocalVarLifetime(
+    "femit-local-var-lifetime",
+    llvm::cl::desc(
+        "Emit local variable lifetime, enabling more optimizations."),
+    llvm::cl::Hidden, llvm::cl::ZeroOrMore);
+
+LocalVariableLifetimeAnnotator::LocalVariableLifetimeAnnotator(IRState &irs)
+    : irs(irs) {
+  allocaType =
+      llvm::Type::getInt8Ty(irs.context())
+          ->getPointerTo(irs.module.getDataLayout().getAllocaAddrSpace());
+}
+
+void LocalVariableLifetimeAnnotator::pushScope() { scopes.emplace_back(); }
+
+void LocalVariableLifetimeAnnotator::addLocalVariable(llvm::Value *address,
+                                                      llvm::Value *size) {
+  assert(address);
+  assert(size);
+
+  if (!fEmitLocalVarLifetime)
+    return;
+
+  if (scopes.empty())
+    return;
+
+  // Push to scopes
+  scopes.back().variables.emplace_back(size, address);
+
+  // Emit lifetime start
+  address = irs.ir->CreateBitCast(address, allocaType);
+  irs.CreateCallOrInvoke(getLLVMLifetimeStartFn(), {size, address}, "",
+                         true /*nothrow*/);
+}
+
+// Emits end-of-lifetime annotation for all variables in current scope.
+void LocalVariableLifetimeAnnotator::popScope() {
+  if (scopes.empty())
+    return;
+
+  for (const auto &var : scopes.back().variables) {
+    auto size = var.first;
+    auto address = var.second;
+
+    address = irs.ir->CreateBitCast(address, allocaType);
+    assert(address);
+
+    irs.CreateCallOrInvoke(getLLVMLifetimeEndFn(), {size, address}, "",
+                           true /*nothrow*/);
+  }
+  scopes.pop_back();
+}
+
+/// Lazily declare the @llvm.lifetime.start intrinsic.
+llvm::Function *LocalVariableLifetimeAnnotator::getLLVMLifetimeStartFn() {
+  if (lifetimeStartFunction)
+    return lifetimeStartFunction;
+
+  lifetimeStartFunction = llvm::Intrinsic::getDeclaration(
+      &irs.module, llvm::Intrinsic::lifetime_start, allocaType);
+  assert(lifetimeStartFunction);
+  return lifetimeStartFunction;
+}
+
+/// Lazily declare the @llvm.lifetime.end intrinsic.
+llvm::Function *LocalVariableLifetimeAnnotator::getLLVMLifetimeEndFn() {
+  if (lifetimeEndFunction)
+    return lifetimeEndFunction;
+
+  lifetimeEndFunction = llvm::Intrinsic::getDeclaration(
+      &irs.module, llvm::Intrinsic::lifetime_end, allocaType);
+  assert(lifetimeEndFunction);
+  return lifetimeEndFunction;
+}

--- a/gen/variable_lifetime.h
+++ b/gen/variable_lifetime.h
@@ -1,0 +1,56 @@
+//===-- gen/variable_lifetime.h - -------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Codegen for local variable lifetime: llvm.lifetime.start abd
+// llvm.lifetime.end.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+#include <utility>
+
+namespace llvm {
+class Function;
+class Type;
+class Value;
+}
+struct IRState;
+
+struct LocalVariableLifetimeAnnotator {
+  struct LocalVariableScope {
+    std::vector<std::pair<llvm::Value *, llvm::Value *>> variables;
+  };
+  /// Stack of scopes, each scope can have multiple variables.
+  std::vector<LocalVariableScope> scopes;
+
+  /// Cache the llvm types and intrinsics used for codegen.
+  llvm::Function *lifetimeStartFunction = nullptr;
+  llvm::Function *lifetimeEndFunction = nullptr;
+  llvm::Type *allocaType = nullptr;
+
+  llvm::Function *getLLVMLifetimeStartFn();
+  llvm::Function *getLLVMLifetimeEndFn();
+
+  IRState &irs;
+
+public:
+  LocalVariableLifetimeAnnotator(IRState &irs);
+
+  /// Opens a new scope.
+  void pushScope();
+
+  /// Closes current scope and emits end-of-lifetime annotation for all
+  /// variables in current scope.
+  void popScope();
+
+  /// Register a new local variable for lifetime annotation.
+  void addLocalVariable(llvm::Value *address, llvm::Value *size);
+};

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -38,7 +38,7 @@ set(BUILD_SHARED_LIBS     AUTO                                CACHE STRING "Whet
 set(D_FLAGS               -w;-de;-preview=dip1000;-preview=dtorfields;-preview=fieldwise CACHE STRING "Runtime D compiler flags, separated by ';'")
 set(D_EXTRA_FLAGS         ""                                  CACHE STRING "Runtime extra D compiler flags, separated by ';'")
 set(D_FLAGS_DEBUG         -g;-link-defaultlib-debug;-d-debug  CACHE STRING "Runtime D compiler flags (debug libraries), separated by ';'")
-set(D_FLAGS_RELEASE       -O3;-release                        CACHE STRING "Runtime D compiler flags (release libraries), separated by ';'")
+set(D_FLAGS_RELEASE       -O3;-release;-femit-local-var-lifetime  CACHE STRING "Runtime D compiler flags (release libraries), separated by ';'")
 set(COMPILE_ALL_D_FILES_AT_ONCE ON                            CACHE BOOL   "Compile all D files for the runtime libs in a single command line instead of separately. Disabling this is useful for many CPU cores and/or iterative development.")
 set(RT_ARCHIVE_WITH_LDC   ON                                  CACHE STRING "Whether to archive the static runtime libs via LDC instead of CMake archiver")
 set(RT_CFLAGS             ""                                  CACHE STRING "Runtime extra C compiler flags, separated by ' '")

--- a/tests/codegen/lifetime_local_variables.d
+++ b/tests/codegen/lifetime_local_variables.d
@@ -1,0 +1,122 @@
+// RUN: %ldc -femit-local-var-lifetime -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+extern(C): // disable mangling for easier matching
+
+void opaque(byte* i);
+
+// CHECK-LABEL: define void @foo_array_foo()
+void foo_array_foo() {
+    // CHECK: alloca [400 x i8]
+    // CHECK: alloca [800 x i8]
+    {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 400
+        byte[400] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 400
+    }
+
+    {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 800
+        byte[800] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 800
+    }
+
+    // CHECK-LABEL: ret void
+}
+
+// CHECK-LABEL: define void @foo_forloop_foo()
+void foo_forloop_foo() {
+    byte i;
+    // CHECK: call void @opaque
+    // This call should appear before lifetime start of while-loop variable.
+    opaque(&i);
+    for (byte[13] d; d[0] < 2; d[0]++) {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 13
+        // Lifetime should start before initializing the variable
+        // CHECK: call void @llvm.memset.p0i8.i{{.*}}13
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 44
+        byte[44] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 44
+        // CHECK: endfor:
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 13
+    }
+
+    // CHECK-LABEL: ret void
+}
+
+// CHECK-LABEL: define void @foo_whileloop_foo()
+void foo_whileloop_foo() {
+    byte i;
+    // CHECK: call void @opaque
+    // This call should appear before lifetime start of while-loop variable.
+    opaque(&i);
+    while (ulong d = 131) {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 8
+        // Lifetime should start before initializing the variable
+        // CHECK: store i64 131
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 33
+        byte[33] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 33
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 8
+    }
+
+    // CHECK-LABEL: ret void
+}
+
+// CHECK-LABEL: define void @foo_if_foo()
+void foo_if_foo() {
+    byte i;
+    // CHECK: call void @opaque
+    // This call should appear before lifetime start of if-statement condition variable.
+    opaque(&i);
+    // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 8
+    // Lifetime should start before initializing the variable
+    // CHECK: store i64 565
+    if (ulong d = 565) {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 72
+        byte[72] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 72
+    } else {
+        // d is out of scope here.
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 51
+        byte[51] arr = void;
+        // CHECK: call void @opaque
+        opaque(&arr[0]);
+        // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 51
+    }
+    // CHECK: endif:
+    // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 8
+
+    // CHECK-LABEL: ret void
+}
+
+struct S {
+    byte[123] a;
+    ~this() {
+        opaque(&a[1]);
+    }
+}
+
+void opaque_S(S* i);
+
+// CHECK-LABEL: define void @foo_struct_foo()
+void foo_struct_foo() {
+    {
+        // CHECK: call void @llvm.lifetime.start.p0i8(i64 immarg 123
+        S s;
+        // CHECK: invoke void @opaque_S
+        opaque_S(&s);
+    }
+
+    // CHECK: call void @llvm.lifetime.end.p0i8(i64 immarg 123
+    // CHECK-NEXT: ret void
+}

--- a/tests/sanitizers/asan_use_after_scope.d
+++ b/tests/sanitizers/asan_use_after_scope.d
@@ -1,0 +1,24 @@
+// REQUIRES: ASan
+
+// RUN: %ldc -femit-local-var-lifetime -g -fsanitize=address %s -of=%t%exe
+// RUN: not %t%exe 2>&1 | FileCheck %s
+
+// CHECK: ERROR: AddressSanitizer: stack-use-after-scope
+// CHECK-NEXT: WRITE of size 4
+
+void useAfterScope() {
+  int* p;
+  {
+    int x = 0;
+    p = &x;  // cannot statically disallow this because
+    *p = 1;  // this is a valid use of things
+  }
+// CHECK-NEXT: #0 {{.*}} in {{.*}}asan_use_after_scope.d:[[@LINE+1]]
+  *p = 5;  // but then this can happen... stack use after scope bug!
+}
+
+void main()
+{
+// CHECK-NEXT: #1 {{.*}} in {{.*}}asan_use_after_scope.d:[[@LINE+1]]
+    useAfterScope();
+}

--- a/tests/sanitizers/asan_use_after_scope_if.d
+++ b/tests/sanitizers/asan_use_after_scope_if.d
@@ -1,0 +1,23 @@
+// REQUIRES: ASan
+
+// RUN: %ldc -femit-local-var-lifetime -g -fsanitize=address %s -of=%t%exe
+// RUN: not %t%exe 2>&1 | FileCheck %s
+
+// CHECK: ERROR: AddressSanitizer: stack-use-after-scope
+// CHECK-NEXT: WRITE of size 4
+
+void useAfterScope(int xparam) {
+  int* p;
+  if (int x = xparam) {
+    p = &x;  // cannot statically disallow this because
+    *p = 1;  // this is a valid use of things
+  }
+// CHECK-NEXT: #0 {{.*}} in {{.*}}asan_use_after_scope_if.d:[[@LINE+1]]
+  *p = 5;  // but then this can happen... stack use after scope bug!
+}
+
+void main()
+{
+// CHECK-NEXT: #1 {{.*}} in {{.*}}asan_use_after_scope_if.d:[[@LINE+1]]
+    useAfterScope(1);
+}


### PR DESCRIPTION
… lifetime annotation to LLVM IR, which enables sharing stack space for variables whose lifetimes do not overlap.

Resolves issue #2227

This is not enabled by default yet, to prevent miscompilation due to bugs (should be enabled for optimization levels > 0, and when sanitizers are enabled).

Compiling a piece of druntime, this is the stack space diff (output with `-fwarn-stack-size=100`):
```diff
-Without lifetime annotation
+WITH lifetime annotation!
-warning: stack frame size (144) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp3zip10ZipArchive5buildMFNaNfZ9__lambda6TACQDiQBt13ArchiveMemberZQDfMFNaNbNiNfQBlmZv'
+warning: stack frame size (128) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp3zip10ZipArchive5buildMFNaNfZ9__lambda6TACQDiQBt13ArchiveMemberZQDfMFNaNbNiNfQBlmZv'
-warning: stack frame size (128) exceeds limit (100) in function '_D3std7variant__T8VariantNVmi16ZQp__T7handlerTSQBt11concurrency3TidZQBfFEQCtQCs__TQCnVmi16ZQCw4OpIDPG16hPvZl'
+warning: stack frame size (112) exceeds limit (100) in function '_D3std7variant__T8VariantNVmi16ZQp__T7handlerTSQBt11concurrency3TidZQBfFEQCtQCs__TQCnVmi16ZQCw4OpIDPG16hPvZl'
-warning: stack frame size (224) exceeds limit (100) in function '_D3std3uni__T16UnicodeSetParserTSQBf5regex8internal6parser__T6ParserTAyaTSQCuQBpQBmQBg7CodeGenZQBiZQDi8parseSetMFNfZSQElQEk__T13InversionListTSQFlQFk8GcPolicyZQBh'
+warning: stack frame size (192) exceeds limit (100) in function '_D3std3uni__T16UnicodeSetParserTSQBf5regex8internal6parser__T6ParserTAyaTSQCuQBpQBmQBg7CodeGenZQBiZQDi8parseSetMFNfZSQElQEk__T13InversionListTSQFlQFk8GcPolicyZQBh'
-warning: stack frame size (176) exceeds limit (100) in function '_D3std3uni__T16UnicodeSetParserTSQBf5regex8internal6parser__T6ParserTAyaTSQCuQBpQBmQBg7CodeGenZQBiZQDi8parseSetMFZ5applyFNfEQEsQEr__TQEqTQEbZQEy8OperatorKSQFxQFw__T5StackTSQGoQGn__T13InversionListTSQHoQHn8GcPolicyZQBhZQCcZb'
-warning: stack frame size (112) exceeds limit (100) in function '_D3std6string__T8_indexOfTAxaZQoFNaNbNiNfQpwEQBr8typecons__T4FlagVAyaa13_6361736553656e736974697665ZQBoZl'
-warning: stack frame size (160) exceeds limit (100) in function '_D3std6socket10getAddressFNfMAxaMQeZACQBkQBj7Address'
+warning: stack frame size (144) exceeds limit (100) in function '_D3std6socket10getAddressFNfMAxaMQeZACQBkQBj7Address'
-warning: stack frame size (368) exceeds limit (100) in function '_D3std5regex8internal6parser7CodeGen11charsetToIrMFNeSQCa3uni__T13InversionListTSQDbQBb8GcPolicyZQBhZv'
+warning: stack frame size (304) exceeds limit (100) in function '_D3std5regex8internal6parser7CodeGen11charsetToIrMFNeSQCa3uni__T13InversionListTSQDbQBb8GcPolicyZQBhZv'
-warning: stack frame size (144) exceeds limit (100) in function '_D3std5regex8internal6parser7CodeGen13fixRepetitionMFkkkbZv'
+warning: stack frame size (128) exceeds limit (100) in function '_D3std5regex8internal6parser7CodeGen13fixRepetitionMFkkkbZv'
-warning: stack frame size (400) exceeds limit (100) in function '_D3std5regex8internal6parser__T6ParserTAyaTSQBqQBpQBmQBg7CodeGenZQBi11parseEscapeMFNeZv'
+warning: stack frame size (320) exceeds limit (100) in function '_D3std5regex8internal6parser__T6ParserTAyaTSQBqQBpQBmQBg7CodeGenZQBi11parseEscapeMFNeZv'
-warning: stack frame size (704) exceeds limit (100) in function '_D3std5regex8internal9kickstart__T7ShiftOrTaZQl6__ctorMFNcNeKSQCiQChQCe2ir__T5RegexTaZQjAkZSQDmQDlQDiQDc__TQCvTaZQDb'
+warning: stack frame size (576) exceeds limit (100) in function '_D3std5regex8internal9kickstart__T7ShiftOrTaZQl6__ctorMFNcNeKSQCiQChQCe2ir__T5RegexTaZQjAkZSQDmQDlQDiQDc__TQCvTaZQDb'
-warning: stack frame size (432) exceeds limit (100) in function '_D3std5regex8internal12backtracking9CtContext10ctGenGroupMFKAxSQCjQCiQCf2ir8BytecodeiZSQDhQDgQDdQCxQCm7CtState'
+warning: stack frame size (416) exceeds limit (100) in function '_D3std5regex8internal12backtracking9CtContext10ctGenGroupMFKAxSQCjQCiQCf2ir8BytecodeiZSQDhQDgQDdQCxQCm7CtState'
-warning: stack frame size (880) exceeds limit (100) in function '_D3std7process11environment13opIndexAssignFNeNkMNgAaMAxaZANga'
+warning: stack frame size (608) exceeds limit (100) in function '_D3std7process11environment13opIndexAssignFNeNkMNgAaMAxaZANga'
-warning: stack frame size (880) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg12spawnProcessTAxAaZQBsFNeMQmEQCrQCq8RedirectxHAyaAyaSQDpQDo6ConfigMAxaZSQEiQEh12ProcessPipes'
-warning: stack frame size (880) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg12spawnProcessTAxaZQBrFNeMQlEQCqQCp8RedirectxHAyaAyaSQDoQDn6ConfigMQCaZSQEhQEg12ProcessPipes'
-warning: stack frame size (896) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg10spawnShellTAxaTAyaZQBtFNeMQpEQCsQCr8RedirectxHQBfAyaSQDqQDp6ConfigMQCeQCdZSQEmQEl12ProcessPipes'
+warning: stack frame size (608) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg12spawnProcessTAxAaZQBsFNeMQmEQCrQCq8RedirectxHAyaAyaSQDpQDo6ConfigMAxaZSQEiQEh12ProcessPipes'
+warning: stack frame size (608) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg12spawnProcessTAxaZQBrFNeMQlEQCqQCp8RedirectxHAyaAyaSQDoQDn6ConfigMQCaZSQEhQEg12ProcessPipes'
+warning: stack frame size (624) exceeds limit (100) in function '_D3std7process__T15pipeProcessImplSQBhQBg10spawnShellTAxaTAyaZQBtFNeMQpEQCsQCr8RedirectxHQBfAyaSQDqQDp6ConfigMQCeQCdZSQEmQEl12ProcessPipes'
-warning: stack frame size (304) exceeds limit (100) in function '_D3std7process__T11executeImplSQBdQBc11pipeProcessTAxAaZQBnFNeQlxHAyaAyaSQCtQCs6ConfigmMAxaZSQDn8typecons__T5TupleTiVQBza6_737461747573TQCsVQCwa6_6f7574707574ZQBz'
-warning: stack frame size (304) exceeds limit (100) in function '_D3std7process__T11executeImplSQBdQBc11pipeProcessTAxaZQBmFNeQkxHAyaAyaSQCsQCr6ConfigmMQBkZSQDm8typecons__T5TupleTiVQBza6_737461747573TQCsVQCwa6_6f7574707574ZQBz'
-warning: stack frame size (320) exceeds limit (100) in function '_D3std7process__T11executeImplS_DQBfQBe9pipeShellFNfMAxaEQCdQCc8RedirectxHAyaAyaSQDbQDa6ConfigMQBqQyZSQDwQDv12ProcessPipesTQCsTQCbZQEkFNeQDgxQCqQCmmMQDsQDaZSQFz8typecons__T5TupleTiVQEda6_737461747573TQEwVQFaa6_6f7574707574ZQBz'
+warning: stack frame size (224) exceeds limit (100) in function '_D3std7process__T11executeImplSQBdQBc11pipeProcessTAxAaZQBnFNeQlxHAyaAyaSQCtQCs6ConfigmMAxaZSQDn8typecons__T5TupleTiVQBza6_737461747573TQCsVQCwa6_6f7574707574ZQBz'
+warning: stack frame size (224) exceeds limit (100) in function '_D3std7process__T11executeImplSQBdQBc11pipeProcessTAxaZQBmFNeQkxHAyaAyaSQCsQCr6ConfigmMQBkZSQDm8typecons__T5TupleTiVQBza6_737461747573TQCsVQCwa6_6f7574707574ZQBz'
+warning: stack frame size (240) exceeds limit (100) in function '_D3std7process__T11executeImplS_DQBfQBe9pipeShellFNfMAxaEQCdQCc8RedirectxHAyaAyaSQDbQDa6ConfigMQBqQyZSQDwQDv12ProcessPipesTQCsTQCbZQEkFNeQDgxQCqQCmmMQDsQDaZSQFz8typecons__T5TupleTiVQEda6_737461747573TQEwVQFaa6_6f7574707574ZQBz'
-warning: stack frame size (224) exceeds limit (100) in function '_D3std4path__T9buildPathTAAxaZQqFNaNbNfMQpZAya'
+warning: stack frame size (208) exceeds limit (100) in function '_D3std4path__T9buildPathTAAxaZQqFNaNbNfMQpZAya'
-warning: stack frame size (1360) exceeds limit (100) in function '_D3std3net4curl4HTTP4Impl15onReceiveHeaderMFNdDFIAaIQdZvZ9__lambda2MFIQvZv'
+warning: stack frame size (1152) exceeds limit (100) in function '_D3std3net4curl4HTTP4Impl15onReceiveHeaderMFNdDFIAaIQdZvZ9__lambda2MFIQvZv'
-warning: stack frame size (240) exceeds limit (100) in function '_D3std4json__T6toJSONTSQv5array__T8AppenderTAyaZQoZQBlFKQBiKxSQCiQCh9JSONValueIbIEQDcQDb11JSONOptionsZ11toValueImplMFNeKxQCimZv'
+warning: stack frame size (224) exceeds limit (100) in function '_D3std4json__T6toJSONTSQv5array__T8AppenderTAyaZQoZQBlFKQBiKxSQCiQCh9JSONValueIbIEQDcQDb11JSONOptionsZ11toValueImplMFNeKxQCimZv'
-warning: stack frame size (288) exceeds limit (100) in function '_D3std8internal4math11biguintcore11mulInternalFNaNbNfAkAxkQdZv'
+warning: stack frame size (224) exceeds limit (100) in function '_D3std8internal4math11biguintcore11mulInternalFNaNbNfAkAxkQdZv'
-warning: stack frame size (176) exceeds limit (100) in function '_D3std6format5write__T14formattedWriteTSQBmQBl8NoOpSinkTaTmTmZQBoFNaNfQBfMxAammZk'
+warning: stack frame size (192) exceeds limit (100) in function '_D3std6format5write__T14formattedWriteTSQBmQBl8NoOpSinkTaTmTmZQBoFNaNfQBfMxAammZk'
-warning: stack frame size (176) exceeds limit (100) in function '_D3std6format4spec__T10FormatSpecTaZQp6fillUpMFNaNlNfZv'
+warning: stack frame size (144) exceeds limit (100) in function '_D3std6format4spec__T10FormatSpecTaZQp6fillUpMFNaNlNfZv'
-warning: stack frame size (240) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPvTaZQCbFNaNfKQBsMxPvMKxSQDyQDx4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (160) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPvTaZQCbFNaNfKQBsMxPvMKxSQDyQDx4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (352) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTQhTaZQBxFNaNfKQBsKQzMKxSQDtQDs4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (272) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTQhTaZQBxFNaNfKQBsKQzMKxSQDtQDs4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (352) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5stdio4File17LockingTextWriterTAyaTaZQCdFNfKQBwKQrMKxSQDxQDw4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (272) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5stdio4File17LockingTextWriterTAyaTaZQCdFNfKQBwKQrMKxSQDxQDw4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (240) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPxSQDcQDb4spec__T10FormatSpecTaZQpTaZQDhFNaNfKQCyMxPQByMKxQCeZv'
+warning: stack frame size (160) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPxSQDcQDb4spec__T10FormatSpecTaZQpTaZQDhFNaNfKQCyMxPQByMKxQCeZv'
-warning: stack frame size (352) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTAxaTaZQByFNaNfKQBtKQtMKxSQDuQDt4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (272) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTAxaTaZQByFNaNfKQBtKQtMKxSQDuQDt4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (352) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTyAaZQoTAyaTaZQByFNaNfKQBtKQtMKxSQDuQDt4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (272) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTyAaZQoTAyaTaZQByFNaNfKQBtKQtMKxSQDuQDt4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (352) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5stdio4File17LockingTextWriterTAxaTaZQCdFNfKQBwKQrMKxSQDxQDw4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (272) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5stdio4File17LockingTextWriterTAxaTaZQCdFNfKQBwKQrMKxSQDxQDw4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (240) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPxhTaZQCcFNaNfKQBtMxPhMKxSQDzQDy4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (160) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPxhTaZQCcFNaNfKQBtMxPhMKxSQDzQDy4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (256) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTAyAaTaZQBzFNaNfKQBuKQuMKxSQDvQDu4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (240) exceeds limit (100) in function '_D3std6format8internal5write__T11formatRangeTSQBs5array__T8AppenderTAyaZQoTAyAaTaZQBzFNaNfKQBuKQuMKxSQDvQDu4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (240) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPSQDb11parallelism12AbstractTaskTaZQDfFNaNfKQCwMxPSQEyQBxQBnMKxSQFlQFk4spec__T10FormatSpecTaZQpZv'
+warning: stack frame size (160) exceeds limit (100) in function '_D3std6format8internal5write__T15formatValueImplTSQBw5array__T8AppenderTAyaZQoTPSQDb11parallelism12AbstractTaskTaZQDfFNaNfKQCwMxPSQEyQBxQBnMKxSQFlQFk4spec__T10FormatSpecTaZQpZv'
-warning: stack frame size (448) exceeds limit (100) in function '_D3std4file8copyImplFNeMAxaMQeMPxaMQeEQBk8typecons__T4FlagVAyaa18_707265736572766541747472696275746573ZQByZv'
+warning: stack frame size (432) exceeds limit (100) in function '_D3std4file8copyImplFNeMAxaMQeMPxaMQeEQBk8typecons__T4FlagVAyaa18_707265736572766541747472696275746573ZQByZv'
-warning: stack frame size (592) exceeds limit (100) in function '_D3std4file7tempDirFNeZ__T15findExistingDirTAyaTQeTQhTQkTQnTQqZQBlFNfLQBaLQBeLQBiLQBmLQBqLQBuZQBy'
+warning: stack frame size (512) exceeds limit (100) in function '_D3std4file7tempDirFNeZ__T15findExistingDirTAyaTQeTQhTQkTQnTQqZQBlFNfLQBaLQBeLQBiLQBmLQBqLQBuZQBy'
-warning: stack frame size (144) exceeds limit (100) in function '_D3std12experimental9allocator15building_blocks14allocator_list__T13AllocatorListTSQDdQDcQCr8showcase14mmapRegionListFmZ7FactoryTSQEyQExQEmQEf14null_allocator13NullAllocatorZQEe12addAllocatorMFNaNbNimZPSQHtQHsQHhQHaQGm__TQFzTQFnTQDwZQGl4Node'
+warning: stack frame size (112) exceeds limit (100) in function '_D3std12experimental9allocator15building_blocks14allocator_list__T13AllocatorListTSQDdQDcQCr8showcase14mmapRegionListFmZ7FactoryTSQEyQExQEmQEf14null_allocator13NullAllocatorZQEe12addAllocatorMFNaNbNimZPSQHtQHsQHhQHaQGm__TQFzTQFnTQDwZQGl4Node'
-warning: stack frame size (160) exceeds limit (100) in function '_D3std8encoding14EncodingScheme6createFAyaZ24registerDefaultEncodingsFZb'
+warning: stack frame size (240) exceeds limit (100) in function '_D3std8encoding14EncodingScheme6createFAyaZ24registerDefaultEncodingsFZb'
-warning: stack frame size (544) exceeds limit (100) in function '_D3std8datetime8timezone13PosixTimeZone11getTimeZoneFNeAyaQdZyCQCjQCiQCcQBw'
+warning: stack frame size (528) exceeds limit (100) in function '_D3std8datetime8timezone13PosixTimeZone11getTimeZoneFNeAyaQdZyCQCjQCiQCcQBw'
-warning: stack frame size (192) exceeds limit (100) in function '_D3std11concurrency10MessageBox3putMFKSQBlQBk7MessageZv'
+warning: stack frame size (160) exceeds limit (100) in function '_D3std11concurrency10MessageBox3putMFKSQBlQBk7MessageZv'
-warning: stack frame size (192) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa17_612e74696d6554203c20622e74696d6554VQBqa1_61VQBza1_62ZQCtTASQFg8datetime8timezone13PosixTimeZone14TempTransitionZQGiFNaNbNiNfQCpmZv'
+warning: stack frame size (176) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa17_612e74696d6554203c20622e74696d6554VQBqa1_61VQBza1_62ZQCtTASQFg8datetime8timezone13PosixTimeZone14TempTransitionZQGiFNaNbNiNfQCpmZv'
-warning: stack frame size (160) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa17_612e74696d6554203c20622e74696d6554VQBqa1_61VQBza1_62ZQCtTASQFg8datetime8timezone13PosixTimeZone10LeapSecondZQGeFNaNbNiNfQClmZv'
+warning: stack frame size (144) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa17_612e74696d6554203c20622e74696d6554VQBqa1_61VQBza1_62ZQCtTASQFg8datetime8timezone13PosixTimeZone10LeapSecondZQGeFNaNbNiNfQClmZv'
-warning: stack frame size (160) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa5_61203c2062VQra1_61VQza1_62ZQBsTAQBmZQDjFNaNbNiNfQrmZv'
+warning: stack frame size (144) exceeds limit (100) in function '_D3std9algorithm7sorting__T13quickSortImplSQBp10functional__T9binaryFunVAyaa5_61203c2062VQra1_61VQza1_62ZQBsTAQBmZQDjFNaNbNiNfQrmZv'
```
