### PR TITLE
Fix a bunch of errors and deprecation for LLVM 21

### DIFF
--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -216,7 +216,11 @@ void CodeGenerator::prepareLLModule(Module *m) {
   // name, as it should not collide with a symbol name used somewhere in the
   // module.
   ir_ = new IRState(m->srcfile.toChars(), context_);
+#if LDC_LLVM_VER >= 2100
+  ir_->module.setTargetTriple(*global.params.targetTriple);
+#else
   ir_->module.setTargetTriple(global.params.targetTriple->str());
+#endif
   ir_->module.setDataLayout(*gDataLayout);
 
   // TODO: Make ldc::DIBuilder per-Module to be able to emit several CUs for

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -652,7 +652,13 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
                     finalFeaturesString.c_str());
   }
 
-  return target->createTargetMachine(triple.str(), cpu, finalFeaturesString,
+  return target->createTargetMachine(
+#if LDC_LLVM_VER >= 2100
+                                     triple,
+#else
+                                     triple.str(),
+#endif
+                                     cpu, finalFeaturesString,
                                      targetOptions, relocModel, codeModel,
                                      static_cast<llvm::CodeGenOptLevel>(codeGenOptLevel));
 }

--- a/gen/abi/aarch64.cpp
+++ b/gen/abi/aarch64.cpp
@@ -130,7 +130,7 @@ public:
     // compiler magic: pass va_list args implicitly by reference
     if (!isReturnVal && isAAPCS64VaList(t)) {
       arg.byref = true;
-      arg.ltype = LLPointerType::getUnqual(arg.ltype);
+      arg.ltype = LLPointerType::get(getGlobalContext(), 0);
       return;
     }
 

--- a/gen/abi/generic.h
+++ b/gen/abi/generic.h
@@ -260,7 +260,11 @@ struct IndirectByvalRewrite : ABIRewrite {
     auto &attrs = arg.attrs;
     attrs.clear();
     attrs.addAttribute(LLAttribute::NoAlias);
+#if LDC_LLVM_VER >= 2100
+    attrs.addCapturesAttr(llvm::CaptureInfo::none());
+#else
     attrs.addAttribute(LLAttribute::NoCapture);
+#endif
     if (auto alignment = DtoAlignment(arg.type))
       attrs.addAlignmentAttr(alignment);
   }

--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -483,7 +483,7 @@ DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl) {
   // get the vtbl for objects
   vtable = DtoGEP(irtc->getMemoryLLType(), vthis, 0u, 0);
   // load vtbl ptr
-  vtable = DtoLoad(LLPointerType::getUnqual(vtblType), vtable);
+  vtable = DtoLoad(LLPointerType::get(getGlobalContext(), 0), vtable);
   // index vtbl
   const std::string name = fdecl->toChars();
   const auto vtblname = name + "@vtbl";

--- a/gen/dcompute/druntime.h
+++ b/gen/dcompute/druntime.h
@@ -14,6 +14,7 @@
 #include "dmd/aggregate.h"
 #include "dmd/mtype.h"
 #include "gen/dcompute/target.h"
+#include "gen/llvmhelpers.h"
 #include "gen/irstate.h"
 #include "gen/llvm.h"
 #include "gen/tollvm.h"
@@ -37,11 +38,11 @@ struct DcomputePointer {
   Type *type;
   DcomputePointer(int as, Type *ty) : addrspace(as), type(ty) {}
   LLType *toLLVMType(bool translate) {
-    auto llType = DtoType(type);
+    DtoType(type);
     int as = addrspace;
     if (translate)
       as = gIR->dcomputetarget->mapping[as];
-    return LLPointerType::get(llType, as);
+    return LLPointerType::get(getGlobalContext(), as);
   }
 };
 llvm::Optional<DcomputePointer> toDcomputePointer(StructDeclaration *sd);

--- a/gen/dcompute/targetCUDA.cpp
+++ b/gen/dcompute/targetCUDA.cpp
@@ -43,7 +43,11 @@ public:
         llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(), false);
 
     _ir = new IRState("dcomputeTargetCUDA", ctx);
