### PR TITLE
Bump min required CMake version from v3.4.3 to v3.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,8 @@ jobs:
           - job_name: Windows x64
             os: windows-2025
             arch: x64
+            base_cmake_flags: >-
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
             extra_cmake_flags: >-
               "-DD_COMPILER_FLAGS=-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
               -DEXTRA_CXXFLAGS=-flto=full
@@ -103,6 +105,8 @@ jobs:
           - job_name: Windows x86
             os: windows-2025
             arch: x86
+            base_cmake_flags: >-
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
             # `RT_CFLAGS=-m32` needed to make 64-bit clang-cl output 32-bit code for druntime integration tests
             extra_cmake_flags: >-
               -DRT_CFLAGS=-m32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.16.0)
 if(POLICY CMP0025)
     cmake_policy(SET CMP0025 NEW)
 endif()
@@ -207,17 +207,11 @@ if(MSVC)
         append("-Llegacy_stdio_definitions.lib" DFLAGS_BASE)
     endif()
 
-    # Link against the static MSVC runtime; CMake's C(++) flags apparently default to the dynamic one.
-    # Host DMD/LDMD already defaults to linking against the static MSVC runtime.
-    if(${LLVM_CXXFLAGS} MATCHES "(^| )/MDd?( |$)")
-        message(FATAL_ERROR "LLVM must be built with CMake option LLVM_USE_CRT_<CMAKE_BUILD_TYPE>=MT[d]")
-    endif()
     set(llvm_ob_flag)
     string(REGEX MATCH "/Ob[0-2]" llvm_ob_flag "${LLVM_CXXFLAGS}")
     foreach(flag_var
             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
         # CMake defaults to /W3, LLVM uses /W4 => MS compiler warns about overridden option.
         # Simply replace with /W4.
         string(REGEX REPLACE "/W[0-3]" "/W4" ${flag_var} "${${flag_var}}")

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.16.0)
 project(runtime C ASM)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -593,6 +593,7 @@ function(set_common_library_properties target name output_dir c_flags ld_flags i
         COMPILE_DEFINITIONS         "LDC=1"
         COMPILE_FLAGS               "${c_flags}"
         LINK_FLAGS                  "${full_ldflags}"
+        MSVC_RUNTIME_LIBRARY        "" # see reasoning for `/MT /Zl` above
         VERSION                     ${DMDFE_MINOR_VERSION}.${DMDFE_PATCH_VERSION}
         SOVERSION                   ${DMDFE_MINOR_VERSION}
         LINKER_LANGUAGE             C


### PR DESCRIPTION
New CMake 4 dropped support for < 3.5, breaking our CI (GHA at least). LLVM 19 requires v3.20. Ubuntu 20 came with v3.16.