### PR TITLE
Fix glibc assert: __assert -> __assert_fail

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -300,7 +300,8 @@ void DtoCAssert(Module *M, const Loc &loc, LLValue *msg) {
     args.push_back(line);
     args.push_back(msg);
   } else if (triple.isOSSolaris() || triple.isMusl() ||
-             global.params.isUClibcEnvironment) {
+             global.params.isUClibcEnvironment ||
+             (triple.isOSGlibc() && triple.isGNUEnvironment())) {
     const auto irFunc = gIR->func();
     const auto funcName =
         (irFunc && irFunc->decl) ? irFunc->decl->toPrettyChars() : "";

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -301,7 +301,7 @@ void DtoCAssert(Module *M, const Loc &loc, LLValue *msg) {
     args.push_back(msg);
   } else if (triple.isOSSolaris() || triple.isMusl() ||
              global.params.isUClibcEnvironment ||
-             (triple.isOSGlibc() && triple.isGNUEnvironment())) {
+             triple.isGNUEnvironment()) {
     const auto irFunc = gIR->func();
     const auto funcName =
         (irFunc && irFunc->decl) ? irFunc->decl->toPrettyChars() : "";

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -355,6 +355,8 @@ llvm::Function *getRuntimeFunction(const Loc &loc, llvm::Module &target,
 //                            const char *funcname);
 // Musl:    void __assert_fail(const char *assertion, const char *filename, int line_num,
 //                             const char *funcname);
+// Glibc:   void __assert_fail(const char *assertion, const char *filename, int line_num,
+//                             const char *funcname);
 // uClibc:  void __assert(const char *assertion, const char *filename, int linenumber,
 //                        const char *function);
 // newlib:  void __assert_func(const char *file, int line, const char *func,
@@ -369,8 +371,7 @@ static const char *getCAssertFunctionName() {
     return "_assert";
   } else if (triple.isOSSolaris()) {
     return "__assert_c99";
-    /* https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/TargetParser/Triple.h */
-  } else if (triple.isMusl() || (triple.isOSGlibc() && triple.isGNUEnvironment())) {
+  } else if (triple.isMusl() || triple.isGNUEnvironment()) {
     return "__assert_fail";
   } else if (global.params.isNewlibEnvironment) {
     return "__assert_func";

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -369,7 +369,8 @@ static const char *getCAssertFunctionName() {
     return "_assert";
   } else if (triple.isOSSolaris()) {
     return "__assert_c99";
-  } else if (triple.isMusl()) {
+    /* https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/TargetParser/Triple.h */
+  } else if (triple.isMusl() || (triple.isOSGlibc() && triple.isGNUEnvironment())) {
     return "__assert_fail";
   } else if (global.params.isNewlibEnvironment) {
     return "__assert_func";
@@ -383,7 +384,7 @@ static std::vector<PotentiallyLazyType> getCAssertFunctionParamTypes() {
   const auto uint = Type::tuns32;
 
   if (triple.isOSDarwin() || triple.isOSSolaris() || triple.isMusl() ||
-      global.params.isUClibcEnvironment) {
+      global.params.isUClibcEnvironment || (triple.isOSGlibc() && triple.isGNUEnvironment())) {
     return {voidPtr, voidPtr, uint, voidPtr};
   }
   if (triple.getEnvironment() == llvm::Triple::Android) {


### PR DESCRIPTION
ldc2 returns SIGSEGV instead of SIGABRT for any value of
assert in betterC (or -checkaction=C or defaultlib="" ...)
due to some improper usage of __assert. As per the C compilers,
(gcc, clang, etc.), __assert_fail should be used for C asserts.


See my related PR for DMD:

https://github.com/dlang/dmd/pull/16515
