### PR TITLE
Android: Add ImportC definitions

### DIFF
--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -209,11 +209,6 @@ typedef struct {} __SVFloat64_t;
 #define __builtin_va_list va_list
 #define __gnuc_va_list va_list
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
-#define __alignof__(x) _Alignof(x)
-#define __builtin_memmove(a,b,c) memmove(a,b,c)
-#define __builtin_memset(a,b,c) memset(a,b,c)
-#define __builtin_ffs(x) ffs(x)
-#define __builtin_ffsl(x) ffsl(x)
-#define __builtin_ffsll(x) ffsll(x)
+#define __alignof__ _Alignof
 #define __sync_synchronize()
 #endif

--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -209,7 +209,7 @@ typedef struct {} __SVFloat64_t;
 #define __builtin_va_list va_list
 #define __gnuc_va_list va_list
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
-#define __alignof__(x) sizeof(x)
+#define __alignof__(x) _Alignof(x)
 #define __builtin_memmove(a,b,c) memmove(a,b,c)
 #define __builtin_memset(a,b,c) memset(a,b,c)
 #define __builtin_ffs(x) ffs(x)

--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -208,7 +208,11 @@ typedef struct {} __SVFloat64_t;
 #define _VA_LIST
 #define __builtin_va_list va_list
 #define __gnuc_va_list va_list
+
+// This macro resolves the ambiguity between Bionic and library ioctl.
+// https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/ioctl.h
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
-#define __alignof__ _Alignof
+
+#define __alignof__(x) _Alignof(x)
 #define __sync_synchronize()
 #endif

--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -213,6 +213,5 @@ typedef struct {} __SVFloat64_t;
 // https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/ioctl.h
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
 
-#define __alignof__(x) _Alignof(x)
 #define __sync_synchronize()
 #endif

--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -201,3 +201,19 @@ typedef struct {} __SVFloat64_t;
 #if __APPLE__
 #undef __SIZEOF_INT128__
 #endif
+
+#if __ANDROID__
+#undef __SIZEOF_INT128__
+#define __GNUC_VA_LIST
+#define _VA_LIST
+#define __builtin_va_list va_list
+#define __gnuc_va_list va_list
+#define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
+#define __alignof__(x) sizeof(x)
+#define __builtin_memmove(a,b,c) memmove(a,b,c)
+#define __builtin_memset(a,b,c) memset(a,b,c)
+#define __builtin_ffs(x) ffs(x)
+#define __builtin_ffsl(x) ffsl(x)
+#define __builtin_ffsll(x) ffsll(x)
+#define __sync_synchronize()
+#endif


### PR DESCRIPTION
This PR fixes broken ImportC on Android targets. Tested on sqlite3, zlib, lwIP.