### PR TITLE
Cirrus CI: Bump FreeBSD image from v13.2 to v13.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -304,9 +304,9 @@ task:
   << : *PACKAGING_STEPS_TEMPLATE
 
 task:
-  name: FreeBSD 13.2 x64
+  name: FreeBSD 13.3 x64
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-13-3
     cpu: 4
     memory: 8G
   timeout_in: 60m


### PR DESCRIPTION
The old one cannot be used at the moment, although 13.2 is supposed to be supported until the end of June according to freebsd.org.