### PR TITLE
Cirrus CI: Remove 2 jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -253,23 +253,6 @@ environment:
   GITHUB_TOKEN: ENCRYPTED[0955bd48c8d4e5391446fc0149d0719ad0b63df27ec9e6c180a5730a5b10dc7f28f09d1383423db158d21380ee2b022a]
 
 task:
-  name: Ubuntu 20.04 x64 multilib rtSanitizers
-  container:
-    image: ubuntu:20.04
-    cpu: 8
-    memory: 16G
-  timeout_in: 20m
-  environment:
-    CI_ARCH: x86_64
-    CI_OS: linux
-    EXTRA_APT_PACKAGES: "llvm-11-dev libclang-common-11-dev"
-    EXTRA_CMAKE_FLAGS: "-DMULTILIB=ON -DRT_SUPPORT_SANITIZERS=ON -DBUILD_LTO_LIBS=ON"
-    PARALLELISM: 8
-    PATH: ${CIRRUS_WORKING_DIR}/../cmake/bin:${CIRRUS_WORKING_DIR}/../ninja:${PATH}
-  << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
-  << : *COMMON_STEPS_TEMPLATE
-
-task:
   name: Ubuntu rolling x64 shared-libs-only gdmd
   # allow failures - gdb v10 came with regressions
   allow_failures: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -274,24 +274,6 @@ task:
   << : *COMMON_STEPS_TEMPLATE
 
 task:
-  name: Ubuntu 20.04 x64 bootstrap
-  container:
-    image: ubuntu:20.04
-    cpu: 8
-    memory: 16G
-  timeout_in: 15m
-  environment:
-    CI_ARCH: x86_64
-    CI_OS: linux
-    HOST_LDC_VERSION: 1.9.0
-    EXTRA_APT_PACKAGES: "llvm-11-dev libclang-common-11-dev"
-    EXTRA_CMAKE_FLAGS: "-DBUILD_LTO_LIBS=ON"
-    PARALLELISM: 8
-    PATH: ${CIRRUS_WORKING_DIR}/../cmake/bin:${CIRRUS_WORKING_DIR}/../ninja:${PATH}
-  << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
-  << : *COMMON_STEPS_TEMPLATE
-
-task:
   name: macOS 12 $TASK_NAME_SUFFIX
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:latest

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -23,9 +23,9 @@ jobs:
             os: ubuntu-20.04
             host_dc: ldc-beta
             llvm_version: 15.0.6
-          - job_name: Ubuntu 20.04, LLVM 12, latest LDC beta
+          - job_name: Ubuntu 20.04, LLVM 12, bootstrap LDC
             os: ubuntu-20.04
-            host_dc: ldc-beta
+            host_dc: ldc-1.9.0
             llvm_version: 12.0.1
             cmake_flags: -DBUILD_SHARED_LIBS=ON -DLIB_SUFFIX=64
           - job_name: Ubuntu 20.04, LLVM 11, latest DMD beta
@@ -106,7 +106,7 @@ jobs:
           rm llvm.tar.xz
 
       - name: 'Linux: Make lld the default linker'
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.host_dc != 'ldc-1.9.0'
         run: |
           set -eux
           echo "Using lld to work around sporadic failures"


### PR DESCRIPTION
As preparation for the upcoming resource limits starting in September.

The 'Ubuntu 20.04 x64 multilib rtSanitizers' job was a duplicate of the *Circle* CI one, except for having twice as many CPU cores and using LDC v1.31 as host compiler, not v1.24 like Circle CI.

And bootstrappability from old LDC v1.9.0 can be tested with a 'Vanilla LLVM' GHA job instead.