### PR TITLE
PowerPC64: Fix build failure on ppc64le

### DIFF
--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -94,7 +94,7 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
     return LLType::getFP128Ty(ctx);
 
   case Triple::ppc64:
-  case Triple::ppc64le:
+  case Triple::ppc64le: {
     if (triple.isMusl()) { // Musl uses double
       return LLType::getDoubleTy(ctx);
     }
@@ -118,6 +118,7 @@ llvm::Type *getRealType(const llvm::Triple &triple) {
     }
 #endif
     return LLType::getPPC_FP128Ty(ctx);
+  }
 
   default:
     // 64-bit double precision for all other targets


### PR DESCRIPTION
Commit b6e3298ca0f701b2674d6830c0cafc3a4f2ab4df introduced a C++ scoping issue where the `nativeTriple` variable was declared inside a case label without proper braces, causing a "jump to case label crosses initialization" error, breaking the build on ppc64le.

This commit adds the missing braces and fixes the build.

--

Here is the build failure I got:
```
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp: In function ‘llvm::Type* {anonymous}::getRealType(const llvm::Triple&)’:
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:122:3: error: jump to case label
  122 |   default:
      |   ^~~~~~~
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:105:10: note:   crosses initialization of ‘llvm::Triple nativeTriple’
  105 |     auto nativeTriple = llvm::Triple(llvm::sys::getProcessTriple());
      |          ^~~~~~~~~~~~
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘UnknownArch’ not handled in switch [-Wswitch]
   71 |   switch (triple.getArch()) {
      |          ^
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘arm’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘armeb’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘aarch64_32’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘arc’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘avr’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘bpfel’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘bpfeb’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘csky’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘dxil’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘hexagon’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘m68k’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘mips’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘mipsel’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘mips64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘mips64el’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘msp430’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘ppc’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘ppcle’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘r600’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘amdgcn’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘sparc’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘sparcv9’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘sparcel’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘systemz’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘tce’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘tcele’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘thumb’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘thumbeb’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘xcore’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘xtensa’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘nvptx’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘nvptx64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘amdil’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘amdil64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘hsail’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘hsail64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘spir’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘spir64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘spirv’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘spirv32’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘spirv64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘kalimba’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘shave’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘lanai’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘renderscript32’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘renderscript64’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘ve’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:71:10: warning: enumeration value ‘LastArchType’ not handled in switch [-Wswitch]
/builddir/build/BUILD/ldc-1.42.0_beta2-build/ldc-1.42.0-beta2-src/gen/target.cpp:127:1: warning: control reaches end of non-void function [-Wreturn-type]
  127 | }
      | ^
make[2]: *** [CMakeFiles/LDCShared.dir/build.make:905: CMakeFiles/LDCShared.dir/gen/target.cpp.o] Error 1
```