### PR TITLE
ldc2.conf dir: Slightly shuffle order and file names, and make `ldc-build-runtime --installWithSuffix` install a .conf file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,11 +67,12 @@ packaging_steps_template: &PACKAGING_STEPS_TEMPLATE
     cd ..
     perl -pi -e s?$PWD/install/?%%ldcbinarypath%%/../?g install/etc/ldc2.conf/*
     if [[ "$CI_OS" == "freebsd" ]]; then
-      cat > install/etc/ldc2.conf/35-ldc-default-CC.conf <<EOF
+      cat > install/etc/ldc2.conf/31-compiler-default-CC.conf <<EOF
+    // Default to the clang version matching LDC's LLVM version.
     "default":
     {
         switches ~= [ "-gcc=${CC}" ];
-    }
+    };
     EOF
     fi
     cp $CIRRUS_WORKING_DIR/{LICENSE,packaging/README} install

--- a/.github/actions/3-build-cross/action.yml
+++ b/.github/actions/3-build-cross/action.yml
@@ -144,7 +144,6 @@ runs:
           --installWithSuffix "" \
           CMAKE_INSTALL_PREFIX="$PWD/install" \
           INCLUDE_INSTALL_DIR="$PWD/install/import" \
-          CONF_INST_DIR="$PWD/install/etc" \
           "${flags[@]}"
 
     - name: Cross-compile LDC executables

--- a/.github/actions/5-install/action.yml
+++ b/.github/actions/5-install/action.yml
@@ -41,24 +41,6 @@ runs:
           cp ldc/packaging/README install/
         fi
 
-    - name: Make portable
-      shell: bash
-      run: |
-        set -eux
-        cd ..
-        absInstallDir="$PWD/install"
-        if [[ '${{ runner.os }}' == Windows ]]; then
-          # /d/a/1/install => D:/a/1/install
-          absInstallDir=$(cygpath --mixed "$absInstallDir")
-        fi
-        confs=( install/etc/ldc2.conf/* )
-        perl -pi -e "s|$absInstallDir/|%%ldcbinarypath%%/../|g" "${confs[@]}"
-        cat "${confs[@]}"
-
-    - name: Rename the installation dir to test portability
-      shell: bash
-      run: mv ../install ../installed
-
     - name: 'Windows: Copy curl & MinGW-w64-based libs'
       if: runner.os == 'Windows'
       shell: bash
@@ -66,7 +48,7 @@ runs:
         set -eux
         cd ..
 
-        cp libcurl/ldc2/* installed/bin/
+        cp libcurl/ldc2/* install/bin/
 
         curl -fL --retry 3 --max-time 60 -o mingw-w64-libs.7z \
           https://github.com/ldc-developers/mingw-w64-libs/releases/download/v8.0.0/mingw-w64-libs-v8.0.0.7z
@@ -80,4 +62,4 @@ runs:
         else
           model=64
         fi
-        cp -r "lib$model" ../installed/lib/mingw
+        cp -r "lib$model" ../install/lib/mingw

--- a/.github/actions/5-install/action.yml
+++ b/.github/actions/5-install/action.yml
@@ -20,11 +20,12 @@ runs:
         else
           # the cross-compiled runtime libs have already been installed:
           # * lib/: runtime library artifacts
-          # * etc/ldc2.conf/30-ldc-runtime-lib.conf
+          # * etc/ldc2.conf/: 50-target-default.conf
 
           # now extend by installing the cross-compiled compiler:
           # * bin/: executables
           # * lib/: LTO plugin and compiler-rt libs
+          # * etc/ldc2.conf/: 00-docs.conf, 30-compiler.conf, 55-target-wasm.conf, 70-compiler-rt.conf
           # * etc/bash_completion.d/
           # * import/: all runtime imports except for ldc/gccbuiltins_*.di
           ninja -C build-cross install

--- a/.github/actions/5a-android-x86/action.yml
+++ b/.github/actions/5a-android-x86/action.yml
@@ -25,11 +25,11 @@ runs:
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
           --installWithSuffix="-android-$arch" \
-          CMAKE_INSTALL_PREFIX="$PWD/installed" \
+          CMAKE_INSTALL_PREFIX="$PWD/install" \
           "${flags[@]}" \
           ANDROID_ABI="$abi" # override the one in CROSS_CMAKE_FLAGS
 
         # patch triple regex in .conf file
-        sed -i "s|\"default\":|\"$arch-.*-linux-android\":|" installed/etc/ldc2.conf/55-target-android-$arch.conf
+        sed -i "s|\"default\":|\"$arch-.*-linux-android\":|" install/etc/ldc2.conf/55-target-android-$arch.conf
         # TODO: append default -gcc switch (x86_64-linux-android30-clang, i686-linux-android29-clang)
-        cat installed/etc/ldc2.conf/55-target-android-$arch.conf
+        cat install/etc/ldc2.conf/55-target-android-$arch.conf

--- a/.github/actions/5a-android-x86/action.yml
+++ b/.github/actions/5a-android-x86/action.yml
@@ -26,10 +26,9 @@ runs:
           --ldcSrcDir="$PWD/ldc" \
           --installWithSuffix="-android-$arch" \
           CMAKE_INSTALL_PREFIX="$PWD/install" \
+          RT_CONF_TRIPLE_REGEX="$arch-.*-linux-android" \
           "${flags[@]}" \
           ANDROID_ABI="$abi" # override the one in CROSS_CMAKE_FLAGS
 
-        # patch triple regex in .conf file
-        sed -i "s|\"default\":|\"$arch-.*-linux-android\":|" install/etc/ldc2.conf/55-target-android-$arch.conf
         # TODO: append default -gcc switch (x86_64-linux-android30-clang, i686-linux-android29-clang)
         cat install/etc/ldc2.conf/55-target-android-$arch.conf

--- a/.github/actions/5a-android-x86/action.yml
+++ b/.github/actions/5a-android-x86/action.yml
@@ -24,7 +24,12 @@ runs:
         bootstrap-ldc/bin/ldc-build-runtime --ninja \
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
-          --installWithSuffix="-$arch" \
+          --installWithSuffix="-android-$arch" \
           CMAKE_INSTALL_PREFIX="$PWD/installed" \
           "${flags[@]}" \
           ANDROID_ABI="$abi" # override the one in CROSS_CMAKE_FLAGS
+
+        # patch triple regex in .conf file
+        sed -i "s|\"default\":|\"$arch-.*-linux-android\":|" installed/etc/ldc2.conf/55-target-android-$arch.conf
+        # TODO: append default -gcc switch (x86_64-linux-android30-clang, i686-linux-android29-clang)
+        cat installed/etc/ldc2.conf/55-target-android-$arch.conf

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -32,6 +32,7 @@ runs:
           CMAKE_OSX_DEPLOYMENT_TARGET="$deployment_target" \
           BUILD_LTO_LIBS=ON
 
+        # overwrite the generated .conf file (need to patch triple regex and append cross-compile flags)
         cat > installed/etc/ldc2.conf/55-target-ios-$arch.conf <<EOF
         "${arch}-apple-ios":
         {

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -32,16 +32,17 @@ runs:
           CMAKE_OSX_DEPLOYMENT_TARGET="$deployment_target" \
           BUILD_LTO_LIBS=ON
 
-        section="\"$arch-apple-ios\":
+        cat > installed/etc/ldc2.conf/55-target-ios-$arch.conf <<EOF
+        "${arch}-apple-ios":
         {
             switches ~= [
-                \"-Xcc=-isysroot\",
-                \"-Xcc=$sysroot\",
+                "-Xcc=-isysroot",
+                "-Xcc=${sysroot}",
             ];
             lib-dirs = [
-                \"%%ldcbinarypath%%/../lib-ios-$arch\",
+                "%%ldcbinarypath%%/../lib-ios-${arch}",
             ];
-            rpath = \"%%ldcbinarypath%%/../lib-ios-$arch\";
-        };"
-        echo "$section" >> installed/etc/ldc2.conf/31-ldc-runtime-lib-ios-$arch.conf
+            rpath = "%%ldcbinarypath%%/../lib-ios-${arch}";
+        };
+        EOF
         cat installed/etc/ldc2.conf/*

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -22,7 +22,7 @@ runs:
             sysroot='/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk'
         fi
 
-        installed/bin/ldc-build-runtime --ninja \
+        install/bin/ldc-build-runtime --ninja \
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
           --installWithSuffix="-ios-$arch" \
@@ -33,7 +33,7 @@ runs:
           BUILD_LTO_LIBS=ON
 
         # overwrite the generated .conf file (need to patch triple regex and append cross-compile flags)
-        cat > installed/etc/ldc2.conf/55-target-ios-$arch.conf <<EOF
+        cat > install/etc/ldc2.conf/55-target-ios-$arch.conf <<EOF
         "${arch}-apple-ios":
         {
             switches ~= [
@@ -46,4 +46,4 @@ runs:
             rpath = "%%ldcbinarypath%%/../lib-ios-${arch}";
         };
         EOF
-        cat installed/etc/ldc2.conf/*
+        cat install/etc/ldc2.conf/*

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -26,24 +26,13 @@ runs:
           --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
           --installWithSuffix="-ios-$arch" \
+          RT_CONF_TRIPLE_REGEX="$arch-apple-ios" \
           CMAKE_SYSTEM_NAME=iOS \
           CMAKE_OSX_SYSROOT="$sysroot" \
           CMAKE_OSX_ARCHITECTURES="$arch" \
           CMAKE_OSX_DEPLOYMENT_TARGET="$deployment_target" \
           BUILD_LTO_LIBS=ON
 
-        # overwrite the generated .conf file (need to patch triple regex and append cross-compile flags)
-        cat > install/etc/ldc2.conf/55-target-ios-$arch.conf <<EOF
-        "${arch}-apple-ios":
-        {
-            switches ~= [
-                "-Xcc=-isysroot",
-                "-Xcc=${sysroot}",
-            ];
-            lib-dirs = [
-                "%%ldcbinarypath%%/../lib-ios-${arch}",
-            ];
-            rpath = "%%ldcbinarypath%%/../lib-ios-${arch}";
-        };
-        EOF
+        # append cross-compile flags to generated .conf file
+        sed -i "" "s|^{\$|{\n    switches ~= [\n        \"-Xcc=-isysroot\",\n        \"-Xcc=${sysroot}\",\n    ];|" install/etc/ldc2.conf/55-target-ios-$arch.conf
         cat install/etc/ldc2.conf/*

--- a/.github/actions/5b-make-portable/action.yml
+++ b/.github/actions/5b-make-portable/action.yml
@@ -1,0 +1,22 @@
+name: Make LDC installation portable
+runs:
+  using: composite
+  steps:
+
+    - name: Make portable
+      shell: bash
+      run: |
+        set -eux
+        cd ..
+        absInstallDir="$PWD/install"
+        if [[ '${{ runner.os }}' == Windows ]]; then
+          # /d/a/1/install => D:/a/1/install
+          absInstallDir=$(cygpath --mixed "$absInstallDir")
+        fi
+        confs=( install/etc/ldc2.conf/* )
+        perl -pi -e "s|$absInstallDir/|%%ldcbinarypath%%/../|g" "${confs[@]}"
+        cat "${confs[@]}"
+
+    - name: Rename the installation dir to test portability
+      shell: bash
+      run: mv ../install ../installed

--- a/.github/actions/merge-macos/action.yml
+++ b/.github/actions/merge-macos/action.yml
@@ -40,14 +40,13 @@ runs:
 
         # ldc2.conf:
 
-        # 1) x86_64 ios config
-        # already present
-        # 2) arm64 ios config
-        cp ../ldc2-arm64/etc/ldc2.conf/31-ldc-runtime-lib-ios-arm64.conf etc/ldc2.conf
-        # 3) x86_64 & arm64 macos
-        rm etc/ldc2.conf/30-ldc-runtime-lib.conf # the old ldc2-x86_64 config
+        # 1) x86_64 iOS: already present (55-target-ios-x86_64.conf)
+        # 2) arm64 iOS config
+        cp ../ldc2-arm64/etc/ldc2.conf/55-target-ios-arm64.conf etc/ldc2.conf/
+        # 3) x86_64 & arm64 macOS
+        rm etc/ldc2.conf/50-target-default.conf # the original x86_64 config
         for arch in x86_64 arm64; do
-          cat > etc/ldc2.conf/30-ldc-runtime-lib-${arch}.conf <<EOF
+          cat > etc/ldc2.conf/50-target-default-${arch}.conf <<EOF
         "${arch}-apple-":
         {
             lib-dirs = [

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -80,8 +80,9 @@ runs:
           --dFlags=-mtriple=aarch64-windows-msvc ^
           "--ldcSrcDir=%CD%" ^
           --installWithSuffix=-windows-arm64 ^
+          RT_CONF_TRIPLE_REGEX="(aarch|arm)64-.*-windows-msvc" ^
           BUILD_LTO_LIBS=ON
-    - name: Patch arm64 .conf file
+    - name: Make arm64 .conf file portable
       shell: bash
       run: |
         set -eux
@@ -89,7 +90,6 @@ runs:
         absInstallDir=$(cygpath --mixed "$PWD")
         conf="etc/ldc2.conf/55-target-windows-arm64.conf"
         sed -i "s|$absInstallDir/|%%ldcbinarypath%%/../|g" $conf
-        sed -i 's@"default":@"(aarch|arm)64-.*-windows-msvc":@' $conf
         cat $conf
     - name: Run arm64 hello-world cross-compilation smoke tests
       shell: cmd

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -79,20 +79,13 @@ runs:
         ldc2-multilib\bin\ldc-build-runtime --ninja ^
           --dFlags=-mtriple=aarch64-windows-msvc ^
           "--ldcSrcDir=%CD%" ^
-          --installWithSuffix=arm64 ^
+          --installWithSuffix=-windows-arm64 ^
           BUILD_LTO_LIBS=ON
-    - name: Add arm64 section to ldc2.conf
+    - name: Patch triple regex in arm64 .conf file
       shell: pwsh
       run: |
         cd ldc2-multilib
-        $conf = '"(aarch|arm)64-.*-windows-msvc":
-        {
-            lib-dirs = [
-                "%%ldcbinarypath%%/../libarm64",
-            ];
-        };
-        '
-        Set-Content etc\ldc2.conf\55-target-windows-arm64.conf $conf
+        (cat etc\ldc2.conf\55-target-windows-arm64.conf).replace('"default":', '"(aarch|arm)64-.*-windows-msvc":') | Set-Content etc\ldc2.conf\55-target-windows-arm64.conf
         cat etc\ldc2.conf\*
     - name: Run arm64 hello-world cross-compilation smoke tests
       shell: cmd
@@ -110,9 +103,9 @@ runs:
         curl -fL --retry 3 --max-time 60 -o libcurl.zip "$url"
         7z x libcurl.zip >/dev/null
         rm libcurl.zip
-        cp curl-*/bin/{libcurl*.dll,curl-ca-bundle.crt} ldc2-multilib/libarm64/
+        cp curl-*/bin/{libcurl*.dll,curl-ca-bundle.crt} ldc2-multilib/lib-windows-arm64/
         rm -rf curl-*
