### PR TITLE
Emit getelementptr inbounds nuw flag where possible

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -751,6 +751,11 @@ cl::opt<unsigned>
                    cl::desc("Warn for stack size bigger than the given number"),
                    cl::value_desc("threshold"));
 
+cl::opt<bool>
+    enableGetElementPtrNuw("enable-getelementptr-nuw", cl::ZeroOrMore,
+                           cl::desc("enable nuw(no-unsigned-wrap) flag to "
+                                    "LLVM's getelementptr insturction"));
+
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
 cl::list<std::string>
     dcomputeTargets("mdcompute-targets", cl::CommaSeparated,

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -140,6 +140,8 @@ extern cl::opt<std::string> saveOptimizationRecord;
 
 extern cl::opt<unsigned> fWarnStackSize;
 
+extern cl::opt<bool> enableGetElementPtrNuw;
+
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
 extern cl::list<std::string> dcomputeTargets;
 extern cl::opt<std::string> dcomputeFilePrefix;

--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -116,16 +116,7 @@ DValue *emitPointerOffset(Loc loc, DValue *base, Expression *offset,
   if (!llResult) {
     if (negateOffset)
       llOffset = gIR->ir->CreateNeg(llOffset);
-#if LDC_LLVM_VER >= 2000
-      llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
-      if (!negateOffset)
-        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
-#endif
-    llResult = DtoGEP1(llBaseTy, llBase, llOffset
-#if LDC_LLVM_VER >= 2000
-                    , "", nullptr, nw
-#endif
-    );
+    llResult = DtoGEP1(llBaseTy, llBase, llOffset);
   }
 
   return new DImValue(resultType, llResult);

--- a/gen/binops.cpp
+++ b/gen/binops.cpp
@@ -116,7 +116,16 @@ DValue *emitPointerOffset(Loc loc, DValue *base, Expression *offset,
   if (!llResult) {
     if (negateOffset)
       llOffset = gIR->ir->CreateNeg(llOffset);
-    llResult = DtoGEP1(llBaseTy, llBase, llOffset);
+#if LDC_LLVM_VER >= 2000
+      llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
+      if (!negateOffset)
+        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+#endif
+    llResult = DtoGEP1(llBaseTy, llBase, llOffset
+#if LDC_LLVM_VER >= 2000
+                    , "", nullptr, nw
+#endif
+    );
   }
 
   return new DImValue(resultType, llResult);

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -17,6 +17,7 @@
 #include "dmd/init.h"
 #include "dmd/module.h"
 #include "dmd/template.h"
+#include "driver/cl_options.h"
 #include "gen/abi/abi.h"
 #include "gen/arrays.h"
 #include "gen/classes.h"
@@ -1880,12 +1881,16 @@ DLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
 
   LLValue *ptr = src;
   LLType * ty = nullptr;
+#if LDC_LLVM_VER >= 2000
+  llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
+  if (opts::enableGetElementPtrNuw)
+    nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+#endif
   if (!isFieldIdx) {
     // apply byte-wise offset from object start
     ptr = DtoGEP1(getI8Type(), ptr, off
 #if LDC_LLVM_VER >= 2000
-      , "", nullptr
-      , llvm::GEPNoWrapFlags::inBounds() | llvm::GEPNoWrapFlags::noUnsignedWrap()
+      , "", nullptr, nw
 #endif
     );
     ty = DtoType(vd->type);
@@ -1903,8 +1908,7 @@ DLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
       }
       ptr = DtoGEP(st, ptr, 0, off
 #if LDC_LLVM_VER >= 2000
-      , "", nullptr
-      , llvm::GEPNoWrapFlags::inBounds() | llvm::GEPNoWrapFlags::noUnsignedWrap()
+      , "", nullptr, nw
 #endif
       );
       ty = isaStruct(st)->getElementType(off);

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1882,7 +1882,12 @@ DLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
   LLType * ty = nullptr;
   if (!isFieldIdx) {
     // apply byte-wise offset from object start
-    ptr = DtoGEP1(getI8Type(), ptr, off);
+    ptr = DtoGEP1(getI8Type(), ptr, off
+#if LDC_LLVM_VER >= 2000
+      , "", nullptr
+      , llvm::GEPNoWrapFlags::inBounds() | llvm::GEPNoWrapFlags::noUnsignedWrap()
+#endif
+    );
     ty = DtoType(vd->type);
   } else {
     if (ad->structsize == 0) { // can happen for extern(C) structs
@@ -1896,7 +1901,12 @@ DLValue *DtoIndexAggregate(LLValue *src, AggregateDeclaration *ad,
       } else {
         st = irTypeAggr->getLLType();
       }
-      ptr = DtoGEP(st, ptr, 0, off);
+      ptr = DtoGEP(st, ptr, 0, off
+#if LDC_LLVM_VER >= 2000
+      , "", nullptr
+      , llvm::GEPNoWrapFlags::inBounds() | llvm::GEPNoWrapFlags::noUnsignedWrap()
+#endif
+      );
       ty = isaStruct(st)->getElementType(off);
     }
   }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1178,7 +1178,16 @@ public:
       }
       LLType *elt = DtoMemType(e1type->nextOf());
       LLType *arrty = llvm::ArrayType::get(elt, e1type->isTypeSArray()->dim->isIntegerExp()->getInteger());
-      arrptr = DtoGEP(arrty, DtoLVal(l), DtoConstUint(0), DtoRVal(r));
+#if LDC_LLVM_VER >= 2000
+      llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
+      if (e->indexIsInBounds)
+        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+#endif
+      arrptr = DtoGEP(arrty, DtoLVal(l), DtoConstUint(0), DtoRVal(r)
+#if LDC_LLVM_VER >= 2000
+                    , "", nullptr, nw
+#endif
+      );
     } else if (e1type->ty == TY::Tarray) {
       if (p->emitArrayBoundsChecks() && !e->indexIsInBounds) {
         DtoIndexBoundsCheck(e->loc, l, r);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1525,16 +1525,7 @@ public:
       assert(e->e2->op == EXP::int64);
       LLConstant *offset =
           e->op == EXP::plusPlus ? DtoConstUint(1) : DtoConstInt(-1);
-#if LDC_LLVM_VER >= 2000
-      auto nw = llvm::GEPNoWrapFlags::inBounds();
-      if (e->op == EXP::plusPlus)
-        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
-#endif
-      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb()
-#if LDC_LLVM_VER >= 2000
-                   , nw
-#endif
-      );
+      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb());
     } else if (e1type->isComplex()) {
       assert(e2type->isComplex());
       LLValue *one = LLConstantFP::get(DtoComplexBaseType(e1type), 1.0);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1508,7 +1508,14 @@ public:
       assert(e->e2->op == EXP::int64);
       LLConstant *offset =
           e->op == EXP::plusPlus ? DtoConstUint(1) : DtoConstInt(-1);
+#if LDC_LLVM_VER >= 2000
+      auto nw = llvm::GEPNoWrapFlags::inBounds();
+      if (e->op == EXP::plusPlus)
+        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb(), nw);
+#else
       post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb());
