### PR TITLE
lit: check more carefully if compiler-rt support is there for ASan/MSan/XRay/... testing

### DIFF
--- a/tests/instrument/lit.local.cfg
+++ b/tests/instrument/lit.local.cfg
@@ -1,5 +1,7 @@
 import platform
+from glob import glob
 
-# Add "XRay_RT" feature on non-Windows, assuming the compiler-rt libraries are available
+# Add "XRay_RT" feature on non-Windows, if the compiler-rt libraries are available
 if (platform.system() != 'Windows'):
-    config.available_features.add('XRay_RT')
+    if glob(os.path.join(config.ldc2_lib_dir, "*xray*")):
+        config.available_features.add('XRay_RT')

--- a/tests/sanitizers/lit.local.cfg
+++ b/tests/sanitizers/lit.local.cfg
@@ -1,27 +1,33 @@
 import os
 import platform
+from glob import glob
 
 sys = platform.system()
 
-# Add "LSan" feature, assuming the compiler-rt library is available
-config.available_features.add('LSan')
+# Add "LSan" feature, if the compiler-rt library is available
+if glob(os.path.join(config.ldc2_lib_dir, "*lsan*")):
+    config.available_features.add('LSan')
 
 # FreeBSD TSan doesn't seem to work,
 # Linux TSan currently only works with static druntime,
 # and there's no Windows TSan (yet?).
 if (sys != 'FreeBSD') and (sys != 'Windows') and not (sys == 'Linux' and config.shared_rt_libs_only):
-    config.available_features.add('TSan')
+    if glob(os.path.join(config.ldc2_lib_dir, "*tsan*")):
+        config.available_features.add('TSan')
 
 # FreeBSD ASan and MSan don't cope well with ASLR (might do with FreeBSD 14 according to https://github.com/llvm/llvm-project/pull/73439)
 if sys != 'FreeBSD':
-    config.available_features.add('ASan')
+    if glob(os.path.join(config.ldc2_lib_dir, "*asan*")):
+        config.available_features.add('ASan')
 
 # MSan is supported on Linux, FreeBSD (modulo ASLR issue), and OpenBSD: https://clang.llvm.org/docs/MemorySanitizer.html#supported-platforms
 if (sys == 'Linux') or (sys == 'OpenBSD'):
-    config.available_features.add('MSan')
+    if glob(os.path.join(config.ldc2_lib_dir, "*msan*")):
+        config.available_features.add('MSan')
 
 # Add "Fuzzer" feature, assuming the compiler-rt library is available
-config.available_features.add('Fuzzer')
+if glob(os.path.join(config.ldc2_lib_dir, "*fuzzer*")):
+    config.available_features.add('Fuzzer')
 
 if 'ASan' in config.available_features:
     # On Darwin, ASan defaults to `abort_on_error=1`, which would make tests run


### PR DESCRIPTION
In case compiler-rt libs are not available, the lit tests would fail. This extra checking should help in that case.