### PR TITLE
update-dmd-rewrite.sh: Deal with frontend headers having moved to compiler/include/

### DIFF
--- a/tools/update-dmd-rewrite.sh
+++ b/tools/update-dmd-rewrite.sh
@@ -45,7 +45,7 @@ fi
 # extract a subset of the dmd monorepo (druntime source + tests + Makefiles, dmd source + tests + osmodel.mak)
 git filter-repo --force \
   --path druntime/src --path druntime/test --path druntime/Makefile --path-glob 'druntime/*.mak' \
-  --path compiler/src/dmd --path compiler/test --path compiler/src/osmodel.mak \
+  --path compiler/src/dmd --path compiler/include/dmd --path compiler/test --path compiler/src/osmodel.mak \
   --path src --path test # required to keep git history before upstream druntime-merge (and associated directory movals)
 # remove unused files
 git filter-repo --invert-paths \
@@ -73,6 +73,7 @@ git filter-repo \
   `# move dirs/files` \
   --path-rename druntime/:runtime/druntime/ \
   --path-rename compiler/src/dmd/:dmd/ \
+  --path-rename compiler/include/dmd/:dmd/ \
   --path-rename compiler/test/:tests/dmd/ \
   --path-rename compiler/src/osmodel.mak:dmd/osmodel.mak \
   `# prefix tags` \


### PR DESCRIPTION
By leaving them as-is in our `dmd/` directory, so that the headers stay next to the D modules (locality is nice for e.g. frontend diffs), and our mods to the headers don't cause any conflicts.