### PR TITLE
Fix C-assert regression for MinGW targets

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -385,7 +385,7 @@ static std::vector<PotentiallyLazyType> getCAssertFunctionParamTypes() {
   const auto uint = Type::tuns32;
 
   if (triple.isOSDarwin() || triple.isOSSolaris() || triple.isMusl() ||
-      global.params.isUClibcEnvironment || (triple.isOSGlibc() && triple.isGNUEnvironment())) {
+      global.params.isUClibcEnvironment || triple.isGNUEnvironment()) {
     return {voidPtr, voidPtr, uint, voidPtr};
   }
   if (triple.getEnvironment() == llvm::Triple::Android) {


### PR DESCRIPTION
Introduced in #4667 and reported in the announce dlang forum.