### PR TITLE
Fix crashing core.thread.fiber unittest for AArch64.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,8 +49,6 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
       cd $CIRRUS_WORKING_DIR/../build
       excludes="dmd-testsuite|ldc2-unittest|lit-tests"
       if [[ "$CI_OS-$CI_ARCH" == "linux-aarch64" ]]; then
-        # FIXME: segfaults with enabled optimizations
-        excludes+='|^core.thread.fiber(-shared)?$'
         # FIXME: failing unittest(s)
         excludes+='|^std.internal.math.gammafunction'
         # FIXME: failing unittest(s) with enabled optimizations

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -182,8 +182,6 @@ jobs:
             if [[ '${{ matrix.os }}' == macos-14 ]]; then
               # FIXME: crashes frequently with enabled optimizations on M1 runners
               excludes+='|^std.internal.math.gammafunction(-shared)?$'
-              # FIXME: sporadically segfaults with enabled optimizations
-              excludes+='|^core.thread.fiber(-shared)?$'
             fi
           else
             N=$(nproc)

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -1134,6 +1134,7 @@ class Fiber
      */
     static Fiber getThis() @safe nothrow @nogc
     {
+        version (LDC) pragma(inline, false);
         return sm_this;
     }
 
@@ -2305,13 +2306,6 @@ unittest
 // Multiple threads running shared fibers
 unittest
 {
-    version (AArch64)
-    {
-        import core.stdc.stdio : puts;
-        puts("FIXME: this test fails for AArch64");
-        return;
-    }
-
     shared bool[10] locks;
     TestFiber[10] fibs;
 
@@ -2329,7 +2323,7 @@ unittest
                         fibs[idx].call();
                         cont |= fibs[idx].state != Fiber.State.TERM;
                     }
-                    locks[idx] = false;
+                    locks[idx].atomicStore(false);
                 }
                 else
                 {

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -558,6 +558,8 @@ version (LDC)
 
     version (Android) version = CheckFiberMigration;
 
+    version (AArch64) version = CheckFiberMigration;
+
     // Fiber migration across threads is (probably) not possible with ASan fakestack enabled (different parts of the stack
     // will contain fakestack pointers that were created on different threads...)
     version (SupportSanitizers) version = CheckFiberMigration;
@@ -2303,6 +2305,13 @@ unittest
 // Multiple threads running shared fibers
 unittest
 {
+    version (AArch64)
+    {
+        import core.stdc.stdio : puts;
+        puts("FIXME: this test fails for AArch64");
+        return;
+    }
+
     shared bool[10] locks;
     TestFiber[10] fibs;
 


### PR DESCRIPTION
Related to https://github.com/ldc-developers/ldc/issues/4613

@kinke I think it is better to disable individual unittests like this, than to disable the whole file in the CI script. I spent quite some time on trying to debug this failing test, thinking it was due to musl libc, but instead I found out from #4613 that it is a general AArch64 issue (indeed, also fails on my mac). I would have liked to see that in the source file, rather than hidden in CI configuration. Similar to how we tag known failures of a lit tests inside that actual lit test. This simply ensures that users (and I ;-)) can expect to successfully run the testsuite as normal (without having to know an exclude list).