### PR TITLE
Emscripten: Predefine versions as for a regular musl Linux platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Android: NDK for prebuilt package bumped from r26d to r27. (#4711)
 - ldc2.conf: %%ldcconfigpath%% placeholder added - specifies the directory where current configuration file is located. (#4717)
 - Add support for building against a system copy of zlib through `-DPHOBOS_SYSTEM_ZLIB=ON`. (#4742)
+- Emscripten: The compiler now mimicks a musl Linux platform wrt. extra predefined versions (`linux`, `Posix`, `CRuntime_Musl`, `CppRuntime_LLVM`). (#4750)
 
 #### Platform support
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -923,6 +923,12 @@ void registerPredefinedTargetVersions() {
     break;
   case llvm::Triple::Emscripten:
     VersionCondition::addPredefinedGlobalIdent("Emscripten");
+    // Emscripten uses musl and libc++, so mimic a musl Linux platform:
+    VersionCondition::addPredefinedGlobalIdent("linux");
+    VersionCondition::addPredefinedGlobalIdent("Posix");
+    VersionCondition::addPredefinedGlobalIdent("CRuntime_Musl");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_LLVM");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang"); // legacy
     break;
   default:
     if (triple.getEnvironment() == llvm::Triple::Android) {

--- a/tests/codegen/emscripten.d
+++ b/tests/codegen/emscripten.d
@@ -1,0 +1,21 @@
+// REQUIRES: target_WebAssembly
+
+// RUN: %ldc -mtriple=wasm32-unknown-emscripten -c %s
+
+
+// test predefined versions:
+
+version (Emscripten) {} else static assert(0);
+version (linux) {} else static assert(0);
+version (Posix) {} else static assert(0);
+version (CRuntime_Musl) {} else static assert(0);
+version (CppRuntime_LLVM) {} else static assert(0);
+
+
+// verify that some druntime C bindings are importable:
+
+import core.stdc.stdio;
+
+extern(C) void _start() {
+    puts("Hello world");
+}


### PR DESCRIPTION
Based on https://github.com/ldc-developers/ldc/pull/4738.