### PR TITLE
Fix compile errors for LLVM 22

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -798,11 +798,11 @@ void createClashingOptions() {
   auto renameAndHide = [&map](const char *from, const char *to) {
     auto i = map.find(from);
     if (i != map.end()) {
-#if LDC_LLVM_VER >= 2300
+#if LDC_LLVM_VER >= 2200
       cl::Option *opt = i->second;
 #else
       cl::Option *opt = i->getValue();
-#endif      
+#endif
       map.erase(i);
       if (to) {
         opt->setArgStr(to);

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -310,11 +310,11 @@ void parseCommandLine(Strings &sourceFiles) {
     if (auto target = lookupTarget("", triple, errMsg)) {
       llvm::errs() << "Targeting " << target->getName() << ". ";
       // this prints the available CPUs and features of the target to stderr...
-#if LDC_LLVM_VER >= 2300
+#if LDC_LLVM_VER >= 2200
       target->createMCSubtargetInfo(triple, "help", "");
 #else
       target->createMCSubtargetInfo(cfg_triple, "help", "");
-#endif    
+#endif
     } else {
       error(Loc(), "%s", errMsg.c_str());
       fatal();

--- a/driver/plugins.cpp
+++ b/driver/plugins.cpp
@@ -25,7 +25,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/ADT/SmallVector.h"
-#if LDC_LLVM_VER >= 2300
+#if LDC_LLVM_VER >= 2200
 #include "llvm/Plugins/PassPlugin.h"
 #else
 #include "llvm/Passes/PassPlugin.h"

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -296,7 +296,7 @@ static std::string getTargetCPU(const llvm::Triple &triple) {
 static const char *getLLVMArchSuffixForARM(llvm::StringRef CPU) {
   return llvm::StringSwitch<const char *>(CPU)
       .Case("strongarm", "v4")
-#if LDC_LLVM_VER >= 2300
+#if LDC_LLVM_VER >= 2200
       .Cases({"arm7tdmi", "arm7tdmi-s", "arm710t"}, "v4t")
       .Cases({"arm720t", "arm9", "arm9tdmi"}, "v4t")
       .Cases({"arm920", "arm920t", "arm922t"}, "v4t")
@@ -417,7 +417,11 @@ const llvm::Target *lookupTarget(const std::string &arch, llvm::Triple &triple,
     }
   } else {
     std::string tempError;
+#if LDC_LLVM_VER >= 2200
+    target = llvm::TargetRegistry::lookupTarget(triple, tempError);
+#else
     target = llvm::TargetRegistry::lookupTarget(triple.getTriple(), tempError);
+#endif
     if (!target) {
       errorMsg = "unable to get target for '" + triple.getTriple() +
                  "', see -version and -mtriple.";

--- a/gen/ctfloat.cpp
+++ b/gen/ctfloat.cpp
@@ -83,7 +83,11 @@ void CTFloat::toAPFloat(const real_t src, APFloat &dst) {
   u.fp = src;
 
   const unsigned sizeInBits = APFloat::getSizeInBits(*apSemantics);
+#if LDC_LLVM_VER >= 2200
+  const APInt bits = APInt(sizeInBits, u.bits);
+#else
   const APInt bits = APInt(sizeInBits, numUint64Parts, u.bits);
+#endif
 
   dst = APFloat(*apSemantics, bits);
 }

--- a/gen/pgo_ASTbased.cpp
+++ b/gen/pgo_ASTbased.cpp
@@ -38,7 +38,17 @@ llvm::cl::opt<bool, false, opts::FlagParser<bool>> enablePGOIndirectCalls(
     "pgo-indirect-calls", llvm::cl::ZeroOrMore, llvm::cl::Hidden,
     llvm::cl::desc("(*) Enable PGO of indirect calls"),
     llvm::cl::init(true));
+
+uint64_t inLittleEndian(uint64_t x) {
+#if LDC_LLVM_VER >= 2200
+  return llvm::support::endian::byte_swap<uint64_t>(x,
+                                                    llvm::endianness::little);
+#else
+  return llvm::support::endian::byte_swap<uint64_t, llvm::endianness::little>(
+      x);
+#endif
 }
+} // anonymous namespace
 
 /// \brief Stable hasher for PGO region counters.
 ///
@@ -115,9 +125,7 @@ public:
 
     // Pass through MD5 if enough work has built up.
     if (Count && Count % NumTypesPerWord == 0) {
-      uint64_t Swapped =
-          llvm::support::endian::byte_swap<uint64_t, llvm::endianness::little>(
-              Working);
+      uint64_t Swapped = inLittleEndian(Working);
       MD5.update(llvm::ArrayRef<uint8_t>((uint8_t *)&Swapped, sizeof(Swapped)));
       Working = 0;
     }
@@ -137,9 +145,7 @@ public:
 
     // Check for remaining work in Working.
     if (Working) {
-      uint64_t Swapped =
-          llvm::support::endian::byte_swap<uint64_t, llvm::endianness::little>(
-              Working);
+      uint64_t Swapped = inLittleEndian(Working);
       MD5.update(llvm::ArrayRef<uint8_t>((uint8_t *)&Swapped, sizeof(Swapped)));
     }
 

--- a/runtime/druntime/src/ldc/intrinsics.di
+++ b/runtime/druntime/src/ldc/intrinsics.di
@@ -23,7 +23,7 @@ else
 else version (LDC_LLVM_1901) enum LLVM_version = 1901;
 else version (LDC_LLVM_2001) enum LLVM_version = 2001;
 else version (LDC_LLVM_2101) enum LLVM_version = 2101;
-else version (LDC_LLVM_2200) enum LLVM_version = 2200;
+else version (LDC_LLVM_2201) enum LLVM_version = 2201;
 else version (LDC_LLVM_2300) enum LLVM_version = 2300;
 else static assert(false, "LDC LLVM version not supported");
 

--- a/tests/plugins/addFuncEntryCall/addFuncEntryCallPass.cpp
+++ b/tests/plugins/addFuncEntryCall/addFuncEntryCallPass.cpp
@@ -13,7 +13,11 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LDC_LLVM_VER >= 2200
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 
 using namespace llvm;
 

--- a/utils/split-file.cpp
+++ b/utils/split-file.cpp
@@ -183,7 +183,7 @@ int main(int argc, const char **argv) {
       argc, argv,
       "Split input into multiple parts separated by regex '^(.|//)--- ' and "
       "extract the part specified by '^(.|//)--- <part>'\n",
-#if LDC_LLVM_VER >= 2300
+#if LDC_LLVM_VER >= 2200
       /*Errs*/nullptr,
 #endif
       /*VFS*/nullptr,


### PR DESCRIPTION
This fixes all compile errors and new deprecations with LLVM 22.1.1 on my Linux box. [There's still an unresolved symbol when trying to link ldc2.]