### PR TITLE
[druntime-test] memoryerror_stackoverflow.d: Prevent hangs with >=llv…

### DIFF
--- a/runtime/druntime/test/exceptions/src/memoryerror_stackoverflow.d
+++ b/runtime/druntime/test/exceptions/src/memoryerror_stackoverflow.d
@@ -1,16 +1,19 @@
 import etc.linux.memoryerror;
+import core.volatile;
 
 pragma(inline, false):
 
 void f(ref ubyte[1024] buf)
 {
     ubyte[1024] cpy = buf;
+    volatileStore(&cpy[0], 1);
     g(cpy);
 }
 
 void g(ref ubyte[1024] buf)
 {
     ubyte[1024] cpy = buf;
+    volatileStore(&cpy[0], 2);
     f(cpy);
 }
 


### PR DESCRIPTION
…m-20

Since llvm-20, the stack variables are optimized away leading to an infinite loop. The affected assembly became:
```
Disassembly of section .text._D25memoryerror_stackoverflow1fFKG1024hZv:

0000000000000000 <_D25memoryerror_stackoverflow1fFKG1024hZv>:
   0:	e9 00 00 00 00       	jmp    5 <_D25memoryerror_stackoverflow1fFKG1024hZv+0x5>

Disassembly of section .text._D25memoryerror_stackoverflow1gFKG1024hZv:

0000000000000000 <_D25memoryerror_stackoverflow1gFKG1024hZv>:
   0:	e9 00 00 00 00       	jmp    5 <_D25memoryerror_stackoverflow1gFKG1024hZv+0x5>
```

Compared to the llvm-19 optimized version:
```
Disassembly of section .text._D25memoryerror_stackoverflow1fFKG1024hZv:

0000000000000000 <_D25memoryerror_stackoverflow1fFKG1024hZv>:
   0:	53                   	push   %rbx
   1:	48 81 ec 00 04 00 00 	sub    $0x400,%rsp
   8:	48 89 fe             	mov    %rdi,%rsi
   b:	48 89 e3             	mov    %rsp,%rbx
   e:	ba 00 04 00 00       	mov    $0x400,%edx
  13:	48 89 df             	mov    %rbx,%rdi
  16:	e8 00 00 00 00       	call   1b <_D25memoryerror_stackoverflow1fFKG1024hZv+0x1b>
  1b:	48 89 df             	mov    %rbx,%rdi
  1e:	e8 00 00 00 00       	call   23 <_D25memoryerror_stackoverflow1fFKG1024hZv+0x23>
  23:	48 81 c4 00 04 00 00 	add    $0x400,%rsp
  2a:	5b                   	pop    %rbx
  2b:	c3                   	ret

Disassembly of section .text._D25memoryerror_stackoverflow1gFKG1024hZv:

0000000000000000 <_D25memoryerror_stackoverflow1gFKG1024hZv>:
   0:	53                   	push   %rbx
   1:	48 81 ec 00 04 00 00 	sub    $0x400,%rsp
   8:	48 89 fe             	mov    %rdi,%rsi
   b:	48 89 e3             	mov    %rsp,%rbx
   e:	ba 00 04 00 00       	mov    $0x400,%edx
  13:	48 89 df             	mov    %rbx,%rdi
  16:	e8 00 00 00 00       	call   1b <_D25memoryerror_stackoverflow1gFKG1024hZv+0x1b>
  1b:	48 89 df             	mov    %rbx,%rdi
  1e:	e8 00 00 00 00       	call   23 <_D25memoryerror_stackoverflow1gFKG1024hZv+0x23>
  23:	48 81 c4 00 04 00 00 	add    $0x400,%rsp
  2a:	5b                   	pop    %rbx
  2b:	c3                   	ret
```