### PR TITLE
cmake: allow building liblphobos with system zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,7 @@ include(HandleLTOPGOBuildOptions)
 #
 set(LDC_DYNAMIC_COMPILE "AUTO" CACHE STRING "Support dynamic compilation (ON|OFF). Enabled by default; not supported for LLVM >= 12.")
 option(LDC_DYNAMIC_COMPILE_USE_CUSTOM_PASSES "Use custom LDC passes in jit" ON)
+option(LDC_PHOBOS_USE_SYSTEM_ZLIB "Use system zlib instead of bundled zlib in libphobos" OFF)
 if(LDC_DYNAMIC_COMPILE STREQUAL "AUTO")
     if(LDC_LLVM_VER LESS 1200)
         set(LDC_DYNAMIC_COMPILE ON)
@@ -460,6 +461,10 @@ message(STATUS "-- Building LDC with dynamic compilation support (LDC_DYNAMIC_CO
 if(LDC_DYNAMIC_COMPILE)
     add_definitions(-DLDC_DYNAMIC_COMPILE)
     add_definitions(-DLDC_DYNAMIC_COMPILE_API_VERSION=3)
+endif()
+if(LDC_PHOBOS_USE_SYSTEM_ZLIB)
+    find_package(ZLIB 1.3 REQUIRED)
+    message(STATUS "Building LDC with system zlib version ${ZLIB_VERSION}")
 endif()
 
 #

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -146,6 +146,10 @@ if("${C_SYSTEM_LIBS}" STREQUAL "AUTO")
 else()
     set(C_SYSTEM_LIBS_SHARED ${C_SYSTEM_LIBS})
 endif()
+if(LDC_PHOBOS_USE_SYSTEM_ZLIB)
+    list(APPEND C_SYSTEM_LIBS ZLIB::ZLIB)
+    list(APPEND C_SYSTEM_LIBS_SHARED ZLIB::ZLIB)
+endif()
 
 message(STATUS "-- LDC runtime configuration:")
 message(STATUS "--  - Building 32/64-bit libraries (MULTILIB): ${MULTILIB}")
@@ -251,6 +255,10 @@ if(PHOBOS2_DIR)
         ${PHOBOS2_DIR}/etc/c/zlib/test/infcover.c
         ${PHOBOS2_DIR}/etc/c/zlib/test/minigzip.c
     )
+endif()
+if(LDC_PHOBOS_USE_SYSTEM_ZLIB)
+    # filter out zlib C parts if system zlib is used
+    list(FILTER PHOBOS2_C EXCLUDE REGEX ".*/etc/c/zlib/.*\\.c")
 endif()
 
 #


### PR DESCRIPTION
This pull request allows third-party distributors to build Phobos runtime shipped with LDC using the system zlib library.

Many Linux distributions ship their own patches to do this; this pull request tries to avoid that and provides a unified way to achieve this goal.