### PR TITLE
Fix a regression in gc2stack optimization

### DIFF
--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -188,7 +188,8 @@ Value* ArrayFI::promote(CallBase *CB, IRBuilder<> &B, const G2StackAnalysis &A) 
     uint64_t size = A.DL.getTypeStoreSize(Ty);
     Value *TypeSize = ConstantInt::get(arrSize->getType(), size);
     // The initialization must be put at the original source variable
-    // definition location.
+    // definition location, because it could be in a loop and because
+    // of lifetime start-end annotation.
     Value *Size = B.CreateMul(TypeSize, arrSize);
     EmitMemZero(B, alloca, Size, A);
   }

--- a/tests/codegen/gh4510.d
+++ b/tests/codegen/gh4510.d
@@ -1,0 +1,13 @@
+// RUN: %ldc --O2 -run %s
+
+void main()
+{
+    int count;
+    foreach (i; 0..34)
+    {
+        auto flags = new bool[](1);
+        if (flags[0] == false) count++;
+            flags[] = true;
+    }
+    assert(count == 34);
+}


### PR DESCRIPTION
This fixes #4510.
LLVM RAII helper did not fit in case, at https://github.com/ldc-developers/ldc/commit/1d969cfccaf7181b5760a0ae7cd6088a36e3de44.