### PR TITLE
Use templated lowering for `_d_newarray*`

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -1578,15 +1578,9 @@ public:
       // get dim
       assert(e->arguments);
       assert(e->arguments->length >= 1);
-      if (e->arguments->length == 1) {
-        DValue *sz = toElem((*e->arguments)[0]);
-        // allocate & init
-        result = DtoNewDynArray(e->loc, e->newtype, sz, true);
-      } else {
-        assert(e->lowering);
-        LLValue *pair = DtoRVal(e->lowering);
-        result = new DSliceValue(e->type, pair);
-      }
+      assert(e->lowering);
+      LLValue *pair = DtoRVal(e->lowering);
+      result = new DSliceValue(e->type, pair);
     }
     // new static array
     else if (ntype->ty == TY::Tsarray) {


### PR DESCRIPTION
I am not sure why, but the dynamic array creation still relies on the old hooks, despite having templated versions of `_d_newarray*` that the expressions are lowered to in `expressionsem`. The old hooks are soon going to be removed, because they were only used by AA hooks but now that is no longer the case.

I did not remove [`DtoNewDynArray`](https://github.com/ldc-developers/ldc/blob/9db6d953149f4698bf017e0ac42f188f58e303a4/gen/arrays.cpp#L616) since it is still used for [ArrayLiteralExp](https://github.com/ldc-developers/ldc/blob/9db6d953149f4698bf017e0ac42f188f58e303a4/gen/toir.cpp#L2391),at least until the templated version of `_d_arrayliteralTX` will be integrated.