### PR TITLE
Add --template-codegen-depth to stop very deep template instantiations.

### DIFF
--- a/dmd/dtemplate.d
+++ b/dmd/dtemplate.d
@@ -4136,6 +4136,13 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 version (IN_LLVM)
 {
         assert(global.params.linkonceTemplates != LinkonceTemplates.aggressive);
+
+        static uint callDepth;
+        callDepth++;
+        scope(exit) callDepth--;
+
+        if (global.params.templateCodegenDepth && (callDepth > global.params.templateCodegenDepth))
+            return false;
 }
 
         //printf("needsCodegen() %s\n", toChars());

--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -326,6 +326,7 @@ version (IN_LLVM)
     bool outputSourceLocations; // if true, output line tables.
 
     LinkonceTemplates linkonceTemplates; // -linkonce-templates
+    uint templateCodegenDepth; // -template-codegen-depth
 
     // Windows-specific:
     bool dllexport;      // dllexport ~all defined symbols?

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -305,6 +305,7 @@ struct Param
     bool outputSourceLocations; // if true, output line tables.
 
     LinkonceTemplates linkonceTemplates; // -linkonce-templates
+    uint32_t templateCodegenDepth; // -template-codegen-depth
 
     // Windows-specific:
     bool dllexport;      // dllexport ~all defined symbols?

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -526,6 +526,11 @@ static cl::opt<LinkonceTemplates, true> linkonceTemplates(
                    "linkonce-templates-aggressive",
                    "Experimental, more aggressive variant")));
 
+static cl::opt<uint32_t, true>
+    templateCodegenDepth("template-codegen-depth",
+             cl::desc("Don't codegen templates beyond this instantiation depth (0 = off)."),
+             cl::location(global.params.templateCodegenDepth), cl::init(0));
+
 cl::opt<bool> disableLinkerStripDead(
     "disable-linker-strip-dead", cl::ZeroOrMore,
     cl::desc("Do not try to remove unused symbols during linking"),


### PR DESCRIPTION
We've had this at Weka for a long time. It is an escape hatch in case very very deep template instantiation leads to stack exhaustion in the recursive `needsCodegen` function.