### PR TITLE
Add -fcf-protection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - C files are now automatically preprocessed using the external C compiler (configurable via `-gcc` or the `CC` environment variable, and `-Xcc` for extra flags). Extra preprocessor flags (e.g., include dirs and manual defines) can be added via new command-line option `-P`. (#4417)
   - Windows: If `clang-cl.exe` is on `PATH`, it is preferred over Microsoft's `cl.exe` by default (e.g., to avoid printing the C source file name to stderr during preprocessing).
 - Less pedantic checks for conflicting C(++) function declarations when compiling multiple modules to a single object file ('Error: Function type does not match previously declared function with the same mangled name'). The error now only appears if an object file actually references multiple conflicting functions. (#4420)
+- New command-line option `--fcf-protection`. (#4437)
 
 #### Platform support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - C files are now automatically preprocessed using the external C compiler (configurable via `-gcc` or the `CC` environment variable, and `-Xcc` for extra flags). Extra preprocessor flags (e.g., include dirs and manual defines) can be added via new command-line option `-P`. (#4417)
   - Windows: If `clang-cl.exe` is on `PATH`, it is preferred over Microsoft's `cl.exe` by default (e.g., to avoid printing the C source file name to stderr during preprocessing).
 - Less pedantic checks for conflicting C(++) function declarations when compiling multiple modules to a single object file ('Error: Function type does not match previously declared function with the same mangled name'). The error now only appears if an object file actually references multiple conflicting functions. (#4420)
-- New command-line option `--fcf-protection`. (#4437)
+- New command-line option `--fcf-protection`, which enables Intel's Control-Flow Enforcement Technology (CET). (#4437)
 
 #### Platform support
 

--- a/driver/cl_options_instrumentation.cpp
+++ b/driver/cl_options_instrumentation.cpp
@@ -123,6 +123,11 @@ void initializeInstrumentationOptionsFromCmdline(const llvm::Triple &triple) {
 
   if (dmdFunctionTrace)
     global.params.trace = true;
+
+  if (fCFProtection != CFProtectionType::None && !triple.isX86()) {
+    error(Loc(), "option '--fcf-protection' cannot be specified on this target "
+                 "architecture");
+  }
 }
 
 } // namespace opts

--- a/driver/cl_options_instrumentation.cpp
+++ b/driver/cl_options_instrumentation.cpp
@@ -124,7 +124,10 @@ void initializeInstrumentationOptionsFromCmdline(const llvm::Triple &triple) {
   if (dmdFunctionTrace)
     global.params.trace = true;
 
-  if (fCFProtection != CFProtectionType::None && !triple.isX86()) {
+  // fcf-protection is only valid for X86
+  if (fCFProtection != CFProtectionType::None &&
+      !(triple.getArch() == llvm::Triple::x86 ||
+        triple.getArch() == llvm::Triple::x86_64)) {
     error(Loc(), "option '--fcf-protection' cannot be specified on this target "
                  "architecture");
   }

--- a/driver/cl_options_instrumentation.cpp
+++ b/driver/cl_options_instrumentation.cpp
@@ -84,6 +84,19 @@ llvm::StringRef getXRayInstructionThresholdString() {
   return thresholdString;
 }
 
+cl::opt<CFProtectionType> fCFProtection(
+    "fcf-protection",
+    cl::desc("Instrument control-flow architecture protection"), cl::ZeroOrMore,
+    cl::ValueOptional,
+    cl::values(clEnumValN(CFProtectionType::None, "none", ""),
+               clEnumValN(CFProtectionType::Branch, "branch", ""),
+               clEnumValN(CFProtectionType::Return, "return", ""),
+               clEnumValN(CFProtectionType::Full, "full", ""),
+               clEnumValN(CFProtectionType::Full, "",
+                          "") // default to "full" if no argument specified
+               ),
+    cl::init(CFProtectionType::None));
+
 void initializeInstrumentationOptionsFromCmdline(const llvm::Triple &triple) {
   if (ASTPGOInstrGenFile.getNumOccurrences() > 0) {
     pgoMode = PGO_ASTBasedInstr;

--- a/driver/cl_options_instrumentation.h
+++ b/driver/cl_options_instrumentation.h
@@ -29,6 +29,9 @@ extern cl::opt<bool> instrumentFunctions;
 extern cl::opt<bool> fXRayInstrument;
 llvm::StringRef getXRayInstructionThresholdString();
 
+enum class CFProtectionType { None, Branch, Return, Full };
+extern cl::opt<CFProtectionType> fCFProtection;
+
 /// This initializes the instrumentation options, and checks the validity of the
 /// commandline flags. targetTriple should be initialized before calling this.
 /// It should be called only once.

--- a/driver/cl_options_instrumentation.h
+++ b/driver/cl_options_instrumentation.h
@@ -29,7 +29,7 @@ extern cl::opt<bool> instrumentFunctions;
 extern cl::opt<bool> fXRayInstrument;
 llvm::StringRef getXRayInstructionThresholdString();
 
-enum class CFProtectionType { None, Branch, Return, Full };
+enum class CFProtectionType { None = 0, Branch = 1, Return = 2, Full = 3 };
 extern cl::opt<CFProtectionType> fCFProtection;
 
 /// This initializes the instrumentation options, and checks the validity of the

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1003,6 +1003,20 @@ void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("LDC_ThreadSanitizer");
   }
 
+  switch (opts::fCFProtection) {
+  case opts::CFProtectionType::Branch:
+    VersionCondition::addPredefinedGlobalIdent("__CET_1__");
+    break;
+  case opts::CFProtectionType::Return:
+    VersionCondition::addPredefinedGlobalIdent("__CET_2__");
+    break;
+  case opts::CFProtectionType::Full:
+    VersionCondition::addPredefinedGlobalIdent("__CET_3__");
+    break;
+  case opts::CFProtectionType::None:
+    break;
+  }
+
 #if LDC_LLVM_VER >= 1400
   // A version identifier for whether opaque pointers are enabled or not. (needed e.g. for intrinsic mangling)
   if (!getGlobalContext().supportsTypedPointers()) {

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1003,20 +1003,6 @@ void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("LDC_ThreadSanitizer");
   }
 
-  switch (opts::fCFProtection) {
-  case opts::CFProtectionType::Branch:
-    VersionCondition::addPredefinedGlobalIdent("__CET_1__");
-    break;
-  case opts::CFProtectionType::Return:
-    VersionCondition::addPredefinedGlobalIdent("__CET_2__");
-    break;
-  case opts::CFProtectionType::Full:
-    VersionCondition::addPredefinedGlobalIdent("__CET_3__");
-    break;
-  case opts::CFProtectionType::None:
-    break;
-  }
-
 #if LDC_LLVM_VER >= 1400
   // A version identifier for whether opaque pointers are enabled or not. (needed e.g. for intrinsic mangling)
   if (!getGlobalContext().supportsTypedPointers()) {

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -393,7 +393,20 @@ void registerModuleInfo(Module *m) {
     emitModuleRefToSection(mangle, moduleInfoSym);
   }
 }
+
+void addModuleFlags(llvm::Module &m) {
+  if (opts::fCFProtection == opts::CFProtectionType::Return ||
+      opts::fCFProtection == opts::CFProtectionType::Full) {
+    m.addModuleFlag(llvm::Module::Min, "cf-protection-return", 1);
+  }
+
+  if (opts::fCFProtection == opts::CFProtectionType::Branch ||
+      opts::fCFProtection == opts::CFProtectionType::Full) {
+    m.addModuleFlag(llvm::Module::Min, "cf-protection-branch", 1);
+  }
 }
+
+} // anonymous namespace
 
 void codegenModule(IRState *irs, Module *m) {
   TimeTraceScope timeScope("Generate IR", m->toChars(), m->loc);
@@ -443,6 +456,8 @@ void codegenModule(IRState *irs, Module *m) {
   if (m->d_cover_valid) {
     addCoverageAnalysisInitializer(m);
   }
+
+  addModuleFlags(irs->module);
 
   gIR = nullptr;
   irs->dmodule = nullptr;

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -395,14 +395,20 @@ void registerModuleInfo(Module *m) {
 }
 
 void addModuleFlags(llvm::Module &m) {
+#if LDC_LLVM_VER >= 1500
+  const auto ModuleMinFlag = llvm::Module::Min;
+#else
+  const auto ModuleMinFlag = llvm::Module::Warning; // Fallback value
+#endif
+
   if (opts::fCFProtection == opts::CFProtectionType::Return ||
       opts::fCFProtection == opts::CFProtectionType::Full) {
-    m.addModuleFlag(llvm::Module::Min, "cf-protection-return", 1);
+    m.addModuleFlag(ModuleMinFlag, "cf-protection-return", 1);
   }
 
   if (opts::fCFProtection == opts::CFProtectionType::Branch ||
       opts::fCFProtection == opts::CFProtectionType::Full) {
-    m.addModuleFlag(llvm::Module::Min, "cf-protection-branch", 1);
+    m.addModuleFlag(ModuleMinFlag, "cf-protection-branch", 1);
   }
 }
 

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -15,6 +15,7 @@
 #include "dmd/mtype.h"
 #include "dmd/target.h"
 #include "driver/cl_options.h"
+#include "driver/cl_options_instrumentation.h"
 #include "driver/linker.h"
 #include "gen/abi/abi.h"
 #include "gen/irstate.h"
@@ -307,6 +308,11 @@ Expression *Target::getTargetInfo(const char *name_, const Loc &loc) {
   if (name == "cppStd") {
     return IntegerExp::create(
         Loc(), static_cast<unsigned>(global.params.cplusplus), Type::tint32);
+  }
+
+  if (name == "CET") {
+    auto cet = opts::fCFProtection.getValue();
+    return IntegerExp::create(loc, static_cast<unsigned>(cet), Type::tint32);
   }
 
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX

--- a/tests/codegen/fcf_protection.d
+++ b/tests/codegen/fcf_protection.d
@@ -1,0 +1,28 @@
+// Test -fcf-protection
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t.ll        %s                         && FileCheck %s --check-prefix=NOTHING < %t.ll
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_branch.ll %s --fcf-protection=branch -d-version=BRANCH && FileCheck %s --check-prefix=BRANCH < %t_branch.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_return.ll %s --fcf-protection=return -d-version=RETURN && FileCheck %s --check-prefix=RETURN < %t_return.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_full.ll   %s --fcf-protection=full   -d-version=FULL   && FileCheck %s --check-prefix=FULL   < %t_full.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_noarg.ll  %s --fcf-protection        -d-version=FULL   && FileCheck %s --check-prefix=FULL   < %t_noarg.ll
+
+// NOTHING-NOT: cf-prot
+// BRANCH-DAG: "cf-protection-branch", i32 1
+// RETURN-DAG: "cf-protection-return", i32 1
+// FULL-DAG: "cf-protection-branch", i32 1
+// FULL-DAG: "cf-protection-return", i32 1
+
+void foo() {}
+
+version(BRANCH) {
+    version(__CET_1__) {} else { static assert(false); };
+}
+version(RETURN) {
+    version(__CET_2__) {} else { static assert(false); };
+}
+version(FULL) {
+    version(__CET_3__) {} else { static assert(false); };
+}

--- a/tests/codegen/fcf_protection.d
+++ b/tests/codegen/fcf_protection.d
@@ -2,7 +2,7 @@
 
 // REQUIRES: target_X86
 
-// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t.ll        %s                         && FileCheck %s --check-prefix=NOTHING < %t.ll
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t.ll        %s                        -d-version=NOTHING && FileCheck %s --check-prefix=NOTHING < %t.ll
 
 // RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_branch.ll %s --fcf-protection=branch -d-version=BRANCH && FileCheck %s --check-prefix=BRANCH < %t_branch.ll
 // RUN: %ldc -mtriple=x86_64-linux-gnu -output-ll -of=%t_return.ll %s --fcf-protection=return -d-version=RETURN && FileCheck %s --check-prefix=RETURN < %t_return.ll
@@ -17,12 +17,15 @@
 
 void foo() {}
 
+version(NOTHING) {
+    static assert(__traits(getTargetInfo, "CET") == 0);
+}
 version(BRANCH) {
-    version(__CET_1__) {} else { static assert(false); };
+    static assert(__traits(getTargetInfo, "CET") == 1);
 }
 version(RETURN) {
-    version(__CET_2__) {} else { static assert(false); };
+    static assert(__traits(getTargetInfo, "CET") == 2);
 }
 version(FULL) {
-    version(__CET_3__) {} else { static assert(false); };
+    static assert(__traits(getTargetInfo, "CET") == 3);
 }


### PR DESCRIPTION
Resolves issue #4435

~~I do not know how to cleanly add compiler-defined enum value (e.g. `__CET__ == 1`), so I opted for adding compiler-defined versions instead.~~