### PR TITLE
Fix #4790: Make sure `TypeInfo_Class.base` is always a `TypeInfo_Class` ref

### DIFF
--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -17,6 +17,7 @@
 #include "dmd/target.h"
 #include "gen/abi/abi.h"
 #include "gen/arrays.h"
+#include "gen/classes.h"
 #include "gen/funcgenstate.h"
 #include "gen/functions.h"
 #include "gen/irstate.h"
@@ -389,7 +390,8 @@ LLConstant *IrClass::getClassInfoInit() {
   // TypeInfo_Class base
   assert(!isInterface || !cd->baseClass);
   if (cd->baseClass) {
-    b.push_typeinfo(cd->baseClass->type);
+    DtoResolveClass(cd->baseClass);
+    b.push(getIrAggr(cd->baseClass)->getClassInfoSymbol());
   } else {
     b.push_null(cinfoType);
   }

--- a/tests/codegen/gh4790.d
+++ b/tests/codegen/gh4790.d
@@ -1,0 +1,12 @@
+// RUN: %ldc -run %s
+
+shared class A {
+}
+
+shared class B : A {
+}
+
+void main() {
+    shared A a1 = cast(shared A) A.classinfo.create();
+    shared A a2 = cast(shared A) B.classinfo.create();
+}


### PR DESCRIPTION
I.e., ignore all modifiers of the base class.