+#endif
     } else if (e1type->isComplex()) {
       assert(e2type->isComplex());
       LLValue *one = LLConstantFP::get(DtoComplexBaseType(e1type), 1.0);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1529,10 +1529,12 @@ public:
       auto nw = llvm::GEPNoWrapFlags::inBounds();
       if (e->op == EXP::plusPlus)
         nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
-      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb(), nw);
-#else
-      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb());
 #endif
+      post = DtoGEP1(DtoMemType(dv->type->nextOf()), val, offset, "", p->scopebb()
+#if LDC_LLVM_VER >= 2000
+                   , nw
+#endif
+      );
     } else if (e1type->isComplex()) {
       assert(e2type->isComplex());
       LLValue *one = LLConstantFP::get(DtoComplexBaseType(e1type), 1.0);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1280,8 +1280,16 @@ public:
       }
 
       // offset by lower
-      eptr = DtoGEP1(DtoMemType(etype->nextOf()), getBasePointer(), vlo, "lowerbound");
-
+#if LDC_LLVM_VER >= 2000
+      llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
+      if (!needCheckUpper && !needCheckLower)
+        nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+#endif
+      eptr = DtoGEP1(DtoMemType(etype->nextOf()), getBasePointer(), vlo, "lowerbound"
+#if LDC_LLVM_VER >= 2000
+                   , nullptr, nw
+#endif
+      );
       // adjust length
       elen = p->ir->CreateSub(vup, vlo);
     }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -22,6 +22,8 @@
 #include "dmd/root/rmem.h"
 #include "dmd/target.h"
 #include "dmd/template.h"
