### PR TITLE
GHA: Downgrade macos-15 image to macos-14, to work around macOS v15.4 breakage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
             with_pgo: true
 
           - job_name: macOS arm64
-            os: macos-15
+            os: macos-14
             arch: arm64
             extra_cmake_flags: >-
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-arm64/libLTO.dylib"
@@ -172,9 +172,12 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           ln -s $(dirname $(dirname $(which ldmd2))) ../bootstrap-ldc
-          # work around a v1.35.0 bug - need to rename libLTO-ldc.dylib to make it loadable
           if [[ '${{ matrix.arch }}' == 'x86_64' ]]; then
+            # work around a v1.35.0 bug - need to rename libLTO-ldc.dylib to make it loadable
             mv ../bootstrap-ldc/lib-x86_64/libLTO-ldc.dylib ../bootstrap-ldc/lib-x86_64/libLTO.dylib
+          else
+            # use Xcode v16 on arm64
+            sudo xcode-select -switch /Applications/Xcode_16.1.app
           fi
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo


### PR DESCRIPTION
But keep using Xcode v16 (the default version for macos-15), not v15.4.