### PR TITLE
support CC envvar to be in the form "command args..."

### DIFF
--- a/driver/cpreprocessor.cpp
+++ b/driver/cpreprocessor.cpp
@@ -22,9 +22,11 @@ const char *getPathToImportc_h(const Loc &loc) {
   return cached;
 }
 
-const std::string &getCC(bool isMSVC) {
-  static std::string cached;
-  if (cached.empty()) {
+const std::string &getCC(bool isMSVC,
+                         std::vector<std::string> &additional_args) {
+  static std::string cached_cc;
+  static std::vector<std::string> cached_args;
+  if (cached_cc.empty()) {
     std::string fallback = "cc";
     if (isMSVC) {
 #ifdef _WIN32
@@ -40,9 +42,11 @@ const std::string &getCC(bool isMSVC) {
       fallback = "clang-cl";
 #endif
     }
-    cached = getGcc(fallback.c_str());
+    cached_cc = getGcc(cached_args, fallback.c_str());
   }
-  return cached;
+
+  additional_args.insert(additional_args.end(), cached_args.cbegin(), cached_args.cend());
+  return cached_cc;
 }
 
 FileName getOutputPath(const Loc &loc, const char *csrcfile) {
@@ -84,8 +88,8 @@ FileName runCPreprocessor(FileName csrcfile, const Loc &loc, bool &ifile,
 
   FileName ipath = getOutputPath(loc, csrcfile.toChars());
 
-  const std::string &cc = getCC(isMSVC);
   std::vector<std::string> args;
+  const std::string &cc = getCC(isMSVC, args);
 
   if (!isMSVC)
     appendTargetArgsForGcc(args);

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -847,11 +847,11 @@ int linkObjToBinaryGcc(llvm::StringRef outputPath,
   std::string tool;
   std::unique_ptr<ArgsBuilder> argsBuilder;
   if (global.params.targetTriple->isOSBinFormatWasm()) {
-    tool = getProgram("wasm-ld", &opts::linker);
     argsBuilder = std::make_unique<LdArgsBuilder>();
+    tool = getProgram("wasm-ld", &opts::linker);
   } else {
-    tool = getGcc();
     argsBuilder = std::make_unique<ArgsBuilder>();
+    tool = getGcc(argsBuilder->args);
   }
 
   // build arguments

--- a/driver/toobj.cpp
+++ b/driver/toobj.cpp
@@ -147,6 +147,9 @@ void codegenModule(llvm::TargetMachine &Target, llvm::Module &m,
 
 static void assemble(const std::string &asmpath, const std::string &objpath) {
   std::vector<std::string> args;
+  std::string gcc;
+  gcc = getGcc(args);
+
   args.push_back("-O3");
   args.push_back("-c");
   args.push_back("-xassembler");
@@ -157,7 +160,7 @@ static void assemble(const std::string &asmpath, const std::string &objpath) {
   appendTargetArgsForGcc(args);
 
   // Run the compiler to assembly the program.
-  int R = executeToolAndWait(Loc(), getGcc(), args, global.params.v.verbose);
+  int R = executeToolAndWait(Loc(), gcc, args, global.params.v.verbose);
   if (R) {
     error(Loc(), "Error while invoking external assembler.");
     fatal();

--- a/driver/tool.h
+++ b/driver/tool.h
@@ -25,7 +25,8 @@ namespace opts {
 extern llvm::cl::opt<std::string> linker;
 }
 
-std::string getGcc(const char *fallback = "cc");
+std::string getGcc(std::vector<std::string> &additional_args,
+		   const char *fallback = "cc");
 void appendTargetArgsForGcc(std::vector<std::string> &args);
 
 std::string getProgram(const char *fallbackName,

--- a/tests/driver/cli_CC_envvar.d
+++ b/tests/driver/cli_CC_envvar.d
@@ -1,0 +1,6 @@
+// UNSUPPORTED: Windows
+
+// RUN: not env CC='cc --linker-arg' %ldc -vv %s | FileCheck %s
+
+// CHECK: Linking with:
+// CHECK-NEXT: --linker-arg


### PR DESCRIPTION
In case CC is set try to split it by spaces into a command and arguments. This is the same behaviour as in dmd.