### PR TITLE
MSVC++ ABI: Fix POD semantics special case

### DIFF
--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -116,27 +116,12 @@ bool TargetABI::isAggregate(Type *t) {
          /*ty == TY::Tarray ||*/ ty == TY::Tdelegate || t->iscomplex();
 }
 
-namespace {
-bool hasCtor(StructDeclaration *s) {
-  if (s->ctor)
-    return true;
-  for (VarDeclaration *field : s->fields) {
-    Type *tf = field->type->baseElemOf();
-    if (auto tstruct = tf->isTypeStruct()) {
-      if (hasCtor(tstruct->sym))
-        return true;
-    }
-  }
-  return false;
-}
-}
-
 bool TargetABI::isPOD(Type *t, bool excludeStructsWithCtor) {
   t = t->baseElemOf();
   if (t->ty != TY::Tstruct)
     return true;
   StructDeclaration *sd = static_cast<TypeStruct *>(t)->sym;
-  return sd->isPOD() && !(excludeStructsWithCtor && hasCtor(sd));
+  return sd->isPOD() && !(excludeStructsWithCtor && sd->ctor);
 }
 
 bool TargetABI::canRewriteAsInt(Type *t, bool include64bit) {

--- a/tests/dmd/runnable/extra-files/cpp_nonpod_byval.cpp
+++ b/tests/dmd/runnable/extra-files/cpp_nonpod_byval.cpp
@@ -17,6 +17,7 @@ Foo(POD);
 struct CtorOnly
 {
     int a;
+    CtorOnly() : a(0) {}
     CtorOnly(int a) : a(a) {}
 };
 Foo(CtorOnly);
@@ -64,3 +65,10 @@ struct MoveOnly
     MoveOnly(MoveOnly &&) = default;
 };
 Foo(MoveOnly);
+
+struct MemberWithCtor
+{
+    int a;
+    CtorOnly m;
+};
+Foo(MemberWithCtor);

--- a/tests/dmd/runnable/nonpod_byval.d
+++ b/tests/dmd/runnable/nonpod_byval.d
@@ -31,14 +31,10 @@ void test(T)()
 
     static if (__traits(hasMember, T, "numDtor"))
     {
-        // TODO: fix for Posix targets (issue #2702)
-        version (CRuntime_Microsoft)
-        {
-            // fooCpp param + fooD param + result => 3 T instances.
-            // There may be an additional destruction of the moved-from T literal
-            // in fooCpp, depending on in-place construction vs. move.
-            assert(T.numDtor == 3 || T.numDtor == 4);
-        }
+        // fooCpp param + fooD param + result => 3 T instances.
+        // There may be an additional destruction of the moved-from T literal
+        // in fooCpp, depending on in-place construction vs. move.
+        assert(T.numDtor == 3 || T.numDtor == 4);
     }
 }
 
@@ -102,6 +98,13 @@ struct MoveOnly
 }
 mixin Foo!MoveOnly;
 
+struct MemberWithCtor
+{
+    int a;
+    CtorOnly m;
+}
+mixin Foo!MemberWithCtor;
+
 void main()
 {
     test!POD();
@@ -111,4 +114,5 @@ void main()
     test!Copy();
     test!CopyAndMove();
     test!MoveOnly();
+    test!MemberWithCtor();
 }


### PR DESCRIPTION
Fixes issue #4679. The test updates originate from https://github.com/dlang/dmd/pull/16570.