### PR TITLE
CI: upgrade GHA steps version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: 11.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 50
@@ -252,7 +252,7 @@ jobs:
       - build-native
       - build-cross
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Merge x86_64 & arm64 packages to universal one
         uses: ./.github/actions/merge-macos
 
@@ -262,7 +262,7 @@ jobs:
     timeout-minutes: 30
     needs: build-native
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Merge x64 & x86 packages to multilib one & build installer
         uses: ./.github/actions/merge-windows
 

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: 11.6 # silence `ld: warning: object file (…) was built for newer macOS version (…) than being linked (…)`
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 50
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get install gdb=9.1-0ubuntu1 llvm
 
       - name: Try to restore cached LLVM
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: llvm
           key: llvm-${{ matrix.llvm_version }}-${{ runner.os }}


### PR DESCRIPTION
This pull request upgrades `actions/checkout` and `actions/cache` in the GitHub Actions workflow file to their latest version.

This upgrade can suppress some warnings during the GitHub Actions CI run (e.g. Node.js deprecation warnings).