### PR TITLE
Windows: Use proper `--target` switch for clang-cl preprocessor

### DIFF
--- a/driver/cpreprocessor.cpp
+++ b/driver/cpreprocessor.cpp
@@ -124,8 +124,7 @@ FileName runCPreprocessor(FileName csrcfile, Loc loc, OutBuffer &defines) {
       args.push_back("/Zc:preprocessor"); // use the new conforming preprocessor
     } else {
       // propagate the target to the preprocessor
-      args.push_back("-target");
-      args.push_back(triple.getTriple());
+      args.push_back("--target=" + triple.getTriple());
 
 #if LDC_LLVM_VER >= 1800 // getAllProcessorFeatures was introduced in this version
       // propagate all enabled/disabled features to the preprocessor
@@ -146,8 +145,7 @@ FileName runCPreprocessor(FileName csrcfile, Loc loc, OutBuffer &defines) {
 
       // print macro definitions (clang-cl doesn't support /PD - use clang's
       // -dD)
-      args.push_back("-Xclang");
-      args.push_back("-dD");
+      args.push_back("/clang:-dD");
 
       // need to redefine some macros in importc.h
       args.push_back("-Wno-builtin-macro-redefined");

--- a/tests/driver/clang-cl-target-forwarding.d
+++ b/tests/driver/clang-cl-target-forwarding.d
@@ -10,8 +10,8 @@
 // RUN: %ldc -mtriple=aarch64-pc-windows-msvc -mcpu=apple-a10 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=apple-a10
 // RUN: %ldc -mtriple=aarch64-pc-windows-msvc -mcpu=apple-a11 -v -c %S/inputs/preprocessable.c | FileCheck %s -check-prefix=apple-a11
 
-// znver1: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+sse4a}}
-// znver1-sans-sse4a: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-sse4a}}
-// znver2: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+clwb}}
-// apple-a10: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a11}}
-// apple-a11: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*-target[[:space:]]+aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a11}}
+// znver1: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*--target=x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+sse4a}}
+// znver1-sans-sse4a: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*--target=x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-clwb.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-sse4a}}
+// znver2: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*--target=x86_64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+clwb}}
+// apple-a10: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*--target=aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a11}}
+// apple-a11: {{\\cl\.exe[[:space:]]|\\clang-cl\.exe[[:space:]].*--target=aarch64-pc-windows-msvc.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\-apple-a10.*-Xclang[[:space:]]+-target-feature[[:space:]]+-Xclang[[:space:]]+\+apple-a11}}


### PR DESCRIPTION
So that older clang versions don't warn about ignored unknown arguments. `--target=<triple>` is the official syntax used in the `clang-cl /help` output (checked for clang v14 and v20).

Fixes #4834.