### PR TITLE
ldc-build-runtime: Add `--installWithSuffix` option

### DIFF
--- a/.github/actions/3-build-cross/action.yml
+++ b/.github/actions/3-build-cross/action.yml
@@ -80,7 +80,7 @@ runs:
         cd ..
         arch='${{ inputs.arch }}'
         triple="$arch-apple-macos$MACOSX_DEPLOYMENT_TARGET"
-        echo "DFLAGS=-mtriple=$triple -L-L$PWD/build-cross-libs/lib -Xcc=-target -Xcc=$triple -Xcc=-isysroot -Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" >> $GITHUB_ENV
+        echo "DFLAGS=-mtriple=$triple -L-L$PWD/install/lib -Xcc=-target -Xcc=$triple -Xcc=-isysroot -Xcc=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" >> $GITHUB_ENV
         echo "CROSS_TRIPLE=$triple" >> $GITHUB_ENV
         echo "CROSS_CMAKE_FLAGS=-DCMAKE_OSX_ARCHITECTURES=$arch" >> $GITHUB_ENV
 
@@ -113,9 +113,9 @@ runs:
         cmakeFlags+=" -DANDROID_STL=c++_static"
         cmakeFlags+=" -DCMAKE_TOOLCHAIN_FILE=$PWD/android-ndk/build/cmake/android.toolchain.cmake"
         cmakeFlags+=" -DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF"
-        cmakeFlags+=" -DLDC_LINK_MANUALLY=ON -DD_LINKER_ARGS='-L$PWD/build-cross-libs/lib;-lphobos2-ldc;-ldruntime-ldc'"
+        cmakeFlags+=" -DLDC_LINK_MANUALLY=ON -DD_LINKER_ARGS='-L$PWD/install/lib;-lphobos2-ldc;-ldruntime-ldc'"
 
-        echo "DFLAGS=-mtriple=$triple -L-L$PWD/build-cross-libs/lib -gcc=$PWD/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/$triple-clang" >> $GITHUB_ENV
+        echo "DFLAGS=-mtriple=$triple -L-L$PWD/install/lib -gcc=$PWD/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/$triple-clang" >> $GITHUB_ENV
         echo "CROSS_TRIPLE=$triple" >> $GITHUB_ENV
         echo "CROSS_CMAKE_FLAGS=$cmakeFlags" >> $GITHUB_ENV
 
@@ -125,7 +125,7 @@ runs:
       with:
         cmake_flags: ${{ env.CROSS_CMAKE_FLAGS }}
 
-    - name: Cross-compile default libraries
+    - name: Cross-compile and install default libraries
       shell: bash
       run: |
         set -euxo pipefail
@@ -136,12 +136,15 @@ runs:
         # convert to array, stripping all `-D` prefixes
         IFS=$'\n' flags=( $(xargs -n1 <<<"$flags" | cut -b3-) )
 
+        # install libs into install/lib/, and ldc2.conf into install/etc/
         bootstrap-ldc/bin/ldc-build-runtime --ninja \
-          --buildDir="build-cross-libs" \
+          --buildDir="build-cross-runtime" \
           --dFlags="${DFLAGS// /;}" \
           --ldcSrcDir="$PWD/ldc" \
+          --installWithSuffix "" \
           CMAKE_INSTALL_PREFIX="$PWD/install" \
           INCLUDE_INSTALL_DIR="$PWD/install/import" \
+          CONF_INST_DIR="$PWD/install/etc" \
           "${flags[@]}"
 
     - name: Cross-compile LDC executables

--- a/.github/actions/5-install/action.yml
+++ b/.github/actions/5-install/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
 
-    - name: Install LDC
+    - name: Install LDC # into ../install/
       shell: bash
       run: |
         set -eux
@@ -18,17 +18,16 @@ runs:
         if [[ '${{ inputs.cross_compiling }}' != true ]]; then
           ninja -C build install >/dev/null
         else
