### PR TITLE
CI Win64: Use clang 21, not v19 currently bundled with VS

### DIFF
--- a/.github/actions/helper-build-ldc/action.yml
+++ b/.github/actions/helper-build-ldc/action.yml
@@ -56,8 +56,8 @@ runs:
           -DCMAKE_BUILD_TYPE=Release ^
           "-DLLVM_ROOT_DIR=%CD%\..\${{ inputs.llvm_dir }}" ^
           "-DD_COMPILER=${{ inputs.host_dc }}" ^
-          -DCMAKE_C_COMPILER=clang-cl ^
-          -DCMAKE_CXX_COMPILER=clang-cl ^
+          "-DCMAKE_C_COMPILER=C:\Program Files\LLVM\bin\clang-cl.exe" ^
+          "-DCMAKE_CXX_COMPILER=C:\Program Files\LLVM\bin\clang-cl.exe" ^
           ${{ inputs.specify_install_dir == 'true' && '"-DCMAKE_INSTALL_PREFIX=%installDir%"' || '' }} ^
           ${{ inputs.specify_install_dir == 'true' && '"-DINCLUDE_INSTALL_DIR=%installDir%\import"' || '' }} ^
           ${{ inputs.cmake_flags }}


### PR DESCRIPTION
Activating the *x64* MSVC environment seems to newly put some bundled `clang-cl` onto PATH first, shadowing the matching version 21 we install into default `C:\Program Files\LLVM`.

No bundled clang-cl for the *x86* environment apparently.