### PR TITLE
Fix `tests/codegen/mangling.d` on x86

### DIFF
--- a/tests/codegen/inputs/mangling_definitions.d
+++ b/tests/codegen/inputs/mangling_definitions.d
@@ -46,6 +46,8 @@ version(AsmX86)
     else
         static assert(naked_cppFunc.mangleof == "_ZN15cpp_naked_funcs13naked_cppFuncEd");
 
-    int naked_dFunc(double a) { asm { naked; ret; } }
-    static assert(naked_dFunc.mangleof == "_D11definitions11naked_dFuncFdZi");
+    // Pass an int instead of a double due to x86 calling convetion
+    // See: https://github.com/ldc-developers/ldc/pull/4661
+    int naked_dFunc(int a) { asm { naked; ret; } }
+    static assert(naked_dFunc.mangleof == "_D11definitions11naked_dFuncFiZi");
 }

--- a/tests/codegen/mangling.d
+++ b/tests/codegen/mangling.d
@@ -61,8 +61,8 @@ version(AsmX86)
     extern(C++, decl_cpp_naked_funcs) pragma(mangle, nakedCppFuncMangle)
     int decl_naked_cppFunc(double a);
 
-    pragma(mangle, "_D11definitions11naked_dFuncFdZi")
-    int decl_naked_dFunc(double a);
+    pragma(mangle, "_D11definitions11naked_dFuncFiZi")
+    int decl_naked_dFunc(int a);
 }
 
 // Interfacing with C via pragma(mangle, …), without having to take care
@@ -84,7 +84,7 @@ void main()
     {
         decl_naked_cFunc(1.0);
         decl_naked_cppFunc(2.0);
-        decl_naked_dFunc(3.0);
+        decl_naked_dFunc(3);
     }
 
     assert(decl_cos(0.0) == 1.0);


### PR DESCRIPTION
The test `codegen/mangling.d` has been failing for me on x86 with a segmentation fault because of stack corruption due to the function: https://github.com/ldc-developers/ldc/blob/93afbfa5e2c22d89e54cb45f588474cc6e3a2595/tests/codegen/inputs/mangling_definitions.d#L49
not respecting the stdcall convention which is set as the default for functions with D linkage on x86.

I've tried to fix this by changing the default calling convention for naked assembly functions on x86 and adding an attribute in the `mangling.d` file to specify the C calling convention.

I'm not sure how this test has been passing on windows x86.