-          # populate first subdirs by installing the cross-compiled compiler:
-          # * bin/: executables
-          # * lib/: LTO plugin and compiler-rt libs only
-          # * etc/bash_completion.d/
-          # * import/: missing ldc/gccbuiltins_*.di
-          ninja -C build-cross install
-
-          # install the cross-compiled libs to populate:
+          # the cross-compiled runtime libs have already been installed:
           # * lib/: runtime library artifacts
           # * etc/ldc2.conf
-          ninja -C build-cross-libs install
+
+          # now extend by installing the cross-compiled compiler:
+          # * bin/: executables
+          # * lib/: LTO plugin and compiler-rt libs
+          # * etc/bash_completion.d/
+          # * import/: all runtime imports except for ldc/gccbuiltins_*.di
+          ninja -C build-cross install
 
           # copy gccbuiltins from bootstrap compiler
           cp bootstrap-ldc/import/ldc/gccbuiltins_*.di install/import/ldc/

--- a/.github/actions/5a-android-x86/action.yml
+++ b/.github/actions/5a-android-x86/action.yml
@@ -22,11 +22,9 @@ runs:
 
         # use bootstrap-ldc, which is guaranteed to be native
         bootstrap-ldc/bin/ldc-build-runtime --ninja \
-          --buildDir="build-libs-$arch" \
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
+          --installWithSuffix="-$arch" \
+          CMAKE_INSTALL_PREFIX="$PWD/installed" \
           "${flags[@]}" \
           ANDROID_ABI="$abi" # override the one in CROSS_CMAKE_FLAGS
