### PR TITLE
GHA: Simplify gathering the bundled imports for cross-compiled packages

### DIFF
--- a/.github/actions/5-install/action.yml
+++ b/.github/actions/5-install/action.yml
@@ -16,24 +16,22 @@ runs:
         cd ..
 
         if [[ '${{ inputs.cross_compiling }}' != true ]]; then
-          cd build
-          ninja install >/dev/null
-          cd ..
+          ninja -C build install >/dev/null
         else
           mkdir -p install/bin
           cp build-cross/bin/{ldc2,ldmd2,ldc-build-runtime,ldc-profdata,ldc-profgen,ldc-prune-cache,timetrace2txt} install/bin/
           cp build-cross/bin/ldc-build-plugin install/bin/ || true
+
           cp -R build-cross-libs/lib install/
           cp build-cross/lib/{libldc_rt.*,libLTO.dylib,LLVMgold-ldc.so} install/lib/ || true
+
           mkdir install/etc
           cp build-cross/bin/ldc2_install.conf install/etc/ldc2.conf
           cp -R ldc/packaging/bash_completion.d install/etc/
-          mkdir install/import
-          cp -R ldc/runtime/druntime/src/{core,etc,ldc,object.d,__importc_builtins.di,importc.h} install/import/
-          cp bootstrap-ldc/runtime/import/ldc/gccbuiltins_*.di install/import/ldc/
-          cp -R ldc/runtime/phobos/etc/c install/import/etc/
-          rm -rf install/import/etc/c/zlib
-          cp -R ldc/runtime/phobos/std install/import/
+
+          # use imports from installed bootstrap compiler
+          ninja -C bootstrap-ldc install >/dev/null
+          mv bootstrap-install/import install/
         fi
 
         cp ldc/LICENSE install/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,6 +268,11 @@ jobs:
           arch: x86_64
       - name: Build bootstrap LDC
         uses: ./.github/actions/2-build-bootstrap
+        with:
+          # prepare for installing the bootstrap compiler to ../bootstrap-install/
+          cmake_flags: >-
+            -DCMAKE_INSTALL_PREFIX="$PWD/../bootstrap-install"
+            -DINCLUDE_INSTALL_DIR="$PWD/../bootstrap-install/import"
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo
         uses: ./.github/actions/2a-build-pgo


### PR DESCRIPTION
By installing the bootstrap compiler and using its imports.