### PR TITLE
GHA macOS: Enable bootstrap stage again

### DIFF
--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -60,6 +60,9 @@ runs:
         mkdir clang
         tar -xf clang.tar.xz --strip 1 -C clang
         rm clang.tar.xz
+        # also upgrade CMake to v4
+        brew install cmake
+        cmake --version
     - name: 'Windows: Install clang v19.1.3 from GitHub'
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -49,19 +49,14 @@ runs:
           sudo ln -sf $tool-19 /usr/bin/$tool
           $tool --version
         done
-    - name: 'macOS arm64: Install clang 19 from GitHub' # see mimalloc comment in ../3-build-native/action.yml
+    - name: 'macOS arm64: Install clang 19' # see mimalloc comment in ../3-build-native/action.yml
       if: runner.os == 'macOS' && inputs.arch == 'arm64'
       shell: bash
       run: |
         set -eux
         cd ..
-        curl -fL --retry 3 --max-time 300 -o clang.tar.xz \
-          https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-macOS-ARM64.tar.xz
-        mkdir clang
-        tar -xf clang.tar.xz --strip 1 -C clang
-        rm clang.tar.xz
         # also upgrade CMake to v4
-        brew install cmake
+        brew install llvm@19 cmake
         cmake --version
     - name: 'Windows: Install clang v19.1.3 from GitHub'
       if: runner.os == 'Windows'

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -60,8 +60,6 @@ runs:
         mkdir clang
         tar -xf clang.tar.xz --strip 1 -C clang
         rm clang.tar.xz
-        # prepend its bin/ dir to PATH for subsequent steps
-        echo "$PWD/clang/bin" >> "$GITHUB_PATH"
     - name: 'Windows: Install clang v19.1.3 from GitHub'
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -121,8 +121,7 @@ runs:
     - name: Install D host compiler
       uses: dlang-community/setup-dlang@v1
       with:
-        # macOS: use LDC with LLVM version matching Xcode - v1.39.0 (LLVM 17) on arm64 with Xcode 16, v1.35.0 (LLVM 16) on x86_64 with Xcode 15
-        compiler: ${{ runner.os != 'macOS' && 'ldc-latest' || (inputs.arch == 'arm64' && 'ldc-1.39.0' || 'ldc-1.35.0') }}
+        compiler: ldc-latest
     - name: 'Posix: Clear LD_LIBRARY_PATH env variable' # don't use host druntime/Phobos .so/.dylib etc.
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -49,6 +49,19 @@ runs:
           sudo ln -sf $tool-19 /usr/bin/$tool
           $tool --version
         done
+    - name: 'macOS arm64: Install clang 19 from GitHub' # see mimalloc comment in ../3-build-native/action.yml
+      if: runner.os == 'macOS' && inputs.arch == 'arm64'
+      shell: bash
+      run: |
+        set -eux
+        cd ..
+        curl -fL --retry 3 --max-time 300 -o clang.tar.xz \
+          https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-macOS-ARM64.tar.xz
+        mkdir clang
+        tar -xf clang.tar.xz --strip 1 -C clang
+        rm clang.tar.xz
+        # prepend its bin/ dir to PATH for subsequent steps
+        echo "$PWD/clang/bin" >> "$GITHUB_PATH"
     - name: 'Windows: Install clang v19.1.3 from GitHub'
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -49,15 +49,10 @@ runs:
           sudo ln -sf $tool-19 /usr/bin/$tool
           $tool --version
         done
-    - name: 'macOS arm64: Install clang 19' # see mimalloc comment in ../3-build-native/action.yml
+    - name: 'macOS arm64: Install Homebrew clang 19' # see mimalloc comment in ../3-build-native/action.yml
       if: runner.os == 'macOS' && inputs.arch == 'arm64'
       shell: bash
-      run: |
-        set -eux
-        cd ..
-        # also upgrade CMake to v4
-        brew install llvm@19 cmake
-        cmake --version
+      run: brew install llvm@19
     - name: 'Windows: Install clang v19.1.3 from GitHub'
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -23,7 +23,7 @@ runs:
         host_dc: ../bootstrap-ldc/bin/ldmd2
         specify_install_dir: true
         cmake_flags: >-