-
-        mkdir "installed/lib-$arch"
-        cp "build-libs-$arch"/lib/* "installed/lib-$arch/"

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -23,17 +23,14 @@ runs:
         fi
 
         installed/bin/ldc-build-runtime --ninja \
-          --buildDir=build-libs-ios \
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
+          --installWithSuffix="-ios-$arch" \
           CMAKE_SYSTEM_NAME=iOS \
           CMAKE_OSX_SYSROOT="$sysroot" \
           CMAKE_OSX_ARCHITECTURES="$arch" \
           CMAKE_OSX_DEPLOYMENT_TARGET="$deployment_target" \
           BUILD_LTO_LIBS=ON
-
-        mkdir "installed/lib-ios-$arch"
-        cp -a build-libs-ios/lib/*.{a,dylib,o} "installed/lib-ios-$arch/"
 
         section="
         \"$arch-apple-ios\":

--- a/.github/actions/7-package/action.yml
+++ b/.github/actions/7-package/action.yml
@@ -19,6 +19,7 @@ runs:
         cd ..
         if [[ '${{ inputs.cross_target_triple }}' != '' ]]; then
           DMD="$PWD/bootstrap-ldc/bin/ldmd2"
+          ln -s installed install # the DFLAGS still reference install/lib/
         else
           DMD="$PWD/installed/bin/ldmd2"
         fi

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -80,17 +80,10 @@ runs:
         call "%VSDIR%\Common7\Tools\VsDevCmd.bat" -arch=arm64 -host_arch=x64 || exit /b
         echo on
         ldc2-multilib\bin\ldc-build-runtime --ninja ^
-          --buildDir=build-libs-arm64 ^
           --dFlags=-mtriple=aarch64-windows-msvc ^
           "--ldcSrcDir=%CD%" ^
+          --installWithSuffix=arm64 ^
           BUILD_LTO_LIBS=ON
-    - name: Copy arm64 libraries
-      shell: bash
-      run: |
-        set -eux
-        cp -R build-libs-arm64/lib ldc2-multilib/libarm64
-        rm ldc2-multilib/libarm64/*.{exp,ilk}
-        rm ldc2-multilib/libarm64/{druntime,phobos2}-ldc-shared.pdb
     - name: Add arm64 section to ldc2.conf
       shell: pwsh
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Big news
 - ldc2.conf: Arrays can now be appended to via the `~=` operator. (#4848, #4856)
+- New `--installWithSuffix` command-line option for the `ldc-build-runtime` tool, to simplify copying the libraries to an existing LDC installation. (#4870)
 
 #### Platform support
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -365,7 +365,9 @@ endif()
 if(NOT DEFINED CONF_INST_DIR) # set by parent LDC build
     set(CONF_INST_DIR "${CMAKE_INSTALL_PREFIX}/etc")
 endif()
-install(FILES ${install_conf_path} DESTINATION ${CONF_INST_DIR} RENAME ${CONFIG_BASE}.conf)
+if(NOT CONF_INST_DIR STREQUAL "") # allow skipping the ldc2.conf installation
+    install(FILES ${install_conf_path} DESTINATION ${CONF_INST_DIR} RENAME ${CONFIG_BASE}.conf)
+endif()
 
 #
 # druntime/Phobos compilation helpers.
@@ -858,13 +860,17 @@ foreach(libname ${libs_to_install})
         # import .lib in regular lib dir
         install(FILES       $<TARGET_LINKER_FILE:${libname}>
                 DESTINATION ${destination_dir})
-        # .dll in bin dir
+        # when included from the LDC parent build, install .dll and .pdb into bin/
+        if(LDC_EXE)
+            set(destination_dir ${CMAKE_INSTALL_PREFIX}/bin)
+        endif()
+        # .dll in bin or lib dir
         install(FILES       $<TARGET_FILE:${libname}>
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-        # .pdb of debug DLLs in bin dir
+                DESTINATION ${destination_dir})
+        # .pdb of debug DLLs in bin or lib dir
         if(${libname} MATCHES "-debug")
             install(FILES       $<TARGET_PDB_FILE:${libname}>
-                    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+                    DESTINATION ${destination_dir})
         endif()
     else()
         install(TARGETS     ${libname}

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -22,6 +22,7 @@ struct Config {
     uint numBuildJobs;
     bool systemZlib;
     string[string] cmakeVars;
+    string installWithSuffix;
 }
 
 version (Windows) enum exeSuffix = ".exe";
@@ -167,6 +168,13 @@ void runCMake() {
     if (config.cFlags.length)       args ~= "-DRT_CFLAGS=" ~ config.cFlags.join(" ");
     if (config.linkerFlags.length)  args ~= "-DLD_FLAGS=" ~ config.linkerFlags.join(" ");
     if (config.systemZlib)          args ~= "-DPHOBOS_SYSTEM_ZLIB=ON";
+    if (config.installWithSuffix.ptr) {
+        args ~= [
+            "-DCMAKE_INSTALL_PREFIX=" ~ config.ldcExecutable.dirName.dirName,
+            "-DLIB_SUFFIX=" ~ config.installWithSuffix,
+            "-DCONF_INST_DIR=", // don't install/overwrite existing etc/ldc2.conf!
+        ];
+    }
 
     foreach (pair; config.cmakeVars.byPair)
         args ~= "-D" ~ pair[0] ~ '=' ~ pair[1];
@@ -182,7 +190,8 @@ void runCMake() {
 void build() {
     const wd = WorkingDirScope(config.buildDir);
 
-    string[] args = [ config.ninja ? "ninja" : "make" ];
+    const buildTool = config.ninja ? "ninja" : "make";
+    string[] args = [ buildTool ];
     if (config.numBuildJobs != 0) {
         import std.conv : to;
         args ~= "-j" ~ config.numBuildJobs.to!string;
@@ -192,6 +201,9 @@ void build() {
         args ~= "all-test-runners";
 
     exec(args);
+
+    if (config.installWithSuffix.ptr)
+        exec([buildTool, "install"]);
 }
 
 /**
@@ -333,6 +345,7 @@ void parseCommandLine(string[] args) {
             "linkerFlags", "Extra C linker flags for shared libraries and testrunner executables (separated by ';')", &config.linkerFlags,
             "j",           "Number of parallel build jobs", &config.numBuildJobs,
             "systemZlib",  "Use system zlib instead of Phobos' vendored version", &config.systemZlib,
+            "installWithSuffix", "Install the built libraries to '<directory containing LDC executable>/../lib<suffix>/'", &config.installWithSuffix,
         );
 
         // getopt() has removed all consumed args from `args`


### PR DESCRIPTION
To simplify copying the libraries to an existing LDC installation.