### PR TITLE
add debug info for function parameter types

### DIFF
--- a/gen/dibuilder.cpp
+++ b/gen/dibuilder.cpp
@@ -25,12 +25,10 @@
 #include "driver/cl_options.h"
 #include "driver/ldc-version.h"
 #include "gen/functions.h"
-#include "gen/abi/abi.h"
 #include "gen/irstate.h"
 #include "gen/llvmhelpers.h"
 #include "gen/logger.h"
 #include "gen/optimizer.h"
-#include "gen/pragma.h"
 #include "gen/tollvm.h"
 #include "ir/irfunction.h"
 #include "ir/irfuncty.h"
@@ -722,59 +720,51 @@ DIType DIBuilder::CreateAArrayType(TypeAArray *type) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-DISubroutineType DIBuilder::CreateFunctionType(Type *type, FuncDeclaration* fd) {
+DISubroutineType DIBuilder::CreateFunctionType(Type *type,
+                                               FuncDeclaration *fd) {
   TypeFunction *t = type->isTypeFunction();
   assert(t);
 
-  Type *retType = t->next;
   llvm::SmallVector<LLMetadata *, 8> params;
-
-  auto irFunc = fd ? getIrFunc(fd, false) : nullptr;
-  if (irFunc) {
-    auto push_arg = [&](IrFuncTyArg *arg) {
-      if (!arg)
-        return;
-      auto ditype = CreateTypeDescription(arg->type);
-      if (arg->byref) {
-        ditype = DBuilder.createPointerType(ditype, target.ptrsize * 8, 0, llvm::None,
-            processDIName((type->toPrettyChars(true) + llvm::StringRef("*")).str()));
+  auto pushParam = [&](Type *type, bool isRef) {
+    auto ditype = CreateTypeDescription(type);
+    if (isRef) {
+      if (!ditype) { // void or noreturn
+        ditype = CreateTypeDescription(Type::tuns8);
       }
-      params.push_back(ditype);
-    };
-    // mimmicking what happens in DtoFunctionType
-    IrFuncTy &irFty = irFunc->irFty;
-    push_arg(irFty.ret);
-    push_arg(irFty.arg_sret);
-    push_arg(irFty.arg_this);
-    push_arg(irFty.arg_nest);
-    push_arg(irFty.arg_objcSelector);
-    push_arg(irFty.arg_arguments);
+      ditype = DBuilder.createReferenceType(llvm::dwarf::DW_TAG_reference_type,
+                                            ditype, target.ptrsize * 8);
+    }
+    params.emplace_back(ditype);
+  };
 
-    TargetABI *abi = DtoIsIntrinsic(fd) ? TargetABI::getIntrinsic() : gABI;
-    if (irFty.arg_sret && irFty.arg_this && abi->passThisBeforeSret(t)) {
-      std::swap(params[0], params[1]);
+  // the first 'param' is the return value
+  pushParam(t->next, t->isref());
+
+  // then the implicit 'this'/context pointer
+  if (fd) {
+    DIType pointeeType = nullptr;
+    if (auto parentAggregate = fd->isThis()) {
+      pointeeType = CreateCompositeType(parentAggregate->type);
+    } else if (fd->isNested()) {
+      pointeeType = CreateTypeDescription(Type::tuns8); // cannot use void
     }
 
-    const size_t numExplicitLLArgs = irFty.args.size();
-    for (size_t i = 0; i < numExplicitLLArgs; i++) {
-      push_arg(irFty.args[i]);
-    }
-  } else {
-    // incomplete information without actual code gen
-    params.emplace_back(CreateTypeDescription(t->next)); // return type
-    auto len = t->parameterList.length();
-    for (size_t i = 0; i < len; i++) {
-      auto ptype = t->parameterList[i]->type;
-      auto ditype = CreateTypeDescription(ptype);
-      if (t->parameterList[i]->isReference()) {
-        auto name = processDIName(
-            (ptype->toPrettyChars(true) + llvm::StringRef("*")).str());
-        ditype = DBuilder.createPointerType(
-            ditype, target.ptrsize * 8, 0, llvm::None, name);
-      }
+    if (pointeeType) {
+      DIType ditype = DBuilder.createReferenceType(
+          llvm::dwarf::DW_TAG_pointer_type, pointeeType, target.ptrsize * 8);
+      ditype = DBuilder.createObjectPointerType(ditype);
       params.emplace_back(ditype);
     }
   }
+
+  // and finally the formal parameters
+  const auto len = t->parameterList.length();
+  for (size_t i = 0; i < len; i++) {
+    const auto param = t->parameterList[i];
+    pushParam(param->type, param->isReference());
+  }
+
   auto paramsArray = DBuilder.getOrCreateTypeArray(params);
   return DBuilder.createSubroutineType(paramsArray, DIFlags::FlagZero, 0);
 }
@@ -852,7 +842,7 @@ DIType DIBuilder::CreateTypeDescription(Type *t, bool voidToUbyte) {
                                       llvm::None, processDIName(name));
   }
   if (auto tf = t->isTypeFunction())
-    return CreateFunctionType(tf, nullptr);
+    return CreateFunctionType(tf);
   if (auto td = t->isTypeDelegate())
     return CreateDelegateType(td);
 

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -184,7 +184,7 @@ private:
   DIType CreateArrayType(TypeArray *type);
   DIType CreateSArrayType(TypeSArray *type);
   DIType CreateAArrayType(TypeAArray *type);
-  DISubroutineType CreateFunctionType(Type *type);
+  DISubroutineType CreateFunctionType(Type *type, FuncDeclaration *fd);
   DISubroutineType CreateEmptyFunctionType();
   DIType CreateDelegateType(TypeDelegate *type);
   DIType CreateUnspecifiedType(Dsymbol *sym);

--- a/gen/dibuilder.h
+++ b/gen/dibuilder.h
@@ -184,7 +184,7 @@ private:
   DIType CreateArrayType(TypeArray *type);
   DIType CreateSArrayType(TypeSArray *type);
   DIType CreateAArrayType(TypeAArray *type);
-  DISubroutineType CreateFunctionType(Type *type, FuncDeclaration *fd);
+  DISubroutineType CreateFunctionType(Type *type, FuncDeclaration *fd = nullptr);
   DISubroutineType CreateEmptyFunctionType();
   DIType CreateDelegateType(TypeDelegate *type);
   DIType CreateUnspecifiedType(Dsymbol *sym);


### PR DESCRIPTION
A couple of days ago I added support to mago to evaluate the `__debugOverview`, `__debugExpanded` and `__debugStringview` hooks as free functions instead of struct members (see https://rainers.github.io/visuald/visuald/Debugging.html#customization). Apart from allowing to add debug visualizers for library types without editing the source, I hoped to also have LDC support this feature even though it omits class and struct members in the debug info. Here's a tiny example:

```D
struct String
{
    string _s;
}
string __debugOverview(const String* s)
{
    return s._s;
}
```

Unfortunately, LDC omits the function parameters from the function type, but they are needed for overload resolution. This a small patch to add these. It also ticks off one item of https://github.com/ldc-developers/ldc/issues/1716 as the call stack now displays parameter types and values.

While mago supports passing the argument as a pointer or a reference, the latter doesn't work with LDC as the ref argument is typed as value. Is this removed somewhere in LDC if the ABI passes the value by reference anyway?