+#include "driver/cl_options.h"
+#include "gen/aa.h"
 #include "gen/abi/abi.h"
 #include "gen/arrays.h"
 #include "gen/binops.h"
@@ -1180,7 +1182,7 @@ public:
       LLType *arrty = llvm::ArrayType::get(elt, e1type->isTypeSArray()->dim->isIntegerExp()->getInteger());
 #if LDC_LLVM_VER >= 2000
       llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
-      if (e->indexIsInBounds)
+      if (e->indexIsInBounds && opts::enableGetElementPtrNuw)
         nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
 #endif
       arrptr = DtoGEP(arrty, DtoLVal(l), DtoConstUint(0), DtoRVal(r)
@@ -1282,7 +1284,7 @@ public:
       // offset by lower
 #if LDC_LLVM_VER >= 2000
       llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds();
-      if (!needCheckUpper && !needCheckLower)
+      if (!needCheckUpper && !needCheckLower && opts::enableGetElementPtrNuw)
         nw |= llvm::GEPNoWrapFlags::noUnsignedWrap();
 #endif
       eptr = DtoGEP1(DtoMemType(etype->nextOf()), getBasePointer(), vlo, "lowerbound"

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -354,34 +354,74 @@ LLIntegerType *DtoSize_t() {
 namespace {
 llvm::GetElementPtrInst *DtoGEP(LLType *pointeeTy, LLValue *ptr,
                                 llvm::ArrayRef<LLValue *> indices,
-                                const char *name, llvm::BasicBlock *bb) {
+                                const char *name, llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+                              , llvm::GEPNoWrapFlags nw
+#endif
+                              ) {
   auto gep = llvm::GetElementPtrInst::Create(pointeeTy, ptr, indices, name,
                                              bb ? bb : gIR->scopebb());
+#if LDC_LLVM_VER >= 2000
+  gep->setNoWrapFlags(nw);
+#else
   gep->setIsInBounds(true);
+#endif
   return gep;
 }
 }
 
 LLValue *DtoGEP1(LLType *pointeeTy, LLValue *ptr, LLValue *i0, const char *name,
-                 llvm::BasicBlock *bb) {
-  return DtoGEP(pointeeTy, ptr, i0, name, bb);
+                 llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+               , llvm::GEPNoWrapFlags nw
+#endif
+                ) {
+  return DtoGEP(pointeeTy, ptr, i0, name, bb
+#if LDC_LLVM_VER >= 2000
+              , nw
+#endif
+  );
 }
 
 LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, LLValue *i0, LLValue *i1,
-                const char *name, llvm::BasicBlock *bb) {
+                const char *name, llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+              , llvm::GEPNoWrapFlags nw
+#endif
+              ) {
   LLValue *indices[] = {i0, i1};
-  return DtoGEP(pointeeTy, ptr, indices, name, bb);
+  return DtoGEP(pointeeTy, ptr, indices, name, bb
+#if LDC_LLVM_VER >= 2000
+               , nw
+#endif
+  );
 }
 
 LLValue *DtoGEP1(LLType *pointeeTy, LLValue *ptr, unsigned i0, const char *name,
-                 llvm::BasicBlock *bb) {
-  return DtoGEP(pointeeTy, ptr, DtoConstUint(i0), name, bb);
+                 llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+               , llvm::GEPNoWrapFlags nw
+#endif
+                ) {
+  return DtoGEP(pointeeTy, ptr, DtoConstUint(i0), name, bb
+#if LDC_LLVM_VER >= 2000
+                , nw
+#endif
+  );
 }
 
 LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
-                const char *name, llvm::BasicBlock *bb) {
+                const char *name, llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+              , llvm::GEPNoWrapFlags nw
+#endif
+              ) {
   LLValue *indices[] = {DtoConstUint(i0), DtoConstUint(i1)};
-  return DtoGEP(pointeeTy, ptr, indices, name, bb);
+  return DtoGEP(pointeeTy, ptr, indices, name, bb
+#if LDC_LLVM_VER >= 2000
+              , nw
+#endif
+  );
 }
 
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
@@ -392,8 +432,16 @@ LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
 }
 
 LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,
