### PR TITLE
Add initial support for LoongArch64

### DIFF
--- a/dmd/cond.d
+++ b/dmd/cond.d
@@ -728,6 +728,10 @@ extern (C++) final class VersionCondition : DVCondition
             case "SPARC_HardFloat":
             case "SPARC_SoftFloat":
             case "SPARC_V8Plus":
+            case "LoongArch32":
+            case "LoongArch64":
+            case "LoongArch_HardFloat":
+            case "LoongArch_SoftFloat":
             case "SystemZ":
             case "SysV3":
             case "SysV4":

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -765,6 +765,14 @@ void registerPredefinedTargetVersions() {
   case llvm::Triple::wasm64:
     VersionCondition::addPredefinedGlobalIdent("WebAssembly");
     break;
+  case llvm::Triple::loongarch32:
+    VersionCondition::addPredefinedGlobalIdent("LoongArch32");
+    registerPredefinedFloatABI("LoongArch_SoftFloat", "LoongArch_HardFloat");
+    break;
+  case llvm::Triple::loongarch64:
+    VersionCondition::addPredefinedGlobalIdent("LoongArch64");
+    registerPredefinedFloatABI("LoongArch_SoftFloat", "LoongArch_HardFloat");
+    break;
   default:
     warning(Loc(), "unknown target CPU architecture: %s",
             triple.getArchName().str().c_str());

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -765,6 +765,7 @@ void registerPredefinedTargetVersions() {
   case llvm::Triple::wasm64:
     VersionCondition::addPredefinedGlobalIdent("WebAssembly");
     break;
+#if LDC_LLVM_VER >= 1600
   case llvm::Triple::loongarch32:
     VersionCondition::addPredefinedGlobalIdent("LoongArch32");
     registerPredefinedFloatABI("LoongArch_SoftFloat", "LoongArch_HardFloat");
@@ -773,6 +774,7 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("LoongArch64");
     registerPredefinedFloatABI("LoongArch_SoftFloat", "LoongArch_HardFloat");
     break;
+#endif // LDC_LLVM_VER >= 1600
   default:
     warning(Loc(), "unknown target CPU architecture: %s",
             triple.getArchName().str().c_str());

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -117,6 +117,14 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
       if (ABIName.startswith("ilp32"))
         return "ilp32";
       break;
+    case llvm::Triple::loongarch32:
+      if (ABIName.startswith("ilp32s"))
+        return "ilp32s";
+      if (ABIName.startswith("ilp32f"))
+        return "ilp32f";
+      if (ABIName.startswith("ilp32d"))
+        return "ilp32d";
+      break;
     case llvm::Triple::loongarch64:
       if (ABIName.startswith("lp64f"))
         return "lp64f";
@@ -148,6 +156,12 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
     return "lp64";
   case llvm::Triple::riscv32:
     return "ilp32";
+  case llvm::Triple::loongarch32:
+    if (isFeatureEnabled(features, "d"))
+      return "ilp32d";
+    if (isFeatureEnabled(features, "f"))
+      return "ilp32f";
+    return "ilp32s";
   case llvm::Triple::loongarch64:
     if (isFeatureEnabled(features, "d"))
       return "lp64d";
@@ -251,6 +265,10 @@ static std::string getRiscv64TargetCPU(const llvm::Triple &triple) {
   return "generic-rv64";
 }
 
+static std::string getLoongArch32TargetCPU(const llvm::Triple &triple) {
+  return "generic-la32";
+}
+
 static std::string getLoongArch64TargetCPU(const llvm::Triple &triple) {
   return "generic-la64";
 }
@@ -276,6 +294,8 @@ static std::string getTargetCPU(const llvm::Triple &triple) {
     return getRiscv32TargetCPU(triple);
   case llvm::Triple::riscv64:
     return getRiscv64TargetCPU(triple);
+  case llvm::Triple::loongarch32:
+    return getLoongArch32TargetCPU(triple);
   case llvm::Triple::loongarch64:
     return getLoongArch64TargetCPU(triple);
   }

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -117,6 +117,7 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
       if (ABIName.startswith("ilp32"))
         return "ilp32";
       break;
+#if LDC_LLVM_VER >= 1600
     case llvm::Triple::loongarch32:
       if (ABIName.startswith("ilp32s"))
         return "ilp32s";
@@ -133,6 +134,7 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
       if (ABIName.startswith("lp64s"))
         return "lp64s";
       break;
+#endif // LDC_LLVM_VER >= 1600
     default:
       break;
     }
@@ -156,6 +158,7 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
     return "lp64";
   case llvm::Triple::riscv32:
     return "ilp32";
+#if LDC_LLVM_VER >= 1600
   case llvm::Triple::loongarch32:
     if (isFeatureEnabled(features, "d"))
       return "ilp32d";
@@ -168,6 +171,7 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
     if (isFeatureEnabled(features, "f"))
       return "lp64f";
     return "lp64d";
+#endif // LDC_LLVM_VER >= 1600
   default:
     return "";
   }
