### PR TITLE
druntime: adds ASM language to cmake project() directive

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(runtime C)
+project(runtime C ASM)
 
 cmake_minimum_required(VERSION 3.4.3)
 


### PR DESCRIPTION
Sometimes CMake silently(!) ignores `.S` (asm) files if ASM isn't mentioned in the project directive. I ran into it during build my custom non-posix && non-windows target. It was very hard to understand what is happens

Similar issue: https://stackoverflow.com/questions/23452089/why-is-cmake-ignoring-assembly-files-when-building-static-library/67902603#67902603