-        mv ldc2-multilib/libarm64/libcurl*.dll ldc2-multilib/libarm64/libcurl.dll
+        mv ldc2-multilib/lib-windows-arm64/libcurl*.dll ldc2-multilib/lib-windows-arm64/libcurl.dll
 
     - name: Pack multilib package
       shell: bash

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -81,12 +81,16 @@ runs:
           "--ldcSrcDir=%CD%" ^
           --installWithSuffix=-windows-arm64 ^
           BUILD_LTO_LIBS=ON
-    - name: Patch triple regex in arm64 .conf file
-      shell: pwsh
+    - name: Patch arm64 .conf file
+      shell: bash
       run: |
+        set -eux
         cd ldc2-multilib
-        (cat etc\ldc2.conf\55-target-windows-arm64.conf).replace('"default":', '"(aarch|arm)64-.*-windows-msvc":') | Set-Content etc\ldc2.conf\55-target-windows-arm64.conf
-        cat etc\ldc2.conf\*
+        absInstallDir=$(cygpath --mixed "$PWD")
+        conf="etc/ldc2.conf/55-target-windows-arm64.conf"
+        sed -i "s|$absInstallDir/|%%ldcbinarypath%%/../|g" $conf
+        sed -i 's@"default":@"(aarch|arm)64-.*-windows-msvc":@' $conf
+        cat $conf
     - name: Run arm64 hello-world cross-compilation smoke tests
       shell: cmd
       run: |

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -20,14 +20,13 @@ runs:
         mv ldc2-*-x64 ldc2-multilib
         cd ldc2-multilib
         mv lib lib64
