### PR TITLE
CMake: Pass EXTRA_CXXFLAGS when building ldc-profgen

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -31,7 +31,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LDCPROFDATA_SRC})
     set_target_properties(
         ldc-profdata PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+        COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS} ${EXTRA_CXXFLAGS}"
         LINK_FLAGS "${SANITIZE_LDFLAGS}"
     )
     target_link_libraries(ldc-profdata ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
@@ -53,7 +53,7 @@ if(LDC_LLVM_VER GREATER_EQUAL 1400)
         set_target_properties(
             ${ldc_name} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
-            COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
+            COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS} ${EXTRA_CXXFLAGS}"
             LINK_FLAGS "${SANITIZE_LDFLAGS}"
         )
         target_link_libraries(${ldc_name} ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})


### PR DESCRIPTION
This makes sure that NDEBUG is correctly defined/undefined, depending on whether we are building against llvm that has debug enabled or disabled.

Fixes #4573.