### PR TITLE
Fix #5095: LDC fails to build on Windows with DMD/MSVC due to real_t confusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ set(ALTERNATIVE_MALLOC_O   ""     CACHE STRING "If specified, adds ALTERNATIVE_M
 # Most linux distributions have a policy of not bundling dependencies like zlib
 set(PHOBOS_SYSTEM_ZLIB OFF CACHE BOOL "Use system zlib instead of Phobos' vendored version")
 
+# Force use of softfloat for compiler
+option(LDC_FORCE_SOFTFLOAT_REAL "Force LDC to be built with 80-bit real in software" OFF)
+
 if(D_VERSION EQUAL 1)
     message(FATAL_ERROR "D version 1 is no longer supported.
 Please consider using D version 2 or checkout the 'd1' git branch for the last version supporting D version 1.")
@@ -135,6 +138,7 @@ if(NOT MSVC_IDE)
 endif()
 
 if(MSVC)
+    set(LDC_FORCE_SOFTFLOAT_REAL ON)
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         message(STATUS "Let D host compiler output 64-bit object files")
         append("-m64" DFLAGS_BASE)
@@ -164,6 +168,11 @@ if(MSVC)
             string(REGEX REPLACE "/Ob[0-2]" "${llvm_ob_flag}" ${flag_var} "${${flag_var}}")
         endif()
     endforeach()
+endif()
+
+if (LDC_FORCE_SOFTFLOAT_REAL)
+    append("-version=LDC_real_softfloat" DFLAGS_LDC)
+    append("-DLDC_real_softfloat" LDC_CXXFLAGS)
 endif()
 
 # Use separate compiler flags for the frontend and for the LDC-specific parts,

--- a/dmd/root/longdouble.d
+++ b/dmd/root/longdouble.d
@@ -11,8 +11,14 @@
 
 module dmd.root.longdouble;
 
-version (CRuntime_Microsoft)
+version (LDC_real_softfloat)
 {
+    version = EnableSoftfloat;
+    alias longdouble = longdouble_soft;
+}
+else version (CRuntime_Microsoft)
+{
+    version = EnableSoftfloat;
     static if (real.sizeof > 8)
         alias longdouble = real;
     else
@@ -23,7 +29,7 @@ else
 
 // longdouble_soft needed when building the backend with
 // Visual C or the frontend with LDC on Windows
-version (CRuntime_Microsoft):
+version (EnableSoftfloat):
 extern (C++):
 nothrow:
 @nogc:
@@ -71,7 +77,7 @@ bool initFPU()
     return true;
 }
 
-version(unittest) version(CRuntime_Microsoft)
+version(unittest)
 extern(D) shared static this()
 {
     initFPU(); // otherwise not guaranteed to be run before pure unittest below

--- a/dmd/root/longdouble.h
+++ b/dmd/root/longdouble.h
@@ -11,7 +11,13 @@
 
 #pragma once
 
-#if !_MSC_VER // has native 10 byte doubles
+#if defined(LDC_real_softfloat)
+#define USE_LONGDOUBLE_SOFTFLOAT 1
+#elif defined(_MSC_VER)
+#define USE_LONGDOUBLE_SOFTFLOAT 1
+#endif
+
+#if !USE_LONGDOUBLE_SOFTFLOAT // has native 10 byte doubles
 #include <stdio.h>
 typedef long double longdouble;
 typedef volatile long double volatile_longdouble;


### PR DESCRIPTION
N.B. not tested

cc @gnavdev28