### PR TITLE
CI: Bump Alpine image to v3.21

### DIFF
--- a/.github/actions/2-build-bootstrap/action.yml
+++ b/.github/actions/2-build-bootstrap/action.yml
@@ -23,6 +23,7 @@ runs:
         host_dc: ldmd2
         cmake_flags: >-
           -DBUILD_SHARED_LIBS=OFF
+          -DLDC_DYNAMIC_COMPILE=OFF
           ${{ inputs.cmake_flags }}
         arch: ${{ inputs.arch }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,10 +63,12 @@ jobs:
               -DTEST_COMPILER_RT_LIBRARIES="profile;lsan;asan;msan;fuzzer"
               -DLDC_INSTALL_LTOPLUGIN=OFF
               -DLDC_FULLY_STATIC=ON
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
-              -DD_COMPILER_FLAGS="-O -flto=full"
-            # FIXME: -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
-            with_pgo: false
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
 
           - job_name: macOS x86_64
             os: macos-13
@@ -128,11 +130,13 @@ jobs:
           else
             # set up Alpine container
             apk add \
-              git cmake ninja-is-really-ninja g++ ldc llvm-dev llvm-static compiler-rt \
+              git cmake ninja-is-really-ninja g++ clang ldc lld llvm-dev llvm-static compiler-rt \
               libxml2-static zstd-static zlib-static \
               bash grep diffutils make curl 7zip perl
             # create missing 7za symlink
             ln -s 7z /usr/bin/7za
+            # make lld the default linker (note: /usr/bin/ld seems unused)
+            ln -sf /usr/bin/ld.lld /usr/x86_64-alpine-linux-musl/bin/ld
             # create ../llvm symlink to distro LLVM (no prebuilt LDC-LLVM for musl)
             ln -s /usr/lib/llvm19 $(dirname $(pwd))/llvm
             ../llvm/bin/llvm-config --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
           - job_name: Alpine musl x86_64
             os: ubuntu-latest
-            container_image: alpine:3.20
+            container_image: alpine:3.21
             arch: x86_64
             bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
             # TSan and XRay do not work.
@@ -150,7 +150,7 @@ jobs:
             # create missing 7za symlink
             ln -s 7z /usr/bin/7za
             # create ../llvm symlink to distro LLVM (no prebuilt LDC-LLVM for musl)
-            ln -s /usr/lib/llvm17 $(dirname $(pwd))/llvm
+            ln -s /usr/lib/llvm19 $(dirname $(pwd))/llvm
             ../llvm/bin/llvm-config --version
           fi
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,9 @@ jobs:
           - job_name: Linux x86_64 multilib
             os: ubuntu-20.04
             arch: x86_64
-            bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
             # To improve portability of the generated binaries, link the C++ standard library statically.
             extra_cmake_flags: >-
               -DMULTILIB=ON
-              -DBUILD_LTO_LIBS=ON
               -DCMAKE_C_COMPILER=clang
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
@@ -39,12 +37,9 @@ jobs:
             os: ubuntu-22.04-arm # Ubuntu 20 not natively supported
             container_image: ubuntu:20.04
             arch: aarch64
-            bootstrap_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
+            base_cmake_flags: >-
               -DCOMPILER_RT_LIBDIR_OS=aarch64-unknown-linux-gnu
             extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
-              -DCOMPILER_RT_LIBDIR_OS=aarch64-unknown-linux-gnu
               -DCMAKE_C_COMPILER=clang
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
@@ -57,19 +52,18 @@ jobs:
             os: ubuntu-latest
             container_image: alpine:3.21
             arch: x86_64
-            bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
-            # TSan and XRay do not work.
-            extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
+            base_cmake_flags: >-
+              -DCOMPILER_RT_LIBDIR_OS=linux
+              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=x86_64
               -DLLVM_IS_SHARED=OFF
               -DLDC_ENABLE_PLUGINS=OFF
               -DLDC_DYNAMIC_COMPILE=OFF
-              -DLDC_INSTALL_LTOPLUGIN=OFF
-              -DCOMPILER_RT_LIBDIR_OS=linux
-              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=x86_64
+            # TSan and XRay do not work.
+            extra_cmake_flags: >-
               -DTEST_COMPILER_RT_LIBRARIES="profile;lsan;asan;msan;fuzzer"
-              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
+              -DLDC_INSTALL_LTOPLUGIN=OFF
               -DLDC_FULLY_STATIC=ON
+              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
               -DD_COMPILER_FLAGS="-O -flto=full"
             # FIXME: -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
             with_pgo: false
@@ -77,8 +71,6 @@ jobs:
           - job_name: macOS x86_64
             os: macos-13
             arch: x86_64
-            bootstrap_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
@@ -87,7 +79,6 @@ jobs:
             # * Specify a macOS triple with OS version. And exclude LTO-able host druntime/Phobos because precompiled without OS version.
             # * Manually specify the path to the bundled libLTO.dylib (broken for *universal* packages for LDC <= v1.40.0).
             extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
               -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-x86_64/libLTO.dylib -mtriple=x86_64-apple-macos$MACOSX_DEPLOYMENT_TARGET"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
@@ -95,10 +86,7 @@ jobs:
           - job_name: macOS arm64
             os: macos-15
             arch: arm64
-            bootstrap_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
             extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-arm64/libLTO.dylib"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
@@ -106,9 +94,7 @@ jobs:
           - job_name: Windows x64
             os: windows-2022
             arch: x64
-            bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
             extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
               "-DD_COMPILER_FLAGS=-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
@@ -116,10 +102,8 @@ jobs:
           - job_name: Windows x86
             os: windows-2022
             arch: x86
-            bootstrap_cmake_flags: -DBUILD_LTO_LIBS=ON
             # `RT_CFLAGS=-m32` needed to make 64-bit clang-cl output 32-bit code for druntime integration tests
             extra_cmake_flags: >-
-              -DBUILD_LTO_LIBS=ON
               -DRT_CFLAGS=-m32
             # Undefined symbol errors with FullLTO; ThinLTO used to work, but apparently miscompiles a lexer.d:138 assertion since v1.33.
             #  "-DD_COMPILER_FLAGS=-O -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
@@ -168,7 +152,7 @@ jobs:
         if: runner.os != 'macOS'
         uses: ./.github/actions/2-build-bootstrap
         with:
-          cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
+          cmake_flags: -DBUILD_LTO_LIBS=ON ${{ matrix.base_cmake_flags }}
           arch: ${{ matrix.arch }}
       # FIXME: on macOS, mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang is problematic,
       #        leading to sporadic 'libc++abi: Pure virtual function called!' compiler crashes etc.
@@ -184,12 +168,12 @@ jobs:
         if: matrix.with_pgo
         uses: ./.github/actions/2a-build-pgo
         with:
-          cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
+          cmake_flags: ${{ matrix.base_cmake_flags }}
           arch: ${{ matrix.arch }}
       - name: Build LDC & LDC D unittests & defaultlib unittest runners
         uses: ./.github/actions/3-build-native
         with:
-          cmake_flags: ${{ matrix.extra_cmake_flags }}
+          cmake_flags: -DBUILD_LTO_LIBS=ON ${{ matrix.base_cmake_flags }} ${{ matrix.extra_cmake_flags }}
           arch: ${{ matrix.arch }}
           with_pgo: ${{ matrix.with_pgo }}
 
@@ -280,13 +264,9 @@ jobs:
           arch: x86_64
       - name: Build bootstrap LDC
         uses: ./.github/actions/2-build-bootstrap
-        with:
-          cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo
         uses: ./.github/actions/2a-build-pgo
-        with:
-          cmake_flags: ${{ matrix.bootstrap_cmake_flags }}
       - name: Cross-compile LDC to ${{ matrix.os }}-${{ matrix.arch }}
         uses: ./.github/actions/3-build-cross
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Big news
 - Latest frontend and druntime patches from DMD stable (v2.110.0-rc.1+). (#4854)
 - LLVM for prebuilt packages bumped to v19.1.7. (#4822)
-- New prebuilt package for Alpine Linux x86_64 with musl libc. It's currently generated on Alpine v3.20, using its default LLVM 17. Most bundled executables are fully static and can be run on ~all distros. (#4826)
+- New prebuilt package for Alpine Linux x86_64 with musl libc. It's currently generated on Alpine v3.21, using its default LLVM 19. Most bundled executables are fully static and can be run on ~all distros. (#4826, #4862)
 - Revived dynamic-compile (JIT) functionality (formerly unsupported since LLVM 12), supporting LLVM 18+ now. (#4774)
 - ldc2.conf: `%%ldcversion%%` placeholder added, allowing to refer to version-specific directories.
 - Windows: The prebuilt packages now bundle an official libcurl build (from https://curl.se/windows/), currently v8.12.1. The static library (`curl_a.lib`) isn't available anymore. (#4855)

--- a/tests/dmd/fail_compilation/needspkgmod.d
+++ b/tests/dmd/fail_compilation/needspkgmod.d
@@ -9,7 +9,7 @@
 /*
 TEST_OUTPUT:
 ----
-$r:.+_D7imports9pkgmod3133mod3barFZv.*$
+$r:.+(_D7imports9pkgmod3133mod3barFZv|imports\.pkgmod313\.mod\.bar).*$
 Error: $r:.+$ failed with status: $n$
 ----
 */


### PR DESCRIPTION
Incl. enabling C++ LTO for the compiler, as well as PGO (although I'm not sure PGO really works; >1k warnings wrt. changed function control flows... **edit**: oh well, looks like those are for the `ldc2-unittest` object file only).