### PR TITLE
timetrace2txt: make the text output just a little bit prettier

### DIFF
--- a/tools/timetrace2txt.d
+++ b/tools/timetrace2txt.d
@@ -249,16 +249,21 @@ struct Node
         // Output in milliseconds.
         outputTextFile.writef(duration_format_string, cast(double)(this.duration) / 1000);
 
-        if (last_child)
-            indentstring[$-1] = '└';
-        outputTextFile.write(indentstring);
-        outputTextFile.write("- ", this.name);
+        if (indentstring.length > 0) {
+            outputTextFile.write(indentstring[0..$-1]);
+            if (last_child)
+                outputTextFile.write("╰");
+            else
+                outputTextFile.write("├");
+        }
+
+        outputTextFile.write("╼ ", this.name);
         outputTextFile.write(", ", this.detail);
         outputTextFile.writeln(", ", this.location);
         if (last_child)
             indentstring[$-1] = ' ';
 
-        wchar[] child_indentstring = indentstring ~ " |";
+        wchar[] child_indentstring = indentstring ~ "  │";
         foreach (i, ref child; this.children) {
             child.printTree(child_indentstring, i == this.children.length-1);
         }


### PR DESCRIPTION
Making use of UTF Box drawing characters https://en.wikipedia.org/wiki/Box-drawing_characters  (TIL ;-)

Example:
```
        5.348 ╼ ExecuteCompiler, , <no file>
        0.934   ├╼ Sema1: Module timetrace2txt_1, , <no file>
        0.917   │  ├╼ Sema1: Import object, timetrace2txt_1.object, <no file>
        0.917   │  ├╼ Sema1: Module object, , <no file>
        0.121   │  │  ├╼ Sema1: Import attribute, __anonymous, /Users/johan/ldc/ldc/runtime/druntime/src/object.d:111
        0.120   │  │  │  ╰╼ Sema1: Module core.attribute, , /Users/johan/ldc/ldc/runtime/druntime/src/object.d:111
        0.105   │  │  │     ├╼ Sema1: Import attributes, core.attribute.ldc, /Users/johan/ldc/ldc/runtime/druntime/src/core/attribute.d:37
        0.104   │  │  │     │  ╰╼ Sema1: Module ldc.attributes, , /Users/johan/ldc/ldc/runtime/druntime/src/core/attribute.d:37
        0.006   │  │  │     │     ├╼ Sema1: Func _xopEquals, object._xopEquals, /Users/johan/ldc/ldc/runtime/druntime/src/object.d:3805
        0.001   │  │  │     │     ├╼ Sema1: Func __xopEquals, ldc.attributes.callingConvention.__xopEquals, <no file>
        0.001   │  │  │     │     ├╼ Sema1: Func __xtoHash, __xtoHash, <no file>
        0.001   │  │  │     │     ├╼ Sema1: Func __xopEquals, ldc.attributes.llvmAttr.__xopEquals, <no file>
        0.002   │  │  │     │     ├╼ Sema1: Func __xopEquals, ldc.attributes.llvmFastMathFlag.__xopEquals, <no file>
        0.001   │  │  │     │     ├╼ Sema1: Func __xopEquals, ldc.attributes.noSanitize.__xopEquals, <no file>
        0.002   │  │  │     │     ├╼ Sema1: Func __xopEquals, ldc.attributes.section.__xopEquals, <no file>
        0.001   │  │  │     │     ╰╼ Sema1: Func __xopEquals, ldc.attributes.target.__xopEquals, <no file>
        0.002   │  │  │     ╰╼ Sema1: Func __xopEquals, core.attribute.gnuAbiTag.__xopEquals, <no file>
        0.002   │  │  ├╼ Sema1: Func toString, object.Object.toString, /Users/johan/ldc/ldc/runtime/druntime/src/object.d:144
        0.002   │  │  ├╼ Sema1: Func toHash, object.Object.toHash, /Users/johan/ldc/ldc/runtime/druntime/src/object.d:166
        0.001   │  │  ├╼ Sema1: Func opC
```
(looks prettier in my editor than in github here... no gaps between the vertical lines)