### PR TITLE
CI: Disable flaky `std.experimental.allocator.building_blocks.allocator_list` unittests altogether

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,13 @@ commonSteps: &commonSteps
     - run:
         name: Run defaultlib unittests & druntime integration tests
         when: always
-        command: cd ../build && ctest -j$PARALLELISM --output-on-failure -E "dmd-testsuite|ldc2-unittest|lit-tests" --timeout 120
+        command: |
+          set -ux
+          excludes='dmd-testsuite|lit-tests|ldc2-unittest'
+          # FIXME: https://github.com/dlang/phobos/issues/10730
+          excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
+          cd ../build
+          ctest -j$PARALLELISM --output-on-failure -E "$excludes" --timeout 120
 
 version: 2
 jobs:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,11 +49,9 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
     run_defaultlib_tests_script: |
       # Run defaultlib unittests & druntime integration tests
       cd $CIRRUS_WORKING_DIR/../build
-      excludes="dmd-testsuite|lit-tests|ldc2-unittest"
-      if [[ "$CI_OS" == "freebsd" ]]; then
-        # FIXME: https://github.com/dlang/phobos/issues/10730
-        excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
-      fi
+      excludes='dmd-testsuite|lit-tests|ldc2-unittest'
+      # FIXME: https://github.com/dlang/phobos/issues/10730
+      excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
       ctest -j$PARALLELISM --output-on-failure -E "$excludes" --timeout 120
 
 # Performs the extra packaging steps for jobs producing a prebuilt package.

--- a/.github/actions/4d-test-libs/action.yml
+++ b/.github/actions/4d-test-libs/action.yml
@@ -18,20 +18,18 @@ runs:
           N=$(nproc)
         fi
 
-        excludes="dmd-testsuite|lit-tests|ldc2-unittest"
+        excludes='dmd-testsuite|lit-tests|ldc2-unittest'
+        # FIXME: https://github.com/dlang/phobos/issues/10730
+        excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
         if [[ '${{ runner.os }}-${{ inputs.arch }}' == Linux-aarch64 ]]; then
           if type -P apk &>/dev/null; then
             # FIXME: empty exception backtraces on musl AArch64 with enabled optimizations
             excludes+='|^druntime-test-exceptions-release$'
           fi
         fi
-        if [[ '${{ runner.os }}' == macOS ]]; then
-          # FIXME: https://github.com/dlang/phobos/issues/10730
-          excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
-          if [[ '${{ inputs.arch }}' == x86_64 ]]; then
-            # FIXME: regressed with image bump from macos-13 to macos-15-intel, apparently wrt. getpwnam_r() setting unexpected errno
-            excludes+='|^std.path'
-          fi
+        if [[ '${{ runner.os }}-${{ inputs.arch }}' == macOS-x86_64 ]]; then
+          # FIXME: regressed with image bump from macos-13 to macos-15-intel, apparently wrt. getpwnam_r() setting unexpected errno
+          excludes+='|^std.path'
         fi
 
         ctest -j$N --output-on-failure -E "$excludes" --timeout 120
@@ -50,4 +48,5 @@ runs:
         call "%LDC_VSDIR%\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }} || exit /b
         echo on
         cd build || exit /b
-        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest" --timeout 120 || exit /b
+        # FIXME: https://github.com/dlang/phobos/issues/10730
+        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^std.experimental.allocator.building_blocks.allocator_list" --timeout 120 || exit /b

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -164,10 +164,10 @@ jobs:
         run: |
           set -eux
           excludes='dmd-testsuite|lit-tests|ldc2-unittest'
+          # FIXME: https://github.com/dlang/phobos/issues/10730
+          excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
           if [[ '${{ runner.os }}' == macOS ]]; then
             N=$(sysctl -n hw.logicalcpu)
-            # FIXME: https://github.com/dlang/phobos/issues/10730
-            excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
           else
             N=$(nproc)
           fi


### PR DESCRIPTION
While they seem to more frequently fail on FreeBSD, macOS and musl, they can fail in general, on all platforms (at least glibc Linux too), according to https://github.com/dlang/phobos/pull/10876#issuecomment-3367406468.

I'm not sure if I've ever seen them fail on Windows; skip the unittests there too, just in case; that module is clearly still experimental indeed.