### PR TITLE
Allow `@target` attribute to overwrite global attributes.

### DIFF
--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -328,6 +328,9 @@ void applyAttrTarget(StructLiteralExp *sle, llvm::Function *func,
   llvm::StringRef CPU;
   std::vector<std::string> features;
 
+  // Preserve the order of the features as they appear in the source
+  // code. `hasFnAttribute` returns all the features accumulated
+  // so far and they should remain at the beginning of the result.
   if (func->hasFnAttribute("target-features")) {
     auto attr = func->getFnAttribute("target-features");
     features.push_back(std::string(attr.getValueAsString()));
@@ -371,10 +374,6 @@ void applyAttrTarget(StructLiteralExp *sle, llvm::Function *func,
   }
 
   if (!features.empty()) {
-    // Sorting the features puts negative features ("-") after positive features
-    // ("+"). This provides the desired behavior of negative features overriding
-    // positive features regardless of their order in the source code.
-    sort(features.begin(), features.end());
     func->addFnAttr("target-features",
                     llvm::join(features.begin(), features.end(), ","));
     irFunc->targetFeaturesOverridden = true;

--- a/tests/codegen/attr_target_overrides_mattr_x86.d
+++ b/tests/codegen/attr_target_overrides_mattr_x86.d
@@ -1,0 +1,35 @@
+// Test that @target attribute overrides command line -mattr
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -O -c -mattr=sse -mcpu=i386 -mtriple=i386-linux-gnu -output-ll -of=%t.sse.ll %s && FileCheck %s --check-prefix LLVM-SSE < %t.sse.ll
+// RUN: %ldc -O -c -mattr=-sse -mcpu=i386 -mtriple=i386-linux-gnu -output-ll -of=%t.nosse.ll %s && FileCheck %s --check-prefix LLVM-NOSSE < %t.nosse.ll
+
+import ldc.attributes;
+
+// LLVM-SSE-LABEL: define{{.*}} void @{{.*}}foo_nosse
+// LLVM-SSE-SAME: #[[NOSSE:[0-9]+]]
+// LLVM-NOSSE-LABEL: define{{.*}} void @{{.*}}foo_nosse
+// LLVM-NOSSE-SAME: #[[NOSSE:[0-9]+]]
+@target("no-sse")
+void foo_nosse(float *A, float *B, float K) {
+    for (int i = 0; i < 128; ++ i)
+	A[i] *= B[i] + K;
+}
+
+// LLVM-SSE-LABEL: define{{.*}} void @{{.*}}foo_sse
+// LLVM-SSE-SAME: #[[SSE:[0-9]+]]
+// LLVM-NOSSE-LABEL: define{{.*}} void @{{.*}}foo_sse
+// LLVM-NOSSE-SAME: #[[SSE:[0-9]+]]
+@target("sse")
+void foo_sse(float *A, float *B, float K) {
+    for (int i = 0; i < 128; ++ i)
+	A[i] *= B[i] + K;
+}
+
+// The -mattr feature should come before the @target one in the "target-features" below.
+
+// LLVM-SSE-DAG: attributes #[[SSE]] = {{.*}} "target-features"="+sse,+sse"
+// LLVM-SSE-DAG: attributes #[[NOSSE]] = {{.*}} "target-features"="+sse,-sse"
+// LLVM-NOSSE-DAG: attributes #[[SSE]] = {{.*}} "target-features"="-sse,+sse"
+// LLVM-NOSSE-DAG: attributes #[[NOSSE]] = {{.*}} "target-features"="-sse,-sse"

--- a/tests/codegen/attr_target_x86.d
+++ b/tests/codegen/attr_target_x86.d
@@ -25,18 +25,21 @@ void foo_sse(float *A, float* B, float K) {
 // ASM: addps
 }
 
-// Make sure that no-sse overrides sse (attribute sorting). Also tests multiple @target attribs.
-// LLVM-LABEL: define{{.*}} void @{{.*}}foo_nosse
-// LLVM-SAME: #[[NOSSE:[0-9]+]]
-// ASM-LABEL: _D15attr_target_x869foo_nosseFPfQcfZv:
+// `sse` should take precedence over `no-sse` since it appears later.
+// LLVM-LABEL: define{{.*}} void @{{.*}}bar_sse
+// LLVM-SAME: #[[SSE2:[0-9]+]]
+// ASM-LABEL: _D15attr_target_x867bar_sseFPfQcfZv:
 @(target("no-sse\n  , \tsse  "))
-void foo_nosse(float *A, float* B, float K) {
+void bar_sse(float *A, float* B, float K) {
     for (int i = 0; i < 128; ++i)
         A[i] *= B[i] + K;
-// ASM-NOT: addps
+// ASM: addps
 }
+
+
+// Same reason as above, except the other way around
 // LLVM-LABEL: define{{.*}} void @{{.*}}bar_nosse
-// LLVM-SAME: #[[NOSSE]]
+// LLVM-SAME: #[[NOSSE:[0-9]+]]
 // ASM-LABEL: _D15attr_target_x869bar_nosseFPfQcfZv:
 @(target("sse"))
 @(target("  no-sse"))
@@ -58,5 +61,6 @@ void haswell(float *A, float* B, float K) {
 
 
 // LLVM-DAG: attributes #[[SSE]] = {{.*}} "target-features"="+sse"
+// LLVM-DAG: attributes #[[SSE2]] = {{.*}} "target-features"="-sse,+sse"
 // LLVM-DAG: attributes #[[NOSSE]] = {{.*}} "target-features"="+sse,-sse"
 // LLVM-DAG: attributes #[[HSW]] = {{.*}} "target-cpu"="haswell"


### PR DESCRIPTION
If a target feature has been specified both in source code through `@target` and on the command line through `-mattr` let the former overwrite the latter.

Reported first as https://github.com/libmir/mir-ion/pull/46 there is an inconsistency to how `@target` is handled that can lead to ugly errors during compilation.

Assuming the file:
```d
import ldc.attributes;
import ldc.intrinsics;

pragma(LDC_intrinsic, "llvm.x86.avx2.pshuf.b")
__vector(ubyte[32]) avx2_pshuf_b(__vector(ubyte[32]), __vector(ubyte[32]));

@target("avx2")
void foo () {
	__vector(ubyte[32]) x;
	x = avx2_pshuf_b(x, x);
}

void main() {}
```

Currently, compiling it with `ldc2 -mattr=-avx2` results in:
```
LLVM ERROR: Cannot select: 0x563de78b7350: v32i8 = X86ISD::PSHUFB 0x563de78b70b0, 0x563de78b7190
  0x563de78b70b0: v32i8,ch = CopyFromReg 0x563de786cad0, Register:v32i8 %1
    0x563de78b7040: v32i8 = Register %1
  0x563de78b7190: v32i8,ch = CopyFromReg 0x563de786cad0, Register:v32i8 %2
    0x563de78b7120: v32i8 = Register %2
In function: _D5repro3fooFZv
 #0 0x00007f71f1ba2812 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x9a2812)
 #1 0x00007f71f1ba03e4 llvm::sys::RunSignalHandlers() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x9a03e4)
 #2 0x00007f71f1ba0566 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x9a0566)
 #3 0x00007f71f0671930 (/usr/lib64/libc.so.6+0x3a930)
 #4 0x00007f71f06c2e9c (/usr/lib64/libc.so.6+0x8be9c)
 #5 0x00007f71f0671886 gsignal (/usr/lib64/libc.so.6+0x3a886)
 #6 0x00007f71f06598b7 abort (/usr/lib64/libc.so.6+0x228b7)
 #7 0x00007f71f16c0830 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x4c0830)
 #8 0x00007f71f251bc59 llvm::SelectionDAGISel::CannotYetSelect(llvm::SDNode*) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x131bc59)
 #9 0x00007f71f2522d30 llvm::SelectionDAGISel::SelectCodeCommon(llvm::SDNode*, unsigned char const*, unsigned int) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x1322d30)
#10 0x00007f71f50696ce (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x3e696ce)
#11 0x00007f71f251a4bc llvm::SelectionDAGISel::DoInstructionSelection() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x131a4bc)
#12 0x00007f71f25261d6 llvm::SelectionDAGISel::CodeGenAndEmitDAG() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x13261d6)
#13 0x00007f71f25284d3 llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x13284d3)
#14 0x00007f71f252a0c7 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x132a0c7)
#15 0x00007f71f5070684 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x3e70684)
#16 0x00007f71f1fc957b llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xdc957b)
#17 0x00007f71f1cfddb6 llvm::FPPassManager::runOnFunction(llvm::Function&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xafddb6)
#18 0x00007f71f1cfe05b llvm::FPPassManager::runOnModule(llvm::Module&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xafe05b)
#19 0x00007f71f1cfe717 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xafe717)
#20 0x0000563de56b3fd7 (anonymous namespace)::codegenModule(llvm::TargetMachine&, llvm::Module&, char const*, llvm::CodeGenFileType) toobj.cpp:0:0
#21 0x0000563de56b4e51 (anonymous namespace)::writeObjectFile(llvm::Module*, char const*) toobj.cpp:0:0
#22 0x0000563de56b60e9 writeModule(llvm::Module*, char const*) (./ldc-orig/bin/ldc2+0xb020e9)
#23 0x0000563de56af29f ldc::CodeGenerator::writeAndFreeLLModule(char const*) (./ldc-orig/bin/ldc2+0xafb29f)
#24 0x0000563de56aee02 ldc::CodeGenerator::~CodeGenerator() (./ldc-orig/bin/ldc2+0xafae02)
#25 0x0000563de566c785 codegenModules(Array<Module*>&) (./ldc-orig/bin/ldc2+0xab8785)
#26 0x0000563de53e8cf3 mars_mainBody(Param&, Array<char const*>&, Array<char const*>&) (./ldc-orig/bin/ldc2+0x834cf3)
#27 0x0000563de566bf70 cppmain() (./ldc-orig/bin/ldc2+0xab7f70)
#28 0x0000563de54a2e95 D main (./ldc-orig/bin/ldc2+0x8eee95)
#29 0x00007f71f10589fb _D2rt6dmain212_d_run_main2UAAamPUQgZiZ6runAllMFZ9__lambda2MFZv (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x4589fb)
#30 0x00007f71f10588aa _D2rt6dmain212_d_run_main2UAAamPUQgZiZ7tryExecMFMDFZvZv (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x4588aa)
#31 0x00007f71f1058983 _D2rt6dmain212_d_run_main2UAAamPUQgZiZ6runAllMFZv (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x458983)
#32 0x00007f71f10588aa _D2rt6dmain212_d_run_main2UAAamPUQgZiZ7tryExecMFMDFZvZv (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x4588aa)
#33 0x00007f71f1058813 _d_run_main2 (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x458813)
#34 0x00007f71f10585fc _d_run_main (/usr/lib/dmd/2.107/lib64/libphobos2.so.0.107+0x4585fc)
#35 0x0000563de56a4493 args::forwardToDruntime(int, char const**) (./ldc-orig/bin/ldc2+0xaf0493)
#36 0x0000563de566b81a main (./ldc-orig/bin/ldc2+0xab781a)
#37 0x00007f71f065b2e0 (/usr/lib64/libc.so.6+0x242e0)
#38 0x00007f71f065b399 __libc_start_main (/usr/lib64/libc.so.6+0x24399)
#39 0x0000563de516b955 _start (./ldc-orig/bin/ldc2+0x5b7955)
Aborted (core dumped)
```

The error above is related, as far as my reading of similar opened llvm issues, to improper usage of intrinsics and target features. With some printing, the target features passed to llvm are `final features: "+avx2,-avx2,+cx16"`. Where `-avx2,+cx16` come from the command line (and some other place) and `+avx2` was generated because of `@target` on the `foo` function. This behavior is the intended one as explained in the comments: https://github.com/ldc-developers/ldc/blob/908a2e3d816f3e21d82b61d4b0624de92f871feb/gen/uda.cpp#L374-L376

There are 2 issues with this approach. The first, demonstrated above, makes `@target` specifications in source code useless if, on the command line, `-mattr` is passed.

The second issues is apparent in the ordering of the features, `-avx2` comes before `+cx16` because, in the features vector, they are, in fact, one singular string so: `features = { "+avx2", "-avx2,+cx16" }`. Sorting the vector like this is bad because the final place of the whole features passed (or implicitly deduced) on the command line becomes tied to its first value.

This PR fixes this by:
1. Only sorting the features implied by `@target`, which preserves the old behavior of `-feature` overwrites a `+feature`.
2. Adds global features after the sorting is done and places them before `@target` features, to allow the desired overwriting capability. The order of the global features is preserved, whatever that was during compiler invocation.