### PR TITLE
Fix building with trunk LLVM23

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1365,7 +1365,7 @@ void printLabelName(std::ostream &target, const char *func_mangle,
   // note: quotes needed for Unicode
   target << '"'
 #if LLVM_VERSION_MAJOR >= 23
-         << gTargetMachine->getMCAsmInfo()->getPrivateLabelPrefix().str()
+         << gTargetMachine->getMCAsmInfo().getPrivateLabelPrefix().str()
 #else
          << gTargetMachine->getMCAsmInfo()->getPrivateGlobalPrefix().str()
 #endif


### PR DESCRIPTION
In trunk llvm23, getMCAsmInfo returns a reference, so I guess we need to use dot here.