### PR TITLE
Propagate the target to `clang-cl` when it's used to preprocess C.

### DIFF
--- a/tests/driver/clang-cl-target-forwarding.d
+++ b/tests/driver/clang-cl-target-forwarding.d
@@ -1,0 +1,17 @@
+// On Windows, either clang-cl or cl is used to preprocess C.
+// If clang-cl is used, LDC's target triple and any target features should be
+// passed to clang-cl.
+
+// REQUIRES: Windows && target_X86 && target_AArch64
+
+// RUN: %ldc -mtriple=x86_64-pc-windows-msvc -mcpu=znver1 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=znver1
+// RUN: %ldc -mtriple=x86_64-pc-windows-msvc -mcpu=znver1 -mattr -sse4a -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=znver1-sans-sse4a
+// RUN: %ldc -mtriple=x86_64-pc-windows-msvc -mcpu=znver2 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=znver2
+// RUN: %ldc -mtriple=aarch64-pc-windows-msvc -mcpu=apple-a10 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=apple-a10
+// RUN: %ldc -mtriple=aarch64-pc-windows-msvc -mcpu=apple-a11 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=apple-a11
+
+// znver1: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+sse4a}}
+// znver1-sans-sse4a: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-sse4a}}
+// znver2: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+clwb}}
+// apple-a10: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a11}}
+// apple-a11: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a11}}


### PR DESCRIPTION
This PR propagates the target to `clang-cl` when it's used to preprocess C, addressing https://github.com/ldc-developers/ldc/issues/4626.

`clang-cl` doesn't seem to support `-mcpu=` nor `-mtune=`, and `-march=` can't be used in their place for AArch64/ARM targets.

So, to ensure the features of LDC's targeted CPU are propagated, every processor feature gets forwarded on via the `-target-feature` option—the downside of this being that it generates a massive command-line: the longest being 11,691 characters just for the target-features when targeting AArch64, which is a non-negligible contribution to Windows' limit of 32,766 UTF-16 code-units for a command-line, but there are only four paths in the command so I think it should be fine.