### PR TITLE
tests/codegen/casm.c: Move to casm.i to avoid calling the preprocessor

### DIFF
--- a/tests/codegen/casm.c
+++ b/tests/codegen/casm.c
@@ -1,6 +1,0 @@
-// REQUIRES: target_X86
-// UNSUPPORTED: Windows
-// RUN: %ldc -mtriple=x86_64-freebsd13 -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
-
-// CHECK: module asm ".symver __qsort_r_compat, qsort_r@FBSD_1.0"
-__asm__(".symver " "__qsort_r_compat" ", " "qsort_r" "@" "FBSD_1.0");

--- a/tests/codegen/casm.i
+++ b/tests/codegen/casm.i
@@ -1,0 +1,4 @@
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK: module asm ".symver __qsort_r_compat, qsort_r@FBSD_1.0"
+asm(".symver " "__qsort_r_compat" ", " "qsort_r" "@" "FBSD_1.0");


### PR DESCRIPTION
This test may fail on x86 because, when calling the C preprocessor, ldc will append a -m argument based on the target. If the target is x86_64 and the host is x86 the C compiler may fail with:
```
cc1: error: CPU you selected does not support x86-64 instruction set
```

An easy solution for this is to specify i386 instead of x86_64 in the target triple.

I'm not 100% sure if the `-mtriple` argument can be just dropped so I went ahead with a more conservative fix.