-        mv etc/ldc2.conf/30-ldc-runtime-{lib,lib64}.conf
         cp -R ../ldc2-x86/lib lib32
         cp ../ldc2-x86/bin/{*.dll,*.pdb,curl-ca-bundle.crt} lib32/
     - name: Merge ldc2.conf
       shell: pwsh
       run: |
         cd ldc2-multilib
-        (cat etc\ldc2.conf\30-ldc-runtime-lib64.conf).replace('%%ldcbinarypath%%/../lib', '%%ldcbinarypath%%/../lib64') | Set-Content etc\ldc2.conf\30-ldc-runtime-lib64.conf
+        (cat etc\ldc2.conf\50-target-default.conf).replace('%%ldcbinarypath%%/../lib', '%%ldcbinarypath%%/../lib64') | Set-Content etc\ldc2.conf\50-target-default.conf
         $conf32 = '"i[3-6]86-.*-windows-msvc":
         {
             lib-dirs = [
@@ -35,7 +34,7 @@ runs:
             ];
         };
         '
-        Set-Content etc\ldc2.conf\31-ldc-runtime-lib32.conf $conf32
+        Set-Content etc\ldc2.conf\55-target-windows-x86.conf $conf32
         cat etc\ldc2.conf\*
 
     - name: Generate hello.d
