### PR TITLE
Implement -fsanitize-recover for ASan and MSan.

### DIFF
--- a/driver/cl_options_sanitizers.h
+++ b/driver/cl_options_sanitizers.h
@@ -37,12 +37,18 @@ enum SanitizerCheck : SanitizerBits {
   LeakSanitizer = 1 << 5,
 };
 extern SanitizerBits enabledSanitizers;
+extern SanitizerBits enabledSanitizerRecoveries;
+extern const SanitizerBits supportedSanitizerRecoveries;
 
 extern cl::opt<llvm::AsanDetectStackUseAfterReturnMode> fSanitizeAddressUseAfterReturn;
 
 inline bool isAnySanitizerEnabled() { return enabledSanitizers; }
 inline bool isSanitizerEnabled(SanitizerBits san) {
   return enabledSanitizers & san;
+}
+
+inline bool isSanitizerRecoveryEnabled(SanitizerBits san) {
+  return enabledSanitizerRecoveries & san;
 }
 
 SanitizerCheck parseSanitizerName(llvm::StringRef name,

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -508,6 +508,13 @@ void ArgsBuilder::addSanitizers(const llvm::Triple &triple) {
   if (opts::isSanitizerEnabled(opts::ThreadSanitizer)) {
     addSanitizerLinkFlags(triple, "tsan", "-fsanitize=thread");
   }
+
+  if (opts::isSanitizerRecoveryEnabled(opts::AddressSanitizer)) {
+      args.push_back("-fsanitize-recover=address");
+  }
+  if (opts::isSanitizerRecoveryEnabled(opts::MemorySanitizer)) {
+      args.push_back("-fsanitize-recover=memory");
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -184,7 +184,7 @@ static void addAddressSanitizerPasses(ModulePassManager &mpm,
                                       OptimizationLevel level ) {
   AddressSanitizerOptions aso;
   aso.CompileKernel = false;
-  aso.Recover = false;
+  aso.Recover = opts::isSanitizerRecoveryEnabled(opts::AddressSanitizer);
   aso.UseAfterScope = true;
   aso.UseAfterReturn = opts::fSanitizeAddressUseAfterReturn;
 
@@ -199,7 +199,7 @@ static void addMemorySanitizerPass(ModulePassManager &mpm,
                                    FunctionPassManager &fpm,
                                    OptimizationLevel level ) {
   int trackOrigins = fSanitizeMemoryTrackOrigins;
-  bool recover = false;
+  bool recover = opts::isSanitizerRecoveryEnabled(opts::MemorySanitizer);
   bool kernel = false;
 #if LDC_LLVM_VER >= 1600
   mpm.addPass(MemorySanitizerPass(

--- a/tests/sanitizers/asan_recover_stackoverflow.d
+++ b/tests/sanitizers/asan_recover_stackoverflow.d
@@ -1,0 +1,32 @@
+// Test recovery with AddressSanitizer
+
+// REQUIRES: ASan
+
+// RUN: %ldc -g -fsanitize=address -fsanitize-recover=address %s -of=%t%exe
+// RUN: not %t%exe 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=halt_on_error=true not %t%exe 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=halt_on_error=false %t%exe 2>&1 | FileCheck %s
+
+// RUN: %ldc -g -fsanitize=address -fsanitize-recover=all %s -of=%t%exe
+// RUN: not %t%exe 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=halt_on_error=true not %t%exe 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=halt_on_error=false %t%exe 2>&1 | FileCheck %s
+
+void foo(int* arr)
+{
+    // CHECK: stack-buffer-overflow
+    // CHECK: WRITE of size 4
+    // CHECK-NEXT: #0 {{.*}} in {{.*foo.*}} {{.*}}asan_recover_stackoverflow.d:[[@LINE+1]]
+    arr[10] = 1;
+}
+
+// CHECK: Address {{.*}} is located in stack of
+// CHECK-NEXT: #0 {{.*}} in {{.*main.*}} {{.*}}asan_recover_stackoverflow.d:[[@LINE+1]]
+void main()
+{
+    // Test for the name of the variable that is overflown.
+    // CHECK: 'aiaiaiaiaiaiai'{{.*}} <== {{.*}} overflows this variable
+    int[10] aiaiaiaiaiaiai;
+    int b;
+    foo(&aiaiaiaiaiaiai[0]);
+}


### PR DESCRIPTION
Resolves #4770

Note that env variable setting `ASAN_OPTIONS=halt_on_error=false` is needed to actually recover from failures (executables built with clang behaves the same).