### PR TITLE
Fix #4938 - Be stricter wrt. supported AddrExp in toConstElem()

### DIFF
--- a/tests/fail_compilation/gh4938.d
+++ b/tests/fail_compilation/gh4938.d
@@ -1,0 +1,4 @@
+// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+
+// CHECK: gh4938.d(4): Error: expression `&"whoops"w[0]` is not a constant
+immutable(wchar)* x = &"whoops"w[0];


### PR DESCRIPTION
DMD seems to support AddrExp of struct literals only...