### PR TITLE
Make distinction between CC and CXX in the testsuite

### DIFF
--- a/tests/dmd/dshell/cpp_header_gen.d
+++ b/tests/dmd/dshell/cpp_header_gen.d
@@ -4,16 +4,16 @@ import dshell;
 
 int main()
 {
-    if (!CC.length)
+    if (!CXX.length)
     {
-        writeln("CPP header generation test was skipped because $CC is empty!");
+        writeln("CPP header generation test was skipped because $CXX is empty!");
         return DISABLED;
     }
     // DMC cannot compile the generated headers ...
     version (Windows)
     {
         import std.algorithm : canFind;
-        if (CC.canFind("dmc"))
+        if (CXX.canFind("dmc"))
         {
             writeln("CPP header generation test was skipped because DMC is not supported!");
             return DISABLED;
@@ -46,11 +46,11 @@ int main()
     else                  enum X86_Any = false;
 
     version (Windows)
-        run([CC, "/c", "/Fo" ~ Vars.CPP_OBJ, "/I" ~ OUTPUT_BASE, "/I" ~ EXTRA_FILES ~"/../../../../../dmd/root", Vars.SOURCE_DIR ~ "/app.cpp"]);
+        run([CXX, "/c", "/Fo" ~ Vars.CPP_OBJ, "/I" ~ OUTPUT_BASE, "/I" ~ EXTRA_FILES ~"/../../../../../dmd/root", Vars.SOURCE_DIR ~ "/app.cpp"]);
     else static if (X86_Any)
-        run("$CC -std=c++11 -m$MODEL -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../../../dmd/root $SOURCE_DIR/app.cpp");
+        run("$CXX -std=c++11 -m$MODEL -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../../../dmd/root $SOURCE_DIR/app.cpp");
     else
-        run("$CC -std=c++11 -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../../../dmd/root $SOURCE_DIR/app.cpp");
+        run("$CXX -std=c++11 -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../../../dmd/root $SOURCE_DIR/app.cpp");
     run("$DMD -m$MODEL -of=$HEADER_EXE $LIB $CPP_OBJ");
     run("$HEADER_EXE");
 

--- a/tests/dmd/dshell/dll_cxx.d
+++ b/tests/dmd/dshell/dll_cxx.d
@@ -4,8 +4,8 @@ import std.stdio;
 
 int main()
 {
-    // Only run this test, if CC has been set.
-    if (Vars.CC.empty)
+    // Only run this test, if CXX has been set.
+    if (Vars.CXX.empty)
         return DISABLED;
 
     version (Windows)
@@ -20,20 +20,20 @@ int main()
     Vars.set(`EXE_NAME`, `$OUTPUT_BASE${SEP}testdll$EXE`);
     Vars.set(`DLL`, `$OUTPUT_BASE${SEP}mydll$SOEXT`);
 
-    string[] dllCmd = [Vars.CC];
+    string[] dllCmd = [Vars.CXX];
     string mainExtra;
     version (Windows)
     {
         Vars.set(`DLL_LIB`, `$OUTPUT_BASE${SEP}mydll.lib`);
         if (Vars.MODEL == "32omf")
         {
-            // CC should be dmc for win32omf.
+            // CXX should be dmc for win32omf.
             dllCmd ~= [`-mn`, `-L/implib:` ~ Vars.DLL_LIB, `-WD`, `-o` ~ Vars.DLL, `kernel32.lib`, `user32.lib`];
             mainExtra = `$DLL_LIB`;
         }
         else
         {
-            // CC should be cl for win32mscoff.
+            // CXX should be cl for win32mscoff.
             dllCmd ~= [`/LD`, `/nologo`, `/Fe` ~ Vars.DLL];
             mainExtra = `$DLL_LIB`;
         }

--- a/tests/dmd/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/tests/dmd/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -51,7 +51,7 @@ private alias requiredEnvVars = AliasSeq!(
     "BUILD_SHARED_LIBS" // LDC - passed through from CMake
 );
 private alias optionalEnvVars = AliasSeq!(
-    "CC", "PIC_FLAG"
+    "CC", "CXX", "PIC_FLAG"
 );
 private alias allVars = AliasSeq!(
     requiredEnvVars,


### PR DESCRIPTION
Clang makes a distinction between clang and clang++. In particular, clang++ will give a warning when it is passed .c source files; and the extra output warning text means that dmd testsuite output checking fails. The warning can be silenced (-Wno-deprecated) but then other tests will fail because #ifdef __cplusplus will be true, leading to header file import issues.

Cherry-pick from https://github.com/dlang/dmd/pull/16434  +  extra LDC-specific changes

(I ran into this issue during Alpine MUSL LDC work, and also when explicitly setting CC=clang++ on macOS. With this PR, CC=clang CXX=clang++ works)