### PR TITLE
tests/dmd/dshell/dll_cxx.d: Don't add -mMODEL before cheking NO_ARCH_…

### DIFF
--- a/tests/dmd/dshell/dll_cxx.d
+++ b/tests/dmd/dshell/dll_cxx.d
@@ -45,7 +45,7 @@ int main()
     }
     else
     {
-        dllCmd ~= [ `-m` ~ Vars.MODEL, `-shared`, `-fPIC`, `-o`, Vars.DLL ];
+        dllCmd ~= [ `-shared`, `-fPIC`, `-o`, Vars.DLL ];
         mainExtra = `-fPIC -L-L$OUTPUT_BASE -L$DLL -L-lstdc++ -L--no-demangle`;
         if (environment.get("NO_ARCH_VARIANT", "") != "1")
             dllCmd ~= `-m` ~ Vars.MODEL;


### PR DESCRIPTION
…VARIANT