### PR TITLE
Switch FreeBSD CI to LLVM 19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,14 @@ commonSteps: &commonSteps
           fi
     - checkout
     - run:
+        name: Merge PR with target branch
+        command: |
+          set -ux
+          if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
+            git fetch origin "+refs/pull/$CIRCLE_PR_NUMBER/merge:"
+            git checkout -f FETCH_HEAD
+          fi
+    - run:
         name: Checkout git submodules
         command: git submodule update --init
     - run:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,10 +76,7 @@ packaging_steps_template: &PACKAGING_STEPS_TEMPLATE
   # Run dynamic-compile integration test
   run_dynamic_compile_integration_test_script: |
     cd $CIRRUS_WORKING_DIR/..
-    # FreeBSD's LLVM 15 is too old (need LLVM 18+ for dynamic-compile)
-    if [[ "$CI_OS" != "freebsd" ]]; then
-      installed/bin/ldc2 -enable-dynamic-compile -run $CIRRUS_WORKING_DIR/tests/dynamiccompile/array.d
-    fi
+    installed/bin/ldc2 -enable-dynamic-compile -run $CIRRUS_WORKING_DIR/tests/dynamiccompile/array.d
   # Run ImportC integration test
   run_importC_integration_test_script: |
     cd $CIRRUS_WORKING_DIR/..
@@ -220,17 +217,17 @@ task:
       -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
       -DEXTRA_CXXFLAGS=-flto=full
     PARALLELISM: 4
-    CC: clang15
-    CXX: clang++15
+    CC: clang19
+    CXX: clang++19
   install_prerequisites_script: |
     cd $CIRRUS_WORKING_DIR/..
     sysctl -n hw.ncpu
-    pkg install -y git cmake ninja gmake llvm15 bash gtar 7-zip ldc
+    pkg install -y git cmake ninja gmake llvm19 bash gtar 7-zip ldc
     python3 --version
     python3 -m ensurepip
     # set up default llvm-config
     ls -l /usr/local/bin/llvm-config*
-    ln -sf llvm-config15 /usr/local/bin/llvm-config
+    ln -sf llvm-config19 /usr/local/bin/llvm-config
   clone_submodules_early_script: |
     cd $CIRRUS_WORKING_DIR
     git submodule update --init --depth $CIRRUS_CLONE_DEPTH

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,11 @@
+# For PRs: check out the current *merge* ref, i.e., merge with target branch
+clone_steps_template: &CLONE_STEPS_TEMPLATE
+  merge_with_target_branch_script: |
+    if [ -n "${CIRRUS_PR:-}" ]; then
+      git fetch origin "+refs/pull/$CIRRUS_PR/merge:"
+      git checkout -f FETCH_HEAD
+    fi
+
 # Installs lit, clones the git submodules, builds LDC and the test
 # runners and runs the tests.
 # Requires env variables CI_ARCH, CI_OS, EXTRA_CMAKE_FLAGS and PARALLELISM.
@@ -190,6 +198,7 @@ task:
     # for gdmd:
     LANG: C.UTF-8
   << : *INSTALL_UBUNTU_PREREQUISITES_TEMPLATE
+  << : *CLONE_STEPS_TEMPLATE
   # to get the LTO lit-tests working:
   make_lld_the_default_linker_script: |
     ln -sf ld.lld /usr/bin/ld
@@ -228,6 +237,7 @@ task:
     # set up default llvm-config
     ls -l /usr/local/bin/llvm-config*
     ln -sf llvm-config19 /usr/local/bin/llvm-config