-          ${{ runner.os == 'Linux' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
+          ${{ runner.os != 'Windows' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}
           ${{ inputs.with_pgo == 'true' && '-DDFLAGS_LDC=-fprofile-use=../pgo-ldc/merged.profdata' || '' }}
         build_targets: all ldc2-unittest all-test-runners

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -23,7 +23,7 @@ runs:
         host_dc: ../bootstrap-ldc/bin/ldmd2
         specify_install_dir: true
         cmake_flags: >-
-          ${{ runner.os != 'Windows' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
+          ${{ runner.os == 'Linux' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}
           ${{ inputs.with_pgo == 'true' && '-DDFLAGS_LDC=-fprofile-use=../pgo-ldc/merged.profdata' || '' }}
         build_targets: all ldc2-unittest all-test-runners

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -15,6 +15,8 @@ runs:
     - name: 'Posix: Build mimalloc'
       if: runner.os != 'Windows'
       uses: ./.github/actions/helper-mimalloc
+      with:
+        cmake_flags: ${{ inputs.cmake_flags }} # propagate C(++) compilers and ignored LDC-specific vars
 
     - name: Build LDC & LDC D unittests & defaultlib unittest runners
       uses: ./.github/actions/helper-build-ldc

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -4,7 +4,7 @@ inputs:
     required: false
     default: ''
   arch:
-    required: false # Windows only
+    required: true
   with_pgo:
     required: false
     default: false
@@ -22,8 +22,10 @@ runs:
         build_dir: build
         host_dc: ../bootstrap-ldc/bin/ldmd2
         specify_install_dir: true
+        # FIXME: sporadic compiler crashes on macOS arm64 when using mimalloc *and* mixing LLVM versions for Xcode clang/host LDC:
+        # libc++abi: Pure virtual function called!
         cmake_flags: >-
-          ${{ runner.os != 'Windows' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
+          ${{ (runner.os != 'Windows' && !(runner.os == 'macOS' && inputs.arch == 'arm64')) && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}
           ${{ inputs.with_pgo == 'true' && '-DDFLAGS_LDC=-fprofile-use=../pgo-ldc/merged.profdata' || '' }}
         build_targets: all ldc2-unittest all-test-runners

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -22,11 +22,13 @@ runs:
         build_dir: build
         host_dc: ../bootstrap-ldc/bin/ldmd2
         specify_install_dir: true
-        # FIXME: mimalloc on macOS is tricky - when mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang,
-        #        causing *sporadic* compiler crashes: `libc++abi: Pure virtual function called!`
-        #        on x86_64, this is 'fixed' by using LTO - on arm64, this doesn't suffice
+        # NOTE:
+        # mimalloc on macOS is tricky - when mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang,
+        # causing *sporadic* compiler crashes: `libc++abi: Pure virtual function called!`
+        # On x86_64, this is 'fixed' by using LTO (for both D and C++ parts of ldc2).
+        # On arm64, we need a matching clang to enable C++ LTO anyway, due to `LLVM ERROR: Unsupported stack probing method` with Xcode clang.
         cmake_flags: >-
-          ${{ (runner.os != 'Windows' && !(runner.os == 'macOS' && inputs.arch == 'arm64')) && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
+          ${{ runner.os != 'Windows' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}
           ${{ inputs.with_pgo == 'true' && '-DDFLAGS_LDC=-fprofile-use=../pgo-ldc/merged.profdata' || '' }}
         build_targets: all ldc2-unittest all-test-runners

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -22,8 +22,9 @@ runs:
         build_dir: build
         host_dc: ../bootstrap-ldc/bin/ldmd2
         specify_install_dir: true
-        # FIXME: sporadic compiler crashes on macOS arm64 when using mimalloc *and* mixing LLVM versions for Xcode clang/host LDC:
-        # libc++abi: Pure virtual function called!
+        # FIXME: mimalloc on macOS is tricky - when mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang,
+        #        causing *sporadic* compiler crashes: `libc++abi: Pure virtual function called!`
+        #        on x86_64, this is 'fixed' by using LTO - on arm64, this doesn't suffice
         cmake_flags: >-
           ${{ (runner.os != 'Windows' && !(runner.os == 'macOS' && inputs.arch == 'arm64')) && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -27,8 +27,11 @@ runs:
         # NOTE:
         # mimalloc on macOS is tricky - when mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang,
         # causing *sporadic* compiler crashes: `libc++abi: Pure virtual function called!`
-        # On x86_64, this is 'fixed' by using LTO (for both D and C++ parts of ldc2).
-        # On arm64, we need a matching clang to enable C++ LTO anyway, due to `LLVM ERROR: Unsupported stack probing method` with Xcode clang.
+        # What apparently makes it work with newer LLVM versions on both x86_64 and arm64 is using mixed LTO for both
+        # C++ and D parts of ldc2 (with prebuilt non-LTO'd LLVM compiled with Xcode clang); the compiler used for
+        # non-LTO'd mimalloc doesn't seem to play a role.
+        # On macOS arm64, we need a matching Homebrew clang to get C++ LTO to work, otherwise hitting linker error
+        # `LLVM ERROR: Unsupported stack probing method` with bitcode files produced by older Xcode clang.
         cmake_flags: >-
           ${{ runner.os != 'Windows' && '-DALTERNATIVE_MALLOC_O="$PWD/../build-mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o"' || '' }}
           ${{ inputs.cmake_flags }}

--- a/.github/actions/7-package/action.yml
+++ b/.github/actions/7-package/action.yml
@@ -170,7 +170,6 @@ runs:
       run: mv ../artifacts ./
 
     - name: Upload artifact(s)
-      if: runner.os != 'macOS'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}

--- a/.github/actions/7-package/action.yml
+++ b/.github/actions/7-package/action.yml
@@ -170,6 +170,7 @@ runs:
       run: mv ../artifacts ./
 
     - name: Upload artifact(s)
+      if: runner.os != 'macOS'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,19 +76,19 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
-            #extra_cmake_flags: >-
-            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-            #  -DEXTRA_CXXFLAGS=-flto=full
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: macOS arm64
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
-              -DCMAKE_C_COMPILER=$(brew --prefix llvm@19)/bin/clang
-              -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@19)/bin/clang++
-            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-            #  -DEXTRA_CXXFLAGS=-flto=full
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: Windows x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,9 +76,9 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
+            #extra_cmake_flags: >-
+            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: macOS arm64
@@ -87,8 +87,8 @@ jobs:
             extra_cmake_flags: >-
               -DCMAKE_C_COMPILER=$(brew --prefix llvm@19)/bin/clang
               -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@19)/bin/clang++
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
+            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: Windows x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,8 @@ jobs:
             arch: arm64
             extra_cmake_flags: >-
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            # FIXME: cannot enable LTO for C++ parts too, due to: `LLVM ERROR: Unsupported stack probing method` when linking ldc2
+            #        (apparently from bitcode files compiled with older Xcode clang)
             #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,54 +23,7 @@ jobs:
       matrix:
         include:
 
-          - job_name: Linux x86_64 multilib
-            os: ubuntu-22.04
-            arch: x86_64
-            # To improve portability of the generated binaries, link the C++ standard library statically.
-            extra_cmake_flags: >-
-              -DMULTILIB=ON
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
-              -DJITRT_EXTRA_LDFLAGS=-static-libstdc++
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-
-          - job_name: Linux aarch64
-            os: ubuntu-22.04-arm
-            arch: aarch64
-            extra_cmake_flags: >-
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
-              -DJITRT_EXTRA_LDFLAGS=-static-libstdc++
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-
-          - job_name: Alpine musl x86_64
-            os: ubuntu-latest
-            container_image: alpine:3.21
-            arch: x86_64
-            base_cmake_flags: >-
-              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=x86_64
-              -DLLVM_IS_SHARED=OFF
-              -DLDC_ENABLE_PLUGINS=OFF
-              -DLDC_DYNAMIC_COMPILE=OFF
-            # TSan and XRay do not work.
-            extra_cmake_flags: >-
-              -DTEST_COMPILER_RT_LIBRARIES="profile;lsan;asan;msan;fuzzer"
-              -DLDC_INSTALL_LTOPLUGIN=OFF
-              -DLDC_FULLY_STATIC=ON
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-
-          - job_name: macOS x86_64
+          - job_name: macOS x86_64_1
             os: macos-13
             arch: x86_64
             # https://github.com/ldc-developers/ldc/issues/4462:
@@ -80,36 +33,65 @@ jobs:
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
+          - job_name: macOS x86_64_2
+            os: macos-13
+            arch: x86_64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+          - job_name: macOS x86_64_3
+            os: macos-13
+            arch: x86_64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+          - job_name: macOS x86_64_4
+            os: macos-13
+            arch: x86_64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+          - job_name: macOS x86_64_5
+            os: macos-13
+            arch: x86_64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
 
-          - job_name: macOS arm64
+          - job_name: macOS arm64_1
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
             #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
-
-          - job_name: Windows x64
-            os: windows-2025
-            arch: x64
-            base_cmake_flags: >-
-              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+          - job_name: macOS arm64_2
+            os: macos-14
+            arch: arm64
             extra_cmake_flags: >-
-              "-DD_COMPILER_FLAGS=-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
-              -DEXTRA_CXXFLAGS=-flto=full
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
             with_pgo: true
-
-          - job_name: Windows x86
-            os: windows-2025
-            arch: x86
-            base_cmake_flags: >-
-              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
-            # `RT_CFLAGS=-m32` needed to make 64-bit clang-cl output 32-bit code for druntime integration tests
+          - job_name: macOS arm64_3
+            os: macos-14
+            arch: arm64
             extra_cmake_flags: >-
-              -DRT_CFLAGS=-m32
-            # Undefined symbol errors with FullLTO; ThinLTO used to work, but apparently miscompiles a lexer.d:138 assertion since v1.33.
-            #  "-DD_COMPILER_FLAGS=-O -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
-            #  -DEXTRA_CXXFLAGS=-flto=thin
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            with_pgo: true
+          - job_name: macOS arm64_4
+            os: macos-14
+            arch: arm64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            with_pgo: true
+          - job_name: macOS arm64_5
+            os: macos-14
+            arch: arm64
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
             with_pgo: true
 
     name: ${{ matrix.job_name }}
@@ -225,112 +207,3 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           os: ${{ startsWith(matrix.container_image, 'alpine') && 'alpine' || '' }}
-
-
-  # Cross-compilation jobs for non-native targets.
-  # druntime/Phobos/LDC unittests aren't built; all test stages are skipped.
-  build-cross:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-
-          - job_name: Android armv7a
-            host_os: ubuntu-22.04
-            os: android
-            arch: armv7a
-            android_x86_arch: i686
-
-          - job_name: Android aarch64
-            host_os: ubuntu-22.04
-            os: android
-            arch: aarch64
-            android_x86_arch: x86_64
-            extra_cmake_flags: >-
-              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64-android
-
-    name: ${{ matrix.job_name }}
-    runs-on: ${{ matrix.host_os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 50
-      - name: Install prerequisites
-        uses: ./.github/actions/1-setup
-        with:
-          llvm_version: ${{ env.LLVM_VERSION }}
-          arch: x86_64
-      - name: Build bootstrap LDC
-        uses: ./.github/actions/2-build-bootstrap
-      - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
-        if: matrix.with_pgo
-        uses: ./.github/actions/2a-build-pgo
-      - name: Cross-compile LDC to ${{ matrix.os }}-${{ matrix.arch }}
-        uses: ./.github/actions/3-build-cross
-        with:
-          arch: ${{ matrix.arch }}
-          os: ${{ matrix.os }}
-          llvm_version: ${{ env.LLVM_VERSION }}
-          cmake_flags: ${{ matrix.extra_cmake_flags }}
-          with_pgo: ${{ matrix.with_pgo }}
-
-      - name: Install LDC & make portable
-        uses: ./.github/actions/5-install
-        with:
-          cross_compiling: true
-      - name: 'Android: Cross-compile ${{ matrix.android_x86_arch }} libraries & copy to install dir'
-        if: matrix.os == 'android'
-        uses: ./.github/actions/5a-android-x86
-        with:
-          arch: ${{ matrix.android_x86_arch }}
-
-      - name: Create package & upload artifact(s)
-        uses: ./.github/actions/7-package
-        with:
-          arch: ${{ matrix.arch }}
-          os: ${{ matrix.os }}
-          cross_target_triple: ${{ env.CROSS_TRIPLE }}
-
-
-  merge-macos:
-    name: macOS universal
-    runs-on: macos-latest
-    timeout-minutes: 30
-    needs: build-native
-    steps:
-      - uses: actions/checkout@v4
-      - name: Merge x86_64 & arm64 packages to universal one
-        uses: ./.github/actions/merge-macos
-
-  merge-windows:
-    name: Windows multilib
-    runs-on: windows-2025
-    timeout-minutes: 30
-    needs: build-native
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 50
-      - name: Merge x64 & x86 packages to multilib one & build installer
-        uses: ./.github/actions/merge-windows
-
-
-  upload-to-github:
-    name: Upload to GitHub
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-      - build-native
-      - build-cross
-      - merge-macos
-      - merge-windows
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Upload all artifacts to GitHub release
-        uses: ./.github/actions/upload-to-github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,8 +85,8 @@ jobs:
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_C_COMPILER=$PWD/../clang/bin/clang
+              -DCMAKE_CXX_COMPILER=$PWD/../clang/bin/clang++
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,16 +76,16 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
-            #extra_cmake_flags: >-
-            #  -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w"
-            #  -DEXTRA_CXXFLAGS=-flto=full
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: macOS arm64
             os: macos-14
             arch: arm64
-            #extra_cmake_flags: >-
-            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            extra_cmake_flags: >-
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
             #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,54 @@ jobs:
       matrix:
         include:
 
-          - job_name: macOS x86_64_1
+          - job_name: Linux x86_64 multilib
+            os: ubuntu-22.04
+            arch: x86_64
+            # To improve portability of the generated binaries, link the C++ standard library statically.
+            extra_cmake_flags: >-
+              -DMULTILIB=ON
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
+              -DJITRT_EXTRA_LDFLAGS=-static-libstdc++
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+
+          - job_name: Linux aarch64
+            os: ubuntu-22.04-arm
+            arch: aarch64
+            extra_cmake_flags: >-
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
+              -DJITRT_EXTRA_LDFLAGS=-static-libstdc++
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+
+          - job_name: Alpine musl x86_64
+            os: ubuntu-latest
+            container_image: alpine:3.21
+            arch: x86_64
+            base_cmake_flags: >-
+              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=x86_64
+              -DLLVM_IS_SHARED=OFF
+              -DLDC_ENABLE_PLUGINS=OFF
+              -DLDC_DYNAMIC_COMPILE=OFF
+            # TSan and XRay do not work.
+            extra_cmake_flags: >-
+              -DTEST_COMPILER_RT_LIBRARIES="profile;lsan;asan;msan;fuzzer"
+              -DLDC_INSTALL_LTOPLUGIN=OFF
+              -DLDC_FULLY_STATIC=ON
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DEXTRA_CXXFLAGS=-flto=full
+            with_pgo: true
+
+          - job_name: macOS x86_64
             os: macos-13
             arch: x86_64
             # https://github.com/ldc-developers/ldc/issues/4462:
@@ -33,65 +80,36 @@ jobs:
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
-          - job_name: macOS x86_64_2
-            os: macos-13
-            arch: x86_64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-          - job_name: macOS x86_64_3
-            os: macos-13
-            arch: x86_64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-          - job_name: macOS x86_64_4
-            os: macos-13
-            arch: x86_64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
-          - job_name: macOS x86_64_5
-            os: macos-13
-            arch: x86_64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
-            with_pgo: true
 
-          - job_name: macOS arm64_1
+          - job_name: macOS arm64
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
             #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
-          - job_name: macOS arm64_2
-            os: macos-14
-            arch: arm64
+
+          - job_name: Windows x64
+            os: windows-2025
+            arch: x64
+            base_cmake_flags: >-
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
             extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              "-DD_COMPILER_FLAGS=-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+              -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
-          - job_name: macOS arm64_3
-            os: macos-14
-            arch: arm64
+
+          - job_name: Windows x86
+            os: windows-2025
+            arch: x86
+            base_cmake_flags: >-
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+            # `RT_CFLAGS=-m32` needed to make 64-bit clang-cl output 32-bit code for druntime integration tests
             extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-            with_pgo: true
-          - job_name: macOS arm64_4
-            os: macos-14
-            arch: arm64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-            with_pgo: true
-          - job_name: macOS arm64_5
-            os: macos-14
-            arch: arm64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+              -DRT_CFLAGS=-m32
+            # Undefined symbol errors with FullLTO; ThinLTO used to work, but apparently miscompiles a lexer.d:138 assertion since v1.33.
+            #  "-DD_COMPILER_FLAGS=-O -flto=thin -defaultlib=phobos2-ldc-lto,druntime-ldc-lto"
+            #  -DEXTRA_CXXFLAGS=-flto=thin
             with_pgo: true
 
     name: ${{ matrix.job_name }}
@@ -207,3 +225,112 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           os: ${{ startsWith(matrix.container_image, 'alpine') && 'alpine' || '' }}
+
+
+  # Cross-compilation jobs for non-native targets.
+  # druntime/Phobos/LDC unittests aren't built; all test stages are skipped.
+  build-cross:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          - job_name: Android armv7a
+            host_os: ubuntu-22.04
+            os: android
+            arch: armv7a
+            android_x86_arch: i686
+
+          - job_name: Android aarch64
+            host_os: ubuntu-22.04
+            os: android
+            arch: aarch64
+            android_x86_arch: x86_64
+            extra_cmake_flags: >-
+              -DLDC_INSTALL_LLVM_RUNTIME_LIBS_ARCH=aarch64-android
+
+    name: ${{ matrix.job_name }}
+    runs-on: ${{ matrix.host_os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 50
+      - name: Install prerequisites
+        uses: ./.github/actions/1-setup
+        with:
+          llvm_version: ${{ env.LLVM_VERSION }}
+          arch: x86_64
+      - name: Build bootstrap LDC
+        uses: ./.github/actions/2-build-bootstrap
+      - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
+        if: matrix.with_pgo
+        uses: ./.github/actions/2a-build-pgo
+      - name: Cross-compile LDC to ${{ matrix.os }}-${{ matrix.arch }}
+        uses: ./.github/actions/3-build-cross
+        with:
+          arch: ${{ matrix.arch }}
+          os: ${{ matrix.os }}
+          llvm_version: ${{ env.LLVM_VERSION }}
+          cmake_flags: ${{ matrix.extra_cmake_flags }}
+          with_pgo: ${{ matrix.with_pgo }}
+
+      - name: Install LDC & make portable
+        uses: ./.github/actions/5-install
+        with:
+          cross_compiling: true
+      - name: 'Android: Cross-compile ${{ matrix.android_x86_arch }} libraries & copy to install dir'
+        if: matrix.os == 'android'
+        uses: ./.github/actions/5a-android-x86
+        with:
+          arch: ${{ matrix.android_x86_arch }}
+
+      - name: Create package & upload artifact(s)
+        uses: ./.github/actions/7-package
+        with:
+          arch: ${{ matrix.arch }}
+          os: ${{ matrix.os }}
+          cross_target_triple: ${{ env.CROSS_TRIPLE }}
+
+
+  merge-macos:
+    name: macOS universal
+    runs-on: macos-latest
+    timeout-minutes: 30
+    needs: build-native
+    steps:
+      - uses: actions/checkout@v4
+      - name: Merge x86_64 & arm64 packages to universal one
+        uses: ./.github/actions/merge-macos
+
+  merge-windows:
+    name: Windows multilib
+    runs-on: windows-2025
+    timeout-minutes: 30
+    needs: build-native
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 50
+      - name: Merge x64 & x86 packages to multilib one & build installer
+        uses: ./.github/actions/merge-windows
+
+
+  upload-to-github:
+    name: Upload to GitHub
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - build-native
+      - build-cross
+      - merge-macos
+      - merge-windows
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload all artifacts to GitHub release
+        uses: ./.github/actions/upload-to-github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,8 +85,8 @@ jobs:
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
-              -DCMAKE_C_COMPILER=$PWD/../clang/bin/clang
-              -DCMAKE_CXX_COMPILER=$PWD/../clang/bin/clang++
+              -DCMAKE_C_COMPILER=$(brew --prefix llvm@19)/bin/clang
+              -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@19)/bin/clang++
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,8 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
-            #
-            # We also need to work around issues with the used LDC v1.35.0 host/bootstrap compiler:
-            # * Specify a macOS triple with OS version. And exclude LTO-able host druntime/Phobos because precompiled without OS version.
-            # * Manually specify the path to the bundled libLTO.dylib (broken for *universal* packages for LDC <= v1.40.0).
             extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-x86_64/libLTO.dylib -mtriple=x86_64-apple-macos$MACOSX_DEPLOYMENT_TARGET"
+              -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
@@ -89,7 +85,7 @@ jobs:
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w -flto-binary=$PWD/../bootstrap-ldc/lib-arm64/libLTO.dylib"
+              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
               -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
@@ -161,25 +157,14 @@ jobs:
         uses: ./.github/actions/helper-build-gdb
         with:
           arch: ${{ matrix.arch }}
+      - name: 'macOS arm64: Switch to Xcode 16'
+        if: runner.os == 'macOS' && matrix.arch == 'arm64'
+        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
       - name: Build bootstrap LDC
-        if: runner.os != 'macOS'
         uses: ./.github/actions/2-build-bootstrap
         with:
           cmake_flags: -DBUILD_LTO_LIBS=ON ${{ matrix.base_cmake_flags }}
           arch: ${{ matrix.arch }}
-      # FIXME: on macOS, mixing newer LLVM from bootstrap LDC with older LLVM from Xcode clang is problematic,
-      #        leading to sporadic 'libc++abi: Pure virtual function called!' compiler crashes etc.
-      - name: 'macOS: Use host LDC (with Xcode-compatible LLVM version) as bootstrap LDC'
-        if: runner.os == 'macOS'
-        run: |
-          ln -s $(dirname $(dirname $(which ldmd2))) ../bootstrap-ldc
-          if [[ '${{ matrix.arch }}' == 'x86_64' ]]; then
-            # work around a v1.35.0 bug - need to rename libLTO-ldc.dylib to make it loadable
-            mv ../bootstrap-ldc/lib-x86_64/libLTO-ldc.dylib ../bootstrap-ldc/lib-x86_64/libLTO.dylib
-          else
-            # use Xcode v16 on arm64
-            sudo xcode-select -switch /Applications/Xcode_16.1.app
-          fi
       - name: Build LDC with PGO instrumentation & gather profile from compiling default libs
         if: matrix.with_pgo
         uses: ./.github/actions/2a-build-pgo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,10 +85,10 @@ jobs:
             os: macos-14
             arch: arm64
             extra_cmake_flags: >-
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
               -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-            # FIXME: cannot enable LTO for C++ parts too, due to: `LLVM ERROR: Unsupported stack probing method` when linking ldc2
-            #        (apparently from bitcode files compiled with older Xcode clang)
-            #  -DEXTRA_CXXFLAGS=-flto=full
+              -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: Windows x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,17 +76,17 @@ jobs:
             # https://github.com/ldc-developers/ldc/issues/4462:
             # When using LTO, we need to explicitly export ~all symbols for plugin support via `ld64 -exported_symbol '__*'`.
             # Additionally `-w` to suppress resulting linker warnings.
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
+            #extra_cmake_flags: >-
+            #  -DD_COMPILER_FLAGS="-O -flto=full -L-exported_symbol '-L__*' -L-w"
+            #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: macOS arm64
             os: macos-14
             arch: arm64
-            extra_cmake_flags: >-
-              -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
-              -DEXTRA_CXXFLAGS=-flto=full
+            #extra_cmake_flags: >-
+            #  -DD_COMPILER_FLAGS="-O -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -L-exported_symbol '-L__*' -L-w"
+            #  -DEXTRA_CXXFLAGS=-flto=full
             with_pgo: true
 
           - job_name: Windows x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ if(UNIX AND LDC_FULLY_STATIC)
 endif()
 
 # Suppress superfluous randlib warnings about "*.a" having no symbols on MacOSX.
-if (APPLE)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang") # not supported by llvm-ranlib used with Homebrew clang
     set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")


### PR DESCRIPTION
And the latest stable LDC release as first host compiler.

Fixes #4899 for good.