### PR TITLE
[dcompute] update `@kernel` UDA, include launch dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - macOS: Fix weird linker error when running CMake the first time. (#3901, #4926)
   - Reworked integration of the LLVM compiler-rt libraries. Package maintainers may want to see [docs/compiler_rt.md](https://github.com/ldc-developers/ldc/blob/master/docs/compiler_rt.md). (#4665)
   - Somewhat simplify separate compiler and runtime builds, incl. cross-compiling LDC itself. (#4872)
+- **Breaking change for dcompute**: The special `@kernel` UDA is now a function and _**requires**_ parentheses as in `@kernel() void foo(){}`. Optionally you can provide launch dimensions, `@kernel([2,4,8])`, to specify to the compute runtime how the kernel is intended to be launched. 
 
 #### Platform support
 - Supports LLVM 15 - 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LDC master
 
 #### Big news
+- **Breaking change for dcompute**: The special `@kernel` UDA is now a function and _**requires**_ parentheses as in `@kernel() void foo(){}`. Optionally you can provide launch dimensions, `@kernel([2,4,8])`, to specify to the compute runtime how the kernel is intended to be launched. 
 
 #### Platform support
 
@@ -23,7 +24,6 @@
   - macOS: Fix weird linker error when running CMake the first time. (#3901, #4926)
   - Reworked integration of the LLVM compiler-rt libraries. Package maintainers may want to see [docs/compiler_rt.md](https://github.com/ldc-developers/ldc/blob/master/docs/compiler_rt.md). (#4665)
   - Somewhat simplify separate compiler and runtime builds, incl. cross-compiling LDC itself. (#4872)
-- **Breaking change for dcompute**: The special `@kernel` UDA is now a function and _**requires**_ parentheses as in `@kernel() void foo(){}`. Optionally you can provide launch dimensions, `@kernel([2,4,8])`, to specify to the compute runtime how the kernel is intended to be launched. 
 
 #### Platform support
 - Supports LLVM 15 - 20.

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -660,7 +660,7 @@ StructLiteralExp *getKernelAttr(Dsymbol *sym) {
   if (!sle)
     return nullptr;
 
-  checkStructElems(sle, {});
+  checkStructElems(sle, {dmd::sarrayOf(Type::tsize_t, 3)});
 
   if (!sym->isFuncDeclaration() &&
       hasComputeAttr(sym->getModule()) != DComputeCompileFor::hostOnly) {

--- a/runtime/druntime/src/ldc/dcompute.d
+++ b/runtime/druntime/src/ldc/dcompute.d
@@ -65,14 +65,16 @@ struct compute
 + @compute(CompileFor.deviceOnly) module foo;
 + import ldc.dcompute;
 +
-+ @kernel void bar()
++ @kernel() void bar()
 + {
 +     //...
 + }
 + ---
 +/
-private struct _kernel {}
-enum kernel = _kernel();
+private struct _kernel {
+    size_t[3] bounds;
+}
+_kernel kernel(size_t[3] a = [1,1,1]) => _kernel(a);
 
 /++
  + DCompute has the notion of adress spaces, provide by the magic structs below.

--- a/tests/codegen/dcompute_cl_images.d
+++ b/tests/codegen/dcompute_cl_images.d
@@ -24,7 +24,7 @@ pragma(mangle,"_Z11read_imagef11ocl_image1d_ro11ocl_sampleri")
 pragma(mangle,"_Z12write_imagef11ocl_image1d_woiDv4_f")
     void write(GlobalPointer!image1d_wo_t,int,__vector(float[4]));
 
-@kernel void img(GlobalPointer!image1d_ro_t src, GlobalPointer!image1d_wo_t dst)
+@kernel() void img(GlobalPointer!image1d_ro_t src, GlobalPointer!image1d_wo_t dst)
 {
 // CHECK: %{{[0-9+]}} = call spir_func ptr addrspace(2) @__translate_sampler_initializer(i32 0) {{.*}}
 // CHECK: %{{[0-9+]}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d_ro11ocl_sampleri(ptr addrspace(1) %.DComputePointerRewrite_arg, ptr addrspace(2) %.DComputePointerRewrite_arg1, i32 0) {{.*}}
@@ -33,7 +33,7 @@ pragma(mangle,"_Z12write_imagef11ocl_image1d_woiDv4_f")
     dst.write(0,x);
 }
 
-@kernel void img2(GlobalPointer!image1d_ro_t src, Sampler samp)
+@kernel() void img2(GlobalPointer!image1d_ro_t src, Sampler samp)
 {
 // CHECK: %{{[0-9+]}} = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d_ro11ocl_sampleri(ptr addrspace(1) %.DComputePointerRewrite_arg, ptr addrspace(2) %.DComputePointerRewrite_arg1, i32 0) {{.*}}
     auto x = src.read(samp, 0);


### PR DESCRIPTION
This PR does not update the OpenCL nor CUDA backends to their corresponding attributes (`reqd_work_group_size(X, Y, Z)`. This is required for the Vulkan compute backend to function.