### PR TITLE
PowerPC64: Generalize inherit-real-ABI-from-C++-host-compiler logic to all PowerPC64 hosts, not just Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 #### Platform support
 - Supports LLVM 15 - 21.
+- PowerPC64: `real` now matches the C++ host compiler's `long double` when compiling for the native target, not just on Linux hosts. (#5054)
 
 #### Bug fixes
 

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -98,11 +98,12 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
     if (triple.isMusl()) { // Musl uses double
       return LLType::getDoubleTy(ctx);
     }
-#if defined(__linux__) && defined(__powerpc64__)
-    // for a PowerPC64 Linux build:
-    // default to the C++ host compiler's `long double` ABI when targeting
-    // PowerPC64 (non-musl) Linux
-    if (triple.isOSLinux()) {
+#if defined(__powerpc64__)
+    // for a PowerPC64 LDC build:
+    // for native builds (targeting some PowerPC64 with native OS), default to
+    // the C++ host compiler's `long double` ABI
+    auto nativeTriple = llvm::Triple(llvm::sys::getProcessTriple());
+    if (triple.getOS() == nativeTriple.getOS()) {
 #if __LDBL_MANT_DIG__ == 113
       return LLType::getFP128Ty(ctx);
 #elif __LDBL_MANT_DIG__ == 106


### PR DESCRIPTION
Should fix #4959 for FreeBSD.