### PR TITLE
CircleCI: Remove Mac jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,24 +33,6 @@ commonSteps: &commonSteps
             rm ninja-linux.zip
             # Add CMake and Ninja to PATH for future steps
             echo "export PATH=$PWD/cmake/bin:$PWD/ninja:$PATH" >> $BASH_ENV
-          else
-            # Download & extract CMake
-            curl -fL --retry 3 --max-time 300 -o cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-macos-universal.tar.gz
-            mkdir cmake
-            tar -xf cmake.tar.gz --strip 3 -C cmake
-            rm cmake.tar.gz
-            # Download & extract Ninja
-            curl -fL --retry 3 --max-time 60 -O https://github.com/symmetryinvestments/ninja/releases/download/v1.11.1-sym1/ninja-mac.zip
-            mkdir ninja
-            unzip ninja-mac.zip -d ninja
-            rm ninja-mac.zip
-            # Download & extract LDC-flavoured LLVM with enabled assertions
-            curl -fL --retry 3 --max-time 300 -o llvm.tar.xz https://github.com/ldc-developers/llvm-project/releases/download/ldc-v$LLVM_VERSION/llvm-$LLVM_VERSION-osx-x86_64-withAsserts.tar.xz
-            mkdir llvm
-            tar -xf llvm.tar.xz --strip 1 -C llvm
-            rm llvm.tar.xz
-            # Add CMake, Ninja and LLVM to PATH for future steps
-            echo "export PATH=$PWD/cmake/bin:$PWD/ninja:$PWD/llvm/bin:$PATH" >> $BASH_ENV
           fi
           # Install lit
           python3 --version
@@ -129,28 +111,6 @@ jobs:
       - EXTRA_APT_PACKAGES: gdmd llvm-11-dev libclang-common-11-dev
       - HOST_LDC_VERSION: 1.24.0
       - EXTRA_CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=ON -DBUILD_LTO_LIBS=ON -DD_COMPILER=gdmd -DLDC_LINK_MANUALLY=ON"
-  macOS-x64:
-    <<: *commonSteps
-    macos:
-      xcode: "13.2.1"
-    environment:
-      - PARALLELISM: 4
-      - CI_OS: osx
-      - LLVM_VERSION: 15.0.7
-      - HOST_LDC_VERSION: 1.24.0
-      - EXTRA_CMAKE_FLAGS: "-DD_COMPILER_FLAGS=-gcc=/usr/bin/c++ -DBUILD_LTO_LIBS=ON"
-      - MACOSX_DEPLOYMENT_TARGET: 11.0 # silence `ld: warning: object file (…/libphobos2-ldc.a(adler32.c.o)) was built for newer macOS version (11.6) than being linked (11.0)`
-  macOS-x64-sharedLibsOnly:
-    <<: *commonSteps
-    macos:
-      xcode: "13.2.1"
-    environment:
-      - PARALLELISM: 4
-      - CI_OS: osx
-      - LLVM_VERSION: 15.0.7
-      - HOST_LDC_VERSION: 1.24.0
-      - EXTRA_CMAKE_FLAGS: "-DD_COMPILER_FLAGS=-gcc=/usr/bin/c++ -DBUILD_SHARED_LIBS=ON -DBUILD_LTO_LIBS=ON"
-      - MACOSX_DEPLOYMENT_TARGET: 11.0
 
 workflows:
   version: 2
@@ -158,5 +118,3 @@ workflows:
     jobs:
       - Ubuntu-20.04-multilib-rtSanitizers
       - Ubuntu-20.04-sharedLibsOnly-gdmd
-      - macOS-x64
-      - macOS-x64-sharedLibsOnly


### PR DESCRIPTION
Mac isn't covered by the open-source credit budget, and apparently the monthly 30k credits for these 2 jobs are exhaused rather soon; there hasn't been *that* much activity lately, but the jobs fail to trigger for some days now. On some days, we've apparently reached 8k credits.

The 'Vanilla LLVM' GHA Mac x64 jobs are similar (e.g., testing BUILD_SHARED_LIBS).