### PR TITLE
[Xtensa] addPredefinedGlobalIdent for Xtensa

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -764,6 +764,9 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("LoongArch64");
     registerPredefinedFloatABI("LoongArch_SoftFloat", "LoongArch_HardFloat");
     break;
+  case llvm::Triple::xtensa:
+    VersionCondition::addPredefinedGlobalIdent("Xtensa");
+    break;
 #endif // LDC_LLVM_VER >= 1600
   default:
     warning(Loc(), "unknown target CPU architecture: %s",

--- a/tests/codegen/xtensa.d
+++ b/tests/codegen/xtensa.d
@@ -1,0 +1,6 @@
+// REQUIRES: target_Xtensa
+
+// RUN: %ldc -mtriple=xtensa -betterC
+
+version (Xtensa) {} else static assert(0);
+


### PR DESCRIPTION
cc @Turkeyman

TODO

- [ x ]  tests
- [ x ] PR for enabling Xtensa in release workflow https://github.com/ldc-developers/llvm-project/pull/2

Druntime C bindings can be done at a later date.