-                    llvm::BasicBlock *bb) {
-  return DtoGEP(pointeeTy, ptr, DtoConstUlong(i0), name, bb);
+                    llvm::BasicBlock *bb
+#if LDC_LLVM_VER >= 2000
+                  , llvm::GEPNoWrapFlags nw
+#endif
+                  ) {
+  return DtoGEP(pointeeTy, ptr, DtoConstUlong(i0), name, bb
+#if LDC_LLVM_VER >= 2000
+              , nw
+#endif
+  );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -698,7 +746,7 @@ LLGlobalVariable *makeGlobal(LLStringRef name, LLType* type, LLStringRef section
 
   if (!section.empty())
     var->setSection(section);
-    
+
   return var;
 }
 
@@ -734,7 +782,7 @@ LLGlobalVariable *makeGlobalWithBytes(LLStringRef name, LLConstantList packedCon
     0u,
     externInit
   );
-  
+
   return var;
 }
 

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -425,10 +425,19 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 }
 
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
-                   unsigned i1) {
+                   unsigned i1
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw
+#endif
+                  ) {
   LLValue *indices[] = {DtoConstUint(i0), DtoConstUint(i1)};
   return llvm::ConstantExpr::getGetElementPtr(pointeeTy, ptr, indices,
-                                              /* InBounds = */ true);
+#if LDC_LLVM_VER >= 2000
+                                              nw
+#else
+                                              /* InBounds = */ true
+#endif
+                                            );
 }
 
 LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0, const char *name,

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -102,7 +102,11 @@ LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
 #endif
               );
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
-                   unsigned i1);
+                   unsigned i1
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+                  );
 
 LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
                     const char *name = "", llvm::BasicBlock *bb = nullptr

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -77,19 +77,39 @@ LLStructType *DtoModuleReferenceType();
 
 // getelementptr helpers
 LLValue *DtoGEP1(LLType *pointeeTy, LLValue *ptr, LLValue *i0,
-                 const char *name = "", llvm::BasicBlock *bb = nullptr);
+                 const char *name = "", llvm::BasicBlock *bb = nullptr
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+                );
 LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, LLValue *i0, LLValue *i1,
