### PR TITLE
GHA: Remove now-defunct and superfluous ninja installation

### DIFF
--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -119,9 +119,6 @@ runs:
         sudo ln -sf ld.lld /usr/bin/ld
         ld --version
 
-    - name: Install ninja v1.12.1
-      uses: Ahajha/gha-setup-ninja@69595b0cf872acdad8ce599142fbdc88724b9a2b
-
     - name: Install D host compiler
       uses: dlang-community/setup-dlang@v1
       with:

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -68,8 +68,6 @@ runs:
         ldc2-multilib\bin\ldc2 -link-defaultlib-shared -m32 -run hello.d || exit /b
 
     # preliminary arm64 cross-compilation support
-    - name: Install ninja v1.12.1
-      uses: Ahajha/gha-setup-ninja@69595b0cf872acdad8ce599142fbdc88724b9a2b
     - name: Set VSDIR env variable
       shell: bash
       run: echo "VSDIR=$(vswhere -latest -property installationPath)" >> $GITHUB_ENV

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -54,8 +54,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 50
-      - name: Install ninja
-        uses: symmetryinvestments/gha-setup-ninja@v2
       - name: Install D host compiler
         uses: dlang-community/setup-dlang@v1
         with:


### PR DESCRIPTION
As ninja v1.13.0 comes pre-installed with all GHA images now.