### PR TITLE
[LLVM 21] fix calls to `llvm.lifetime.start`

### DIFF
--- a/gen/variable_lifetime.h
+++ b/gen/variable_lifetime.h
@@ -21,12 +21,13 @@ namespace llvm {
 class Function;
 class Type;
 class Value;
+class AllocaInst;
 }
 struct IRState;
 
 struct LocalVariableLifetimeAnnotator {
   struct LocalVariableScope {
-    std::vector<std::pair<llvm::Value *, llvm::Value *>> variables;
+    std::vector<std::pair<llvm::Value *, llvm::AllocaInst *>> variables;
   };
   /// Stack of scopes, each scope can have multiple variables.
   std::vector<LocalVariableScope> scopes;
@@ -52,5 +53,5 @@ public:
   void popScope();
 
   /// Register a new local variable for lifetime annotation.
-  void addLocalVariable(llvm::Value *address, llvm::Value *size);
+  void addLocalVariable(llvm::AllocaInst *address, llvm::Value *size);
 };


### PR DESCRIPTION
This mostly fixes compilation for LLVM21, except for some breakage with regards to moving `llvm.lifetime.start` to taking only and `AllocaInst` (or a `Poison`).

This both produces a call to `@llvm.lifetime.start.p0(ptr captures(none) %0)` and `%0` in this case is an `Argument` not an `AllocaInst`. 

I'm trying to figure out where those calls are coming from. Is it the ABI messing things up somehow? I don't know what is special about those functions.
```
% git grep getLLVMLifetimeStartFn
variable_lifetime.cpp:  irs.CreateCallOrInvoke(getLLVMLifetimeStartFn(),
variable_lifetime.cpp:llvm::Function *LocalVariableLifetimeAnnotator::getLLVMLifetimeStartFn() {
variable_lifetime.h:  llvm::Function *getLLVMLifetimeStartFn();
```
there is only the one use of it and 
```
% git grep lifetime_start
variable_lifetime.cpp:      &irs.module, llvm::Intrinsic::lifetime_start, allocaType);
```