### PR TITLE
AggrTypeBuilder: mark aggregate as packed when field offset is not naturally aligned, to fix #4719

### DIFF
--- a/ir/irtypeaggr.cpp
+++ b/ir/irtypeaggr.cpp
@@ -40,7 +40,11 @@ AggrTypeBuilder::AggrTypeBuilder(unsigned offset) : m_offset(offset) {
 void AggrTypeBuilder::addType(llvm::Type *type, unsigned size) {
   const unsigned fieldAlignment = getABITypeAlign(type);
   assert(fieldAlignment);
-  assert((m_offset & (fieldAlignment - 1)) == 0 && "Field is misaligned");
+  // If the field offset does not have natural alignment, mark the aggregate as
+  // packed for IR.
+  if ((m_offset & (fieldAlignment - 1)) != 0) {
+    m_packed = true;
+  }
   m_defaultTypes.push_back(type);
   m_offset += size;
   m_fieldIndex++;

--- a/tests/codegen/gh4719.d
+++ b/tests/codegen/gh4719.d
@@ -1,0 +1,32 @@
+// RUN: %ldc -c -output-ll -of=%t.ll %s
+
+struct TraceBuf {
+    align(1) uint args;
+}
+
+// Test correct compilation (no error) of the context pointer type for the delegate of `foo`.
+void foo() {
+    byte[2] fixDescs;
+    TraceBuf fixLog;
+
+    auto dlg = delegate() {
+        fixDescs[0] = 1;
+        fixLog.args = 1;
+    };
+}
+
+class TraceClass {
+    align(1)
+    uint args;
+}
+
+// Test correct compilation (no error) of the context pointer type for the delegate of `foo2`.
+void foo2() {
+    byte[2] fixDescs;
+    scope TraceClass fixLog;
+
+    auto dlg = delegate() {
+        fixDescs[0] = 1;
+        fixLog.args = 1;
+    };
+}

--- a/tests/codegen/gh4719.d
+++ b/tests/codegen/gh4719.d
@@ -1,4 +1,5 @@
-// RUN: %ldc -c -output-ll -of=%t.ll %s
+// RUN: %ldc -c -of=%t.o %s
+// RUN: %ldc -c -of=%t.o %s -O
 
 struct TraceBuf {
     align(1) uint args;

--- a/tests/compilable/gh4719.d
+++ b/tests/compilable/gh4719.d
@@ -1,5 +1,5 @@
-// RUN: %ldc -c -of=%t.o %s
-// RUN: %ldc -c -of=%t.o %s -O
+// RUN: %ldc -c %s
+// RUN: %ldc -c %s -O
 
 struct TraceBuf {
     align(1) uint args;


### PR DESCRIPTION
Alternative to https://github.com/ldc-developers/ldc/pull/4720