### PR TITLE
Fix #5027: segfault in DComputeSemanticAnalyser::visit(VarDeclaration)

### DIFF
--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -92,6 +92,9 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
       return;
     }
 
+    if (!decl->type)
+      return;
+
     if (decl->type->ty == TY::Taarray) {
       error(decl->loc, "associative arrays not allowed in `@compute` code");
       stop = true;

--- a/tests/compilable/dcompute_template_import.d
+++ b/tests/compilable/dcompute_template_import.d
@@ -1,0 +1,14 @@
+// Regression test: importing a module with a recursive template via -I and using
+// __traits(compiles, ...) on it should not crash the compiler during dcompute
+// semantic analysis. Previously, the VarDeclaration's type field could be null
+// for error'd template instantiations, causing a segfault in
+// DComputeSemanticAnalyser::visit(VarDeclaration*).
+
+// REQUIRES: target_NVPTX
+// RUN: %ldc -mdcompute-targets=cuda-350 -o- -I%S/inputs %s
+
+@compute(CompileFor.deviceOnly) module tests.compilable.dcompute_template_import;
+import ldc.dcompute;
+import dcompute_testmod;
+
+static assert(!__traits(compiles, { imported!"dcompute_testmod".hasIndirections!(int[]); }));

--- a/tests/compilable/inputs/dcompute_testmod.d
+++ b/tests/compilable/inputs/dcompute_testmod.d
@@ -1,0 +1,5 @@
+template hasIndirections(T)
+{
+    static if (is(T == enum))
+        enum hasIndirections = hasIndirections;
+}


### PR DESCRIPTION
While looking into this issue I noticed that decl->type can sometimes be null when semantic analysis visits VarDeclarations coming from failed template instantiations in imported modules.

This showed up when a @compute module imports a template via -I and checks it with __traits(compiles, ...). In that case the recursive walker can reach a VarDeclaration whose type was never set, and the code was dereferencing decl->type unconditionally when checking for Taarray/Tclass, which leads to a segfault.

I added a small guard for this case. Let me know if this looks reasonable or if there’s a better way to handle it.

Thank you so much

Fixes #5027.