### PR TITLE
Cirrus CI: Try `stateful` for AArch64 task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -321,6 +321,7 @@ task:
 
 task:
   name: Ubuntu 20.04 aarch64
+  stateful: true
   arm_container:
     image: ubuntu:20.04
     cpu: 4


### PR DESCRIPTION
Wrt. https://github.com/cirruslabs/cirrus-ci-docs/issues/1196.