### PR TITLE
Revise unwind-table emission, enabling them for most popular targets

### DIFF
--- a/gen/abi/aarch64.cpp
+++ b/gen/abi/aarch64.cpp
@@ -57,6 +57,10 @@ private:
 public:
   AArch64TargetABI() {}
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return isDarwin() ? llvm::UWTableKind::Sync : llvm::UWTableKind::Async;
+  }
+
   bool returnInArg(TypeFunction *tf, bool) override {
     Type *rt = tf->next->toBasetype();
     if (rt->ty == TY::Tstruct || rt->ty == TY::Tsarray) {

--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -155,6 +155,17 @@ llvm::CallingConv::ID TargetABI::callingConv(FuncDeclaration *fdecl) {
   return callingConv(tf, fdecl->needThis() || fdecl->isNested());
 }
 
+void TargetABI::setUnwindTableKind(llvm::Function *fn) {
+  llvm::UWTableKind kind = defaultUnwindTableKind();
+  if (kind != llvm::UWTableKind::None) {
+#if LDC_LLVM_VER >= 1600
+    fn->setUWTableKind(kind);
+#else
+    fn->setUWTableKind(kind);
+#endif
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 bool TargetABI::returnInArg(TypeFunction *tf, bool needsThis) {

--- a/gen/abi/abi.h
+++ b/gen/abi/abi.h
@@ -19,6 +19,7 @@
 #include "dmd/globals.h"
 #include "gen/dvalue.h"
 #include "llvm/IR/CallingConv.h"
+#include "llvm/Support/CodeGen.h" // for UWTableKind
 #include <vector>
 
 class Type;
@@ -33,6 +34,7 @@ namespace llvm {
 class Type;
 class Value;
 class FunctionType;
+class Function;
 }
 
 /// Transforms function arguments and return values.
@@ -110,13 +112,13 @@ public:
     return name;
   }
 
-  /// Returns true if all functions require the LLVM uwtable attribute.
-  virtual bool needsUnwindTables() {
-    // Condensed logic of Clang implementations of
-    // `clang::ToolChain::IsUnwindTablesDefault()` based on early Clang 5.0.
-    return global.params.targetTriple->getArch() == llvm::Triple::x86_64 ||
-           global.params.targetTriple->getOS() == llvm::Triple::NetBSD;
+  /// Returns the default unwind-table kind for all functions.
+  /// Analogous to clang's ToolChain::getDefaultUnwindTableLevel().
+  virtual llvm::UWTableKind defaultUnwindTableKind() {
+    return llvm::UWTableKind::None;
   }
+
+  void setUnwindTableKind(llvm::Function *fn);
 
   /// Returns true if the target is darwin-based.
   bool isDarwin() {

--- a/gen/abi/arm.cpp
+++ b/gen/abi/arm.cpp
@@ -26,6 +26,13 @@ struct ArmTargetABI : TargetABI {
   CompositeToArray64 compositeToArray64;
   IntegerRewrite integerRewrite;
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    const auto &triple = *global.params.targetTriple;
+    return triple.isOSLinux() || triple.isOSOpenBSD()
+               ? llvm::UWTableKind::None
+               : llvm::UWTableKind::Async;
+  }
+
   bool returnInArg(TypeFunction *tf, bool) override {
     // AAPCS 5.4 wants composites > 4-bytes returned by arg except for
     // Homogeneous Aggregates of up-to 4 float types (6.1.2.1) - an HFA.

--- a/gen/abi/nvptx.cpp
+++ b/gen/abi/nvptx.cpp
@@ -44,10 +44,6 @@ struct NVPTXTargetABI : TargetABI {
       pointerRewite.applyTo(arg);
     }
   }
-  // There are no exceptions at all, so no need for unwind tables.
-  bool needsUnwindTables() override {
-    return false;
-  }
 };
 
 TargetABI *createNVPTXABI() { return new NVPTXTargetABI(); }

--- a/gen/abi/ppc.cpp
+++ b/gen/abi/ppc.cpp
@@ -36,6 +36,10 @@ struct PPCTargetABI : TargetABI {
 
   explicit PPCTargetABI(const bool Is64Bit) : Is64Bit(Is64Bit) {}
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return llvm::UWTableKind::Async;
+  }
+
   bool returnInArg(TypeFunction *tf, bool) override {
     Type *rt = tf->next->toBasetype();
 

--- a/gen/abi/ppc64le.cpp
+++ b/gen/abi/ppc64le.cpp
@@ -29,6 +29,10 @@ struct PPC64LETargetABI : TargetABI {
 
   explicit PPC64LETargetABI() : hfvaToArray(8) {}
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return llvm::UWTableKind::Async;
+  }
+
   bool passByVal(TypeFunction *, Type *t) override {
     t = t->toBasetype();
     return isPOD(t) &&

--- a/gen/abi/riscv64.cpp
+++ b/gen/abi/riscv64.cpp
@@ -158,6 +158,11 @@ private:
   IntegerRewrite integerRewrite;
 
 public:
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return global.params.targetTriple->isOSLinux() ? llvm::UWTableKind::Async
+                                                   : llvm::UWTableKind::None;
+  }
+
   Type *vaListType() override {
     // va_list is void*
     return pointerTo(Type::tvoid);

--- a/gen/abi/spirv.cpp
+++ b/gen/abi/spirv.cpp
@@ -50,10 +50,6 @@ struct SPIRVTargetABI : TargetABI {
       pointerRewite.applyTo(arg);
     }
   }
-  // There are no exceptions at all, so no need for unwind tables.
-  bool needsUnwindTables() override {
-    return false;
-  }
 };
 
 TargetABI *createSPIRVABI() { return new SPIRVTargetABI(); }

--- a/gen/abi/win64.cpp
+++ b/gen/abi/win64.cpp
@@ -116,6 +116,10 @@ public:
     return name;
   }
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return llvm::UWTableKind::Async;
+  }
+
   bool returnInArg(TypeFunction *tf, bool needsThis) override {
     Type *rt = tf->next->toBasetype();
 

--- a/gen/abi/x86-64.cpp
+++ b/gen/abi/x86-64.cpp
@@ -146,6 +146,10 @@ struct X86_64TargetABI : TargetABI {
   ImplicitByvalRewrite byvalRewrite;
   IndirectByvalRewrite indirectByvalRewrite;
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return llvm::UWTableKind::Async;
+  }
+
   bool returnInArg(TypeFunction *tf, bool needsThis) override;
 
   bool preferPassByRef(Type *t) override;

--- a/gen/abi/x86.cpp
+++ b/gen/abi/x86.cpp
@@ -84,6 +84,10 @@ struct X86TargetABI : TargetABI {
     return name;
   }
 
+  llvm::UWTableKind defaultUnwindTableKind() override {
+    return isMSVC ? llvm::UWTableKind::None : llvm::UWTableKind::Async;
+  }
+
   // Helper folding the magic __c_complex_{float,double,real} enums to the basic
   // complex type.
   static Type *getExtraLoweredReturnType(TypeFunction *tf) {

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1157,9 +1157,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   }
 
   // function attributes
-  if (gABI->needsUnwindTables()) {
-    func->setUWTableKind(llvm::UWTableKind::Default);
-  }
+  gABI->setUnwindTableKind(func);
   if (opts::isAnySanitizerEnabled() &&
       !opts::functionIsInSanitizerBlacklist(fd)) {
     // Get the @noSanitize mask

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -66,6 +66,7 @@ llvm::Function *buildForwarderFunction(
   llvm::Function *fn = llvm::Function::Create(
       fnTy, llvm::GlobalValue::InternalLinkage, irMangle, &gIR->module);
   fn->setCallingConv(gABI->callingConv(LINK::d));
+  gABI->setUnwindTableKind(fn);
 
   // Emit the body, consisting of...
   const auto bb = llvm::BasicBlock::Create(gIR->context(), "", fn);

--- a/gen/modules.cpp
+++ b/gen/modules.cpp
@@ -287,10 +287,7 @@ void addCoverageAnalysis(Module *m) {
         LLFunction::Create(ctorTy, LLGlobalValue::InternalLinkage,
                            getIRMangledFuncName(ctorname, LINK::d), &gIR->module);
     ctor->setCallingConv(gABI->callingConv(LINK::d));
-    // Set function attributes. See functions.cpp:DtoDefineFunction()
-    if (global.params.targetTriple->getArch() == llvm::Triple::x86_64) {
-      ctor->setUWTableKind(llvm::UWTableKind::Default);
-    }
+    gABI->setUnwindTableKind(ctor);
 
     llvm::BasicBlock *bb = llvm::BasicBlock::Create(gIR->context(), "", ctor);
     IRBuilder<> builder(bb);

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -269,14 +269,8 @@ struct LazyFunctionDeclarer {
 
       fn->setAttributes(attrs);
 
-      // On x86_64, always set 'uwtable' for System V ABI compatibility.
-      // FIXME: Move to better place (abi-x86-64.cpp?)
-      // NOTE: There are several occurances if this line.
-      if (global.params.targetTriple->getArch() == llvm::Triple::x86_64) {
-        fn->setUWTableKind(llvm::UWTableKind::Default);
-      }
-
       fn->setCallingConv(gABI->callingConv(dty, false));
+      gABI->setUnwindTableKind(fn);
     }
   }
 };


### PR DESCRIPTION
Based on the clang 19 logic (but not 100% accurate).

There's an interesting special case - Darwin on arm64 apparently uses *synchronous* tables.