+#if LDC_LLVM_VER >= 2100
+    _ir->module.setTargetTriple(llvm::Triple(tripleString));
+#else
     _ir->module.setTargetTriple(tripleString);
+#endif
     _ir->module.setDataLayout(targetMachine->createDataLayout());
     _ir->dcomputetarget = this;
   }

--- a/gen/dcompute/targetOCL.cpp
+++ b/gen/dcompute/targetOCL.cpp
@@ -73,14 +73,19 @@ public:
     const bool is64 = global.params.targetTriple->isArch64Bit();
 
     _ir = new IRState("dcomputeTargetOCL", ctx);
-    std::string targTriple = is64 ? SPIR_TARGETTRIPLE64
-                                  : SPIR_TARGETTRIPLE32;
+    std::string targTripleStr = is64 ? SPIR_TARGETTRIPLE64
+                                     : SPIR_TARGETTRIPLE32;
+#if LDC_LLVM_VER >= 2100
+    llvm::Triple targTriple = llvm::Triple(targTripleStr);
+#else
+    std::string targTriple = targTripleStr;
+#endif
     _ir->module.setTargetTriple(targTriple);
 
 #if LDC_LLVM_VER >= 1600
     auto floatABI = ::FloatABI::Hard;
     targetMachine = createTargetMachine(
-            targTriple,
+            targTripleStr,
             is64 ? "spirv64" : "spirv32",
             "", {},
             is64 ? ExplicitBitness::M64 : ExplicitBitness::M32, floatABI,

--- a/gen/nested.cpp
+++ b/gen/nested.cpp
@@ -170,7 +170,7 @@ DValue *DtoNestedVariable(Loc loc, Type *astype, VarDeclaration *vd,
     IF_LOG Logger::cout() << "Frame index: " << *val << '\n';
     currFrame = getIrFunc(fd)->frameType;
     gIR->DBuilder.OpDeref(dwarfAddrOps);
-    val = DtoAlignedLoad(LLPointerType::getUnqual(currFrame), val,
+    val = DtoAlignedLoad(LLPointerType::get(getGlobalContext(), 0), val,
                          (std::string(".frame.") + vdparent->toChars()).c_str());
     IF_LOG Logger::cout() << "Frame: " << *val << '\n';
   }
@@ -417,7 +417,7 @@ static void DtoCreateNestedContextType(FuncDeclaration *fd) {
       builder.addType(innerFrameType->getElementType(i), target.ptrsize);
     }
     // Add frame pointer type for last frame
-    builder.addType(LLPointerType::getUnqual(innerFrameType), target.ptrsize);
+    builder.addType(LLPointerType::get(getGlobalContext(), 0), target.ptrsize);
   }
 
   // Add the direct nested variables of this function, and update their
@@ -505,7 +505,7 @@ void DtoCreateNestedContext(FuncGenState &funcGen) {
         mem = gIR->ir->CreateAdd(mem, DtoConstSize_t(mask));
         mem = gIR->ir->CreateAnd(mem, DtoConstSize_t(~mask));
         frame =
-            gIR->ir->CreateIntToPtr(mem, LLPointerType::getUnqual(frameType), ".frame");
+            gIR->ir->CreateIntToPtr(mem, LLPointerType::get(getGlobalContext(), 0), ".frame");
       }
     } else {
       frame = DtoRawAlloca(frameType, frameAlignment, ".frame");

--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -209,8 +209,16 @@ Value *ArraySliceCopyOpt::CallOptimizer(Function *Callee, CallInst *CI,
     Sz = (Int->getValue() * ElemSz->getValue()).getZExtValue();
   }
 
+#if LDC_LLVM_VER >= 2100
+  llvm::LocationSize Sz2 =
+      (Sz == llvm::MemoryLocation::UnknownSize)
+          ? llvm::LocationSize::beforeOrAfterPointer()
+          : llvm::LocationSize::precise(Sz);
+#else
+  std::uint64_t Sz2 = Sz;
+#endif
   // Check if the pointers may alias
-  if (AA->alias(CI->getOperand(0), Sz, CI->getOperand(2), Sz)) {
+  if (AA->alias(CI->getOperand(0), Sz2, CI->getOperand(2), Sz2)) {
     return nullptr;
   }
 

--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -18,6 +18,7 @@
 
 #include "gen/passes/Passes.h"
 #include "gen/passes/SimplifyDRuntimeCalls.h"
+#include "gen/llvmhelpers.h"
 #include "gen/tollvm.h"
 #include "gen/runtime.h"
 #include "llvm/ADT/Statistic.h"
@@ -183,7 +184,7 @@ Value *ArraySliceCopyOpt::CallOptimizer(Function *Callee, CallInst *CI,
                      IRBuilder<> &B) {
   // Verify we have a reasonable prototype for _d_array_slice_copy
   const FunctionType *FT = Callee->getFunctionType();
-  const llvm::Type *VoidPtrTy = PointerType::getUnqual(B.getInt8Ty());
+  const llvm::Type *VoidPtrTy = PointerType::get(getGlobalContext(), 0);
   if (Callee->arg_size() != 5 || FT->getReturnType() != B.getVoidTy() ||
       FT->getParamType(0) != VoidPtrTy ||
       !isa<IntegerType>(FT->getParamType(1)) ||

--- a/gen/tocall.cpp
+++ b/gen/tocall.cpp
@@ -1044,7 +1044,11 @@ DValue *DtoCallFunction(Loc loc, Type *resulttype, DValue *fnval,
     call->setCallingConv(cf->getCallingConv());
     if (cf->isIntrinsic()) { // override intrinsic attrs
       attrlist =
-          llvm::Intrinsic::getAttributes(gIR->context(), cf->getIntrinsicID());
+          llvm::Intrinsic::getAttributes(gIR->context(), cf->getIntrinsicID()
+#if LDC_LLVM_VER >= 2100
+                                         ,cf->getFunctionType()
+#endif
+                                         );
     }
   } else if (dfnval) {
     call->setCallingConv(getCallingConvention(dfnval->func));

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2826,7 +2826,7 @@ public:
       LLValue *val = DtoRVal(ex);
 
       // Get and load vtbl pointer.
-      llvm::Value *vtbl = DtoLoad(LLPointerType::getUnqual(vtblType),
+      llvm::Value *vtbl = DtoLoad(LLPointerType::get(getGlobalContext(), 0),
                                   DtoGEP(irtc->getMemoryLLType(), val, 0u, 0));
 
       // TypeInfo ptr is first vtbl entry.

--- a/gen/variable_lifetime.cpp
+++ b/gen/variable_lifetime.cpp
@@ -78,7 +78,12 @@ llvm::Function *LocalVariableLifetimeAnnotator::getLLVMLifetimeStartFn() {
   if (lifetimeStartFunction)
     return lifetimeStartFunction;
 
-  lifetimeStartFunction = llvm::Intrinsic::getDeclaration(
+  lifetimeStartFunction = llvm::Intrinsic::
+#if LDC_LLVM_VER >= 2100
+    getOrInsertDeclaration(
+#else
+    getDeclaration(
+#endif
       &irs.module, llvm::Intrinsic::lifetime_start, allocaType);
   assert(lifetimeStartFunction);
   return lifetimeStartFunction;
@@ -89,7 +94,12 @@ llvm::Function *LocalVariableLifetimeAnnotator::getLLVMLifetimeEndFn() {
   if (lifetimeEndFunction)
     return lifetimeEndFunction;
 
-  lifetimeEndFunction = llvm::Intrinsic::getDeclaration(
+  lifetimeEndFunction = llvm::Intrinsic::
+#if LDC_LLVM_VER >= 2100
+    getOrInsertDeclaration(
+#else
+    getDeclaration(
+#endif
       &irs.module, llvm::Intrinsic::lifetime_end, allocaType);
   assert(lifetimeEndFunction);
   return lifetimeEndFunction;

--- a/gen/variable_lifetime.cpp
+++ b/gen/variable_lifetime.cpp
@@ -31,7 +31,7 @@ static llvm::cl::opt<bool> fEmitLocalVarLifetime(
 LocalVariableLifetimeAnnotator::LocalVariableLifetimeAnnotator(IRState &irs)
     : irs(irs) {
   allocaType =
-      LLPointerType::get(LLType::getInt8Ty(irs.context()),
+      LLPointerType::get(irs.context(),
                          irs.module.getDataLayout().getAllocaAddrSpace());
 }
 

--- a/ir/irtypeclass.cpp
+++ b/ir/irtypeclass.cpp
@@ -49,8 +49,7 @@ void IrTypeClass::addClassData(AggrTypeBuilder &builder,
 
       // add to the interface map
       addInterfaceToMap(b->sym, builder.currentFieldIndex());
-      auto vtblTy = LLArrayType::get(getOpaquePtrType(), b->sym->vtbl.length);
-      builder.addType(llvm::PointerType::get(vtblTy, 0), target.ptrsize);
+      builder.addType(llvm::PointerType::get(getGlobalContext(), 0), target.ptrsize);
 
       ++num_interface_vtbls;
     }
@@ -92,7 +91,7 @@ llvm::Type *IrTypeClass::getMemoryLLType() {
   }
 
   // add vtbl
-  builder.addType(llvm::PointerType::get(vtbl_type, 0), target.ptrsize);
+  builder.addType(llvm::PointerType::get(getGlobalContext(), 0), target.ptrsize);
 
   if (cd->isInterfaceDeclaration()) {
     // interfaces are just a vtable

--- a/ir/irtypefunction.cpp
+++ b/ir/irtypefunction.cpp
@@ -10,6 +10,7 @@
 #include "ir/irtypefunction.h"
 
 #include "dmd/mtype.h"
+#include "gen/llvmhelpers.h"
 #include "gen/functions.h"
 #include "gen/irstate.h"
 #include "gen/tollvm.h"
@@ -53,9 +54,8 @@ IrTypeDelegate *IrTypeDelegate::get(Type *t) {
   assert(!ctype);
 
   IrFuncTy irFty(tf);
-  llvm::Type *ltf =
-      DtoFunctionType(tf, irFty, nullptr, pointerTo(Type::tvoid));
-  llvm::Type *fptr = LLPointerType::get(ltf, gDataLayout->getProgramAddressSpace());
+  DtoFunctionType(tf, irFty, nullptr, pointerTo(Type::tvoid));
+  llvm::Type *fptr = LLPointerType::get(getGlobalContext(), gDataLayout->getProgramAddressSpace());
   llvm::Type *types[] = {getOpaquePtrType(), fptr};
   LLStructType *lt = LLStructType::get(gIR->context(), types, false);
 

--- a/ir/irtypestruct.cpp
+++ b/ir/irtypestruct.cpp
@@ -80,7 +80,7 @@ IrTypeStruct *IrTypeStruct::get(StructDeclaration *sd) {
     int realAS = gIR->dcomputetarget->mapping[p->addrspace];
 
     llvm::SmallVector<LLType *, 1> body;
-    body.push_back(LLPointerType::get(DtoMemType(p->type), realAS));
+    body.push_back(LLPointerType::get(getGlobalContext(), realAS));
 
     isaStruct(t->type)->setBody(body, false);
     VarGEPIndices v;

--- a/runtime/druntime/src/ldc/intrinsics.di
+++ b/runtime/druntime/src/ldc/intrinsics.di
@@ -26,6 +26,7 @@ else version (LDC_LLVM_1800) enum LLVM_version = 1800;
 else version (LDC_LLVM_1801) enum LLVM_version = 1801;
 else version (LDC_LLVM_1901) enum LLVM_version = 1901;
 else version (LDC_LLVM_2001) enum LLVM_version = 2001;
+else version (LDC_LLVM_2100) enum LLVM_version = 2100;
 else static assert(false, "LDC LLVM version not supported");
 
 enum LLVM_atleast(int major) = (LLVM_version >= major * 100);


### PR DESCRIPTION
Best reviewed per commit.

I am unsure what the correct value to use for the `llvm::LocationSize` in the case we don't know the size.

There are still a bunch of deprecations from using `InsertPosition` e.g. from `gIR->topallocapoint()` instead of `BasicBlock::iterators` for insertion.