@@ -93,7 +92,7 @@ runs:
             ];
         };
         '
-        Set-Content etc\ldc2.conf\31-ldc-runtime-libarm64.conf $conf
+        Set-Content etc\ldc2.conf\55-target-windows-arm64.conf $conf
         cat etc\ldc2.conf\*
     - name: Run arm64 hello-world cross-compilation smoke tests
       shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      - name: Install LDC & make portable
+      - name: Install LDC
         uses: ./.github/actions/5-install
         with:
           arch: ${{ matrix.arch }}
@@ -205,6 +205,8 @@ jobs:
         uses: ./.github/actions/5a-ios
         with:
           arch: ${{ matrix.arch }}
+      - name: Make portable
+        uses: ./.github/actions/5b-make-portable
 
       - name: Run a few integration tests against the installed compiler
         uses: ./.github/actions/6-integration-test
@@ -277,7 +279,7 @@ jobs:
           cmake_flags: ${{ matrix.extra_cmake_flags }}
           with_pgo: ${{ matrix.with_pgo }}
 
-      - name: Install LDC & make portable
+      - name: Install LDC
         uses: ./.github/actions/5-install
         with:
           cross_compiling: true
@@ -286,6 +288,8 @@ jobs:
         uses: ./.github/actions/5a-android-x86
         with:
           arch: ${{ matrix.android_x86_arch }}
