### PR TITLE
Add -lz when PHOBOS_SYSTEM_ZLIB=on and -link-defaultlib-shared

### DIFF
--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -594,7 +594,7 @@ void ArgsBuilder::build(llvm::StringRef outputPath,
     args.push_back("-l" + name);
   }
 #ifdef PHOBOS_SYSTEM_ZLIB
-  if (!defaultLibNames.empty() && !linkAgainstSharedDefaultLibs())
+  if (!defaultLibNames.empty())
       args.push_back("-lz");
 #endif
 


### PR DESCRIPTION
Some projects use the zlib C function directly and, given that those symbols are available when phobos embeds zlib (the default) and when linking the stdlib statically, the projects often don't include a `-lz` in their build settings. This omission then prevents a successful build with PHOBOS_SYSTEM_ZLIB=on and
-link-defaultlib-shared.

Until a permanent decision is made if those projects should change their build scripts or if the compiler should always add `-lz`, add the library anyway, to minimize breakages.

This also makes the behavior consistent with gdc which also adds an unconditional `-lz` when zlib is not embedded.

See-Also: https://github.com/ldc-developers/ldc/pull/4742