### PR TITLE
Fix issue #2257: LLVM does not accept generated inline assembly with variable+offset

### DIFF
--- a/tests/codegen/dmd_style_asm_with_variable_and_offset_memory_reference.d
+++ b/tests/codegen/dmd_style_asm_with_variable_and_offset_memory_reference.d
@@ -1,0 +1,42 @@
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=i686-pc-windows-msvc -O -output-s -of=%t.s %s && FileCheck %s < %t.s
+
+uint getHighHalfWithoutDisplacement(ulong value)
+{
+    asm
+    {
+        // CHECK: movl    4(%esp), %eax
+        mov EAX, dword ptr [value + 4];
+    }
+}
+
+uint getHighHalfWithDisplacement(uint value1, uint value2)
+{
+    asm
+    {
+        // CHECK: movl -2(%ebp), %eax
+        mov EAX, word ptr 2[value1];
+    }
+}
+
+extern(C) __gshared ulong someGlobalVariable;
+
+uint getHighHalfOfGlobal(ulong value)
+{
+    asm
+    {
+        // CHECK: movl    ((4+(-8))+_someGlobalVariable)+8, %eax
+        mov EAX, dword ptr [someGlobalVariable + 4];
+    }
+}
+
+void foo()
+{
+    align(32) uint[4] a;
+    asm pure nothrow @nogc
+    {
+        // CHECK: movl  %ebx, 4(%esp)
+        mov a+4, EBX;
+    }
+}


### PR DESCRIPTION
This is a bodge.

See issue https://github.com/ldc-developers/ldc/issues/2257 and the comments in the code for more context.
But, in short: where now we generate `4+$0` which would expand to `4+someGlobalVariable`, or `4+16(%ebp)`, or `4+(%ebp)` (invalid), we instead generate `4-8+${0:H}` which would expand to `4-8+8+someGlobalVariable`, or `4-8+24(%ebp)`, or `4-8+8(%ebp)` (valid).

The `H` modifier applies the +8 offset unconditionally: https://github.com/llvm/llvm-project/blob/330d8983d25d08580fc1642fea48b2473f47a9da/llvm/lib/Target/X86/X86AsmPrinter.cpp#L405-L406
