### PR TITLE
ABI: Don't rewrite HFVAs if there's no need to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix `static` linkage. (#4484, 4487)
   - Make gcc builtins available. (#4483)
   - Apple: Support weird `asm("_" "<name>")` mangling stuff. (#4485, #4486)
+- AArch64: Fix an ABI-related ICE. (#4489, #4490)
 
 # LDC 1.34.0 (2023-08-26)
 

--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -89,7 +89,7 @@ TypeTuple *TargetABI::getArgTypes(Type *t) {
 LLType *TargetABI::getRewrittenArgType(Type *t, TypeTuple *argTypes) {
   if (!argTypes || argTypes->arguments->empty() ||
       (argTypes->arguments->length == 1 &&
-       argTypes->arguments->front()->type == t)) {
+       argTypes->arguments->front()->type->equivalent(t))) {
     return nullptr; // don't rewrite
   }
 

--- a/tests/compilable/gh4489.d
+++ b/tests/compilable/gh4489.d
@@ -1,0 +1,10 @@
+// REQUIRES: target_AArch64
+// RUN: %ldc -mtriple=arm64-apple-macos -c %s
+
+void foo(inout float[3]);
+
+void bar()
+{
+    float[3] x;
+    foo(x);
+}


### PR DESCRIPTION
An assertion already makes sure we don't. Fixes #4489.