### PR TITLE
Cherry-pick 2 upstream fixes for 2.111 regressions

### DIFF
--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -5672,7 +5672,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             s = "__funcliteral";
 
         DsymbolTable symtab;
-        string parentMangle;
         if (FuncDeclaration func = sc.parent.isFuncDeclaration())
         {
             if (func.localsymtab is null)
@@ -5682,7 +5681,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 func.localsymtab = new DsymbolTable();
             }
             symtab = func.localsymtab;
-            parentMangle = cast(string) mangleExact(func).toDString();
         }
         else
         {
@@ -5695,13 +5693,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 sds.symtab = new DsymbolTable();
             }
             symtab = sds.symtab;
-
-            OutBuffer buf;
-            mangleToBuffer(sds, buf);
-            parentMangle = buf.extractSlice();
         }
         assert(symtab);
-        Identifier id = Identifier.generateIdWithLoc(s, exp.loc, parentMangle);
+        Identifier id = Identifier.generateIdWithLoc(s, exp.loc, cast(const void*) sc.parent);
         exp.fd.ident = id;
         if (exp.td)
             exp.td.ident = id;

--- a/dmd/identifier.d
+++ b/dmd/identifier.d
@@ -221,7 +221,7 @@ nothrow:
      *      Identifier (inside Identifier.idPool) with deterministic name based
      *      on the source location.
      */
-    extern (D) static Identifier generateIdWithLoc(string prefix, Loc loc, string parent = null)
+    extern (D) static Identifier generateIdWithLoc(string prefix, Loc loc, const void* parent = null)
     {
         // generate `<prefix>_L<line>_C<col>`
         auto sl = SourceLoc(loc);
@@ -248,7 +248,7 @@ nothrow:
          * directly, but that would unnecessary lengthen symbols names. See issue:
          * https://issues.dlang.org/show_bug.cgi?id=23722
          */
-        static struct Key { string locKey; string prefix; string parent; }
+        static struct Key { string locKey; string prefix; const(void)* parent; }
         __gshared uint[Key] counters;
 
         const locKey = cast(string) (sl.filename ~ idBuf[]);

--- a/dmd/typesem.d
+++ b/dmd/typesem.d
@@ -7330,7 +7330,7 @@ Type substWildTo(Type type, uint mod)
             t = t.addMod(MODFlags.shared_);
 
         //printf("-Type.substWildTo t = %s\n", t.toChars());
-        return t;
+        return t.merge();
     }
 
     if (!tf.iswild && !(tf.mod & MODFlags.wild))


### PR DESCRIPTION
Yeah well, update an existing cherry-pick to the final upstream version, and cherry-pick a 2nd fix, which we didn't hit with LDC at Symmetry so far (but with DMD).