### PR TITLE
CI: Disable newly flaky `std.experimental.allocator.building_blocks.allocator_list` unittests on macOS and FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,12 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
     run_defaultlib_tests_script: |
       # Run defaultlib unittests & druntime integration tests
       cd $CIRRUS_WORKING_DIR/../build
-      ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" --timeout 120
+      excludes="dmd-testsuite|lit-tests|ldc2-unittest"
+      if [[ "$CI_OS" == "freebsd" ]]; then
+        # FIXME: https://github.com/dlang/phobos/issues/10730
+        excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
+      fi
+      ctest -j$PARALLELISM --output-on-failure -E "$excludes" --timeout 120
 
 # Performs the extra packaging steps for jobs producing a prebuilt package.
 # Requires env variables CI_ARCH, CI_OS, GITHUB_TOKEN and PARALLELISM (and CC for FreeBSD).

--- a/.github/actions/4d-test-libs/action.yml
+++ b/.github/actions/4d-test-libs/action.yml
@@ -30,6 +30,10 @@ runs:
           # FIXME: sporadically hanging
           excludes+='|^core.thread-shared$'
         fi
+        if [[ '${{ runner.os }}' == macOS ]]; then
+          # FIXME: https://github.com/dlang/phobos/issues/10730
+          excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
+        fi
 
         ctest -j$N --output-on-failure -E "$excludes" --timeout 120
 

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -163,6 +163,8 @@ jobs:
               # FIXME: crashes frequently with enabled optimizations on M1 runners
               excludes+='|^std.internal.math.gammafunction(-shared)?$'
             fi
+            # FIXME: https://github.com/dlang/phobos/issues/10730
+            excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
           else
             N=$(nproc)
           fi


### PR DESCRIPTION
https://github.com/dlang/phobos/issues/10730