### PR TITLE
Replace `-release` by `-magazine-benchmark` and `-ludicrous`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - LLVM for prebuilt packages bumped to v18.1.8 (incl. macOS arm64). (#4712)
 - Android: NDK for prebuilt package bumped from r26d to r27. (#4711)
 - ldc2.conf: %%ldcconfigpath%% placeholder added - specifies the directory where current configuration file is located. (#4717)
+- The insanity switch `-release` is now called `-ludicrous`. `-magazine-benchmark` has been added to provide what would have actually been expected by the switch.
 
 #### Platform support
 

--- a/dmd/frontend.h
+++ b/dmd/frontend.h
@@ -8016,6 +8016,8 @@ struct Param final
     bool useUnitTests;
     bool useInline;
     bool release;
+    bool ludicrous;
+    bool magazineBench;
     bool preservePaths;
     DiagnosticReporting warnings;
     bool cov;
@@ -8099,6 +8101,8 @@ struct Param final
         useUnitTests(),
         useInline(false),
         release(),
+        ludicrous(),
+        magazineBench(),
         preservePaths(),
         warnings((DiagnosticReporting)2u),
         cov(),
@@ -8166,7 +8170,7 @@ struct Param final
         mapfile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool ludicrous = false, bool magazineBench = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -8176,6 +8180,8 @@ struct Param final
         useUnitTests(useUnitTests),
         useInline(useInline),
         release(release),
+        ludicrous(ludicrous),
+        magazineBench(magazineBench),
         preservePaths(preservePaths),
         warnings(warnings),
         cov(cov),

--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -190,6 +190,8 @@ extern (C++) struct Param
     bool useUnitTests;          // generate unittest code
     bool useInline = false;     // inline expand functions
     bool release;           // build release version
+    bool ludicrous;         // build ludicrous version
+    bool magazineBench;     // ludicrous + O3
     bool preservePaths;     // true means don't strip path from source file
     DiagnosticReporting warnings = DiagnosticReporting.off;  // how compiler warnings are handled
     bool cov;               // generate code coverage data

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -190,6 +190,8 @@ struct Param
     d_bool useUnitTests;  // generate unittest code
     d_bool useInline;     // inline expand functions
     d_bool release;       // build release version
+    d_bool ludicrous;     // build ludicrous version
+    d_bool magazineBench; // ludicrous + O3
     d_bool preservePaths; // true means don't strip path from source file
     Diagnostic warnings;
     d_bool cov;           // generate code coverage data

--- a/dmd/main.d
+++ b/dmd/main.d
@@ -1185,7 +1185,22 @@ else
             params.useAssert = CHECKENABLE.on;
     }
 
+    if (params.magazineBench)
+    {
+        params.ludicrous = true;
+        //driverParams.optimize = true;
+    }
+
     if (params.release)
+    {
+        deprecation(
+            Loc.initial,
+            "Switch `-release` is deprecated; use `-ludicrous` or `-magazine-benchmark` instead."
+        );
+        params.ludicrous = true;
+    }
+
+    if (params.release || params.ludicrous)
     {
         if (params.useInvariants == CHECKENABLE._default)
             params.useInvariants = CHECKENABLE.off;

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -503,9 +503,21 @@ static cl::opt<CHECKACTION, true> checkAction(
 
 static cl::opt<bool, true>
     release("release", cl::ZeroOrMore, cl::location(global.params.release),
-            cl::desc("Compile release version, defaulting to disabled "
-                     "asserts/contracts/invariants, and bounds checks in @safe "
-                     "functions only"),
+            cl::desc("Deprecated alias of `-ludicrous`."),
+            cl::ValueDisallowed);
+
+static cl::opt<bool, true>
+    ludicrous("ludicrous", cl::ZeroOrMore, cl::location(global.params.ludicrous),
+            cl::desc("Compile for ludicrous runtime performance, disabling "
+                     "asserts/contracts/invariants, and performing bounds checks "
+                     "in @safe functions only. This switch should be used with "
+                     "bug-free code only."),
+            cl::ValueDisallowed);
+
+static cl::opt<bool, true>
+    magazineBench("magazine-benchmark", cl::ZeroOrMore, cl::location(global.params.magazineBench),
+            cl::desc("Special release mode, enables various optimizations for "
+                     "ludicrous speed."),
             cl::ValueDisallowed);
 
 cl::opt<bool, true>

--- a/driver/ldmd.cpp
+++ b/driver/ldmd.cpp
@@ -659,9 +659,10 @@ void translateArgs(const llvm::SmallVectorImpl<const char *> &ldmdArgs,
         goto Lnot_in_ldc;
       } else if (strcmp(p + 1, "quiet") == 0) {
         // ignore
+      } else if (strcmp(p + 1, "release") == 0) {
+        ldcArgs.push_back("-ludicrous");
       }
-      /* -release
-       * -betterC
+      /* -betterC
        */
       else if (strcmp(p + 1, "noboundscheck") == 0) {
         ldcArgs.push_back("-boundscheck=off");

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -943,6 +943,7 @@ void registerPredefinedTargetVersions() {
 
   //Issue deprecations for deprecated arguments
   // N.B `-nodefaultlib` is checked in `getDefaultLibNames`
+  // N.B `-release` is checked in `reconcileCommands`
   if (checkPrintf)
     deprecation(Loc(), "'-check-printf-calls' is deprecated, use `pragma(printf)` instead.");
 }

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -127,6 +127,10 @@ static cl::opt<int> fSanitizeMemoryTrackOrigins(
         "Enable origins tracking in MemorySanitizer (0=disabled, default)"));
 
 unsigned optLevel() {
+  if (global.params.magazineBench) {
+    return 3;
+  }
+
   // Use -O2 as a base for the size-optimization levels.
   return optimizeLevel >= 0 ? optimizeLevel : 2;
 }
@@ -146,6 +150,10 @@ bool willCrossModuleInline() {
 bool isOptimizationEnabled() { return optimizeLevel != 0; }
 
 llvm::CodeGenOptLevel codeGenOptLevel() {
+  if (global.params.magazineBench) {
+    return llvm::CodeGenOptLevel::Aggressive;
+  }
+
   // Use same appoach as clang (see lib/CodeGen/BackendUtil.cpp)
   if (optLevel() == 0) {
     return llvm::CodeGenOptLevel::None;
@@ -165,6 +173,14 @@ std::unique_ptr<TargetLibraryInfoImpl> createTLII(llvm::Module &M) {
 }
 
 static OptimizationLevel getOptimizationLevel(){
+  if (global.params.magazineBench) {
+    switch(optimizeLevel) {
+      case -1: return OptimizationLevel::Os;
+      case -2: return OptimizationLevel::Oz;
+    }
+    return OptimizationLevel::O3;
+  }
+
   switch(optimizeLevel) {
     case 0: return OptimizationLevel::O0;
     case 1: return OptimizationLevel::O1;

--- a/packaging/bash_completion.d/ldc2
+++ b/packaging/bash_completion.d/ldc2
@@ -35,24 +35,24 @@
             -enable-unsafe-fp-math          -fatal-assembler-warnings       -fdata-sections                     -ffunction-sections             \
             -float-abi                      -help                           -ignore                             -internalize-public-api-file    \
             -internalize-public-api-list    -jit-emit-debug                 -jit-enable-eh                      -join-liveintervals             \
-            -lib                            -limit-float-precision          -linkonce-templates                 -m32                            \
-            -m64                            -march                          -mattr                              -mc-x86-disable-arith-relaxation\
-            -mcpu                           -mtriple                        -nested-ctx                         -noasm                          \
-            -nodefaultlib                   -noruntime                      -noverify                           -nozero-initialized-in-bss      \
-            -O                              -O0                             -O1                                 -O2                             \
-            -O3                             -O4                             -O5                                 -o-                             \
-            -od                             -of                             -op                                 -oq                             \
-            -output-bc                      -output-ll                      -output-o                           -output-s                       \
-            -pre-RA-sched                   -print-after-all                -print-before-all                   -print-machineinstrs            \
-            -profile-estimator-loop-weight  -profile-info-file              -profile-verifier-noassert          -realign-stack                  \
-            -regalloc                       -release                        -relocation-model                   -rewriter                       \
-            -run                            -schedule-spills                -segmented-stacks                   -shared                         \
-            -shrink-wrap                    -singleobj                      -soft-float                         -spiller                        \
-            -stack-alignment                -stack-protector-buffer-size    -stats                              -tailcallopt                    \
-            -time-passes                    -unittest                       -v                                  -v-cg                           \
-            -verify-dom-info                -verify-loop-info               -verify-regalloc                    -verify-region-info             \
-            -version                        -vv                             -w                                  -x86-asm-syntax                 \
-            -x86-use-vzeroupper
+            -lib                            -limit-float-precision          -linkonce-templates                 -ludicrous                      \
+            -m32                            -m64                            -magazine-benchmark                 -march                          \
+            -mattr                          -mc-x86-disable-arith-relaxation -mcpu                              -mtriple                        \
+            -nested-ctx                     -noasm                          -nodefaultlib                       -noruntime                      \
+            -noverify                       -nozero-initialized-in-bss      -O                                  -O0                             \
+            -O1                             -O2                             -O3                                 -O4                             \
+            -O5                             -o-                             -od                                 -of                             \
+            -op                             -oq                             -output-bc                          -output-ll                      \
+            -output-o                       -output-s                       -pre-RA-sched                       -print-after-all                \
+            -print-before-all               -print-machineinstrs            -profile-estimator-loop-weight      -profile-info-file              \
+            -profile-verifier-noassert      -realign-stack                  -regalloc                           -relocation-model               \
+            -rewriter                       -run                            -schedule-spills                    -segmented-stacks               \
+            -shared                         -shrink-wrap                    -singleobj                          -soft-float                     \
+            -spiller                        -stack-alignment                -stack-protector-buffer-size        -stats                          \
+            -tailcallopt                    -time-passes                    -unittest                           -v                              \
+            -v-cg                           -verify-dom-info                -verify-loop-info                   -verify-regalloc                \
+            -verify-region-info             -version                        -vv                                 -w                              \
+            -x86-asm-syntax                 -x86-use-vzeroupper
         "
         opts_with_equal=(-Df  Hd  -Hf  -I  -J  -Xf  -code-model  -d-version  -debuglib  -defaultlib  -deps           \
                          -internalize-public-api-file  -float-abi  -limit-float-precision  -march  -mtriple  -mattr  \


### PR DESCRIPTION
Adds a new `-magazine-benchmark` switch that does all the sort of things that OG compiler developers would want journalists to use for their benchmarks.

This also renames `-release` to `-ludicrous` to reflect what it actually is.
It also resolves the ambiguity regarding the term “release build” mentioned in <https://github.com/ldc-developers/ldc/issues/4709>.

#### Further reading

- <https://forum.dlang.org/post/v6t3ne$bgi$1@digitalmars.com> – “Why -release is the way it is” by Walter Bright
- <https://forum.dlang.org/post/ftefkajvonflhbwgqusk@forum.dlang.org> – My original take
- <https://www.youtube.com/watch?v=ygE01sOhzz0>