### PR TITLE
Migrate from macos-12 to macos-13 for Github Action main build on macOS x86_64.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
             with_pgo: true
 
           - job_name: macOS x86_64
-            os: macos-12
+            os: macos-13
             arch: x86_64
             bootstrap_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON


### PR DESCRIPTION
macos-12 will be deprecated soon: https://github.com/actions/runner-images/issues/10721