### PR TITLE
We have to explicitly set the OS version on newer macOSes to support LTO

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -451,7 +451,7 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
       osname += OSVersion.getAsString();
 #else
       // Hardcode this version, because `getMacOSXVersion` is not available.
-      osname += "10.4"
+      osname += "10.4";
 #endif
       triple.setOSName(osname);
     }

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -440,14 +440,13 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     triple = llvm::Triple(
         llvm::Triple::normalize(llvm::sys::getDefaultTargetTriple()));
 
-    // We only support OSX, so darwin should really be macosx.
     if (triple.getOS() == llvm::Triple::Darwin) {
       llvm::SmallString<16> osname;
+      // We only support OSX, so darwin should really be macosx.
       osname = "macosx";
-      if (triple.isAArch64())
-        osname += "11.0.0"; // Update this if MACOSX_VERSION_MIN changes
-      else
-        osname += "10.14.0";
+      llvm::VersionTuple OSVersion;
+      triple.getMacOSXVersion(OSVersion);
+      osname += OSVersion.getAsString();
       triple.setOSName(osname);
     }
 

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -443,10 +443,16 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     if (triple.getOS() == llvm::Triple::Darwin) {
       llvm::SmallString<16> osname;
       // We only support OSX, so darwin should really be macosx.
+      // We have to specify OS version in the triple, to avoid linker warnings, see https://github.com/ldc-developers/ldc/issues/4501
       osname = "macosx";
+#if LDC_LLVM_VER >= 1400
       llvm::VersionTuple OSVersion;
       triple.getMacOSXVersion(OSVersion);
       osname += OSVersion.getAsString();
+#else
+      // Hardcode this version, because `getMacOSXVersion` is not available.
+      osname += "10.4"
+#endif
       triple.setOSName(osname);
     }
 

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -460,7 +460,7 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
         osname += OSVersion.getAsString();
 #else
         // Hardcode the version, because `getMacOSXVersion` is not available.
-        osname += "10.4";
+        osname += "10.7";
 #endif
       }
 

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -442,7 +442,13 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
 
     // We only support OSX, so darwin should really be macosx.
     if (triple.getOS() == llvm::Triple::Darwin) {
-      triple.setOS(llvm::Triple::MacOSX);
+      llvm::SmallString<16> osname;
+      osname = "macosx";
+      if (triple.isAArch64())
+        osname += "11.0.0"; // Update this if MACOSX_VERSION_MIN changes
+      else
+        osname += "10.14.0";
+      triple.setOSName(osname);
     }
 
     // Handle -m32/-m64.


### PR DESCRIPTION
This also fixes these annoying linker warnings:
`ld: warning: no platform load command found in 'libphobos2-ldc.a[113](core.o)', assuming: macOS`  #4501