### PR TITLE
druntime: Implement va_arg for WebAssembly

### DIFF
--- a/runtime/druntime/src/core/stdc/stdarg.d
+++ b/runtime/druntime/src/core/stdc/stdarg.d
@@ -180,6 +180,24 @@ else version (DigitalMars)
  */
 version (GNU)
     T va_arg(T)(ref va_list ap); // intrinsic
+else version (WebAssembly){
+    pragma(LDC_va_arg)
+    T ldc_va_arg(T)(ref va_list ap);
+    T va_arg(T)(ref va_list ap)
+    {
+        static if (__traits(isScalar, T) || is(T == U*, U))
+        {
+            return ldc_va_arg!T(ap);
+        }
+        else
+        {
+            ap = ap.alignUp!(T.alignof);
+            auto p = cast(T*) ap;
+            ap += T.sizeof.alignUp;
+            return *p;
+        }
+    }
+}
 else
 T va_arg(T)(ref va_list ap)
 {


### PR DESCRIPTION
It uses 'pragma(LDC_va_arg)' to emit the LLVM instruction for scalars and pointers (matches how it's implemented in tocall.cpp), else it falls back to manual pointer arithmetic.

I'm not 100% sure if that's correct.
