### PR TITLE
GHA macOS x86_64: Use LDC v1.35.0 as host/bootstrap compiler with Xcode-matching LLVM

### DIFF
--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -131,8 +131,8 @@ runs:
     - name: Install D host compiler
       uses: dlang-community/setup-dlang@v1
       with:
-        # macOS arm64: use LDC v1.39.0 using LLVM v17, as Xcode v16
-        compiler: ${{ inputs.arch == 'arm64' && 'ldc-1.39.0' || 'ldc-latest' }}
+        # macOS: use LDC with LLVM version matching Xcode - v1.39.0 (LLVM 17) on arm64 with Xcode 16, v1.35.0 (LLVM 16) on x86_64 with Xcode 15
+        compiler: ${{ runner.os != 'macOS' && 'ldc-latest' || (inputs.arch == 'arm64' && 'ldc-1.39.0' || 'ldc-1.35.0') }}
     - name: 'Posix: Clear LD_LIBRARY_PATH env variable' # don't use host druntime/Phobos .so/.dylib etc.
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -22,8 +22,7 @@ runs:
             sysroot='/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk'
         fi
 
-        # use bootstrap-ldc, which is guaranteed to be native
-        bootstrap-ldc/bin/ldc-build-runtime --ninja \
+        installed/bin/ldc-build-runtime --ninja \
           --buildDir=build-libs-ios \
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,9 +82,13 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
+            #
+            # We also need to work around issues with the used LDC v1.35.0 host/bootstrap compiler:
+            # * Specify a macOS triple with OS version. And exclude LTO-able host druntime/Phobos because precompiled without OS version.
+            # * Manually specify the path to the bundled libLTO.dylib (broken for *universal* packages for LDC <= v1.40.0).
             extra_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-x86_64/libLTO.dylib -mtriple=x86_64-apple-macos$MACOSX_DEPLOYMENT_TARGET"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
@@ -95,7 +99,7 @@ jobs:
               -DBUILD_LTO_LIBS=ON
             extra_cmake_flags: >-
               -DBUILD_LTO_LIBS=ON
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-arm64/libLTO.dylib"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
@@ -161,16 +165,21 @@ jobs:
           llvm_version: ${{ matrix.llvm_version || env.LLVM_VERSION }}
           arch: ${{ matrix.arch }}
       - name: Build bootstrap LDC
-        if: matrix.os != 'macos-15'
+        if: runner.os != 'macOS'
         uses: ./.github/actions/2-build-bootstrap
         with:
           cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
           arch: ${{ matrix.arch }}
-      # FIXME: on macOS arm64, LLVM 18 (from LDC) and LLVM 17 (from Xcode 16) seem incompatible,
-      #        leading to sporadic 'libc++abi: Pure virtual function called!' compiler crashes
-      - name: 'macOS 15: Use host LDC (with Xcode-compatible LLVM version) as bootstrap LDC'
-        if: matrix.os == 'macos-15'
-        run: ln -s $(dirname $(dirname $(which ldmd2))) ../bootstrap-ldc
+      # FIXME: on macOS, mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang is problematic,
+      #        leading to sporadic 'libc++abi: Pure virtual function called!' compiler crashes etc.
+      - name: 'macOS: Use host LDC (with Xcode-compatible LLVM version) as bootstrap LDC'
+        if: runner.os == 'macOS'
+        run: |
+          ln -s $(dirname $(dirname $(which ldmd2))) ../bootstrap-ldc
+          # work around a v1.35.0 bug - need to rename libLTO-ldc.dylib to make it loadable
+          if [[ '${{ matrix.arch }}' == 'x86_64' ]]; then
+            mv ../bootstrap-ldc/lib-x86_64/libLTO-ldc.dylib ../bootstrap-ldc/lib-x86_64/libLTO.dylib
+          fi
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo
         uses: ./.github/actions/2a-build-pgo


### PR DESCRIPTION
To fix weird issues without LTO and/or with mimalloc, like the dreaded `libc++abi: Pure virtual function called!` errors and unwinding segfaults for the `driver/config_diag.d` lit-test.