+      - name: Make portable
+        uses: ./.github/actions/5b-make-portable
 
       - name: Create package & upload artifact(s)
         uses: ./.github/actions/7-package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Frontend, druntime and Phobos are at version ~[2.112.0](https://dlang.org/changelog/2.112.0.html), incl. new command-line options `-extI`, `-dllimport=externalOnly` and `-edition`. (#4949, #4962)
 - **Breaking change for dcompute**: The special `@kernel` UDA is now a function and _**requires**_ parentheses as in `@kernel() void foo(){}`. Optionally you can provide launch dimensions, `@kernel([2,4,8])`, to specify to the compute runtime how the kernel is intended to be launched.
 - ldc2.conf can now be a directory. All the files inside it, ordered naturally, will be concatenated and treated like a big config. (#4954)
+  - Running `ldc-build-runtime --installWithSuffix` now includes installing a target-specific .conf file to that directory. (#4978)
 - **Breaking change for ldc2.conf cmake generation**: The `cmake` build process now generates the `ldc2.conf` and `ldc2_install.conf` as directories. `ldc2*.conf.in` and `ADDITIONAL_DEFAULT_LDC_SWITCHES` have been removed, if you need to add switches check out `makeConfSection` in `LdcConfig.cmake`. (#4954)
 
 #### Platform support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -962,13 +962,9 @@ if(LDC_LLVM_VER GREATER 1599 AND LDC_LLVM_VER LESS 1700)
     list(APPEND switches "-func-specialization-size-threshold=1000000000")
 endif()
 
-if(DEFINED COMPILER_RT_LIBDIR_CONFIG)
-    message(STATUS "Adding ${COMPILER_RT_LIBDIR_CONFIG} to lib-dirs in configuration file")
-endif()
-
 list(APPEND switches "-defaultlib=phobos2-ldc,druntime-ldc")
 
-makeConfSection(NAME "35-ldc-compiler" SECTION "default"
+makeConfSection(NAME "30-compiler" SECTION "default"
     BUILD
     SWITCHES ${switches}
     # -defaultlib is configure in runtime/CMakeLists.txt
@@ -977,12 +973,10 @@ makeConfSection(NAME "35-ldc-compiler" SECTION "default"
         "-I${PROJECT_BINARY_DIR}/import"
         "-I${PROJECT_SOURCE_DIR}/runtime/phobos"
         "-I${PROJECT_SOURCE_DIR}/runtime/jit-rt/d"
-    LIB_DIRS ${COMPILER_RT_LIBDIR_CONFIG}
 
     INSTALL
     SWITCHES ${switches}
     POST_SWITCHES "-I${INCLUDE_INSTALL_DIR}"
-    LIB_DIRS ${COMPILER_RT_LIBDIR_CONFIG}
 )
 
 set(wasm_switches)
@@ -997,11 +991,23 @@ endif()
 # LLD 8+ requires (new) `--export-dynamic` for WebAssembly (https://github.com/ldc-developers/ldc/issues/3023).
 list(APPEND wasm_switches -L--export-dynamic)
 
-makeConfSection(NAME "40-ldc-wasm"
+makeConfSection(NAME "55-target-wasm"
     SECTION "^wasm(32|64)-"
     SWITCHES ${wasm_switches}
     LIB_DIRS OVERRIDE
 )
+
+if(DEFINED COMPILER_RT_LIBDIR_CONFIG)
+    message(STATUS "Adding ${COMPILER_RT_LIBDIR_CONFIG} to lib-dirs in configuration file")
+
+    makeConfSection(NAME "70-compiler-rt" SECTION "default"
+        BUILD
+        LIB_DIRS ${COMPILER_RT_LIBDIR_CONFIG}
+
+        INSTALL
+        LIB_DIRS ${COMPILER_RT_LIBDIR_CONFIG}
+    )
+endif()
 
 #
 # Test and runtime targets. Note that enable_testing() is order-sensitive!

--- a/packaging/windows_installer.iss
+++ b/packaging/windows_installer.iss
@@ -29,10 +29,10 @@ SolidCompression=yes
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "{#LDCDir}\*"; Excludes: "\lib32,\lib64,\libarm64"; DestDir: "{app}"; Components: core; Flags: ignoreversion recursesubdirs
+Source: "{#LDCDir}\*"; Excludes: "\lib32,\lib64,\lib-windows-arm64"; DestDir: "{app}"; Components: core; Flags: ignoreversion recursesubdirs
 Source: "{#LDCDir}\lib64\*"; DestDir: "{app}\lib64"; Components: lib64; Flags: ignoreversion recursesubdirs
 Source: "{#LDCDir}\lib32\*"; DestDir: "{app}\lib32"; Components: lib32; Flags: ignoreversion recursesubdirs
-Source: "{#LDCDir}\libarm64\*"; DestDir: "{app}\libarm64"; Components: libarm64; Flags: ignoreversion recursesubdirs
+Source: "{#LDCDir}\lib-windows-arm64\*"; DestDir: "{app}\lib-windows-arm64"; Components: libarm64; Flags: ignoreversion recursesubdirs
 
 [Components]
 Name: core; Description: "Executables, config file and imports"; Types: full compact custom; Flags: fixed

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -280,7 +280,18 @@ if(SHARED_LIBS_SUPPORTED)
     set(install_rpath "${install_libdir}")
 endif()
 
-makeConfSection(NAME "50-target-default"
+# LIB_SUFFIX is (ab)used by ldc-build-runtime and set to the optional `--installWithSuffix`.
+# If set and non-empty, change the name of the generated .conf file.
+set(conf_base_name "50-target-default")
+if(NOT "${LIB_SUFFIX}" STREQUAL "")
+    if(LIB_SUFFIX MATCHES "^-")
+        set(conf_base_name "55-target${LIB_SUFFIX}")
+    else()
+        set(conf_base_name "55-target-${LIB_SUFFIX}")
+    endif()
+endif()
+
+makeConfSection(NAME "${conf_base_name}"
     SECTION "default"
 
     BUILD

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -283,8 +283,10 @@ endif()
 # This is e.g. set from `ldc-build-runtime --installWithSuffix`.
 set(RT_CONF_BASE_NAME "50-target-default" CACHE STRING "Base name of the generated runtime .conf file")
 
+set(RT_CONF_TRIPLE_REGEX "default" CACHE STRING "Regex for the target triple in the generated runtime .conf file")
+
 makeConfSection(NAME ${RT_CONF_BASE_NAME}
-    SECTION "default"
+    SECTION ${RT_CONF_TRIPLE_REGEX}
 
     BUILD
     SWITCHES ${switches}

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -280,7 +280,7 @@ if(SHARED_LIBS_SUPPORTED)
     set(install_rpath "${install_libdir}")
 endif()
 
-makeConfSection(NAME "30-ldc-runtime-lib${LIB_SUFFIX}"
+makeConfSection(NAME "50-target-default"
     SECTION "default"
 
     BUILD
@@ -304,7 +304,7 @@ if(MULTILIB AND NOT "${TARGET_SYSTEM}" MATCHES "APPLE")
         set(install_rpath "${install_libdir}")
     endif()
 
-    set(name "31-ldc-runtime-lib${MULTILIB_SUFFIX}")
+    set(name "55-target-m${MULTILIB_SUFFIX}")
     set(sectionPlaceholder "LDC_CONF_MULTILIB_TRIPLE_REGEX")
     makeConfSection(NAME "${name}"
         SECTION "${sectionPlaceholder}"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -280,18 +280,10 @@ if(SHARED_LIBS_SUPPORTED)
     set(install_rpath "${install_libdir}")
 endif()
 
-# LIB_SUFFIX is (ab)used by ldc-build-runtime and set to the optional `--installWithSuffix`.
-# If set and non-empty, change the name of the generated .conf file.
-set(conf_base_name "50-target-default")
-if(NOT "${LIB_SUFFIX}" STREQUAL "")
-    if(LIB_SUFFIX MATCHES "^-")
-        set(conf_base_name "55-target${LIB_SUFFIX}")
-    else()
-        set(conf_base_name "55-target-${LIB_SUFFIX}")
-    endif()
-endif()
+# This is e.g. set from `ldc-build-runtime --installWithSuffix`.
+set(RT_CONF_BASE_NAME "50-target-default" CACHE STRING "Base name of the generated runtime .conf file")
 
-makeConfSection(NAME "${conf_base_name}"
+makeConfSection(NAME ${RT_CONF_BASE_NAME}
     SECTION "default"
 
     BUILD

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -170,7 +170,6 @@ void runCMake() {
         args ~= [
             "-DCMAKE_INSTALL_PREFIX=" ~ config.ldcExecutable.dirName.dirName,
             "-DLIB_SUFFIX=" ~ config.installWithSuffix,
-            "-DCONF_INST_DIR=", // don't install/overwrite existing etc/ldc2.conf!
         ];
     }
 

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -171,6 +171,13 @@ void runCMake() {
             "-DCMAKE_INSTALL_PREFIX=" ~ config.ldcExecutable.dirName.dirName,
             "-DLIB_SUFFIX=" ~ config.installWithSuffix,
         ];
+
+        if (config.installWithSuffix.length) {
+            string confSuffix = config.installWithSuffix;
+            if (confSuffix[0] == '-')
+                confSuffix = confSuffix[1 .. $];
+            args ~= "-DRT_CONF_BASE_NAME=55-target-" ~ confSuffix;
+        }
     }
 
     foreach (pair; config.cmakeVars.byPair)

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -173,6 +173,12 @@ void runCMake() {
         ];
 
         if (config.installWithSuffix.length) {
+            if ("RT_CONF_TRIPLE_REGEX" !in config.cmakeVars &&
+                config.cmakeVars.get("CONF_INST_DIR", "unset") != "") {
+                writeln(".: Error: when using a non-empty `--installWithSuffix`, either set the RT_CONF_TRIPLE_REGEX CMake variable, or disable installing the .conf file by setting CONF_INST_DIR to an empty string");
+                exit(1);
+            }
+
             string confSuffix = config.installWithSuffix;
             if (confSuffix[0] == '-')
                 confSuffix = confSuffix[1 .. $];

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -349,7 +349,7 @@ void parseCommandLine(string[] args) {
             "linkerFlags", "Extra C linker flags for shared libraries and testrunner executables (separated by ';')", &config.linkerFlags,
             "j",           "Number of parallel build jobs", &config.numBuildJobs,
             "systemZlib",  "Use system zlib instead of Phobos' vendored version", &config.systemZlib,
-            "installWithSuffix", "Install the built libraries to '<directory containing LDC executable>/../lib<suffix>/'", &config.installWithSuffix,
+            "installWithSuffix", "Install the built libraries to '<directory containing LDC executable>/../lib<suffix>/'. If the libraries are for a cross-compilation target, please set the RT_CONF_TRIPLE_REGEX CMake variable accordingly. Otherwise, you can set CONF_INST_DIR to an empty string to prevent installing the .conf file.", &config.installWithSuffix,
         );
 
         // getopt() has removed all consumed args from `args`


### PR DESCRIPTION
The proposal is to have:
* `00-docs.conf`
* `30-compiler.conf`: 'compiler-specific defaults'
  * The main goal is to add the implicit `-I` post-switch(es) (=> min priority as post-switches) for the bundled druntime/Phobos imports.
  * Might contain LLVM-version-specific hacks, like the `-func-specialization-size-threshold=1000000000` for LLVM 16.
  * Also drags in druntime and Phobos by default (so a normal (pre-)switch, overrideable in a later config file or by the user directly) for linking via `-defaultlib=phobos2-ldc,druntime-ldc`.
* 5X: This is the group for target-specific settings - mainly `lib-dirs` and according `rpath`, as well as potential extra switches (for cross-compilation and/or to default to `-link-defaultlib-shared[=false]` if only one shared/static version of the libs is available). So by far the most interesting group.
  * `50-target-default.conf`: default target settings, applying to *all* targets by default (as safe fallback for all the weird triples one might use for the actual default/native target)
  * `55-target-…`: cross-compilation targets, all overriding the `lib-dirs` (and `rpath` if supported by the target) inherited from the default target, and potentially appending extra switches required for cross-compilation/linking (`-Xcc`, `-gcc`, `-defaultlib` etc.).
* Optionally a `70-compiler-rt.conf` to append a `lib-dir` (in most cases to a directory provided by the system-default LLVM, which might support a few targets). Any `lib-dir` in the target-specific 5X group takes precedence.