### PR TITLE
ImportC: Support weird `asm("_" "<name>")` mangling stuff

### DIFF
--- a/gen/mangling.cpp
+++ b/gen/mangling.cpp
@@ -98,6 +98,9 @@ std::string hashSymbolName(llvm::StringRef name, Dsymbol *symb) {
 
 std::string getIRMangledName(FuncDeclaration *fdecl, LINK link) {
   std::string mangledName = mangleExact(fdecl);
+  if (fdecl->adFlags & 4) { // nounderscore
+    mangledName.insert(0, "\1");
+  }
 
   // Hash the name if necessary
   if (((link == LINK::d) || (link == LINK::default_)) &&

--- a/tests/dmd/runnable/test23343.c
+++ b/tests/dmd/runnable/test23343.c
@@ -1,6 +1,4 @@
-/* DISABLED: win32 win64 linux32 linux64 freebsd32 freebsd64 osx32 dragonflybsd32 netbsd32 LDC
- * LDC: this was apparently hacked around in DMD, requiring the glue layer to
-        know about this ImportC special case and only apply it for Mac targets...
+/* DISABLED: win32 win64 linux32 linux64 freebsd32 freebsd64 osx32 dragonflybsd32 netbsd32
  */
 
 /* https://issues.dlang.org/show_bug.cgi?id=23343


### PR DESCRIPTION
These are apparently used in the Mac system headers. Fixes https://github.com/ldc-developers/ldc/issues/4485.