### PR TITLE
run on and build for Windows on ARM64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Platform support
 - Supports LLVM 15 - 19.
 - Initial compiler and runtime support for ppc64 and ppc64le systems that use IEEE 754R 128-bit floating-point as the default 128-bit floating-point format. (#4833)
-- Added support for building for Windows on ARM64. Use option '-march=arm64' to compile, 'ldc-build-runtime.exe --dFlags -march=arm64' to build the runtime libraries.
+- Added support for building for Windows on ARM64. Use option '-march=arm64' to compile, 'ldc-build-runtime.exe --dFlags -march=arm64' to build the runtime libraries. (#4835)
 
 #### Bug fixes
 - Building multi-file D applications with control-flow protection will no longer cause LDC to throw an internal compiler error. (#4828)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Platform support
 - Supports LLVM 15 - 19.
 - Initial compiler and runtime support for ppc64 and ppc64le systems that use IEEE 754R 128-bit floating-point as the default 128-bit floating-point format. (#4833)
+- Added support for building for Windows on ARM64. Use option '-march=arm64' to compile, 'ldc-build-runtime.exe --dFlags -march=arm64' to build the runtime libraries.
 
 #### Bug fixes
 - Building multi-file D applications with control-flow protection will no longer cause LDC to throw an internal compiler error. (#4828)

--- a/dmd/root/longdouble.d
+++ b/dmd/root/longdouble.d
@@ -342,7 +342,7 @@ void ld_setull(longdouble_soft* pthis, ulong d)
     {
         // emulator accuracy not good enough when running on Windows on ARM,
         // so avoid chopping off small numbers
-        version(all)
+        version(LDC)
         {
             if (!(d & (1L << 63)))
             {

--- a/dmd/root/longdouble.d
+++ b/dmd/root/longdouble.d
@@ -342,17 +342,14 @@ void ld_setull(longdouble_soft* pthis, ulong d)
     {
         // emulator accuracy not good enough when running on Windows on ARM,
         // so avoid chopping off small numbers
-        version(LDC)
+        if (!(d & (1L << 63)))
         {
-            if (!(d & (1L << 63)))
+            asm nothrow @nogc pure @trusted
             {
-                asm nothrow @nogc pure @trusted
-                {
-                    fild qword ptr d;
-                }
-                mixin(fstp_parg!("pthis"));
-                return;
+                fild qword ptr d;
             }
+            mixin(fstp_parg!("pthis"));
+            return;
         }
         d ^= (1L << 63);
         auto pTwoPow63 = &twoPow63;

--- a/dmd/root/longdouble.d
+++ b/dmd/root/longdouble.d
@@ -338,9 +338,23 @@ void ld_setll(longdouble_soft* pthis, long d)
 
 void ld_setull(longdouble_soft* pthis, ulong d)
 {
-    d ^= (1L << 63);
     version(AsmX86)
     {
+        // emulator accuracy not good enough when running on Windows on ARM,
+        // so avoid chopping off small numbers
+        version(all)
+        {
+            if (!(d & (1L << 63)))
+            {
+                asm nothrow @nogc pure @trusted
+                {
+                    fild qword ptr d;
+                }
+                mixin(fstp_parg!("pthis"));
+                return;
+            }
+        }
+        d ^= (1L << 63);
         auto pTwoPow63 = &twoPow63;
         mixin(fld_parg!("pTwoPow63"));
         asm nothrow @nogc pure @trusted

--- a/gen/abi/aarch64.cpp
+++ b/gen/abi/aarch64.cpp
@@ -32,8 +32,13 @@ private:
   IndirectByvalRewrite indirectByvalRewrite;
   ArgTypesRewrite argTypesRewrite;
 
+  bool hasAAPCS64VaList() {
+    return !isDarwin() &&
+           !global.params.targetTriple->isWindowsMSVCEnvironment();
+  }
+
   bool isAAPCS64VaList(Type *t) {
-    if (isDarwin())
+    if (!hasAAPCS64VaList())
       return false;
 
     // look for a __va_list struct in a `std` C++ namespace
@@ -152,7 +157,7 @@ public:
   }
 
   Type *vaListType() override {
-    if (isDarwin())
+    if (!hasAAPCS64VaList())
       return TargetABI::vaListType(); // char*
 
     // We need to pass the actual va_list type for correct mangling. Simply

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -77,9 +77,9 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
 
   case Triple::aarch64:
   case Triple::aarch64_be:
-    // AArch64 has 128-bit quad precision; Apple uses double
-    return triple.isOSDarwin() ? LLType::getDoubleTy(ctx)
-                               : LLType::getFP128Ty(ctx);
+    // AArch64 has 128-bit quad precision; Apple and MSVC use double
+    return triple.isOSDarwin() || triple.isWindowsMSVCEnvironment()
+               ? LLType::getDoubleTy(ctx) : LLType::getFP128Ty(ctx);
 
   case Triple::riscv32:
   case Triple::riscv64:

--- a/runtime/druntime/src/__importc_builtins.di
+++ b/runtime/druntime/src/__importc_builtins.di
@@ -39,11 +39,12 @@ version (LDC)
     }
     else version (ARM_Any)
     {
-        // Darwin does not use __va_list
+        // Darwin and Windows do not use __va_list
         version (OSX) {}
         else version (iOS) {}
         else version (TVOS) {}
         else version (WatchOS) {}
+        else version (CRuntime_Microsoft) {}
         else:
 
         version (ARM)

--- a/runtime/druntime/src/core/internal/vararg/aarch64.d
+++ b/runtime/druntime/src/core/internal/vararg/aarch64.d
@@ -14,7 +14,7 @@ module core.internal.vararg.aarch64;
 
 version (AArch64):
 
-// Darwin uses a simpler varargs implementation
+// Darwin and Windows use a simpler varargs implementation
 version (OSX) {}
 else version (iOS) {}
 else version (TVOS) {}

--- a/runtime/druntime/src/core/internal/vararg/aarch64.d
+++ b/runtime/druntime/src/core/internal/vararg/aarch64.d
@@ -19,6 +19,7 @@ version (OSX) {}
 else version (iOS) {}
 else version (TVOS) {}
 else version (WatchOS) {}
+else version (CRuntime_Microsoft) {}
 else:
 
 import core.stdc.stdarg : alignUp;

--- a/runtime/druntime/src/core/stdc/math.d
+++ b/runtime/druntime/src/core/stdc/math.d
@@ -482,7 +482,7 @@ version (CRuntime_Microsoft) // fully supported since MSVCRT 12 (VS 2013) only
         else // for backward compatibility with older runtimes
         {
             ///
-            pure int isnan(float x)      { version (Win64) return _isnanf(x); else return _isnan(cast(double) x); }
+            pure int isnan(float x)      { version (X86_64) return _isnanf(x); else return _isnan(cast(double) x); }
             ///
             extern(C) pragma(mangle, "_isnan") pure int isnan(double x);
             ///

--- a/runtime/druntime/src/core/stdc/stdarg.d
+++ b/runtime/druntime/src/core/stdc/stdarg.d
@@ -55,7 +55,7 @@ version (GNU)
 }
 else version (ARM_Any)
 {
-    // Darwin uses a simpler varargs implementation
+    // Darwin and Windows use a simpler varargs implementation
     version (OSX) {}
     else version (iOS) {}
     else version (TVOS) {}

--- a/runtime/druntime/src/core/stdc/stdarg.d
+++ b/runtime/druntime/src/core/stdc/stdarg.d
@@ -60,6 +60,7 @@ else version (ARM_Any)
     else version (iOS) {}
     else version (TVOS) {}
     else version (WatchOS) {}
+    else version (CRuntime_Microsoft) {}
     else:
 
     version (ARM)

--- a/runtime/druntime/src/core/sys/windows/dll.d
+++ b/runtime/druntime/src/core/sys/windows/dll.d
@@ -402,7 +402,7 @@ private bool isWindows8OrLater() nothrow @nogc
 int dll_getRefCount( HINSTANCE hInstance ) nothrow @nogc
 {
     void** peb;
-    version (Win64)
+    version (X86_64)
     {
         asm pure nothrow @nogc
         {
@@ -411,13 +411,17 @@ int dll_getRefCount( HINSTANCE hInstance ) nothrow @nogc
             mov peb, RAX;
         }
     }
-    else version (Win32)
+    else version (X86)
     {
         asm pure nothrow @nogc
         {
             mov EAX,FS:[0x30];
             mov peb, EAX;
         }
+    }
+    else version (AArch64)
+    {
+        asm nothrow @nogc { "ldr %0, [x18,%1]" : "=r" (peb) : "r" (0x30); }
     }
     dll_aux.LDR_MODULE *ldrMod = dll_aux.findLdrModule( hInstance, peb );
     if ( !ldrMod )

--- a/runtime/druntime/src/core/sys/windows/stacktrace.d
+++ b/runtime/druntime/src/core/sys/windows/stacktrace.d
@@ -230,6 +230,7 @@ private:
 
         version (X86)         enum imageType = IMAGE_FILE_MACHINE_I386;
         else version (X86_64) enum imageType = IMAGE_FILE_MACHINE_AMD64;
+        else version (AArch64) enum imageType = IMAGE_FILE_MACHINE_ARM64;
         else                  static assert(0, "unimplemented");
 
         size_t frameNum = 0;

--- a/runtime/druntime/src/core/sys/windows/threadaux.d
+++ b/runtime/druntime/src/core/sys/windows/threadaux.d
@@ -167,8 +167,9 @@ struct thread_aux
   {
     static void** getTEB() nothrow @nogc @naked
     {
-        version (Win32)      return __asm!(void**)("mov %fs:(0x18), $0", "=r");
-        else version (Win64) return __asm!(void**)("mov %gs:0($1), $0", "=r,r", 0x30);
+        version (X86)          return __asm!(void**)("mov %fs:(0x18), $0", "=r");
+        else version (X86_64)  return __asm!(void**)("mov %gs:0($1), $0", "=r,r", 0x30);
+        else version (AArch64) return __asm!(void**)("mov $0, x18", "=r");
         else static assert(false);
     }
   }

--- a/runtime/druntime/src/core/sys/windows/winnt.d
+++ b/runtime/druntime/src/core/sys/windows/winnt.d
@@ -1131,7 +1131,8 @@ enum : WORD {
     IMAGE_FILE_MACHINE_MIPSFPU16 = 0x0466,
     IMAGE_FILE_MACHINE_EBC       = 0x0EBC,
     IMAGE_FILE_MACHINE_AMD64     = 0x8664,
-    IMAGE_FILE_MACHINE_M32R      = 0x9041
+    IMAGE_FILE_MACHINE_M32R      = 0x9041,
+    IMAGE_FILE_MACHINE_ARM64     = 0xAA64,
 }
 
 // ???
@@ -2257,6 +2258,51 @@ enum LEGACY_SAVE_AREA_LENGTH = XMM_SAVE_AREA32.sizeof;
         DWORD64 LastExceptionFromRip;
     }
 
+} else version(AArch64) {
+	enum CONTEXT_ARM64 = 0x400000;
+
+	enum CONTEXT_CONTROL         = (CONTEXT_ARM64 | 0x1L);
+	enum CONTEXT_INTEGER         = (CONTEXT_ARM64 | 0x2L);
+	enum CONTEXT_SEGMENTS        = (CONTEXT_ARM64 | 0x4L);
+	enum CONTEXT_FLOATING_POINT  = (CONTEXT_ARM64 | 0x8L);
+	enum CONTEXT_DEBUG_REGISTERS = (CONTEXT_ARM64 | 0x10L);
+
+    enum CONTEXT_FULL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
+    enum CONTEXT_ALL  = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT | CONTEXT_DEBUG_REGISTERS);
+
+    enum ARM64_MAX_BREAKPOINTS = 8;
+    enum ARM64_MAX_WATCHPOINTS = 2;
+
+    union ARM64_NT_NEON128 {
+        struct {
+            ULONGLONG Low;
+            LONGLONG High;
+        };
+        double[2] D;
+        float[4] S;
+        WORD[8] H;
+        BYTE[16] B;
+    }
+    alias PARM64_NT_NEON128 = ARM64_NT_NEON128*;
+
+    align(16) struct CONTEXT
+    {
+        DWORD ContextFlags;
+        DWORD Cpsr;
+        DWORD64[31] X;
+        DWORD64 Sp;
+        DWORD64 Pc;
+
+        ARM64_NT_NEON128[32] V;
+        DWORD Fpcr;
+
+        DWORD Fpsr;
+
+        DWORD[ARM64_MAX_BREAKPOINTS] Bcr;
+        DWORD64[ARM64_MAX_BREAKPOINTS] Bvr;
+        DWORD[ARM64_MAX_WATCHPOINTS] Wcr;
+        DWORD64[ARM64_MAX_WATCHPOINTS] Wvr;
+    }
 } else {
     static assert(false, "Unsupported CPU");
     // Versions for PowerPC, Alpha, SHX, and MIPS removed.

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -373,18 +373,10 @@ private
                 stp x27, x28, [sp, #-16]!;
                 stp x29, x31, [sp, #-16]!; // fp,0
 
-                mov x19, v8.d[0];
-                mov x20, v9.d[0];
-                stp x19, x20, [sp, #-16]!;
-                mov x19, v10.d[0];
-                mov x20, v11.d[0];
-                stp x19, x20, [sp, #-16]!;
-                mov x19, v12.d[0];
-                mov x20, v13.d[0];
-                stp x19, x20, [sp, #-16]!;
-                mov x19, v14.d[0];
-                mov x20, v15.d[0];
-                stp x19, x20, [sp, #-16]!;
+                stp d8, d9, [sp, #-16]!;
+                stp d10, d11, [sp, #-16]!;
+                stp d12, d13, [sp, #-16]!;
+                stp d14, d15, [sp, #-16]!;
 
                 ldr x19, [x18];
                 ldr x20, [x18, #8];
@@ -405,18 +397,10 @@ private
                 str x19, [x18];
 
                 // load saved state from new stack
-                ldp x19, x20, [sp], #16;
-                mov v15.d[0], x20;
-                mov v14.d[0], x19;
-                ldp x19, x20, [sp], #16;
-                mov v13.d[0], x20;
-                mov v12.d[0], x19;
-                ldp x19, x20, [sp], #16;
-                mov v11.d[0], x20;
-                mov v10.d[0], x19;
-                ldp x19, x20, [sp], #16;
-                mov v9.d[0], x20;
-                mov v8.d[0], x19;
+                ldp d14, d15, [sp], #16;
+                ldp d12, d13, [sp], #16;
+                ldp d10, d11, [sp], #16;
+                ldp d8, d9, [sp], #16;
 
                 ldp x29, x31, [sp], #16; // fp,0
                 ldp x27, x28, [sp], #16;

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -363,59 +363,59 @@ private
         else version (AsmAArch64_Windows)
         {
             pragma(LDC_never_inline);
-            __asm(
+            asm pure nothrow @nogc
+            {
                 `// save current stack state (similar to posix version in threadasm.S)
-                stp x19, x20, [sp, #-16]!
-                stp x21, x22, [sp, #-16]!
-                stp x23, x24, [sp, #-16]!
-                stp x25, x26, [sp, #-16]!
-                stp x27, x28, [sp, #-16]!
-                stp fp,  lr,  [sp, #-16]!
-                mov x19, sp               // no need to scan FP registers, so snapshot sp here
+                stp x19, x20, [sp, #-16]!;
+                stp x21, x22, [sp, #-16]!;
+                stp x23, x24, [sp, #-16]!;
+                stp x25, x26, [sp, #-16]!;
+                stp x27, x28, [sp, #-16]!;
+                stp fp,  lr,  [sp, #-16]!;
+                mov x19, sp;               // no need to scan FP registers, so snapshot sp here
 
-                stp d8,  d9,  [sp, #-16]!
-                stp d10, d11, [sp, #-16]!
-                stp d12, d13, [sp, #-16]!
-                stp d14, d15, [sp, #-16]!
+                stp d8,  d9,  [sp, #-16]!;
+                stp d10, d11, [sp, #-16]!;
+                stp d12, d13, [sp, #-16]!;
+                stp d14, d15, [sp, #-16]!;
 
-                ldr x20, [x18, #8]        // read stack range from TEB
-                ldr x21, [x18, #16]
-                stp x20, x21, [sp, #-16]!
+                ldr x20, [x18, #8];        // read stack range from TEB
+                ldr x21, [x18, #16];
+                stp x20, x21, [sp, #-16]!;
 
-                ldr x20, [x18, #0x1478]   // read Deallocation Stack
-                ldr w21, [x18, #0x1748]   // read GuaranteedStackBytes
-                stp x20, x21, [sp, #-16]!
+                ldr x20, [x18, #0x1478];   // read Deallocation Stack
+                ldr w21, [x18, #0x1748];   // read GuaranteedStackBytes
+                stp x20, x21, [sp, #-16]!;
 
                 // store oldp
-                str x19, [x0]
+                str x19, [x0];
                 // load newp to begin context switch
-                sub x1, x1, #6*16
-                mov sp, x1
+                sub x1, x1, #6*16;
+                mov sp, x1;
 
-                ldp x20, x21, [sp], #16   // restore Deallocation/GuaranteedStackBytes
-                str x20, [x18, #0x1478]
-                str w21, [x18, #0x1748]   // word only
+                ldp x20, x21, [sp], #16;   // restore Deallocation/GuaranteedStackBytes
+                str x20, [x18, #0x1478];
+                str w21, [x18, #0x1748];   // word only
 
-                ldp x20, x21, [sp], #16   // restore stack range
-                str x20, [x18, #8]
-                str x21, [x18, #16]
+                ldp x20, x21, [sp], #16;   // restore stack range
+                str x20, [x18, #8];
+                str x21, [x18, #16];
 
                 // load saved state from new stack
-                ldp d14, d15, [sp], #16
-                ldp d12, d13, [sp], #16
-                ldp d10, d11, [sp], #16
-                ldp d8,  d9,  [sp], #16
+                ldp d14, d15, [sp], #16;
+                ldp d12, d13, [sp], #16;
+                ldp d10, d11, [sp], #16;
+                ldp d8,  d9,  [sp], #16;
 
-                ldp fp,  lr,  [sp], #16
-                ldp x27, x28, [sp], #16
-                ldp x25, x26, [sp], #16
-                ldp x23, x24, [sp], #16
-                ldp x21, x22, [sp], #16
-                ldp x19, x20, [sp], #16
+                ldp fp,  lr,  [sp], #16;
+                ldp x27, x28, [sp], #16;
+                ldp x25, x26, [sp], #16;
+                ldp x23, x24, [sp], #16;
+                ldp x21, x22, [sp], #16;
+                ldp x19, x20, [sp], #16;
 
-                ret`,
-                ""
-            );
+                ret;`;
+            }
         }
         else
             static assert(false);

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -366,55 +366,55 @@ private
             asm pure nothrow @nogc
             {
                 `// save current stack state (similar to posix version in threadasm.S)
-                stp x19, x20, [sp, #-16]!;
-                stp x21, x22, [sp, #-16]!;
-                stp x23, x24, [sp, #-16]!;
-                stp x25, x26, [sp, #-16]!;
-                stp x27, x28, [sp, #-16]!;
-                stp fp,  lr,  [sp, #-16]!;
-                mov x19, sp;               // no need to scan FP registers, so snapshot sp here
+                stp x19, x20, [sp, #-16]!
+                stp x21, x22, [sp, #-16]!
+                stp x23, x24, [sp, #-16]!
+                stp x25, x26, [sp, #-16]!
+                stp x27, x28, [sp, #-16]!
+                stp fp,  lr,  [sp, #-16]!
+                mov x19, sp               // no need to scan FP registers, so snapshot sp here
 
-                stp d8,  d9,  [sp, #-16]!;
-                stp d10, d11, [sp, #-16]!;
-                stp d12, d13, [sp, #-16]!;
-                stp d14, d15, [sp, #-16]!;
+                stp d8,  d9,  [sp, #-16]!
+                stp d10, d11, [sp, #-16]!
+                stp d12, d13, [sp, #-16]!
+                stp d14, d15, [sp, #-16]!
 
-                ldr x20, [x18, #8];        // read stack range from TEB
-                ldr x21, [x18, #16];
-                stp x20, x21, [sp, #-16]!;
+                ldr x20, [x18, #8]        // read stack range from TEB
+                ldr x21, [x18, #16]
+                stp x20, x21, [sp, #-16]!
 
-                ldr x20, [x18, #0x1478];   // read Deallocation Stack
-                ldr w21, [x18, #0x1748];   // read GuaranteedStackBytes
-                stp x20, x21, [sp, #-16]!;
+                ldr x20, [x18, #0x1478]   // read Deallocation Stack
+                ldr w21, [x18, #0x1748]   // read GuaranteedStackBytes
+                stp x20, x21, [sp, #-16]!
 
                 // store oldp
-                str x19, [x0];
+                str x19, [x0]
                 // load newp to begin context switch
-                sub x1, x1, #6*16;
-                mov sp, x1;
+                sub x1, x1, #6*16
+                mov sp, x1
 
-                ldp x20, x21, [sp], #16;   // restore Deallocation/GuaranteedStackBytes
-                str x20, [x18, #0x1478];
-                str w21, [x18, #0x1748];   // word only
+                ldp x20, x21, [sp], #16   // restore Deallocation/GuaranteedStackBytes
+                str x20, [x18, #0x1478]
+                str w21, [x18, #0x1748]   // word only
 
-                ldp x20, x21, [sp], #16;   // restore stack range
-                str x20, [x18, #8];
-                str x21, [x18, #16];
+                ldp x20, x21, [sp], #16   // restore stack range
+                str x20, [x18, #8]
+                str x21, [x18, #16]
 
                 // load saved state from new stack
-                ldp d14, d15, [sp], #16;
-                ldp d12, d13, [sp], #16;
-                ldp d10, d11, [sp], #16;
-                ldp d8,  d9,  [sp], #16;
+                ldp d14, d15, [sp], #16
+                ldp d12, d13, [sp], #16
+                ldp d10, d11, [sp], #16
+                ldp d8,  d9,  [sp], #16
 
-                ldp fp,  lr,  [sp], #16;
-                ldp x27, x28, [sp], #16;
-                ldp x25, x26, [sp], #16;
-                ldp x23, x24, [sp], #16;
-                ldp x21, x22, [sp], #16;
-                ldp x19, x20, [sp], #16;
+                ldp fp,  lr,  [sp], #16
+                ldp x27, x28, [sp], #16
+                ldp x25, x26, [sp], #16
+                ldp x23, x24, [sp], #16
+                ldp x21, x22, [sp], #16
+                ldp x19, x20, [sp], #16
 
-                ret;`;
+                ret`;
             }
         }
         else

--- a/runtime/druntime/src/core/thread/fiber.d
+++ b/runtime/druntime/src/core/thread/fiber.d
@@ -363,59 +363,59 @@ private
         else version (AsmAArch64_Windows)
         {
             pragma(LDC_never_inline);
-            asm nothrow @nogc {
-            "
-                // save current stack state (similar to posix version in threadasm.S)
-                stp x19, x20, [sp, #-16]!;
-                stp x21, x22, [sp, #-16]!;
-                stp x23, x24, [sp, #-16]!;
-                stp x25, x26, [sp, #-16]!;
-                stp x27, x28, [sp, #-16]!;
-                stp fp,  lr,  [sp, #-16]!;
-                mov x19, sp;               // no need to scan FP registers, so snapshot sp here
+            __asm(
+                `// save current stack state (similar to posix version in threadasm.S)
+                stp x19, x20, [sp, #-16]!
+                stp x21, x22, [sp, #-16]!
+                stp x23, x24, [sp, #-16]!
+                stp x25, x26, [sp, #-16]!
+                stp x27, x28, [sp, #-16]!
+                stp fp,  lr,  [sp, #-16]!
+                mov x19, sp               // no need to scan FP registers, so snapshot sp here
 
-                stp d8,  d9,  [sp, #-16]!;
-                stp d10, d11, [sp, #-16]!;
-                stp d12, d13, [sp, #-16]!;
-                stp d14, d15, [sp, #-16]!;
+                stp d8,  d9,  [sp, #-16]!
+                stp d10, d11, [sp, #-16]!
+                stp d12, d13, [sp, #-16]!
+                stp d14, d15, [sp, #-16]!
 
-                ldr x20, [x18, #8];        // read stack range from TEB
-                ldr x21, [x18, #16];
-                stp x20, x21, [sp, #-16]!;
+                ldr x20, [x18, #8]        // read stack range from TEB
+                ldr x21, [x18, #16]
+                stp x20, x21, [sp, #-16]!
 
-                ldr x20, [x18, #0x1478];   // read Deallocation Stack
-                ldr w21, [x18, #0x1748];   // read GuaranteedStackBytes
-                stp x20, x21, [sp, #-16]!;
+                ldr x20, [x18, #0x1478]   // read Deallocation Stack
+                ldr w21, [x18, #0x1748]   // read GuaranteedStackBytes
+                stp x20, x21, [sp, #-16]!
 
                 // store oldp
-                str x19, [x0];
+                str x19, [x0]
                 // load newp to begin context switch
-                sub x1, x1, #6*16;
-                mov sp, x1;
+                sub x1, x1, #6*16
+                mov sp, x1
 
-                ldp x20, x21, [sp], #16;   // restore Deallocation/GuaranteedStackBytes
-                str x20, [x18, #0x1478];
-                str w21, [x18, #0x1748];   // word only
+                ldp x20, x21, [sp], #16   // restore Deallocation/GuaranteedStackBytes
+                str x20, [x18, #0x1478]
+                str w21, [x18, #0x1748]   // word only
 
-                ldp x20, x21, [sp], #16;   // restore stack range
-                str x20, [x18, #8];
-                str x21, [x18, #16];
+                ldp x20, x21, [sp], #16   // restore stack range
+                str x20, [x18, #8]
+                str x21, [x18, #16]
 
                 // load saved state from new stack
-                ldp d14, d15, [sp], #16;
-                ldp d12, d13, [sp], #16;
-                ldp d10, d11, [sp], #16;
-                ldp d8,  d9,  [sp], #16;
+                ldp d14, d15, [sp], #16
+                ldp d12, d13, [sp], #16
+                ldp d10, d11, [sp], #16
+                ldp d8,  d9,  [sp], #16
 
-                ldp fp,  lr,  [sp], #16;
-                ldp x27, x28, [sp], #16;
-                ldp x25, x26, [sp], #16;
-                ldp x23, x24, [sp], #16;
-                ldp x21, x22, [sp], #16;
-                ldp x19, x20, [sp], #16;
+                ldp fp,  lr,  [sp], #16
+                ldp x27, x28, [sp], #16
+                ldp x25, x26, [sp], #16
+                ldp x23, x24, [sp], #16
+                ldp x21, x22, [sp], #16
+                ldp x19, x20, [sp], #16
 
-                ret;
-            " : ; }
+                ret`,
+                ""
+            );
         }
         else
             static assert(false);
@@ -1682,32 +1682,32 @@ private:
         {
             version (StackGrowsDown) {} else static assert( false );
 
-            push( 0x00000000_00000000 );                            // lr
-            push( 0x00000000_00000000 );                            // fp
+            push( 0x00000000_00000000 );                            // another stack frame is needed
+            push( 0x00000000_00000000 );                            // to catch exceptions in fiber_entryPoint
             auto nextfp = pstack;
 
-            push( 0x00000000_00000000 );                            // X19
             push( 0x00000000_00000000 );                            // X20
-            push( 0x00000000_00000000 );                            // X21
+            push( 0x00000000_00000000 );                            // X19
             push( 0x00000000_00000000 );                            // X22
-            push( 0x00000000_00000000 );                            // X23
+            push( 0x00000000_00000000 );                            // X21
             push( 0x00000000_00000000 );                            // X24
-            push( 0x00000000_00000000 );                            // X25
+            push( 0x00000000_00000000 );                            // X23
             push( 0x00000000_00000000 );                            // X26
-            push( 0x00000000_00000000 );                            // X27
+            push( 0x00000000_00000000 );                            // X25
             push( 0x00000000_00000000 );                            // X28
+            push( 0x00000000_00000000 );                            // X27
             push( cast(size_t) &fiber_entryPoint );                 // X30 (lr)
             push( cast(size_t) nextfp );                            // X29 (fp)
-            push( 0x00000000_00000000 );                            // V8 (low)
             push( 0x00000000_00000000 );                            // V9 (low)
-            push( 0x00000000_00000000 );                            // V10 (low)
+            push( 0x00000000_00000000 );                            // V8 (low)
             push( 0x00000000_00000000 );                            // V11 (low)
-            push( 0x00000000_00000000 );                            // V12 (low)
+            push( 0x00000000_00000000 );                            // V10 (low)
             push( 0x00000000_00000000 );                            // V13 (low)
-            push( 0x00000000_00000000 );                            // V14 (low)
+            push( 0x00000000_00000000 );                            // V12 (low)
             push( 0x00000000_00000000 );                            // V15 (low)
-            push( cast(size_t) m_ctxt.bstack - m_size );            // x18[16]
-            push( cast(size_t) m_ctxt.bstack );                     // x18[8] (X18 is TEB)
+            push( 0x00000000_00000000 );                            // V14 (low)
+            push( cast(size_t) m_ctxt.bstack - m_size );            // StackLimit x18[16] (X18 is TEB)
+            push( cast(size_t) m_ctxt.bstack );                     // StackBase  x18[8]
             push( 0x00000000_00000000 );                            // GuaranteedStackBytes
             push( cast(size_t) m_ctxt.bstack - m_size );            // DeallocationStack
 

--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -377,6 +377,10 @@ class Thread : ThreadBase
             ulong[16]       m_reg; // rdi,rsi,rbp,rsp,rbx,rdx,rcx,rax
                                    // r8,r9,r10,r11,r12,r13,r14,r15
         }
+        else version (AArch64)
+        {
+            ulong[33]       m_reg; // x0-x31, pc
+        }
         else
         {
             static assert(false, "Architecture not supported." );
@@ -1760,6 +1764,8 @@ version (LDC_Windows)
             return __asm!(void*)("mov %fs:(4), $0", "=r");
         else version (X86_64)
             return __asm!(void*)("mov %gs:0($1), $0", "=r,r", 8);
+        else version (AArch64)
+            return __asm!(void*)("ldr $0, [x18,$1]", "=r,r", 8);
         else
             static assert(false, "Architecture not supported.");
     }
@@ -1917,6 +1923,14 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
             t.m_reg[13] = context.R13;
             t.m_reg[14] = context.R14;
             t.m_reg[15] = context.R15;
+        }
+        else version (AArch64)
+        {
+            for( int i = 0; i < 31; i++ )
+                t.m_reg[i] = context.X[i];
+
+            t.m_reg[31] = context.Sp;
+            t.m_reg[32] = context.Pc;
         }
         else
         {

--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -1931,6 +1931,8 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
 
             t.m_reg[31] = context.Sp;
             t.m_reg[32] = context.Pc;
+            if ( !t.m_lock )
+                t.m_curr.tstack = cast(void*) context.Sp;
         }
         else
         {

--- a/runtime/druntime/src/ldc/eh_msvc.d
+++ b/runtime/druntime/src/ldc/eh_msvc.d
@@ -544,24 +544,24 @@ void msvc_eh_terminate() nothrow @naked
     {
         asm pure nothrow @nogc
         {`
-            bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm;
-            cmp w0, #0;
-            ble 1f;
+            bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm
+            cmp w0, #0
+            ble 1f
 
             // hacking into the call chain to return EXCEPTION_EXECUTE_HANDLER
             //  as the return value of __FrameUnwindFilter so that
             // __FrameUnwindToState continues with the next unwind block
-            ldr x0, [fp]; // __FrameUnwindFilter's fp
-            mov sp, x0;
-            mov w0, #1;   // return EXCEPTION_EXECUTE_HANDLER
-            ldp fp,lr,[sp],#16;
-            ldp x19,x20,[sp],#0x10;
-            autibsp;      // uses lr,sp and x19 as input to hash
-            ret;
+            ldr x0, [fp] // __FrameUnwindFilter's fp
+            mov sp, x0
+            mov w0, #1   // return EXCEPTION_EXECUTE_HANDLER
+            ldp fp,lr,[sp],#16
+            ldp x19,x20,[sp],#0x10
+            autibsp      // uses lr,sp and x19 as input to hash
+            ret
 
         1:
-            ldp fp,lr,[sp],#16;
-            ret;`
+            ldp fp,lr,[sp],#16
+            ret`
             : : : "x0", "x19", "x20";
         }
     }

--- a/runtime/druntime/src/ldc/eh_msvc.d
+++ b/runtime/druntime/src/ldc/eh_msvc.d
@@ -542,27 +542,28 @@ void msvc_eh_terminate() nothrow @naked
     }
     else version (AArch64)
     {
-        __asm(`
-            bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm
-            cmp w0, #0
-            ble 1f
+        asm pure nothrow @nogc
+        {`
+            bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm;
+            cmp w0, #0;
+            ble 1f;
 
             // hacking into the call chain to return EXCEPTION_EXECUTE_HANDLER
             //  as the return value of __FrameUnwindFilter so that
             // __FrameUnwindToState continues with the next unwind block
-            ldr x0, [fp] // __FrameUnwindFilter's fp
-            mov sp, x0
-            mov w0, #1   // return EXCEPTION_EXECUTE_HANDLER
-            ldp fp,lr,[sp],#16
-            ldp x19,x20,[sp],#0x10
-            autibsp      // uses lr,sp and x19 as input to hash
-            ret
+            ldr x0, [fp]; // __FrameUnwindFilter's fp
+            mov sp, x0;
+            mov w0, #1;   // return EXCEPTION_EXECUTE_HANDLER
+            ldp fp,lr,[sp],#16;
+            ldp x19,x20,[sp],#0x10;
+            autibsp;      // uses lr,sp and x19 as input to hash
+            ret;
 
         1:
-            ldp fp,lr,[sp],#16
-            ret`,
-            "~{memory},~{x0},~{x19},~{x20}"
-        );
+            ldp fp,lr,[sp],#16;
+            ret;`
+            : : : "x0", "x19", "x20";
+        }
     }
 }
 

--- a/runtime/druntime/src/ldc/eh_msvc.d
+++ b/runtime/druntime/src/ldc/eh_msvc.d
@@ -346,7 +346,7 @@ auto tlsOldTerminateHandler() nothrow @assumeUsed
 
 void msvc_eh_terminate() nothrow @naked
 {
-    version (Win32)
+    version (X86)
     {
         __asm(
            `call __D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZk
@@ -380,7 +380,7 @@ void msvc_eh_terminate() nothrow @naked
             "~{memory},~{flags},~{ebp},~{esp},~{eax}"
         );
     }
-    else
+    else version (X86_64)
     {
         __asm(
            `push %rbx                      // align stack for better debuggability
@@ -538,6 +538,34 @@ void msvc_eh_terminate() nothrow @naked
         L_ret:
             ret`,
             "~{memory},~{flags},~{rbp},~{rsp},~{rax},~{rbx},~{rdx}"
+        );
+    }
+    else version (AArch64)
+    {
+        __asm(`
+            stp  fp,lr,[sp,#-16]!; // setup stack for better debuggability
+            mov fp,sp;
+
+            bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm
+            cmp w0, #0
+            ble 1f
+
+            // hacking into the call chain to return EXCEPTION_EXECUTE_HANDLER
+            //  as the return value of __FrameUnwindFilter so that
+            // __FrameUnwindToState continues with the next unwind block
+            ldr x0, [fp]; // terminate's fp
+            ldr x0, [x0]; // __FrameUnwindFilter's fp
+            mov sp, x0;
+            mov w0, #0;   // return EXCEPTION_CONTINUE_SEARCH
+            ldp fp,lr,[sp],#16;
+            ldp x19,x20,[sp],#0x10;
+            autibsp; // uses lr,sp and x19 as input to hash
+            ret;
+
+        1:
+            ldp fp,lr,[sp],#16;
+            ret`,
+            ""
         );
     }
 }

--- a/runtime/druntime/src/ldc/eh_msvc.d
+++ b/runtime/druntime/src/ldc/eh_msvc.d
@@ -543,9 +543,6 @@ void msvc_eh_terminate() nothrow @naked
     else version (AArch64)
     {
         __asm(`
-            stp  fp,lr,[sp,#-16]!; // setup stack for better debuggability
-            mov fp,sp;
-
             bl _D3ldc7eh_msvc21tlsUncaughtExceptionsFNbZm
             cmp w0, #0
             ble 1f
@@ -553,19 +550,18 @@ void msvc_eh_terminate() nothrow @naked
             // hacking into the call chain to return EXCEPTION_EXECUTE_HANDLER
             //  as the return value of __FrameUnwindFilter so that
             // __FrameUnwindToState continues with the next unwind block
-            ldr x0, [fp]; // terminate's fp
-            ldr x0, [x0]; // __FrameUnwindFilter's fp
-            mov sp, x0;
-            mov w0, #0;   // return EXCEPTION_CONTINUE_SEARCH
-            ldp fp,lr,[sp],#16;
-            ldp x19,x20,[sp],#0x10;
-            autibsp; // uses lr,sp and x19 as input to hash
-            ret;
+            ldr x0, [fp] // __FrameUnwindFilter's fp
+            mov sp, x0
+            mov w0, #1   // return EXCEPTION_EXECUTE_HANDLER
+            ldp fp,lr,[sp],#16
+            ldp x19,x20,[sp],#0x10
+            autibsp      // uses lr,sp and x19 as input to hash
+            ret
 
         1:
-            ldp fp,lr,[sp],#16;
+            ldp fp,lr,[sp],#16
             ret`,
-            ""
+            "~{memory},~{x0},~{x19},~{x20}"
         );
     }
 }

--- a/runtime/druntime/src/object.d
+++ b/runtime/druntime/src/object.d
@@ -91,7 +91,7 @@ version (LDC) // note: there's a copy for importC in __importc_builtins.di
     }
     else version (ARM_Any)
     {
-        // Darwin does not use __va_list
+        // Darwin and Windows do not use __va_list
         version (OSX) {}
         else version (iOS) {}
         else version (TVOS) {}

--- a/runtime/druntime/src/object.d
+++ b/runtime/druntime/src/object.d
@@ -96,6 +96,7 @@ version (LDC) // note: there's a copy for importC in __importc_builtins.di
         else version (iOS) {}
         else version (TVOS) {}
         else version (WatchOS) {}
+        else version (CRuntime_Microsoft) {}
         else:
 
         version (ARM)

--- a/runtime/druntime/src/rt/dso.d
+++ b/runtime/druntime/src/rt/dso.d
@@ -125,11 +125,13 @@ else version (Windows)
     void[] getTLSRange() nothrow @nogc
     {
         void** _tls_array;
-        version (Win32)
+        version (X86)
             asm nothrow @nogc { "mov %%fs:(0x2C), %0" : "=r" (_tls_array); }
-        else version (Win64)
+        else version (X86_64)
             asm nothrow @nogc { "mov %%gs:0(%1),  %0" : "=r" (_tls_array) : "r" (0x58); }
-        else
+        else version (AArch64)
+            asm nothrow @nogc { "ldr %0, [x18,%1]" : "=r" (_tls_array) : "r" (0x58); }
+         else
             static assert(0);
 
         void* pbeg = _tls_array[_tls_index];


### PR DESCRIPTION
This allows to build and run the runtime with ldc-build-runtime and option `-march=arm64` on Windows on ARM. The compiler used is the one for x64 (it shows some floating-point inaccuracies in the x86-emulator).

All druntime unittests pass but the two disabled ones involving chained exceptions in fibers.

In phobos a std.process test fails (but also for emulated x64) and a tests in std.outbuffer indicates that there is still an issue with va_arg handling. Without a curl build, the respective tests fail, too.

I haven't yet managed to run the compiler test suite on the ARM machine.