### PR TITLE
Add memory invariant assumptions for virtual calls to improve devirtualization

### DIFF
--- a/gen/classes.h
+++ b/gen/classes.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "gen/structs.h"
 
 class ClassDeclaration;
@@ -37,4 +39,6 @@ DValue *DtoDynamicCastObject(const Loc &loc, DValue *val, Type *to);
 
 DValue *DtoDynamicCastInterface(const Loc &loc, DValue *val, Type *to);
 
-llvm::Value *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl);
+/// Returns pair of function pointer and vtable pointer.
+std::pair<llvm::Value *, llvm::Value *>
+DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl);

--- a/gen/dvalue.cpp
+++ b/gen/dvalue.cpp
@@ -105,11 +105,13 @@ LLValue *DSliceValue::getPtr() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DFuncValue::DFuncValue(Type *t, FuncDeclaration *fd, LLValue *v, LLValue *vt)
-    : DRValue(t, v), func(fd), vthis(vt) {}
+DFuncValue::DFuncValue(Type *t, FuncDeclaration *fd, LLValue *v, LLValue *vt,
+                       LLValue *vtable)
+    : DRValue(t, v), func(fd), vthis(vt), vtable(vtable) {}
 
-DFuncValue::DFuncValue(FuncDeclaration *fd, LLValue *v, LLValue *vt)
-    : DFuncValue(fd->type, fd, v, vt) {}
+DFuncValue::DFuncValue(FuncDeclaration *fd, LLValue *v, LLValue *vt,
+                       LLValue *vtable)
+    : DFuncValue(fd->type, fd, v, vt, vtable) {}
 
 bool DFuncValue::definedInFuncEntryBB() {
   return isDefinedInFuncEntryBB(val) &&
@@ -235,7 +237,7 @@ DRValue *DDcomputeLValue::getRVal() {
     llvm_unreachable("getRVal() for memory-only type");
     return nullptr;
   }
-  
+
   LLValue *rval = DtoLoad(lltype, val);
   
   const auto ty = type->toBasetype()->ty;

--- a/gen/dvalue.h
+++ b/gen/dvalue.h
@@ -137,15 +137,18 @@ public:
   llvm::Value *getPtr();
 };
 
