### PR TITLE
Bump bundled dub to latest stable with crucial regression fix

### DIFF
--- a/packaging/dub_version
+++ b/packaging/dub_version
@@ -1,1 +1,1 @@
-v1.39.0-beta.1
+ec809a547edbad6252c0ed195efc2f3d87ab11c2

--- a/packaging/reggae_version
+++ b/packaging/reggae_version
@@ -1,1 +1,1 @@
-6bfbead1b82af50b620fb1caa6612c82bfc2ae7e
+e4e0e0a1343ba6ce08e267dc2672bbf1e028e21b


### PR DESCRIPTION
Incl. reggae to a version which uses that dub (https://github.com/atilaneves/reggae/pull/315).

The dub regression was https://github.com/dlang/dub/issues/2973.