### PR TITLE
Keep frame pointers by default with -O for some targets

### DIFF
--- a/.github/actions/4c-test-dmd/action.yml
+++ b/.github/actions/4c-test-dmd/action.yml
@@ -9,20 +9,7 @@ runs:
     - name: 'Posix: Run DMD testsuite'
       if: runner.os != 'Windows'
       shell: bash
-      run: |
-        set -eux
-        repoDir=$PWD
-        cd ../build
-        if type -P apk &>/dev/null; then
-          # Alpine: run full dmd-testsuite-debug
-          ctest -V -R 'dmd-testsuite' -E '^dmd-testsuite$'
-          # these two tests require extra flags "-link-defaultlib-debug -frame-pointer=all": https://github.com/ldc-developers/ldc/issues/4694
-          # => remove before running optimized dmd-testsuite separately
-          rm $repoDir/tests/dmd/runnable/{test17559.d,test19086.d}
-          ctest -V -R '^dmd-testsuite$'
-        else
-          ctest -V -R "dmd-testsuite"
-        fi
+      run: cd ../build && ctest -V -R "dmd-testsuite"
 
     - name: 'Windows: Run DMD testsuite'
       if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LDC master
 
 #### Big news
+- Keep frame pointers by default with `-O` for some targets, notably AArch64 (except Windows), x86_64 (except Windows and glibc Linux), Windows x86, and Android. This fixes druntime backtraces with optimized code (incl. prebuilt druntime/Phobos). (#4889)
 - ldc2.conf: Arrays can now be appended to via the `~=` operator. (#4848, #4856)
 
 #### Platform support

--- a/tests/codegen/attr_targetoptions.d
+++ b/tests/codegen/attr_targetoptions.d
@@ -1,9 +1,5 @@
 // Tests that our TargetMachine options are added as function attributes
 
-// RUN: %ldc -c -output-ll -of=%t.ll %s
-// RUN: FileCheck %s --check-prefix=COMMON --check-prefix=WITH_FP < %t.ll
-// RUN: %ldc -c -output-ll -of=%t.ll %s -O2
-// RUN: FileCheck %s --check-prefix=COMMON --check-prefix=NO_FP < %t.ll
 // RUN: %ldc -c -output-ll -of=%t.ll %s -O2 -frame-pointer=all
 // RUN: FileCheck %s --check-prefix=COMMON --check-prefix=WITH_FP < %t.ll
 // RUN: %ldc -c -output-ll -of=%t.ll %s -frame-pointer=none -mattr=test

--- a/tests/codegen/exception_stack_trace.d
+++ b/tests/codegen/exception_stack_trace.d
@@ -1,4 +1,4 @@
-// RUN: %ldc -g -frame-pointer=all -link-defaultlib-debug %s -of=%t%exe
+// RUN: %ldc -g %s -of=%t%exe
 // RUN: %t%exe | FileCheck %s
 
 void bar()

--- a/tests/codegen/frame_pointer_x86.d
+++ b/tests/codegen/frame_pointer_x86.d
@@ -1,12 +1,12 @@
 // REQUIRES: target_X86
 
-// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s
+// RUN: %ldc -c -mtriple=x86_64-linux-gnu -output-s -of=%t.s %s
 // RUN: FileCheck %s --check-prefixes=COMMON,FP < %t.s
-// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s -O2
+// RUN: %ldc -c -mtriple=x86_64-linux-gnu -output-s -of=%t.s %s -O2
 // RUN: FileCheck %s --check-prefixes=COMMON,NO_FP < %t.s
-// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s -O2 -frame-pointer=all
+// RUN: %ldc -c -mtriple=x86_64-linux-gnu -output-s -of=%t.s %s -O2 -frame-pointer=all
 // RUN: FileCheck %s --check-prefixes=COMMON,FP < %t.s
-// RUN: %ldc -c -mtriple=x86_64 -output-s -of=%t.s %s -frame-pointer=none
+// RUN: %ldc -c -mtriple=x86_64-linux-gnu -output-s -of=%t.s %s -frame-pointer=none
 // RUN: FileCheck %s --check-prefixes=COMMON,NO_FP < %t.s
 
 // COMMON-LABEL: _D17frame_pointer_x8613inlineAsmLeafFZv:

--- a/tests/codegen/vector_abi_x86.d
+++ b/tests/codegen/vector_abi_x86.d
@@ -3,10 +3,10 @@
 
 // REQUIRES: host_X86
 
-// RUN: %ldc -O -output-s -m32 -of=%t_32.s %s -mattr=+sse2
+// RUN: %ldc -O -frame-pointer=none -output-s -m32 -of=%t_32.s %s -mattr=+sse2
 // RUN: FileCheck --check-prefix=COMMON %s < %t_32.s
 
-// RUN: %ldc -O -output-s -m64 -of=%t_64.s %s
+// RUN: %ldc -O -frame-pointer=none -output-s -m64 -of=%t_64.s %s
 // RUN: FileCheck --check-prefix=COMMON --check-prefix=X64 %s < %t_64.s
 
 import core.simd;

--- a/tests/dmd/runnable/test17559.d
+++ b/tests/dmd/runnable/test17559.d
@@ -1,7 +1,5 @@
 // REQUIRED_ARGS: -g
 // REQUIRED_ARGS(linux freebsd openbsd dragonflybsd): -L-export-dynamic
-// LDC (required for Win32 and -O): REQUIRED_ARGS(windows32): -link-defaultlib-debug
-// LDC (FreeBSD's libexecinfo apparently doesn't like elided frame pointers): REQUIRED_ARGS(freebsd): -link-defaultlib-debug -frame-pointer=all
 // PERMUTE_ARGS:
 // DISABLED: osx
 

--- a/tests/dmd/runnable/test19086.d
+++ b/tests/dmd/runnable/test19086.d
@@ -1,6 +1,5 @@
 // REQUIRED_ARGS: -g
 // REQUIRED_ARGS(linux freebsd openbsd dragonflybsd): -L-export-dynamic
-// LDC (FreeBSD's libexecinfo apparently doesn't like elided frame pointers): REQUIRED_ARGS(freebsd): -link-defaultlib-debug -frame-pointer=all
 // DISABLED: LDC_win32 // no file/line info for the `run19086` frame (and only that frame), even without -O
 // PERMUTE_ARGS:
 // DISABLED: osx

--- a/tests/sanitizers/fuzz_asan.d
+++ b/tests/sanitizers/fuzz_asan.d
@@ -2,9 +2,8 @@
 
 // REQUIRES: Fuzzer, ASan
 
-// See https://github.com/ldc-developers/ldc/issues/2222 for -frame-pointer=all
 // See https://github.com/ldc-developers/ldc/pull/4328 for -fsanitize-address-use-after-return=never
-// RUN: %ldc -g -fsanitize=address,fuzzer -fsanitize-address-use-after-return=never -frame-pointer=all %s -of=%t%exe
+// RUN: %ldc -g -fsanitize=address,fuzzer -fsanitize-address-use-after-return=never %s -of=%t%exe
 // RUN: not %t%exe 2>&1 | FileCheck %s
 
 bool FuzzMe(ubyte* data, size_t dataSize)


### PR DESCRIPTION
Primarily to fix (druntime) backtraces with optimized code for those targets, incl. prebuilt release druntime/Phobos.

Fixes #4594 and #4694.