### PR TITLE
gen: fix control-flow protection attribute marking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Platform support
 
 #### Bug fixes
+- Building multi-file D applications with control-flow protection will no longer cause LDC to throw an internal compiler error. (#4828)
 
 # LDC 1.40.0 (2024-12-15)
 

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -391,15 +391,18 @@ void registerModuleInfo(Module *m) {
 
 void addModuleFlags(llvm::Module &m) {
   const auto ModuleMinFlag = llvm::Module::Min;
+  const auto ConstantOne =
+      llvm::ConstantInt::get(LLType::getInt32Ty(m.getContext()), 1);
+  const auto ConstantOneMetadata = llvm::ConstantAsMetadata::get(ConstantOne);
 
   if (opts::fCFProtection == opts::CFProtectionType::Return ||
       opts::fCFProtection == opts::CFProtectionType::Full) {
-    m.addModuleFlag(ModuleMinFlag, "cf-protection-return", 1);
+    m.setModuleFlag(ModuleMinFlag, "cf-protection-return", ConstantOneMetadata);
   }
 
   if (opts::fCFProtection == opts::CFProtectionType::Branch ||
       opts::fCFProtection == opts::CFProtectionType::Full) {
-    m.addModuleFlag(ModuleMinFlag, "cf-protection-branch", 1);
+    m.setModuleFlag(ModuleMinFlag, "cf-protection-branch", ConstantOneMetadata);
   }
 }
 


### PR DESCRIPTION
This pull request fixes control-flow protection attribute marking by explicitly replacing the old values to avoid an LLVM assertion.

This can happen when compiling multiple D source files in one command line invocation.