### PR TITLE
ldc-build-runtime: require absolute --buildDir for --reset

### DIFF
--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -77,6 +77,14 @@ void prepareBuildDir() {
     if (config.buildDir is null)
         config.buildDir = "ldc-build-runtime.tmp";
 
+    if (config.resetBuildDir && !config.buildDir.isAbsolute) {
+        writefln(".: Error: --reset / --resetOnly requires --buildDir to be an absolute path (got %s)",
+            config.buildDir);
+        exit(1);
+    }
+
+    config.buildDir = config.buildDir.absolutePath;
+
     if (config.buildDir.exists) {
         if (!config.resetBuildDir) {
             writefln(".: Warning: build directory already exists: %s", config.buildDir);
@@ -96,8 +104,6 @@ void prepareBuildDir() {
         writefln(".: Creating build directory: %s", config.buildDir);
         mkdirRecurse(config.buildDir);
     }
-
-    config.buildDir = config.buildDir.absolutePath;
 }
 
 void prepareLdcSource() {


### PR DESCRIPTION
disclaimer i used AI.
When --reset / --resetOnly is passed and --buildDir is a relative path (including the default `ldc-build-runtime.tmp`), the deletion loop resolves the path against the current working directory at the moment the tool runs. If that CWD happens to be a project root — for example `ldc-build-runtime --buildDir=. --reset` invoked from the project — the loop iterates the project's top-level entries and removes every file plus every subdirectory not literally named `ldc-src`. This has destroyed working repositories.

Refuse to proceed when --reset is requested with a relative --buildDir, and resolve the path to absolute before any deletion runs. Builds without --reset continue to accept relative paths unchanged (no deletion happens, so no destruction risk).

note - i got burned pretty badly by this...