### PR TITLE
GHA main: Bump macos-14 job to macos-15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
             with_pgo: true
 
           - job_name: macOS arm64
-            os: macos-14
+            os: macos-15
             arch: arm64
             bootstrap_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
@@ -94,9 +94,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 50
-      - name: 'macOS 14: Switch to Xcode 16'
-        if: matrix.os == 'macos-14'
-        run: sudo xcode-select -switch /Applications/Xcode_16.app
       - name: Install prerequisites
         uses: ./.github/actions/1-setup
         with:
@@ -104,15 +101,15 @@ jobs:
           llvm_version: ${{ matrix.llvm_version || env.LLVM_VERSION }}
           arch: ${{ matrix.arch }}
       - name: Build bootstrap LDC
-        if: matrix.os != 'macos-14'
+        if: matrix.os != 'macos-15'
         uses: ./.github/actions/2-build-bootstrap
         with:
           cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
           arch: ${{ matrix.arch }}
       # FIXME: on macOS arm64, LLVM 18 (from LDC) and LLVM 17 (from Xcode 16) seem incompatible,
       #        leading to sporadic 'libc++abi: Pure virtual function called!' compiler crashes
-      - name: 'macOS 14: Use host LDC (with Xcode-compatible LLVM version) as bootstrap LDC'
-        if: matrix.os == 'macos-14'
+      - name: 'macOS 15: Use host LDC (with Xcode-compatible LLVM version) as bootstrap LDC'
+        if: matrix.os == 'macos-15'
         run: ln -s $(dirname $(dirname $(which ldmd2))) ../bootstrap-ldc
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo


### PR DESCRIPTION
The arm64 macOS images have changed to support a single major Xcode version each; Xcode v16 isn't available for macos-14 anymore (only v15). So switch to the macos-15 image, with Xcode v16.

https://github.com/actions/runner-images/issues/10703