### PR TITLE
Fix recent dynamic-compile regression

### DIFF
--- a/gen/passes/SimplifyDRuntimeCalls.cpp
+++ b/gen/passes/SimplifyDRuntimeCalls.cpp
@@ -184,7 +184,7 @@ Value *ArraySliceCopyOpt::CallOptimizer(Function *Callee, CallInst *CI,
                      IRBuilder<> &B) {
   // Verify we have a reasonable prototype for _d_array_slice_copy
   const FunctionType *FT = Callee->getFunctionType();
-  const llvm::Type *VoidPtrTy = PointerType::get(getGlobalContext(), 0);
+  const llvm::Type *VoidPtrTy = PointerType::get(Callee->getContext(), 0);
   if (Callee->arg_size() != 5 || FT->getReturnType() != B.getVoidTy() ||
       FT->getParamType(0) != VoidPtrTy ||
       !isa<IntegerType>(FT->getParamType(1)) ||


### PR DESCRIPTION
Fix the undefined `getGlobalContext()` symbol for libldc-jit.so, showing up with CircleCI, introduced in #4950.