### PR TITLE
[dcompute] `has`->`getKernelAttr`, return expression literal

### DIFF
--- a/gen/abi/nvptx.cpp
+++ b/gen/abi/nvptx.cpp
@@ -23,7 +23,7 @@ struct NVPTXTargetABI : TargetABI {
       return llvm::CallingConv::PTX_Device;
   }
   llvm::CallingConv::ID callingConv(FuncDeclaration *fdecl) override {
-    return hasKernelAttr(fdecl) ? llvm::CallingConv::PTX_Kernel
+    return getKernelAttr(fdecl) ? llvm::CallingConv::PTX_Kernel
                                 : llvm::CallingConv::PTX_Device;
   }
   bool passByVal(TypeFunction *, Type *t) override {

--- a/gen/abi/spirv.cpp
+++ b/gen/abi/spirv.cpp
@@ -23,7 +23,7 @@ struct SPIRVTargetABI : TargetABI {
       return llvm::CallingConv::SPIR_FUNC;
   }
   llvm::CallingConv::ID callingConv(FuncDeclaration *fdecl) override {
-    return hasKernelAttr(fdecl) ? llvm::CallingConv::SPIR_KERNEL
+    return getKernelAttr(fdecl) ? llvm::CallingConv::SPIR_KERNEL
                                 : llvm::CallingConv::SPIR_FUNC;
   }
   bool passByVal(TypeFunction *, Type *t) override {

--- a/gen/dcompute/target.h
+++ b/gen/dcompute/target.h
@@ -49,7 +49,9 @@ public:
   void writeModule();
 
   virtual void addMetadata() = 0;
-  virtual void addKernelMetadata(FuncDeclaration *df, llvm::Function *llf) = 0;
+  virtual void addKernelMetadata(FuncDeclaration *df,
+                                 llvm::Function *llf,
+                                 StructLiteralExp *kernAttr) = 0;
 };
 
 #if LDC_LLVM_SUPPORTED_TARGET_NVPTX

--- a/gen/dcompute/targetCUDA.cpp
+++ b/gen/dcompute/targetCUDA.cpp
@@ -52,7 +52,7 @@ public:
     // sm version?
   }
 
-  void addKernelMetadata(FuncDeclaration *df, llvm::Function *llf) override {
+  void addKernelMetadata(FuncDeclaration *df, llvm::Function *llf, StructLiteralExp *_unused_) override {
     // TODO: Handle Function attibutes
     llvm::NamedMDNode *na =
         _ir->module.getOrInsertNamedMetadata("nvvm.annotations");

--- a/gen/dcompute/targetOCL.cpp
+++ b/gen/dcompute/targetOCL.cpp
@@ -138,7 +138,7 @@ public:
       KernArgMD_name,
       count_KernArgMD
   };
-  void addKernelMetadata(FuncDeclaration *fd, llvm::Function *llf) override {
+  void addKernelMetadata(FuncDeclaration *fd, llvm::Function *llf, StructLiteralExp *_unused_) override {
     // By the time we get here the ABI should have rewritten the function
     // type so that the magic types in ldc.dcompute are transformed into
     // what the LLVM backend expects.

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1342,9 +1342,12 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     allocaPoint = nullptr;
   }
 
-  if (gIR->dcomputetarget && hasKernelAttr(fd)) {
-    auto fn = gIR->module.getFunction(fd->mangleString);
-    gIR->dcomputetarget->addKernelMetadata(fd, fn);
+  if (gIR->dcomputetarget) {
+    auto kernAttr = getKernelAttr(fd);
+    if (kernAttr) {
+      auto fn = gIR->module.getFunction(fd->mangleString);
+      gIR->dcomputetarget->addKernelMetadata(fd, fn, kernAttr);
+    }
   }
 
   if (func->getLinkage() == LLGlobalValue::WeakAnyLinkage &&

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -237,7 +237,7 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
   }
 
   void visit(FuncDeclaration *fd) override {
-    if (hasKernelAttr(fd) && fd->vthis) {
+    if (getKernelAttr(fd) && fd->vthis) {
       error(fd->loc, "`@kernel` functions must not require `this`");
       stop = true;
       return;

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -654,11 +654,11 @@ extern "C" DComputeCompileFor hasComputeAttr(Dsymbol *sym) {
   return static_cast<DComputeCompileFor>(1 + (*sle->elements)[0]->toInteger());
 }
 
-/// Checks whether 'sym' has the @ldc.dcompute._kernel() UDA applied.
-bool hasKernelAttr(Dsymbol *sym) {
+/// Returns whether `sym` has the `@ldc.dcompute._kernel()` UDA applied.
+StructLiteralExp *getKernelAttr(Dsymbol *sym) {
   auto sle = getMagicAttribute(sym, Id::udaKernel, Id::dcompute);
   if (!sle)
-    return false;
+    return nullptr;
 
   checkStructElems(sle, {});
 
@@ -668,7 +668,7 @@ bool hasKernelAttr(Dsymbol *sym) {
                     " in modules marked `@ldc.dcompute.compute`");
   }
 
-  return true;
+  return sle;
 }
 
 /// Check whether `fd` has the `@ldc.attributes.noSplitStack` UDA applied.

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -19,6 +19,7 @@
 class Dsymbol;
 class FuncDeclaration;
 class VarDeclaration;
+class StructLiteralExp;
 struct IrFunction;
 namespace llvm {
 class GlobalVariable;
@@ -29,7 +30,7 @@ void applyVarDeclUDAs(VarDeclaration *decl, llvm::GlobalVariable *gvar);
 
 bool hasCallingConventionUDA(FuncDeclaration *fd, llvm::CallingConv::ID *callconv);
 bool hasWeakUDA(Dsymbol *sym);
-bool hasKernelAttr(Dsymbol *sym);
+StructLiteralExp *getKernelAttr(Dsymbol *sym);
 /// Must match ldc.dcompute.Compilefor + 1 == DComputeCompileFor
 enum class DComputeCompileFor : int
 {


### PR DESCRIPTION
Needed for Vulkan where information about the number of threads to use is supplied to the attribute.