### PR TITLE
[LLVM22] version out removed `TargetOptions.UnsafeFPMath`

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -557,7 +557,7 @@ void setDefaultMathOptions(llvm::TargetOptions &targetOptions) {
     defaultFMF.setFast();
 #if LDC_LLVM_VER < 2200
     targetOptions.UnsafeFPMath = true;
-#if LDC_LLVM_VER < 2200
+#endif
   }
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/164549