-                const char *name = "", llvm::BasicBlock *bb = nullptr);
+                const char *name = "", llvm::BasicBlock *bb = nullptr
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+              );
 
 LLValue *DtoGEP1(LLType *pointeeTy, LLValue *ptr, unsigned i0,
-                 const char *name = "", llvm::BasicBlock *bb = nullptr);
+                 const char *name = "", llvm::BasicBlock *bb = nullptr
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+                );
 LLValue *DtoGEP(LLType *pointeeTy, LLValue *ptr, unsigned i0, unsigned i1,
-                const char *name = "", llvm::BasicBlock *bb = nullptr);
+                const char *name = "", llvm::BasicBlock *bb = nullptr
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+              );
 LLConstant *DtoGEP(LLType *pointeeTy, LLConstant *ptr, unsigned i0,
                    unsigned i1);
 
 LLValue *DtoGEP1i64(LLType *pointeeTy, LLValue *ptr, uint64_t i0,
-                    const char *name = "", llvm::BasicBlock *bb = nullptr);
+                    const char *name = "", llvm::BasicBlock *bb = nullptr
+#if LDC_LLVM_VER >= 2000
+                 , llvm::GEPNoWrapFlags nw = llvm::GEPNoWrapFlags::inBounds()
+#endif
+                  );
 
 // to constant helpers
 LLConstantInt *DtoConstSize_t(uint64_t);

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -30,21 +30,21 @@ int foo3(int* p, int i) {
 // PostExp in pointer
 // CHECK-LABEL: @foo4
 int foo4(int* p) {
-    // CHECK: getelementptr inbounds{{( nuw)?}}
+    // CHECK: getelementptr inbounds
     return *p++;
 }
 
 // PreExp in pointer
 // CHECK-LABEL: @foo5
 int foo5(int* p) {
-    // CHECK: getelementptr inbounds{{( nuw)?}}
+    // CHECK: getelementptr inbounds
     return *++p;
 }
 
 // Add offset to pointer
 // CHECK-LABEL: @foo6
 int foo6(int* p, int i) {
-    // CHECK: getelementptr inbounds{{( nuw)?}}
+    // CHECK: getelementptr inbounds
     return *(p + i);
 }
 

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -9,7 +9,7 @@ extern(C):  // Avoid name mangling
 // IndexExp in static array with const exp
 // CHECK-LABEL: @foo1
 int foo1(int[3] a) {
-    // CHECK: getelementptr inbounds [3 x i32]
+    // CHECK: getelementptr inbounds{{( nuw)?}} [3 x i32]
     return a[1];
 }
 

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -79,7 +79,7 @@ int foo10(int[] a, int i) {
 // SliceExp for static array with const lower bound
 // CHECK-LABEL: @foo11
 int[] foo11(ref int[3] a) {
-    // CHECK: getelementptr inbounds i32, ptr
+    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr
     return a[1 .. $];
 }
 

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -30,7 +30,7 @@ int foo3(int* p, int i) {
 // PostExp in pointer
 // CHECK-LABEL: @foo4
 int foo4(int* p) {
-    // CHECK: getelementptr inbounds
+    // CHECK: getelementptr inbounds{{( nuw)?}}
     return *p++;
 }
 

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -1,4 +1,4 @@
-// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// RUN: %ldc -enable-getelementptr-nuw -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
 
 struct S {
     float x, y;

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -58,7 +58,7 @@ int foo7(int* p, int i) {
 // Struct field
 // CHECK-LABEL: @foo8
 float foo8(S s) {
-    // CHECK: getelementptr inbounds
+    // CHECK: getelementptr inbounds{{( nuw)?}}
     return s.y;
 }
 

--- a/tests/codegen/inbounds.d
+++ b/tests/codegen/inbounds.d
@@ -37,14 +37,14 @@ int foo4(int* p) {
 // PreExp in pointer
 // CHECK-LABEL: @foo5
 int foo5(int* p) {
-    // CHECK: getelementptr inbounds
+    // CHECK: getelementptr inbounds{{( nuw)?}}
     return *++p;
 }
 
 // Add offset to pointer
 // CHECK-LABEL: @foo6
 int foo6(int* p, int i) {
-    // CHECK: getelementptr inbounds
+    // CHECK: getelementptr inbounds{{( nuw)?}}
     return *(p + i);
 }
 


### PR DESCRIPTION
LLVM 19 introduces new getelementptr flag `nuw`.
`inbounds + nuw` implies that the offset is non-negative, so this could be useful for eliminating bounds/overflow check.

see also: https://discourse.llvm.org/t/rfc-add-nusw-and-nuw-flags-for-getelementptr/78672