### PR TITLE
Windows: Avoid accidentally using GNU link.exe for linking

### DIFF
--- a/driver/linker-msvc.cpp
+++ b/driver/linker-msvc.cpp
@@ -292,8 +292,11 @@ int linkObjToBinaryMSVC(llvm::StringRef outputPath,
   std::string linker = opts::linker;
   if (linker.empty()) {
 #ifdef _WIN32
-    // default to lld-link.exe for LTO
-    linker = opts::isUsingLTO() ? "lld-link.exe" : "link.exe";
+    // Default to lld-link.exe for LTO, otherwise Microsoft's link.exe.
+    // Try not to accidentally use a GNU link.exe (if in PATH before the MSVC
+    // bin dir).
+    linker = opts::isUsingLTO() ? "lld-link.exe"
+                                : msvcEnv.tryResolveToolPath("link.exe");
 #else
     linker = "lld-link";
 #endif

--- a/driver/tool.h
+++ b/driver/tool.h
@@ -58,6 +58,10 @@ struct MsvcEnvironmentScope {
 
   ~MsvcEnvironmentScope();
 
+  // Tries to return the absolute path to a VC tool, falling back to the file
+  // name.
+  std::string tryResolveToolPath(const char *fileName) const;
+
 private:
   // for each changed env var: name & original value
   std::vector<std::pair<std::wstring, wchar_t *>> rollback;


### PR DESCRIPTION
This happens in an environment where MSVC was set up first (so env var `VSINSTALLDIR` defined), and later prepending a dir such as `C:\Program Files\Git\usr\bin` to PATH, so that the first `link.exe` on PATH isn't the Microsoft one.