### PR TITLE
Define CppRuntime_Clang when building for Android

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -852,6 +852,7 @@ void registerPredefinedTargetVersions() {
     if (triple.getEnvironment() == llvm::Triple::Android) {
       VersionCondition::addPredefinedGlobalIdent("Android");
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Bionic");
+      VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang");
     } else if (triple.isMusl()) {
       VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
       VersionCondition::addPredefinedGlobalIdent("CppRuntime_Gcc");

--- a/runtime/druntime/src/core/stdcpp/new_.d
+++ b/runtime/druntime/src/core/stdcpp/new_.d
@@ -39,7 +39,7 @@ extern (C++, "std")
     {
     @nogc:
         ///
-        this() { super("bad allocation", 1); }
+        extern(D) this() { super("bad allocation", 1); }
     }
 }
 


### PR DESCRIPTION
With the current switch to NDK 26+ it should now be safe to assume the Clang C++ mangling/runtime.

The background for adding this is that the BindBC bindings currently error out when building for Android, because they require a C++ runtime version in order to potentially perform some manual symbol mangling.