### PR TITLE
Support case-insensitive DMD-style inline assembly.

### DIFF
--- a/gen/asmstmt.cpp
+++ b/gen/asmstmt.cpp
@@ -114,8 +114,11 @@ Statement *asmSemantic(AsmStatement *s, Scope *sc) {
   // this is DMD-style asm
   sc->func->hasReturnExp |= 32;
 
+  const auto caseSensitive = s->caseSensitive;
+
   auto ias = createInlineAsmStatement(s->loc, s->tokens);
   s = ias;
+  s->caseSensitive = caseSensitive;
 
   bool err = false;
   llvm::Triple const &t = *global.params.targetTriple;

--- a/tests/compilable/c_masm.c
+++ b/tests/compilable/c_masm.c
@@ -1,0 +1,13 @@
+// DMD supports case-insensitive register operands for x86 assembly in C files, when targeting Windows.
+// Additionally, a new-line can be used to terminate an instruction.
+
+// REQUIRES: Windows && target_X86
+// RUN: %ldc -mtriple=i686-pc-windows-msvc -c %s
+
+unsigned int subtract(unsigned int a, unsigned int b) {
+    __asm {
+        mov eax, dword ptr [a]
+        mov eDX, dword ptr [b]
+        sub Eax, edx
+    }
+}


### PR DESCRIPTION
DMD recently gained support for case-insensitive DMD-style inline assembly, for ImportC, when targeting Windows: https://github.com/dlang/dmd/pull/15595
This PR replicates that support in LDC.