-/// Represents a D function value with optional this/context pointer.
+/// Represents a D function value with optional this/context pointer, and
+/// optional vtable pointer.
 class DFuncValue : public DRValue {
 public:
   FuncDeclaration *func;
   llvm::Value *vthis;
+  llvm::Value *vtable;
 
   DFuncValue(Type *t, FuncDeclaration *fd, llvm::Value *v,
-             llvm::Value *vt = nullptr);
-  DFuncValue(FuncDeclaration *fd, llvm::Value *v, llvm::Value *vt = nullptr);
+             llvm::Value *vt = nullptr, llvm::Value *vtable = nullptr);
+  DFuncValue(FuncDeclaration *fd, llvm::Value *v, llvm::Value *vt = nullptr,
+             llvm::Value *vtable = nullptr);
 
   bool definedInFuncEntryBB() override;
 

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -97,8 +97,7 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
     for (auto &II : *bb) {
       llvm::Instruction *Inst = &II;
       llvm::Instruction *newInst = nullptr;
-      if (funclet && !llvm::isa<llvm::DbgInfoIntrinsic>(Inst) &&
-          !llvm::isa<llvm::AssumeInst>(Inst)) { // should we exclude any IntrinsicInst?
+      if (funclet && !llvm::isa<llvm::IntrinsicInst>(Inst)) {
         if (auto IInst = llvm::dyn_cast<llvm::InvokeInst>(Inst)) {
           auto invoke = llvm::InvokeInst::Create(
               IInst, llvm::OperandBundleDef("funclet", funclet));

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -97,8 +97,8 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
     for (auto &II : *bb) {
       llvm::Instruction *Inst = &II;
       llvm::Instruction *newInst = nullptr;
-      if (funclet &&
-          !llvm::isa<llvm::DbgInfoIntrinsic>(Inst)) { // IntrinsicInst?
+      if (funclet && !llvm::isa<llvm::DbgInfoIntrinsic>(Inst) &&
+          !llvm::isa<llvm::AssumeInst>(Inst)) { // should we exclude any IntrinsicInst?
         if (auto IInst = llvm::dyn_cast<llvm::InvokeInst>(Inst)) {
           auto invoke = llvm::InvokeInst::Create(
               IInst, llvm::OperandBundleDef("funclet", funclet));

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -771,22 +771,6 @@ public:
 
     // get func value if any
     DFuncValue *dfnval = fnval->isFunc();
-    if (dfnval && dfnval->func) {
-      assert(!DtoIsMagicIntrinsic(dfnval->func));
-
-      // If loading the vtable was not needed for function call, we have to load
-      // it here to do the "assume" optimization below.
-      if (!dfnval->vtable && dfnval->vthis && dfnval->func->isVirtual() &&
-          dfnval->func->_linkage == LINK::d && (optLevel() >= 2)) {
-        dfnval->vtable =
-            DtoLoad(getVoidPtrType(),
-                    DtoBitCast(dfnval->vthis, getVoidPtrType()->getPointerTo()),
-                    "saved_vtable");
-      }
-    }
-
-    DValue *result =
-        DtoCallFunction(e->loc, e->type, fnval, e->arguments, sretPointer);
 
     // If this is a virtual function call, the object is passed by reference
     // through the `this` parameter, and therefore the optimizer has to assume
@@ -803,8 +787,28 @@ public:
     // ```
     // Only emit this extra code from -O2.
     // This optimization is only valid for D class method calls (not C++).
-    if (dfnval && dfnval->vtable && (optLevel() >= 2) &&
-        dfnval->func->_linkage == LINK::d) {
+    bool canEmitVTableUnchangedAssumption =
+        dfnval && dfnval->func && (dfnval->func->_linkage == LINK::d) &&
+        (optLevel() >= 2);
+
+    if (dfnval && dfnval->func) {
+      assert(!DtoIsMagicIntrinsic(dfnval->func));
+
+      // If loading the vtable was not needed for function call, we have to load
+      // it here to do the "assume" optimization below.
+      if (canEmitVTableUnchangedAssumption && !dfnval->vtable &&
+          dfnval->vthis && dfnval->func->isVirtual()) {
+        dfnval->vtable =
+            DtoLoad(getVoidPtrType(),
+                    DtoBitCast(dfnval->vthis, getVoidPtrType()->getPointerTo()),
+                    "saved_vtable");
+      }
+    }
+
+    DValue *result =
+        DtoCallFunction(e->loc, e->type, fnval, e->arguments, sretPointer);
+
+    if (canEmitVTableUnchangedAssumption && dfnval->vtable) {
       // Reload vtable ptr. It's the first element so instead of GEP+load we can
       // do a void* load+bitcast (at this point in the code we don't have easy
       // access to the type of the class to do a GEP).

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -777,7 +777,7 @@ public:
       // If loading the vtable was not needed for function call, we have to load
       // it here to do the "assume" optimization below.
       if (!dfnval->vtable && dfnval->vthis && dfnval->func->isVirtual() &&
-          dfnval->func->_linkage == LINK::d && (optLevel() >= 0)) {
+          dfnval->func->_linkage == LINK::d && (optLevel() >= 2)) {
         dfnval->vtable =
             DtoLoad(dfnval->vthis->getType(), dfnval->vthis, "saved_vtable");
       }
@@ -801,7 +801,7 @@ public:
     // ```
     // Only emit this extra code from -O2.
     // This optimization is only valid for D class method calls (not C++).
-    if (dfnval && dfnval->vtable && (optLevel() >= 0) &&
+    if (dfnval && dfnval->vtable && (optLevel() >= 2) &&
         dfnval->func->_linkage == LINK::d) {
       // Reload vtable ptr. It's the first element so instead of GEP+load we can
       // do a void* load+bitcast (at this point in the code we don't have easy

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -779,7 +779,9 @@ public:
       if (!dfnval->vtable && dfnval->vthis && dfnval->func->isVirtual() &&
           dfnval->func->_linkage == LINK::d && (optLevel() >= 2)) {
         dfnval->vtable =
-            DtoLoad(dfnval->vthis->getType(), dfnval->vthis, "saved_vtable");
+            DtoLoad(getVoidPtrType(),
+                    DtoBitCast(dfnval->vthis, getVoidPtrType()->getPointerTo()),
+                    "saved_vtable");
       }
     }
 

--- a/tests/codegen/devirtualization_assumevtable.d
+++ b/tests/codegen/devirtualization_assumevtable.d
@@ -42,14 +42,14 @@ void directcall()
 // CHECK-LABEL: define{{.*}}exacttypeunknown
 void exacttypeunknown(A a, A b)
 {
-    // CHECK: %[[FOO:[0-9a-z]+]] = load {{.*}}"foo@vtbl
+    // CHECK: %[[FOO:[0-9a-z]+]] = load {{.*}}!invariant
     // CHECK: call{{.*}} void %[[FOO]](
     a.foo();
     // CHECK: call{{.*}} void %[[FOO]](
     a.foo();
 
     a = b;
-    // CHECK: %[[FOO2:[0-9a-z]+]] = load {{.*}}"foo@vtbl
+    // CHECK: %[[FOO2:[0-9a-z]+]] = load {{.*}}!invariant
     // CHECK: call{{.*}} void %[[FOO2]](
     a.foo();
 }

--- a/tests/codegen/devirtualization_assumevtable.d
+++ b/tests/codegen/devirtualization_assumevtable.d
@@ -16,9 +16,9 @@ class B : A {
 void ggg()
 {
     A a = new A();
-    // CHECK: call void @_D29devirtualization_assumevtable1A3foo
+    // CHECK: call {{.*}}_D29devirtualization_assumevtable1A3foo
     a.foo();
-    // CHECK: call void @_D29devirtualization_assumevtable1A3foo
+    // CHECK: call {{.*}}_D29devirtualization_assumevtable1A3foo
     a.foo();
 }
 
@@ -26,9 +26,9 @@ void ggg()
 void hhh()
 {
     A a = new A();
-    // CHECK: call void @_D29devirtualization_assumevtable1A3foo
+    // CHECK: call {{.*}}_D29devirtualization_assumevtable1A3foo
     a.foo();
-    // CHECK: call void @_D29devirtualization_assumevtable1A3oof
+    // CHECK: call {{.*}}_D29devirtualization_assumevtable1A3oof
     a.oof();
 }
 
@@ -36,13 +36,31 @@ void hhh()
 void exacttypeunknown(A a, A b)
 {
     // CHECK: %[[FOO:[0-9a-z]+]] = load {{.*}}"foo@vtbl
-    // CHECK: call void %[[FOO]](
+    // CHECK: call{{.*}} void %[[FOO]](
     a.foo();
-    // CHECK: call void %[[FOO]](
+    // CHECK: call{{.*}} void %[[FOO]](
     a.foo();
 
     a = b;
     // CHECK: %[[FOO2:[0-9a-z]+]] = load {{.*}}"foo@vtbl
-    // CHECK: call void %[[FOO2]](
+    // CHECK: call{{.*}} void %[[FOO2]](
+    a.foo();
+}
+
+// The devirtualization is not valid for C++ methods.
+extern(C++)
+class CPPClass {
+    void foo();
+    void oof();
+}
+
+// CHECK-LABEL: define{{.*}}exactCPPtypeunknown
+void exactCPPtypeunknown(CPPClass a)
+{
+    // CHECK: %[[FOO:[0-9a-z]+]] = load {{.*}}!invariant
+    // CHECK: call{{.*}} void %[[FOO]](
+    a.foo();
+    // CHECK: %[[FOO2:[0-9a-z]+]] = load {{.*}}!invariant
+    // CHECK: call{{.*}} void %[[FOO2]](
     a.foo();
 }

--- a/tests/codegen/devirtualization_assumevtable.d
+++ b/tests/codegen/devirtualization_assumevtable.d
@@ -35,12 +35,14 @@ void hhh()
 // CHECK-LABEL: define{{.*}}exacttypeunknown
 void exacttypeunknown(A a, A b)
 {
-    // CHECK: call void %[[FOO:[0-9]+]](%devirtualization_assumevtable.A*
+    // CHECK: %[[FOO:[0-9a-z]+]] = load {{.*}}"foo@vtbl
+    // CHECK: call void %[[FOO]](
     a.foo();
-    // CHECK: call void %[[FOO]](%devirtualization_assumevtable.A*
+    // CHECK: call void %[[FOO]](
     a.foo();
 
     a = b;
-    // CHECK-NOT: call void %[[FOO]](%devirtualization_assumevtable.A*
+    // CHECK: %[[FOO2:[0-9a-z]+]] = load {{.*}}"foo@vtbl
+    // CHECK: call void %[[FOO2]](
     a.foo();
 }

--- a/tests/codegen/inlining_leakdefinitions.d
+++ b/tests/codegen/inlining_leakdefinitions.d
@@ -23,6 +23,8 @@ int call_class_function(A a)
     // There should be only one call to "virtual_func".
     // OPT3: call
     // OPT3-NOT: call
+    // OPT3: call{{.*}}assume
+    // OPT3-NOT: call
     return a.final_func();
     // There should be a return from an LLVM variable (not a direct value)
     // OPT0: ret i32 %

--- a/tests/codegen/inlining_leakdefinitions.d
+++ b/tests/codegen/inlining_leakdefinitions.d
@@ -23,8 +23,6 @@ int call_class_function(A a)
     // There should be only one call to "virtual_func".
     // OPT3: call
     // OPT3-NOT: call
-    // OPT3: call{{.*}}assume
-    // OPT3-NOT: call
     return a.final_func();
     // There should be a return from an LLVM variable (not a direct value)
     // OPT0: ret i32 %


### PR DESCRIPTION
Assumptions added:
- class methods do not change the object's vtable pointer
- loads through vtable pointer are invariant (vtables are immutable throughout program life)

Examples of the improvement in devirtualization:
```d
class A {
    void foo();
    void oof();
}

void ggg() {
    A a = new A();
    a.foo();  // was already devirtualized
    a.foo();  // devirtualized by this PR
}

void exacttypeunknown(A a, A b) {
    a.foo();
    a.foo(); // no vtable lookup, PR removes 2 memory reads
}
```