@@ -294,10 +298,12 @@ static std::string getTargetCPU(const llvm::Triple &triple) {
     return getRiscv32TargetCPU(triple);
   case llvm::Triple::riscv64:
     return getRiscv64TargetCPU(triple);
+#if LDC_LLVM_VER >= 1600
   case llvm::Triple::loongarch32:
     return getLoongArch32TargetCPU(triple);
   case llvm::Triple::loongarch64:
     return getLoongArch64TargetCPU(triple);
+#endif // LDC_LLVM_VER >= 1600
   }
 }
 
@@ -510,9 +516,11 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
 
   // For LoongArch 64-bit target default to la64 if nothing has been selected
   // All current LoongArch targets have 64-bit floating point registers.
+#if LDC_LLVM_VER >= 1600
   if (triple.getArch() == llvm::Triple::loongarch64 && features.empty()) {
     features = {"+d"};
   }
+#endif
 
   // Handle cases where LLVM picks wrong default relocModel
 #if LDC_LLVM_VER >= 1600

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -96,6 +96,11 @@ void appendTargetArgsForGcc(std::vector<std::string> &args) {
     args.push_back(triple.isArch64Bit() ? "-m64" : "-m32");
     return;
 
+  // LoongArch does not use -m32/-m64 and uses -mabi=.
+  case Triple::loongarch64:
+    args.emplace_back(triple.isArch64Bit() ? "-mabi=lp64d" : "-mabi=ilp32d");
+    return;
+
   // MIPS does not have -m32/-m64 but requires -mabi=.
   case Triple::mips64:
   case Triple::mips64el:

--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -95,12 +95,12 @@ void appendTargetArgsForGcc(std::vector<std::string> &args) {
   case Triple::nvptx64:
     args.push_back(triple.isArch64Bit() ? "-m64" : "-m32");
     return;
-
+#if LDC_LLVM_VER >= 1600
   // LoongArch does not use -m32/-m64 and uses -mabi=.
   case Triple::loongarch64:
     args.emplace_back(triple.isArch64Bit() ? "-mabi=lp64d" : "-mabi=ilp32d");
     return;
-
+#endif // LDC_LLVM_VER >= 1600
   // MIPS does not have -m32/-m64 but requires -mabi=.
   case Triple::mips64:
   case Triple::mips64el:

--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -284,6 +284,8 @@ TargetABI *TargetABI::getTarget() {
   case llvm::Triple::thumb:
   case llvm::Triple::thumbeb:
     return getArmTargetABI();
+  case llvm::Triple::loongarch64:
+    return getLoongArch64TargetABI();
   default:
     Logger::cout() << "WARNING: Unknown ABI, guessing...\n";
     return new UnknownTargetABI;

--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -284,8 +284,10 @@ TargetABI *TargetABI::getTarget() {
   case llvm::Triple::thumb:
   case llvm::Triple::thumbeb:
     return getArmTargetABI();
+#if LDC_LLVM_VER >= 1600
   case llvm::Triple::loongarch64:
     return getLoongArch64TargetABI();
+#endif // LDC_LLVM_VER >= 1600
   default:
     Logger::cout() << "WARNING: Unknown ABI, guessing...\n";
     return new UnknownTargetABI;

--- a/gen/abi/loongarch64.cpp
+++ b/gen/abi/loongarch64.cpp
@@ -1,0 +1,73 @@
+//===-- gen/abi-loongarch64.cpp - LoongArch64 ABI description -----------*- C++
+//-*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// ABI spec:
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/abi/abi.h"
+#include "gen/abi/generic.h"
+#include "gen/dvalue.h"
+#include "gen/irstate.h"
+#include "gen/llvmhelpers.h"
+#include "gen/tollvm.h"
+
+struct LoongArch64TargetABI : TargetABI {
+private:
+  IndirectByvalRewrite indirectByvalRewrite{};
+
+public:
+  auto returnInArg(TypeFunction *tf, bool) -> bool override {
+    if (tf->isref()) {
+      return false;
+    }
+    Type *rt = tf->next->toBasetype();
+    if (!isPOD(rt)) {
+      return true;
+    }
+    // pass by reference when > 2*GRLEN
+    return rt->size() > 16;
+  }
+
+  auto passByVal(TypeFunction *, Type *t) -> bool override {
+    if (!t->size()) {
+      return false;
+    }
+    return t->size() > 16;
+  }
+
+  void rewriteFunctionType(IrFuncTy &fty) override {
+    if (!fty.ret->byref) {
+      rewriteArgument(fty, *fty.ret);
+    }
+
+    for (auto arg : fty.args) {
+      if (!arg->byref) {
+        rewriteArgument(fty, *arg);
+      }
+    }
+  }
+
+  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
+    if (arg.byref) {
+      return;
+    }
+
+    if (!isPOD(arg.type)) {
+      // non-PODs should be passed in memory
+      indirectByvalRewrite.applyTo(arg);
+      return;
+    }
+  }
+};
+
+// The public getter for abi.cpp
+TargetABI *getLoongArch64TargetABI() { return new LoongArch64TargetABI(); }

--- a/gen/abi/loongarch64.cpp
+++ b/gen/abi/loongarch64.cpp
@@ -38,7 +38,7 @@ public:
   }
 
   auto passByVal(TypeFunction *, Type *t) -> bool override {
-    if (!t->size()) {
+    if (!isPOD(t)) {
       return false;
     }
     return t->size() > 16;

--- a/gen/abi/targets.h
+++ b/gen/abi/targets.h
@@ -37,4 +37,4 @@ TargetABI *getX86_64TargetABI();
 
 TargetABI *getX86TargetABI();
 
-
+TargetABI *getLoongArch64TargetABI();

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -59,6 +59,7 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
 
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::loongarch32:
   case Triple::loongarch64:
     return LLType::getFP128Ty(ctx);
 

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -59,8 +59,10 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
 
   case Triple::riscv32:
   case Triple::riscv64:
+#if LDC_LLVM_VER >= 1600
   case Triple::loongarch32:
   case Triple::loongarch64:
+#endif // LDC_LLVM_VER >= 1600
     return LLType::getFP128Ty(ctx);
 
   default:

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -59,6 +59,7 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
 
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::loongarch64:
     return LLType::getFP128Ty(ctx);
 
   default:

--- a/tests/driver/loongarch64_abi.d
+++ b/tests/driver/loongarch64_abi.d
@@ -1,0 +1,11 @@
+// REQUIRES: target_LoongArch
+
+// RUN: %ldc %s -mtriple=loongarch64-unknown-linux-gnu -mattr=+f,+d --gcc=echo > %t && FileCheck %s < %t
+// CHECK: -mabi=lp64d
+
+version (LoongArch64) {} else static assert(0);
+// the next line checks -mattr=+f,+d
+version (LoongArch_HardFloat) {} else static assert(0);
+version (D_HardFloat) {} else static assert(0);
+
+void main() {}


### PR DESCRIPTION
This pull request ports the LDC compiler to LoongArch64 CPU architecture.

LoongArch64 is a new CPU architecture and has been supported by LLVM/Clang since LLVM 16.

You can find more information about this architecture here: https://loongson.github.io/LoongArch-Documentation/README-EN.html.

------

The port for D runtime is also in progress at https://github.com/dlang/dmd/pull/15628.