### PR TITLE
Handle lambda mangle collisions by emitting lambdas with internal linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Platform support
 
 #### Bug fixes
+- Handle potential lambda mangle collisions across separately compiled object files (and the linker then silently picking an arbitrary implementation). Lambdas (and their nested global variables) are now internal to each referencing object file (`static` linkage in C). (#4415)
 
 # LDC 1.32.2 (2023-05-12)
 

--- a/tests/codegen/inputs/lambdas_dmd23722b.d
+++ b/tests/codegen/inputs/lambdas_dmd23722b.d
@@ -1,0 +1,16 @@
+module lambdas_dmd23722b;
+
+struct A {
+    import core.stdc.stdio;
+    alias x = () {
+        printf("x\n");
+    };
+    alias y = () {
+        printf("y\n");
+    };
+}
+
+// do_x should call A.x (and print "x")
+void do_x() {
+    A.x();
+}

--- a/tests/codegen/lambdas_dmd23722.d
+++ b/tests/codegen/lambdas_dmd23722.d
@@ -1,0 +1,21 @@
+// Test that colliding lambda mangles don't lead to symbol collision during linking,
+// see https://issues.dlang.org/show_bug.cgi?id=23722
+
+// compile both modules separately, then link and check runtime output
+// RUN: %ldc -c %S/inputs/lambdas_dmd23722b.d -of=%t_b%obj
+// RUN: %ldc -I%S/inputs %s %t_b%obj -of=%t%exe
+// RUN: %t%exe | FileCheck %s
+
+import lambdas_dmd23722b;
+
+// do_y should call A.y (and print "y")
+void do_y() {
+    A.y();
+}
+
+void main() {
+    // CHECK: y
+    do_y(); // should print y
+    // CHECK-NEXT: x
+    do_x(); // should print x
+}

--- a/tests/codegen/lambdas_gh3648.d
+++ b/tests/codegen/lambdas_gh3648.d
@@ -1,4 +1,4 @@
-// Tests that lambdas and contained globals are emitted as linkonce_odr.
+// Tests that lambdas and contained globals are emitted with internal linkage.
 
 // RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
@@ -25,10 +25,10 @@ void foo()
     }(123);
 }
 
-// the global variables should be defined as linkonce_odr:
-// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr {{(hidden )?}}thread_local global
-// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr {{(hidden )?}}global
-// CHECK: _D14lambdas_gh36483fooFZ__T9__lambda1TiZQnFiZ12lambda_templi{{.*}} = linkonce_odr {{(hidden )?}}global
+// the global variables should be defined as internal:
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = internal thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = internal global
+// CHECK: _D14lambdas_gh36483fooFZ__T9__lambda1TiZQnFiZ12lambda_templi{{.*}} = internal global
 
 // foo() should only call two lambdas:
 // CHECK: define {{.*}}_D14lambdas_gh36483fooFZv
@@ -36,11 +36,11 @@ void foo()
 // CHECK-NEXT: call {{.*}}__T9__lambda1
 // CHECK-NEXT: ret void
 
-// bar() should be defined as linkonce_odr:
-// CHECK: define linkonce_odr {{.*}}__lambda5
+// bar() should be defined as internal:
+// CHECK: define internal {{.*}}__lambda5
 
 // bar_inlined() should NOT have made it to the .ll:
 // CHECK-NOT: define {{.*}}__lambda6
 
-// the template lambda instance should be defined as linkonce_odr:
-// CHECK: define linkonce_odr {{.*}}__T9__lambda1
+// the template lambda instance should be defined as internal:
+// CHECK: define internal {{.*}}__T9__lambda1

--- a/tests/codegen/lambdas_gh3648b.d
+++ b/tests/codegen/lambdas_gh3648b.d
@@ -1,4 +1,4 @@
-// Tests that *imported* lambdas and contained globals are emitted as linkonce_odr.
+// Tests that *imported* lambdas and contained globals are emitted with internal linkage.
 
 // RUN: %ldc -output-ll -of=%t.ll %s -I%S && FileCheck %s < %t.ll
 
@@ -10,17 +10,17 @@ void foo()
     bar_inlined();
 }
 
-// the global variables should be defined as linkonce_odr:
-// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = linkonce_odr {{(hidden )?}}thread_local global
-// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = linkonce_odr {{(hidden )?}}global
+// the global variables should be defined as internal:
+// CHECK: _D14lambdas_gh36489__lambda5FZ10global_bari{{.*}} = internal thread_local global
+// CHECK: _D14lambdas_gh36489__lambda6FZ18global_bar_inlinedOi{{.*}} = internal global
 
 // foo() should only call one lambda:
 // CHECK: define {{.*}}_D15lambdas_gh3648b3fooFZv
 // CHECK-NEXT: call {{.*}}__lambda5
 // CHECK-NEXT: ret void
 
-// bar() should be defined as linkonce_odr:
-// CHECK: define linkonce_odr {{.*}}__lambda5
+// bar() should be defined as internal:
+// CHECK: define internal {{.*}}__lambda5
 
 // bar_inlined() should NOT have made it to the .ll:
 // CHECK-NOT: define {{.*}}__lambda6


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=23722.