### PR TITLE
Better support building the runtime separately

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,6 +1,5 @@
-project(runtime C ASM)
-
 cmake_minimum_required(VERSION 3.4.3)
+project(runtime C ASM)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -337,7 +337,7 @@ if(LDC_EXE)
                     "$<$<BOOL:${SHARED_LIBS_SUPPORTED}>:${MULTILIB_DIR}>"
                     ${conf_path}.in
                     ${conf_path}
-            DEPENDS ${LDC_EXE} ${LDC_EXE_FULL}
+            DEPENDS ${LDC_EXE_FULL}
         )
         add_custom_command(OUTPUT ${install_conf_path} VERBATIM
             COMMAND ${PROJECT_PARENT_DIR}/tools/add-multilib-section.sh
@@ -347,7 +347,7 @@ if(LDC_EXE)
                     "$<$<BOOL:${SHARED_LIBS_SUPPORTED}>:${MULTILIB_INSTALL_DIR}>"
                     ${install_conf_path}.in
                     ${install_conf_path}
-            DEPENDS ${LDC_EXE} ${LDC_EXE_FULL}
+            DEPENDS ${LDC_EXE_FULL}
         )
         add_custom_target(add-multilib-section ALL
             DEPENDS ${conf_path} ${install_conf_path}
@@ -437,7 +437,9 @@ macro(dc src_files src_basedir d_flags output_basedir emit_bc all_at_once single
         list(APPEND dc_flags -flto=thin --output-bc)
     endif()
 
-    set(dc_deps ${LDC_EXE} ${LDC_EXE_FULL} ${GCCBUILTINS})
+    # dc_deps can only contain paths, otherwise cmake will ignore the dependency.
+    # See: https://github.com/ldc-developers/ldc/pull/4743#issuecomment-2323156173
+    set(dc_deps ${LDC_EXE_FULL} ${GCCBUILTINS})
     if(TARGET add-multilib-section)
         # Make sure the config files are available before invoking LDC.
         set(dc_deps ${dc_deps} add-multilib-section)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -906,6 +906,7 @@ install(FILES ${GCCBUILTINS} DESTINATION ${INCLUDE_INSTALL_DIR}/ldc)
 #
 # Test targets.
 #
+enable_testing()
 
 # Build the "test runner" executables containing the druntime and Phobos unit
 # tests. They are invoked with the modules to test later.

--- a/runtime/DRuntimeIntegrationTests.cmake
+++ b/runtime/DRuntimeIntegrationTests.cmake
@@ -56,6 +56,8 @@ else()
     list(REMOVE_ITEM testnames uuid)
 endif()
 
+string(REPLACE ";" " " LDMD_CMD "${LDMD_EXE_FULL} ${D_EXTRA_FLAGS}")
+
 foreach(name ${testnames})
     foreach(build debug release)
         set(druntime_path_build ${druntime_path})
@@ -72,7 +74,7 @@ foreach(name ${testnames})
         )
         add_test(NAME ${fullname}
             COMMAND ${GNU_MAKE_BIN} -C ${PROJECT_SOURCE_DIR}/druntime/test/${name}
-                ROOT=${outdir} DMD=${LDMD_EXE_FULL} BUILD=${build}
+                ROOT=${outdir} DMD=${LDMD_CMD} BUILD=${build}
                 DRUNTIME=${druntime_path_build} DRUNTIMESO=${shared_druntime_path_build}
                 SHARED=1 ${cflags_base} ${linkdl}
         )


### PR DESCRIPTION
My use case for this is compiling the runtime for x86 on x86_64. `-DMULTILIB=ON` is not sufficient as I need to create a separate project in order to use a system copy of zlib like I've described in https://github.com/ldc-developers/ldc/pull/4742#issue-2489471216. 