### PR TITLE
Add "Posix" global version conditional for Emscripten targets

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -752,11 +752,25 @@ void registerPredefinedTargetVersions() {
     VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
     break;
   case llvm::Triple::wasm32:
+    VersionCondition::addPredefinedGlobalIdent("WebAssembly");
+    if (triple.getOS() == llvm::Triple::Emscripten) {
+      // Emscripten reimplements Posix APIs
+      VersionCondition::addPredefinedGlobalIdent("linux");
+      VersionCondition::addPredefinedGlobalIdent("Posix");
+      VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
+      VersionCondition::addPredefinedGlobalIdent("X86_Any");
+      VersionCondition::addPredefinedGlobalIdent("X86");
+    }
+    break;
   case llvm::Triple::wasm64:
     VersionCondition::addPredefinedGlobalIdent("WebAssembly");
     if (triple.getOS() == llvm::Triple::Emscripten) {
       // Emscripten reimplements Posix APIs
+      VersionCondition::addPredefinedGlobalIdent("linux");
       VersionCondition::addPredefinedGlobalIdent("Posix");
+      VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
+      VersionCondition::addPredefinedGlobalIdent("X86_Any");
+      VersionCondition::addPredefinedGlobalIdent("X86_64");
     }
     break;
 #if LDC_LLVM_VER >= 1600

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -754,6 +754,10 @@ void registerPredefinedTargetVersions() {
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:
     VersionCondition::addPredefinedGlobalIdent("WebAssembly");
+    if (triple.getOS() == llvm::Triple::Emscripten) {
+      // Emscripten reimplements Posix APIs
+      VersionCondition::addPredefinedGlobalIdent("Posix");
+    }
     break;
 #if LDC_LLVM_VER >= 1600
   case llvm::Triple::loongarch32:


### PR DESCRIPTION
I just had this thought after seeing this: https://forum.dlang.org/post/odqtqqravqlfcqjgfywo@forum.dlang.org

Haven't tested yet, but i submit the PR otherwise i'll forget

And i can't compile ldc from source:


`cmake -G Ninja ../  -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=$PWD/../install-ldc`
```
/usr/bin/ld: cannot find -lLLVMSymbolize: No such file or directory
```