### PR TITLE
Add pragma(LDC_no_moduleinfo) to all gccbuiltin generated .di files.

### DIFF
--- a/runtime/druntime/src/ldc/llvmasm.di
+++ b/runtime/druntime/src/ldc/llvmasm.di
@@ -1,5 +1,7 @@
 module ldc.llvmasm;
 
+pragma(LDC_no_moduleinfo);
+
 struct __asmtuple_t(T...)
 {
     T v;

--- a/runtime/druntime/src/ldc/profile.di
+++ b/runtime/druntime/src/ldc/profile.di
@@ -16,6 +16,8 @@
  */
 module ldc.profile;
 
+pragma(LDC_no_moduleinfo); // this module is not standard linked with druntime, don't burden the user with requiring linking.
+
 version = HASHED_FUNC_NAMES;
 
 import ldc.intrinsics : LLVM_version;

--- a/utils/gen_gccbuiltins.cpp
+++ b/utils/gen_gccbuiltins.cpp
@@ -151,9 +151,10 @@ std::string arch;
 
 bool emit(raw_ostream& os, RecordKeeper& records)
 {
-    os << "module ldc.gccbuiltins_";
-    os << arch;
-    os << "; \n\nimport core.simd;\n\nnothrow @nogc:\n\n";
+    os << "module ldc.gccbuiltins_" << arch
+       << ";\n"
+          "pragma(LDC_no_moduleinfo);\n\n"
+          "import core.simd;\n\nnothrow @nogc:\n\n";
 
     const auto &defs = records.getDefs();
 


### PR DESCRIPTION
Moduleinfo is not needed, because there are no module ctors, nor unittests, etc. This prevents missing Moduleinfo symbol linking problems for some use cases.

Resolves #4442