### PR TITLE
Lazily IR-declare all function fwd declarations

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -284,7 +284,9 @@ public:
 
   void visit(FuncDeclaration *decl) override {
     // don't touch function aliases, they don't contribute any new symbols
-    if (!decl->skipCodegen() && !decl->isFuncAliasDeclaration()) {
+    if (!decl->skipCodegen() && !decl->isFuncAliasDeclaration() &&
+        // skip fwd declarations (IR-declared lazily)
+        decl->fbody) {
       DtoDefineFunction(decl);
     }
   }

--- a/tests/codegen/attr_callingconvention.d
+++ b/tests/codegen/attr_callingconvention.d
@@ -59,15 +59,15 @@ void fooinvokesexternCfoofoofoo()
 //////////////////////////////////////////////////////////
 /// Forward-declared function calls and invokes:
 
-// CHECK-LABEL: declare x86_vectorcallcc void @{{.*}}forward_declared_function
-@callingConvention("vectorcall") void forward_declared_function();
-
 // CHECK-LABEL: define{{.*}} @{{.*}}attr_callingconvention34foocalls_forward_declared_function
 void foocalls_forward_declared_function()
 {
   // CHECK: call x86_vectorcallcc void @{{.*}}attr_callingconvention25forward_declared_function
   forward_declared_function();
 }
+
+// CHECK-LABEL: declare x86_vectorcallcc void @{{.*}}forward_declared_function
+@callingConvention("vectorcall") void forward_declared_function();
 
 // CHECK-LABEL: define{{.*}} @{{.*}}attr_callingconvention36fooinvokes_forward_declared_function
 void fooinvokes_forward_declared_function()

--- a/tests/compilable/gh2782.d
+++ b/tests/compilable/gh2782.d
@@ -1,0 +1,4 @@
+// RUN: %ldc -c -singleobj %s %S/inputs/gh2782b.d
+
+struct S {}
+extern(C) void foo(S);

--- a/tests/compilable/inputs/gh2782b.d
+++ b/tests/compilable/inputs/gh2782b.d
@@ -1,0 +1,2 @@
+struct S {}
+extern(C) void foo(S);


### PR DESCRIPTION
Instead of eagerly IR-declaring all such functions in root modules being compiled.

This might reduce compile times in some cases, and is a cheap way to improve the situation wrt. issue #2782.