### PR TITLE
Refactor away LDC-specific `FuncDeclaration::intrinsicName`

### DIFF
--- a/dmd/builtin.d
+++ b/dmd/builtin.d
@@ -91,7 +91,7 @@ version (IN_LLVM)
 
     if (func.llvmInternal == LDCPragma.LLVMintrinsic)
     {
-        const(char)[] name = func.intrinsicName.toDString;
+        const(char)[] name = func.mangleOverride;
         if (name.length < 7 || name[0..5] != "llvm.")
             return BUILTIN.unimp;
 

--- a/dmd/declaration.h
+++ b/dmd/declaration.h
@@ -563,7 +563,6 @@ public:
     const char *mangleString;           // mangled symbol created from mangleExact()
 
 #if IN_LLVM
-    const char *intrinsicName;
     uint32_t priority;
 
     // true if overridden with the pragma(LDC_allow_inline); statement

--- a/dmd/dtemplate.d
+++ b/dmd/dtemplate.d
@@ -690,7 +690,7 @@ version (IN_LLVM)
         auto td = new TemplateDeclaration(loc, ident, p,
                                           constraint ? constraint.syntaxCopy() : null,
                                           Dsymbol.arraySyntaxCopy(members), ismixin, literal);
-        td.intrinsicName = intrinsicName ? strdup(intrinsicName) : null;
+        td.intrinsicName = intrinsicName;
         return td;
 }
 else

--- a/dmd/func.d
+++ b/dmd/func.d
@@ -234,7 +234,6 @@ extern (C++) class FuncDeclaration : Declaration
 
 version (IN_LLVM)
 {
-    const(char)* intrinsicName;
     uint priority;
 
     // true if overridden with the pragma(LDC_allow_inline); statement
@@ -425,7 +424,7 @@ version (IN_LLVM) {} else
         f.fbody = fbody ? fbody.syntaxCopy() : null;
 version (IN_LLVM)
 {
-        f.intrinsicName = intrinsicName ? strdup(intrinsicName) : null;
+        f.mangleOverride = mangleOverride;
 }
         return f;
     }

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1242,6 +1242,8 @@ static char *DtoOverloadedIntrinsicName(TemplateInstance *ti,
   IF_LOG Logger::println("DtoOverloadedIntrinsicName");
   LOG_SCOPE;
 
+  assert(td->intrinsicName);
+
   IF_LOG {
     Logger::println("template instance: %s", ti->toChars());
     Logger::println("template declaration: %s", td->toChars());
@@ -1304,7 +1306,7 @@ static char *DtoOverloadedIntrinsicName(TemplateInstance *ti,
 
   IF_LOG Logger::println("final intrinsic name: %s", name.c_str());
 
-  return strdup(name.c_str());
+  return mem.xstrdup(name.c_str());
 }
 
 /// For D frontend
@@ -1312,11 +1314,9 @@ static char *DtoOverloadedIntrinsicName(TemplateInstance *ti,
 void DtoSetFuncDeclIntrinsicName(TemplateInstance *ti, TemplateDeclaration *td,
                                  FuncDeclaration *fd) {
   if (fd->llvmInternal == LLVMintrinsic) {
-    fd->intrinsicName = DtoOverloadedIntrinsicName(ti, td);
-    const auto cstr = fd->intrinsicName;
-    fd->mangleOverride = {cstr ? strlen(cstr) : 0, cstr};
-  } else {
-    fd->intrinsicName = td->intrinsicName ? strdup(td->intrinsicName) : nullptr;
+    const auto cstr = DtoOverloadedIntrinsicName(ti, td);
+    assert(cstr);
+    fd->mangleOverride = {strlen(cstr), cstr};
   }
 }
 

--- a/gen/pragma.cpp
+++ b/gen/pragma.cpp
@@ -351,15 +351,13 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
 
   switch (llvm_internal) {
   case LLVMintrinsic: {
-    const char *mangle = strdup(arg1str);
     int count = applyFunctionPragma(s, [=](FuncDeclaration *fd) {
       fd->llvmInternal = llvm_internal;
-      fd->intrinsicName = mangle;
-      fd->mangleOverride = {strlen(mangle), mangle};
+      fd->mangleOverride = {strlen(arg1str), arg1str};
     });
     count += applyTemplatePragma(s, [=](TemplateDeclaration *td) {
       td->llvmInternal = llvm_internal;
-      td->intrinsicName = mangle;
+      td->intrinsicName = arg1str;
     });
     if (count != 1) {
       error(s->loc,
@@ -419,7 +417,7 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
   case LLVMatomic_rmw: {
     const int count = applyTemplatePragma(s, [=](TemplateDeclaration *td) {
       td->llvmInternal = llvm_internal;
-      td->intrinsicName = strdup(arg1str);
+      td->intrinsicName = arg1str;
     });
     if (count != 1) {
       error(s->loc,
@@ -452,7 +450,6 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
         fatal();
       }
       td->llvmInternal = llvm_internal;
-      td->onemember->llvmInternal = llvm_internal;
     });
     if (count != 1) {
       error(s->loc,
@@ -503,7 +500,6 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
         fatal();
       }
       td->llvmInternal = llvm_internal;
-      td->onemember->llvmInternal = llvm_internal;
     });
     if (count != 1) {
       error(s->loc,
@@ -523,7 +519,6 @@ void DtoCheckPragma(PragmaDeclaration *decl, Dsymbol *s,
         fatal();
       }
       td->llvmInternal = llvm_internal;
-      td->onemember->llvmInternal = llvm_internal;
     });
     if (count != 1) {
       error(s->loc,

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -14,6 +14,7 @@
 #include "dmd/id.h"
 #include "dmd/mtype.h"
 #include "dmd/target.h"
+#include "dmd/template.h"
 #include "gen/abi/abi.h"
 #include "gen/classes.h"
 #include "gen/dvalue.h"
@@ -544,18 +545,21 @@ bool DtoLowerMagicIntrinsic(IRState *p, FuncDeclaration *fndecl, CallExp *e,
       fatal();
     }
 
-    assert(fndecl->intrinsicName);
+    TemplateInstance *ti = fndecl->parent->isTemplateInstance();
+    assert(ti);
+    const char *opString = ti->tempdecl->isTemplateDeclaration()->intrinsicName;
+    assert(opString);
+
     static const char *ops[] = {"xchg", "add", "sub", "and",  "nand", "or",
                                 "xor",  "max", "min", "umax", "umin", nullptr};
 
     int op = 0;
     for (;; ++op) {
       if (ops[op] == nullptr) {
-        error(e->loc, "unknown `atomicrmw` operation `%s`",
-              fndecl->intrinsicName);
+        error(e->loc, "unknown `atomicrmw` operation `%s`", opString);
         fatal();
       }
-      if (strcmp(fndecl->intrinsicName, ops[op]) == 0) {
+      if (strcmp(opString, ops[op]) == 0) {
         break;
       }
     }


### PR DESCRIPTION
Using `mangleOverride` directly instead. Also get rid of superfluous string copies. And for `LLVMatomic_rmw`, don't store the operation string in the instantiated FuncDeclarations anymore, but fetch it from the parent TemplateDeclaration.