### PR TITLE
use `getTerminatorOrNull` for  Windows EH with LLVM23

### DIFF
--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -96,7 +96,7 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
   for (auto bb : srcblocks) {
     llvm::Function *F = bb->getParent();
     auto nbb = llvm::BasicBlock::Create(bb->getContext(), bb->getName());
-
+    // Loop over all instructions, and copy them over.
     for (auto &II : *bb) {
       llvm::Instruction *Inst = &II;
       llvm::Instruction *newInst = nullptr;
@@ -117,7 +117,7 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
         newInst = Inst->clone();
 
       newInst->insertInto(nbb, nbb->end());
-      VMap[Inst] = newInst;
+      VMap[Inst] = newInst; // Add instruction map to value.
       if (unwindTo)
         if (auto dest = getUnwindDest(Inst))
           VMap[dest] = unwindTo;

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -83,7 +83,6 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
                  llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
                  llvm::Value *funclet) {
   llvm::ValueToValueMapTy VMap;
-  
   // map the terminal branch to the new target
   if (continueWith) {
     if (auto term = srcblocks.back()->getTerminator()) {
@@ -119,7 +118,6 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
 
       newInst->insertInto(nbb, nbb->end());
       VMap[Inst] = newInst;
-      
       if (unwindTo)
         if (auto dest = getUnwindDest(Inst))
           VMap[dest] = unwindTo;

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -83,17 +83,21 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
                  llvm::BasicBlock *continueWith, llvm::BasicBlock *unwindTo,
                  llvm::Value *funclet) {
   llvm::ValueToValueMapTy VMap;
+  
   // map the terminal branch to the new target
-  if (continueWith)
-    if (auto term = srcblocks.back()->getTerminator())
-      if (auto succ = term->getSuccessor(0))
-        VMap[succ] = continueWith;
+  if (continueWith) {
+    if (auto term = srcblocks.back()->getTerminator()) {
+      // FIX: Ensure it is actually a terminator before checking successors
+      if (term->isTerminator() && term->getNumSuccessors() > 0) {
+        VMap[term->getSuccessor(0)] = continueWith;
+      }
+    }
+  }
 
   for (auto bb : srcblocks) {
     llvm::Function *F = bb->getParent();
-
     auto nbb = llvm::BasicBlock::Create(bb->getContext(), bb->getName());
-    // Loop over all instructions, and copy them over.
+
     for (auto &II : *bb) {
       llvm::Instruction *Inst = &II;
       llvm::Instruction *newInst = nullptr;
@@ -114,8 +118,8 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
         newInst = Inst->clone();
 
       newInst->insertInto(nbb, nbb->end());
-
-      VMap[Inst] = newInst; // Add instruction map to value.
+      VMap[Inst] = newInst;
+      
       if (unwindTo)
         if (auto dest = getUnwindDest(Inst))
           VMap[dest] = unwindTo;

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -95,6 +95,7 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
 
   for (auto bb : srcblocks) {
     llvm::Function *F = bb->getParent();
+
     auto nbb = llvm::BasicBlock::Create(bb->getContext(), bb->getName());
     // Loop over all instructions, and copy them over.
     for (auto &II : *bb) {
@@ -117,6 +118,7 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
         newInst = Inst->clone();
 
       newInst->insertInto(nbb, nbb->end());
+
       VMap[Inst] = newInst; // Add instruction map to value.
       if (unwindTo)
         if (auto dest = getUnwindDest(Inst))

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -98,9 +98,9 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
 #else
     auto term = srcblocks.back()->getTerminator();
 #endif
-    if (term && term->getNumSuccessors() > 0) {
-      VMap[term->getSuccessor(0)] = continueWith;
-    }
+    if (term)  
+      if (auto succ = term->getSuccessor(0))  
+            VMap[succ] = continueWith;  
   }
 
   for (auto bb : srcblocks) {

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -85,11 +85,13 @@ void cloneBlocks(const std::vector<llvm::BasicBlock *> &srcblocks,
   llvm::ValueToValueMapTy VMap;
   // map the terminal branch to the new target
   if (continueWith) {
-    if (auto term = srcblocks.back()->getTerminator()) {
-      // FIX: Ensure it is actually a terminator before checking successors
-      if (term->isTerminator() && term->getNumSuccessors() > 0) {
-        VMap[term->getSuccessor(0)] = continueWith;
-      }
+#if LLVM_VERSION_MAJOR >= 23
+    auto term = srcblocks.back()->getTerminatorOrNull();
+#else
+    auto term = srcblocks.back()->getTerminator();
+#endif
+    if (term && term->getNumSuccessors() > 0) {
+      VMap[term->getSuccessor(0)] = continueWith;
     }
   }
 

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -36,10 +36,18 @@ void findSuccessors(std::vector<llvm::BasicBlock *> &blocks,
                     llvm::BasicBlock *bb, llvm::BasicBlock *ebb) {
   blocks.push_back(bb);
   if (bb != ebb) {
+#if LLVM_VERSION_MAJOR >= 23
+    assert(bb->getTerminatorOrNull());
+#else
     assert(bb->getTerminator());
+#endif
     for (size_t pos = 0; pos < blocks.size(); ++pos) {
       bb = blocks[pos];
+#if LLVM_VERSION_MAJOR >= 23
+      if (auto term = bb->getTerminatorOrNull()) {
+#else
       if (auto term = bb->getTerminator()) {
+#endif
         llvm::BasicBlock *unwindDest = getUnwindDest(term);
         unsigned cnt = term->getNumSuccessors();
         for (unsigned s = 0; s < cnt; s++) {

--- a/gen/passes/GarbageCollect2Stack.cpp
+++ b/gen/passes/GarbageCollect2Stack.cpp
@@ -611,7 +611,11 @@ static bool mayBeUsedAfterRealloc(Instruction *Def, BasicBlock::iterator Alloc,
 
     // All instructions after the starting point in this block have been
     // accounted for. Look for successors to add to the work list.
+#if LLVM_VERSION_MAJOR >= 23
+    auto *Term = B->getTerminatorOrNull();
+#else
     auto *Term = B->getTerminator();
+#endif
     unsigned SuccCount = Term->getNumSuccessors();
     for (unsigned i = 0; i < SuccCount; i++) {
       BasicBlock *Succ = Term->getSuccessor(i);

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -331,7 +331,11 @@ llvm::BasicBlock::iterator getTerminatorPos(llvm::BasicBlock *bb) {
 }
 #else
 llvm::Instruction *getTerminatorPos(llvm::BasicBlock *bb) {
+#if LLVM_VERSION_MAJOR >= 23
+  return bb->getTerminatorOrNull();
+#else
   return bb->getTerminator();
+#endif
 }
 #endif
 } // anonymous namespace
@@ -374,7 +378,11 @@ llvm::BasicBlock *CleanupScope::run(IRState &irs, llvm::BasicBlock *sourceBlock,
 
     // And convert the BranchInst to the existing branch target to a
     // SelectInst so we can append the other cases to it.
+#if LLVM_VERSION_MAJOR >= 23
+    endBlock()->getTerminatorOrNull()->eraseFromParent();
+#else
     endBlock()->getTerminator()->eraseFromParent();
+#endif
     llvm::Value *sel =
         new llvm::LoadInst(branchSelectorType, branchSelector, "", endBlock());
     llvm::SwitchInst::Create(
@@ -405,7 +413,11 @@ llvm::BasicBlock *CleanupScope::run(IRState &irs, llvm::BasicBlock *sourceBlock,
 
   // We don't know this branch target yet, so add it to the SwitchInst...
   llvm::ConstantInt *const selectorVal = DtoConstUint(exitTargets.size());
+#if LLVM_VERSION_MAJOR >= 23
+  llvm::cast<llvm::SwitchInst>(endBlock()->getTerminatorOrNull())
+#else
   llvm::cast<llvm::SwitchInst>(endBlock()->getTerminator())
+#endif 
       ->addCase(selectorVal, continueWith);
 
   // ... insert the store into the source block...
@@ -428,7 +440,11 @@ llvm::BasicBlock *CleanupScope::runCopying(IRState &irs,
   if (isCatchSwitchBlock(beginBlock()))
     return continueWith;
   if (exitTargets.empty()) {
+#if LLVM_VERSION_MAJOR >= 23
+    if (!endBlock()->getTerminatorOrNull())
+#else
     if (!endBlock()->getTerminator())
+#endif
       // Set up the unconditional branch at the end of the cleanup
       createBranch(continueWith, endBlock());
 
@@ -459,7 +475,11 @@ llvm::BasicBlock *CleanupScope::runCopying(IRState &irs,
     // change the continuation target if the initial branch was created
     // by another instance with unwinding
     if (continueWith)
+#if LLVM_VERSION_MAJOR >= 23
+      if (auto term = endBlock()->getTerminatorOrNull())
+#else
       if (auto term = endBlock()->getTerminator())
+#endif
         if (auto succ = term->getSuccessor(0))
           if (succ != continueWith)
             remapBlocksValue(blocks, succ, continueWith);

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -331,11 +331,7 @@ llvm::BasicBlock::iterator getTerminatorPos(llvm::BasicBlock *bb) {
 }
 #else
 llvm::Instruction *getTerminatorPos(llvm::BasicBlock *bb) {
-#if LLVM_VERSION_MAJOR >= 23
-  return bb->getTerminatorOrNull();
-#else
   return bb->getTerminator();
-#endif
 }
 #endif
 } // anonymous namespace


### PR DESCRIPTION
This PR contains two related fixes for building and running LDC with LLVM trunk on Windows:

**1. MSVC Build Fix:**
- Fixed compilation errors in `cl_options-llvm.cpp` and `llvmhelpers.cpp` to ensure compatibility with LLVM trunk.

**2. cloneBlocks Segfault Fix:**
- Fixed an `0xC0000005` Access Violation in `cloneBlocks` when compiling code with `try-finally` cleanups.
- Added a defensive check `term->isTerminator()` in `ms-cxx-helper.cpp` to prevent crashing when the frontend generates a basic block without a proper terminator (e.g., ending abruptly with a `call` to `__dtor`).