### PR TITLE
Add configuration placeholder %%ldcversion%%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LDC master
 
 #### Big news
+- ldc2.conf: `%%ldcversion%%` placeholder added, allowing to refer to version-specific directories.
 
 #### Platform support
 

--- a/driver/configfile.d
+++ b/driver/configfile.d
@@ -110,11 +110,18 @@ struct CfgPaths
     }
 }
 
+extern(C++, "ldc")
+{
+    extern __gshared const(const(char) *) ldc_version;
+}
+
 string replacePlaceholders(string str, CfgPaths cfgPaths)
 {
+    const dVersion = ldc_version[0..strlen(ldc_version)];
     return str
         .replace("%%ldcbinarypath%%", cfgPaths.ldcBinaryDir)
-        .replace("%%ldcconfigpath%%", cfgPaths.cfgBaseDir);
+        .replace("%%ldcconfigpath%%", cfgPaths.cfgBaseDir)
+        .replace("%%ldcversion%%", cast(string) dVersion);
 }
 
 extern(C++) struct ConfigFile


### PR DESCRIPTION
Hi, this introduces a placeholder for `ldc2.conf` which is set to the version of LDC.

The rationale is: when following the "Cross-compiling with LDC" on a linux system, according to section "Default libraries", it is required to download prebuilt runtimes of the version matching the host compiler.

Since the host compiler is subject to system updates, I might find myself in a situation of version mismatch if I forget to update target libraries.

Favoring versioned directories may work as a preventive measure against such cases.

```
    lib-dirs = ["/opt/ldc2-%%ldcversion%%-windows-multilib/lib64"];
```
