### PR TITLE
GH Actions: Export ~all symbols from prebuilt LTO'd macOS binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,12 @@ jobs:
             bootstrap_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
               -DD_COMPILER_FLAGS=-gcc=/usr/bin/c++
+            # https://github.com/ldc-developers/ldc/issues/4462:
+            # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
+            # Additionally `-w` to suppress resulting linker warnings.
             extra_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
-              -DD_COMPILER_FLAGS="-gcc=/usr/bin/c++ -O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DD_COMPILER_FLAGS="-gcc=/usr/bin/c++ -O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
@@ -162,9 +165,10 @@ jobs:
             os: osx
             arch: arm64
             bootstrap_cmake_flags: -DD_COMPILER_FLAGS=-gcc=/usr/bin/c++
+            # see native macOS job comment for extra flags (https://github.com/ldc-developers/ldc/issues/4462)
             extra_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 

--- a/tests/plugins/basic_sema_plugin.d
+++ b/tests/plugins/basic_sema_plugin.d
@@ -1,8 +1,5 @@
 // REQUIRES: Plugins
 
-// For some reason this test fails with missing symbol linking issues (or crash) with macOS on Intel x86 (but not for all CI testers...)
-// UNSUPPORTED: Darwin && host_X86
-
 // RUN: split-file %s %t --leading-lines
 // RUN: %buildplugin %t/plugin.d -of=%t/plugin%so --buildDir=%t/build
 // RUN: %ldc -wi -c -o- --plugin=%t/plugin%so %t/testcase.d 2>&1 | FileCheck %t/testcase.d

--- a/tests/plugins/visitor_example.d
+++ b/tests/plugins/visitor_example.d
@@ -1,9 +1,6 @@
 // REQUIRES: Plugins
 // REQUIRES: ABI_compatible_with_host_D
 
-// For some reason this test fails with missing symbol linking issues (or crash) with macOS on Intel x86.
-// UNSUPPORTED: Darwin && host_X86
-
 // RUN: split-file %s %t --leading-lines
 // RUN: %buildplugin %t/plugin.d -of=%t/plugin%so --buildDir=%t/build
 // RUN: %ldc -wi -c -o- --plugin=%t/plugin%so %t/testcase.d 2>&1 | FileCheck %t/testcase.d


### PR DESCRIPTION
Fixes #4462 for our official packages.