### PR TITLE
Port to LLVM 16.0.3

### DIFF
--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -15,6 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - job_name: Ubuntu 20.04, LLVM 16, latest LDC beta
+            os: ubuntu-20.04
+            host_dc: ldc-beta
+            llvm_version: 16.0.3
           - job_name: Ubuntu 20.04, LLVM 15, latest LDC beta
             os: ubuntu-20.04
             host_dc: ldc-beta

--- a/driver/args.cpp
+++ b/driver/args.cpp
@@ -175,7 +175,7 @@ int executeAndWait(std::vector<const char *> fullArgs,
   }
 
   const std::vector<llvm::StringRef> argv = toRefsVector(fullArgs);
-  auto envVars = llvm::None;
+  auto envVars = std::nullopt;
 
   return llvm::sys::ExecuteAndWait(argv[0], argv, envVars, {}, 0, 0, errorMsg);
 }

--- a/driver/cl_options-llvm.cpp
+++ b/driver/cl_options-llvm.cpp
@@ -68,7 +68,7 @@ using FPK = llvm::FramePointerKind;
 using FPK = llvm::FramePointer::FP;
 #endif
 
-llvm::Optional<FPK> framePointerUsage() {
+std::optional<FPK> framePointerUsage() {
 #if LDC_LLVM_VER >= 1100
   // Defaults to `FP::None`; no way to check if set explicitly by user except
   // indirectly via setFunctionAttributes()...
@@ -78,7 +78,7 @@ llvm::Optional<FPK> framePointerUsage() {
     return ::FramePointerUsage.getValue();
   if (disableFPElim.getNumOccurrences() > 0)
     return disableFPElim ? llvm::FramePointer::All : llvm::FramePointer::None;
-  return llvm::None;
+  return std::nullopt;
 #endif
 }
 

--- a/driver/cl_options-llvm.h
+++ b/driver/cl_options-llvm.h
@@ -22,12 +22,12 @@ class Triple;
 namespace opts {
 
 std::string getArchStr();
-llvm::Optional<llvm::Reloc::Model> getRelocModel();
-llvm::Optional<llvm::CodeModel::Model> getCodeModel();
+std::optional<llvm::Reloc::Model> getRelocModel();
+std::optional<llvm::CodeModel::Model> getCodeModel();
 #if LDC_LLVM_VER >= 1300
-llvm::Optional<llvm::FramePointerKind> framePointerUsage();
+std::optional<llvm::FramePointerKind> framePointerUsage();
 #else
-llvm::Optional<llvm::FramePointer::FP> framePointerUsage();
+std::optional<llvm::FramePointer::FP> framePointerUsage();
 #endif
 
 bool disableRedZone();

--- a/driver/linker.cpp
+++ b/driver/linker.cpp
@@ -192,10 +192,10 @@ static std::vector<std::string> getDefaultLibNames() {
 
 //////////////////////////////////////////////////////////////////////////////
 
-llvm::Optional<std::vector<std::string>> getExplicitPlatformLibs() {
+std::optional<std::vector<std::string>> getExplicitPlatformLibs() {
   if (platformLib.getNumOccurrences() > 0)
     return parseLibNames(platformLib);
-  return llvm::None;
+  return std::nullopt;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/driver/linker.h
+++ b/driver/linker.h
@@ -42,7 +42,7 @@ bool linkAgainstSharedDefaultLibs();
 /**
  * Returns the -platformlib library names, if specified.
  */
-llvm::Optional<std::vector<std::string>> getExplicitPlatformLibs();
+std::optional<std::vector<std::string>> getExplicitPlatformLibs();
 
 /**
  * Returns the value of -mscrtlib.

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -579,7 +579,9 @@ void initializePasses() {
 #endif
   initializeVectorization(Registry);
   initializeInstCombine(Registry);
+#if LDC_LLVM_VER < 1600
   initializeAggressiveInstCombine(Registry);
+#endif
   initializeIPO(Registry);
 #if LDC_LLVM_VER < 1600
   initializeInstrumentation(Registry);

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -203,9 +203,11 @@ static std::string getARMTargetCPU(const llvm::Triple &triple) {
 }
 
 static std::string getAArch64TargetCPU(const llvm::Triple &triple) {
+#if LDC_LLVM_VER < 1600
   auto defaultCPU = llvm::AArch64::getDefaultCPU(triple.getArchName());
   if (!defaultCPU.empty())
     return std::string(defaultCPU);
+#endif
 
   return "generic";
 }

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -364,8 +364,8 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
                     std::string cpu, const std::string featuresString,
                     const ExplicitBitness::Type bitness,
                     FloatABI::Type &floatABI,
-                    llvm::Optional<llvm::Reloc::Model> relocModel,
-                    llvm::Optional<llvm::CodeModel::Model> codeModel,
+                    std::optional<llvm::Reloc::Model> relocModel,
+                    std::optional<llvm::CodeModel::Model> codeModel,
                     const llvm::CodeGenOpt::Level codeGenOptLevel,
                     const bool noLinkerStripDead) {
   // Determine target triple. If the user didn't explicitly specify one, use

--- a/driver/targetmachine.h
+++ b/driver/targetmachine.h
@@ -55,8 +55,8 @@ llvm::TargetMachine *
 createTargetMachine(std::string targetTriple, std::string arch, std::string cpu,
                     std::string featuresString, ExplicitBitness::Type bitness,
                     FloatABI::Type &floatABI,
-                    llvm::Optional<llvm::Reloc::Model> relocModel,
-                    llvm::Optional<llvm::CodeModel::Model> codeModel,
+                    std::optional<llvm::Reloc::Model> relocModel,
+                    std::optional<llvm::CodeModel::Model> codeModel,
                     llvm::CodeGenOpt::Level codeGenOptLevel,
                     bool noLinkerStripDead);
 

--- a/gen/abi/nvptx.cpp
+++ b/gen/abi/nvptx.cpp
@@ -39,7 +39,7 @@ struct NVPTXTargetABI : TargetABI {
   }
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
     Type *ty = arg.type->toBasetype();
-    llvm::Optional<DcomputePointer> ptr;
+    std::optional<DcomputePointer> ptr;
     if (ty->ty == TY::Tstruct &&
         (ptr = toDcomputePointer(static_cast<TypeStruct *>(ty)->sym))) {
       pointerRewite.applyTo(arg);

--- a/gen/abi/spirv.cpp
+++ b/gen/abi/spirv.cpp
@@ -49,7 +49,7 @@ struct SPIRVTargetABI : TargetABI {
   }
   void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
     Type *ty = arg.type->toBasetype();
-    llvm::Optional<DcomputePointer> ptr;
+    std::optional<DcomputePointer> ptr;
     if (ty->ty == TY::Tstruct &&
         (ptr = toDcomputePointer(static_cast<TypeStruct *>(ty)->sym))) {
       pointerRewite.applyTo(arg);

--- a/gen/dcompute/druntime.cpp
+++ b/gen/dcompute/druntime.cpp
@@ -41,12 +41,12 @@ bool isFromLDC_OpenCL(Dsymbol *sym) {
   return isFromLDC_Mod(sym,Id::opencl);
 }
 
-llvm::Optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd) {
+std::optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd) {
   if (sd->ident != Id::dcPointer || !isFromLDC_DCompute(sd))
-    return llvm::Optional<DcomputePointer>(llvm::None);
+    return std::optional<DcomputePointer>(std::nullopt);
 
   TemplateInstance *ti = sd->isInstantiated();
   int addrspace = isExpression((*ti->tiargs)[0])->toInteger();
   Type *type = isType((*ti->tiargs)[1]);
-  return llvm::Optional<DcomputePointer>(DcomputePointer(addrspace, type));
+  return std::optional<DcomputePointer>(DcomputePointer(addrspace, type));
 }

--- a/gen/dcompute/druntime.h
+++ b/gen/dcompute/druntime.h
@@ -37,4 +37,4 @@ struct DcomputePointer {
     return llType->getPointerTo(as);
   }
 };
-llvm::Optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd);
+std::optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd);

--- a/gen/dcompute/targetOCL.cpp
+++ b/gen/dcompute/targetOCL.cpp
@@ -174,7 +174,7 @@ public:
   void decodeTypes(std::array<llvm::SmallVector<llvm::Metadata *, 8>,count_KernArgMD>& attrs,
                    VarDeclaration *v)
   {
-    llvm::Optional<DcomputePointer> ptr;
+    std::optional<DcomputePointer> ptr;
     std::string typeQuals;
     std::string baseTyName;
     std::string tyName;

--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -372,7 +372,7 @@ DIType DIBuilder::CreateEnumType(TypeEnum *type) {
 DIType DIBuilder::CreatePointerType(TypePointer *type) {
   // TODO: The addressspace is important for dcompute targets. See e.g.
   // https://www.mail-archive.com/dwarf-discuss@lists.dwarfstd.org/msg00326.html
-  const llvm::Optional<unsigned> DWARFAddressSpace = llvm::None;
+  const std::optional<unsigned> DWARFAddressSpace = std::nullopt;
 
   const auto name = processDIName(type->toPrettyChars(true));
 
@@ -730,7 +730,7 @@ DISubroutineType DIBuilder::CreateFunctionType(Type *type) {
 }
 
 DISubroutineType DIBuilder::CreateEmptyFunctionType() {
-  auto paramsArray = DBuilder.getOrCreateTypeArray(llvm::None);
+  auto paramsArray = DBuilder.getOrCreateTypeArray(std::nullopt);
   return DBuilder.createSubroutineType(paramsArray);
 }
 
@@ -776,7 +776,7 @@ DIType DIBuilder::CreateTypeDescription(Type *t, bool voidToUbyte) {
     // display null as void*
     return DBuilder.createPointerType(
         CreateTypeDescription(Type::tvoid), target.ptrsize * 8, 0,
-        /* DWARFAddressSpace */ llvm::None, "typeof(null)");
+        /* DWARFAddressSpace */ std::nullopt, "typeof(null)");
   }
   if (auto te = t->isTypeEnum())
     return CreateEnumType(te);
@@ -799,7 +799,7 @@ DIType DIBuilder::CreateTypeDescription(Type *t, bool voidToUbyte) {
     const auto name =
         (tc->sym->toPrettyChars(true) + llvm::StringRef("*")).str();
     return DBuilder.createPointerType(aggregateDIType, target.ptrsize * 8, 0,
-                                      llvm::None, processDIName(name));
+                                      std::nullopt, processDIName(name));
   }
   if (auto tf = t->isTypeFunction())
     return CreateFunctionType(tf);

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -114,7 +114,12 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
       if (!newInst)
         newInst = Inst->clone();
 
+      #if LDC_LLVM_VER < 1600
       nbb->getInstList().push_back(newInst);
+      #else
+      newInst->insertInto(nbb, nbb->end());
+      #endif
+
       VMap[Inst] = newInst; // Add instruction map to value.
       if (unwindTo)
         if (auto dest = getUnwindDest(Inst))

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -635,7 +635,11 @@ void runOptimizationPasses(llvm::Module *M) {
   bool debugLogging = false;
   ppo.Indent = false;
   ppo.SkipAnalyses = false;
+  #if LDC_LLVM_VER < 1600
   StandardInstrumentations si(debugLogging, /*VerifyEach=*/false, ppo);
+  #else
+  StandardInstrumentations si(M->getContext(), debugLogging, /*VerifyEach=*/false, ppo);
+  #endif
 
   si.registerCallbacks(pic, &fam);
 

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -557,7 +557,7 @@ static void addGarbageCollect2StackPass(ModulePassManager &mpm,
 }
 
 
-static llvm::Optional<PGOOptions> getPGOOptions() {
+static std::optional<PGOOptions> getPGOOptions() {
  //FIXME: Do we have these anywhere?
  bool debugInfoForProfiling=false;
  bool pseudoProbeForProfiling=false;
@@ -572,7 +572,7 @@ static llvm::Optional<PGOOptions> getPGOOptions() {
                      PGOOptions::CSPGOAction::NoCSAction,
                      debugInfoForProfiling, pseudoProbeForProfiling);
   }
-  return None;
+  return std::nullopt;
 }
 static PipelineTuningOptions getPipelineTuningOptions(unsigned optLevelVal, unsigned sizeLevelVal) {
   PipelineTuningOptions pto;

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -33,7 +33,7 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Attributes.h"
 #if LDC_LLVM_VER >= 1600
-#include "llvm/IR/ModRef.h"
+#include "llvm/Support/ModRef.h"
 #endif
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -219,7 +219,7 @@ void applyAttrAllocSize(StructLiteralExp *sle, IrFunction *irFunc) {
   if (numArgIdx >= 0) {
     builder.addAllocSizeAttr(llvmSizeIdx, llvmNumIdx);
   } else {
-    builder.addAllocSizeAttr(llvmSizeIdx, llvm::Optional<unsigned>());
+    builder.addAllocSizeAttr(llvmSizeIdx, std::optional<unsigned>());
   }
 
   llvm::Function *func = irFunc->getLLVMFunc();

--- a/ir/irtypestruct.cpp
+++ b/ir/irtypestruct.cpp
@@ -71,7 +71,7 @@ IrTypeStruct *IrTypeStruct::get(StructDeclaration *sd) {
 
   // For ldc.dcomptetypes.Pointer!(uint n,T),
   // emit { T addrspace(gIR->dcomputetarget->mapping[n])* }
-  llvm::Optional<DcomputePointer> p;
+  std::optional<DcomputePointer> p;
 
   if (gIR->dcomputetarget && (p = toDcomputePointer(sd))) {
     // Translate the virtual dcompute address space into the real one for

--- a/runtime/jit-rt/cpp-so/bind.h
+++ b/runtime/jit-rt/cpp-so/bind.h
@@ -27,7 +27,7 @@ class Module;
 class Function;
 }
 
-using BindOverride = llvm::Optional<
+using BindOverride = std::optional<
     llvm::function_ref<llvm::Constant *(llvm::Type &, const void *, size_t)>>;
 
 llvm::Function *

--- a/runtime/jit-rt/cpp-so/jit_context.cpp
+++ b/runtime/jit-rt/cpp-so/jit_context.cpp
@@ -63,8 +63,8 @@ std::unique_ptr<llvm::TargetMachine> createTargetMachine() {
   assert(target != nullptr);
   std::unique_ptr<llvm::TargetMachine> ret(target->createTargetMachine(
       triple, llvm::sys::getHostCPUName(), llvm::join(getHostAttrs(), ","), {},
-      llvm::Optional<llvm::Reloc::Model>{},
-      llvm::Optional<llvm::CodeModel::Model>{}, llvm::CodeGenOpt::Default,
+      std::optional<llvm::Reloc::Model>{},
+      std::optional<llvm::CodeModel::Model>{}, llvm::CodeGenOpt::Default,
       /*jit*/ true));
   assert(ret != nullptr);
   return ret;

--- a/runtime/jit-rt/cpp-so/valueparser.h
+++ b/runtime/jit-rt/cpp-so/valueparser.h
@@ -24,7 +24,7 @@ class Type;
 class DataLayout;
 }
 
-using ParseInitializerOverride = llvm::Optional<
+using ParseInitializerOverride = std::optional<
     llvm::function_ref<llvm::Constant *(llvm::Type &, const void *, size_t)>>;
 
 llvm::Constant *parseInitializer(

--- a/utils/not.cpp
+++ b/utils/not.cpp
@@ -43,7 +43,7 @@ int main(int argc, const char **argv) {
   Argv.reserve(argc);
   for (int i = 0; i < argc; ++i)
     Argv.push_back(argv[i]);
-  auto Env = llvm::None;
+  auto Env = std::nullopt;
 
   std::string ErrMsg;
   int Result = sys::ExecuteAndWait(*Program, Argv, Env, {}, 0, 0, &ErrMsg);


### PR DESCRIPTION
This has been tested in as far as building `moss` and `boulder` against patched LDC with LLVM16.0.3 in a Serpent OS test environment. The binaries function perfectly and perhaps actually a bit smaller than they were before.