### PR TITLE
fiber/switch_context_riscv.S: disable executable stack

### DIFF
--- a/runtime/druntime/src/core/thread/fiber/switch_context_asm.S
+++ b/runtime/druntime/src/core/thread/fiber/switch_context_asm.S
@@ -13,7 +13,7 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 
-#if (__linux__ || __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__) && __ELF__
+#if __ELF__
 /*
  * Mark the resulting object file as not requiring execution permissions on
  * stack memory. The absence of this section would mark the whole resulting

--- a/runtime/druntime/src/core/thread/fiber/switch_context_riscv.S
+++ b/runtime/druntime/src/core/thread/fiber/switch_context_riscv.S
@@ -6,7 +6,7 @@
  * Authors:   Denis Feklushkin
  */
 
-#if (__linux__ || __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__) && __ELF__
+#if __ELF__
 /*
  * Mark the resulting object file as not requiring execution permissions on
  * stack memory. The absence of this section would mark the whole resulting

--- a/runtime/druntime/src/ldc/eh_asm.S
+++ b/runtime/druntime/src/ldc/eh_asm.S
@@ -6,6 +6,7 @@
  * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
  */
 
+#if __ELF__
 /*
  * Mark the resulting object file as not requiring execution
  * permissions on stack memory. The absence of this section would mark
@@ -13,8 +14,6 @@
  * making it impossible to dynamically load druntime on several
  * platforms where this is forbidden due to security policies.
  */
-
-#if (defined(__linux__) || defined(__FreeBSD__)) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 .previous
 #endif


### PR DESCRIPTION
Like it is done for the other assembly files, add the GNU-stack note.