+  << : *CLONE_STEPS_TEMPLATE
   clone_submodules_early_script: |
     cd $CIRRUS_WORKING_DIR
     git submodule update --init --depth $CIRRUS_CLONE_DEPTH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,6 +587,12 @@ set_target_properties(
     # Use a custom .props file to set up Visual D (import paths, predefined versions...).
     VS_USER_PROPS "${PROJECT_SOURCE_DIR}/cmake/VisualD.props"
 )
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    # FreeBSD LLVM port links to zstd, but does not convey this information via CMake
+    # Workaround it here until it is fixed in the port
+    find_package(zstd)
+    list(APPEND LLVM_LIBRARIES "$<TARGET_LINKER_FILE:zstd::libzstd_shared>")
+endif()
 # LDFLAGS should actually be in target property LINK_FLAGS, but this works, and gets around linking problems
 target_link_libraries(${LDC_LIB} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS})
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,12 +587,6 @@ set_target_properties(
     # Use a custom .props file to set up Visual D (import paths, predefined versions...).
     VS_USER_PROPS "${PROJECT_SOURCE_DIR}/cmake/VisualD.props"
 )
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    # FreeBSD LLVM port links to zstd, but does not convey this information via CMake
-    # Workaround it here until it is fixed in the port
-    find_package(zstd)
-    list(APPEND LLVM_LIBRARIES "$<TARGET_LINKER_FILE:zstd::libzstd_shared>")
-endif()
 # LDFLAGS should actually be in target property LINK_FLAGS, but this works, and gets around linking problems
 target_link_libraries(${LDC_LIB} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS})
 if(WIN32)
@@ -626,15 +620,20 @@ if(LDC_WITH_LLD)
     else()
         set(LDC_LINKERFLAG_LIST -lLLVMSymbolize ${LDC_LINKERFLAG_LIST})
     endif()
-    set(LLD_MACHO lldMachO)
     if(MSVC)
-        list(APPEND LDC_LINKERFLAG_LIST lldMinGW.lib lldCOFF.lib lldELF.lib ${LLD_MACHO}.lib lldWasm.lib lldCommon.lib)
+        list(APPEND LDC_LINKERFLAG_LIST lldMinGW.lib lldCOFF.lib lldELF.lib lldMachO.lib lldWasm.lib lldCommon.lib)
     else()
-        set(LDC_LINKERFLAG_LIST -llldMinGW -llldCOFF -llldELF -l${LLD_MACHO} -llldWasm -llldCommon ${LDC_LINKERFLAG_LIST})
+        set(LDC_LINKERFLAG_LIST -llldMinGW -llldCOFF -llldELF -llldMachO -llldWasm -llldCommon ${LDC_LINKERFLAG_LIST})
     endif()
     if(APPLE)
         # LLD 13.0.0 on Mac needs libxar
         list(APPEND LDC_LINKERFLAG_LIST -lxar)
+    endif()
+    if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+        # FreeBSD LLVM port links to zstd, but does not convey this information via CMake
+        # Workaround it here until it is fixed in the port
+        find_package(zstd)
+        list(APPEND LDC_LINKERFLAG_LIST "$<TARGET_LINKER_FILE:zstd::libzstd_shared>")
     endif()
 endif()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -30,6 +30,7 @@ if(LDC_BUNDLE_LLVM_TOOLS)
   # Build ldc-profdata for converting profile data formats (source version depends on LLVM version)
   set(LDCPROFDATA_SRC ldc-profdata/llvm-profdata-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.cpp)
   if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LDCPROFDATA_SRC})
+      find_package(Threads)
       add_executable(ldc-profdata ${LDCPROFDATA_SRC})
       set_target_properties(
         ldc-profdata PROPERTIES
@@ -37,7 +38,7 @@ if(LDC_BUNDLE_LLVM_TOOLS)
         COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS}"
         LINK_FLAGS "${SANITIZE_LDFLAGS} ${FULLY_STATIC_LDFLAG}"
       )
-      target_link_libraries(ldc-profdata ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS})
+      target_link_libraries(ldc-profdata ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT})
       install(TARGETS ldc-profdata DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
       # Set path to executable, used by the lit testsuite.


### PR DESCRIPTION
The default LLVM version on FreeBSD Ports was switched to 19 a while ago. Current LDC bootstraps gets build against 15, which forces the port to pull in two LLVM versions, 15 and 19, at the same time.