### PR TITLE
[Dcompute] don't crash on `VarDelaration`s with no type

### DIFF
--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -92,7 +92,11 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
       return;
     }
 
-    if (decl->type->ty == TY::Taarray) {
+    if (!decl->type) {
+      stop = true;
+      return;
+    }
+    else if (decl->type->ty == TY::Taarray) {
       decl->error("associative arrays not allowed in `@compute` code");
       stop = true;
     }

--- a/tests/semantic/dcompute_enum.d
+++ b/tests/semantic/dcompute_enum.d
@@ -1,0 +1,19 @@
+// RUN: %ldc -o- -mdcompute-targets=cuda-430 %s
+
+@compute(CompileFor.deviceOnly) module dcompute_enum;
+pragma(LDC_no_moduleinfo);
+import ldc.dcompute;
+template isUnsigned(T)
+{
+    static if (!__traits(isUnsigned, T))
+        enum isUnsigned = false;
+    else static if (is(T U == enum))
+        enum isUnsigned = isUnsigned!U;
+    else
+        enum isUnsigned = __traits(isZeroInit, T) // Not char, wchar, or dchar.
+            && !is(immutable T == immutable bool) && !is(T == __vector);
+}
+@kernel void tst (uint* dst)
+{
+    dst[0] = isUnsigned!(typeof(dst[0]));
+}


### PR DESCRIPTION
I'm not entirely sure why the VarDeclaration `isUnsigned` has a null type field, but it does.