### PR TITLE
tests/plugins/lit.local.cfg: Properly escape regex

### DIFF
--- a/tests/plugins/lit.local.cfg
+++ b/tests/plugins/lit.local.cfg
@@ -20,7 +20,7 @@ if (config.plugins_supported):
     text1 = p.stdout.readline() # Ex.: "LDC - the LLVM D compiler (1.33.0-git-716f627)"
     text2 = p.stdout.readline() # Ex.: "  based on DMD v2.103.1 and LLVM 14.0.0"
     text3 = p.stdout.readline() # Ex.: "  built with LDC - the LLVM D compiler (1.33.0-beta2)"
-    host_version = re.compile('  built with LDC.* \(1\.([0-9]+).*\)').match(text3)
+    host_version = re.compile('  built with LDC.* \\(1\\.([0-9]+).*\\)').match(text3)
     if (host_version and int(host_version.group(1)) >= 30): # 30 = LDC 1.30
         config.available_features.add('ABI_compatible_with_host_D')
 


### PR DESCRIPTION
.../tests/plugins/lit.local.cfg:23: SyntaxWarning: invalid escape sequence `\(`

A plain `\` is used to escape a character in a string so one needs `\\` to escape a character in a regex. The check worked correctly otherwise, this just fixes the warning.