### PR TITLE
This line points to empty dir?

### DIFF
--- a/ldc2.conf.in
+++ b/ldc2.conf.in
@@ -23,7 +23,6 @@ default:
     // default switches appended after all explicit command-line switches
     post-switches = [
         "-I@RUNTIME_DIR@/src",
-        "-I@LDC_BUILD_IMPORT_DIR@",
         "-I@JITRT_DIR@/d",
     ];
     // default directories to be searched for libraries when linking


### PR DESCRIPTION
When this ldc2.conf is used this line points to dir which contains empty `ldc/` dir