### PR TITLE
CI: Prevent hanging druntime/Phobos unit/integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commonSteps: &commonSteps
     - run:
         name: Run defaultlib unittests & druntime integration tests
         when: always
-        command: cd ../build && ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests"
+        command: cd ../build && ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" --timeout 120
 
 version: 2
 jobs:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,7 +41,7 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
     run_defaultlib_tests_script: |
       # Run defaultlib unittests & druntime integration tests
       cd $CIRRUS_WORKING_DIR/../build
-      ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests"
+      ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" --timeout 120
 
 # Performs the extra packaging steps for jobs producing a prebuilt package.
 # Requires env variables CI_ARCH, CI_OS, GITHUB_TOKEN and PARALLELISM (and CC for FreeBSD).

--- a/.github/actions/4d-test-libs/action.yml
+++ b/.github/actions/4d-test-libs/action.yml
@@ -28,7 +28,7 @@ runs:
           excludes+='|^druntime-test-exceptions-debug$'
         fi
 
-        ctest -j$N --output-on-failure -E "$excludes"
+        ctest -j$N --output-on-failure -E "$excludes" --timeout 120
 
     - name: 'Windows: Run defaultlib unittests & druntime integration tests'
       if: runner.os == 'Windows'
@@ -44,4 +44,4 @@ runs:
         call "%LDC_VSDIR%\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }} || exit /b
         echo on
         cd build || exit /b
-        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest" || exit /b
+        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest" --timeout 120 || exit /b

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -148,4 +148,4 @@ jobs:
           else
             N=$(nproc)
           fi
-          ctest -j$N --output-on-failure -E "$excludes"
+          ctest -j$N --output-on-failure -E "$excludes" --timeout 120


### PR DESCRIPTION
I've seen them hanging yesterday for Linux aarch64 GHA, still running that step after 17 mins.