### PR TITLE
Simplify executeToolAndWait, the optional parameter is specified for every call

### DIFF
--- a/driver/args.cpp
+++ b/driver/args.cpp
@@ -157,13 +157,11 @@ struct ResponseFile {
 };
 } // anonymous namespace
 
-int executeAndWait(
-    std::vector<const char *> fullArgs,
-    llvm::Optional<llvm::sys::WindowsEncodingMethod> responseFileEncoding,
-    std::string *errorMsg) {
+int executeAndWait(std::vector<const char *> fullArgs,
+                   llvm::sys::WindowsEncodingMethod responseFileEncoding,
+                   std::string *errorMsg) {
   args::ResponseFile rspFile;
-  if (responseFileEncoding.hasValue() &&
-      !rspFile.setup(fullArgs, responseFileEncoding.getValue())) {
+  if (!rspFile.setup(fullArgs, responseFileEncoding)) {
     if (errorMsg)
       *errorMsg = "could not write temporary response file";
     return -1;

--- a/driver/args.h
+++ b/driver/args.h
@@ -40,8 +40,7 @@ bool isRunArg(const char *arg);
 // Executes a command line and returns its exit code.
 // Optionally uses a response file to overcome cmdline length limitations.
 int executeAndWait(std::vector<const char *> fullArgs,
-                   llvm::Optional<llvm::sys::WindowsEncodingMethod>
-                       responseFileEncoding = {llvm::None},
+                   llvm::sys::WindowsEncodingMethod responseFileEncoding,
                    std::string *errorMsg = nullptr);
 } // namespace args
 


### PR DESCRIPTION
This helps for LLVM16 support (deprecated llvm::Optional).