### PR TITLE
CMake: Pass NDEBUG through LDC_CXXFLAGS rather than EXTRA_CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,13 +505,13 @@ message(STATUS "-- Building LDC with integrated LLD linker (LDC_WITH_LLD): ${LDC
 
 message(STATUS "-- Building LDC with enabled assertions (LDC_ENABLE_ASSERTIONS): ${LDC_ENABLE_ASSERTIONS}")
 if(LDC_ENABLE_ASSERTIONS)
-    append("-UNDEBUG" EXTRA_CXXFLAGS)
+    append("-UNDEBUG" LDC_CXXFLAGS)
     # avoid MSVC warning D9025 about "-DNDEBUG ... -UNDEBUG"
     string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
     string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
     string(REGEX REPLACE "(^| )[/-]D *NDEBUG( |$)" "\\1-UNDEBUG\\2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 else()
-    append("-DNDEBUG" EXTRA_CXXFLAGS)
+    append("-DNDEBUG" LDC_CXXFLAGS)
 endif()
 
 #


### PR DESCRIPTION
NDEBUG needs to be correctly set depending on how LLVM is built. This commit moves -{D,U}NDEBUG from EXTRA_CXXFLAGS to LDC_CXXFLAGS as LDC_CXXFLAGS is already used for everything that links with LLVM and should be a better place to pass this.

Suggested by Martin Kinkelin in
https://github.com/ldc-developers/ldc/pull/4574

Fixes #4573.