### PR TITLE
driver/toobj.cpp: writeModule: don't use StringRef::data to get a c_str

### DIFF
--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -378,7 +378,7 @@ void writeModule(llvm::Module *m, const char *filename) {
   if (!directory.empty()) {
     if (auto ec = llvm::sys::fs::create_directories(directory)) {
       error(Loc(), "failed to create output directory: %s\n%s",
-            directory.data(), ec.message().c_str());
+            directory.str().c_str(), ec.message().c_str());
       fatal();
     }
   }


### PR DESCRIPTION
The `.data()` method on a `StringRef`, returns a `const char*` to the first character but there is no guarantee that the string is null terminated.

In order to get a proper null terminated string it is necessary to use `.str()` which will return a C++ `std::string` which provided the `.c_str()` method to get the null terminated C string.

The invalid behavior can be seen by running (where the user doesn't have acces to the `inaccessible` folder):
```
$ ldc2 <<< '' - -od=inaccessible/impossible
Error: failed to create output directory: inaccessible/impossible/__stdin_4416.o
```

The error message should only include `inaccessible/impossible`.