### PR TITLE
Fix #5116 - Skip the sematics checks of compiler-generated functions and template instances in dcompute

### DIFF
--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -236,7 +236,13 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     }
       
     Module *m = e->f->getModule();
-    if ((m == nullptr || (hasComputeAttr(m) == DComputeCompileFor::hostOnly)) &&
+    // Template-instantiated functions are cross-module by nature: the template
+    // declaration and the instantiated function live in different modules.
+    // getModule() returns the *declaration* module, which says nothing about
+    // whether the generated code can run on GPU. Skip the module check for them.
+    const bool isTemplateFunc = e->f->isInstantiated() != nullptr;
+    if (!isTemplateFunc &&
+        (m == nullptr || (hasComputeAttr(m) == DComputeCompileFor::hostOnly)) &&
         !isNonComputeCallExpVaild(e)) {
       error(e->loc, "can only call functions from other `@compute` modules in "
                     "`@compute` code");
@@ -247,16 +253,6 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
   void visit(FuncDeclaration *fd) override {
     if (getKernelAttr(fd) && fd->vthis) {
       error(fd->loc, "`@kernel` functions must not require `this`");
-      stop = true;
-      return;
-    }
-
-    // Skip compiler-generated struct support functions (e.g. __xopEquals,
-    // __xopCmp, postblit, destructor). Their bodies may reference non-@compute
-    // templates (such as __equals for static array comparison) that are outside
-    // of user control. They are only codegenerated if actually referenced by
-    // user code, at which point the codegen layer will report any issues.
-    if (fd->isGenerated()) {
       stop = true;
       return;
     }
@@ -275,20 +271,6 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     // as they contain unsupported global variables.
     if (ti->tempdecl == Type::rtinfo || ti->tempdecl == Type::rtinfoImpl) {
       stop = true;
-      return;
-    }
-
-    // Template instantiations for templates declared in non-@compute modules
-    // (e.g. __equals and isEqual from core.internal.array.equality) are
-    // created as a side effect of compiler-generated support functions. They
-    // contain calls back into their declaring (non-@compute) module, which
-    // would produce spurious errors. Skip them.
-    if (ti->tempdecl) {
-      Module *m = ti->tempdecl->getModule();
-      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly) {
-        stop = true;
-        return;
-      }
     }
   }
 

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -234,7 +234,7 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
       stop = true;
       return;
     }
-      
+
     Module *m = e->f->getModule();
     // Template-instantiated functions are cross-module by nature: the template
     // declaration and the instantiated function live in different modules.

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -212,6 +212,11 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     }
   }
   void visit(CallExp *e) override {
+    // Indirect calls via function pointers / delegates have no associated
+    // FuncDeclaration, so there is no module to check.
+    if (!e->f)
+      return;
+
     // SynchronizedStatement is lowered to
     //    Critsec __critsec105; // 105 == line number
     //    _d_criticalenter(& __critsec105); <--
@@ -246,6 +251,16 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
       return;
     }
 
+    // Skip compiler-generated struct support functions (e.g. __xopEquals,
+    // __xopCmp, postblit, destructor). Their bodies may reference non-@compute
+    // templates (such as __equals for static array comparison) that are outside
+    // of user control. They are only codegenerated if actually referenced by
+    // user code, at which point the codegen layer will report any issues.
+    if (fd->isGenerated()) {
+      stop = true;
+      return;
+    }
+
     IF_LOG Logger::println("current function = %s", fd->toChars());
     currentFunction = fd;
   }
@@ -260,6 +275,20 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     // as they contain unsupported global variables.
     if (ti->tempdecl == Type::rtinfo || ti->tempdecl == Type::rtinfoImpl) {
       stop = true;
+      return;
+    }
+
+    // Template instantiations for templates declared in non-@compute modules
+    // (e.g. __equals and isEqual from core.internal.array.equality) are
+    // created as a side effect of compiler-generated support functions. They
+    // contain calls back into their declaring (non-@compute) module, which
+    // would produce spurious errors. Skip them.
+    if (ti->tempdecl) {
+      Module *m = ti->tempdecl->getModule();
+      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly) {
+        stop = true;
+        return;
+      }
     }
   }
 

--- a/tests/compilable/issue5116.d
+++ b/tests/compilable/issue5116.d
@@ -1,10 +1,8 @@
-// Regression test for issue #5116: defining a struct with a static array
-// field in a @compute module previously caused a spurious semantic error
-// ("can only call functions from other `@compute` modules") followed by a
-// null-pointer dereference crash in DComputeSemanticAnalyser::visit(CallExp*).
-// The crash happened because compiler-generated support functions (__xopEquals)
-// triggered instantiation of __equals templates from core.internal.array.equality,
-// whose body contains an indirect call through a function pointer (e->f == null).
+// Issue #5116: defining a struct with a static array field in a @compute
+// module caused DMD to generate __xopEquals, dragging in template
+// instantiations from core.internal.array.equality. The semantic walker
+// then either reported spurious errors on the nested __equals calls or
+// crashed on a null function pointer inside the instantiated body.
 
 // REQUIRES: target_NVPTX
 // RUN: %ldc -mdcompute-targets=cuda-350 %s
@@ -16,4 +14,14 @@ private enum N = 16u;
 
 struct S {
     float[N] data;
+}
+
+@kernel void testEqualExp() {
+    float[N] a, b;
+    bool c = (a == b);
+}
+
+@kernel void testExplicitEquals() {
+    float[N] a, b;
+    bool c = __equals(a, b);
 }

--- a/tests/compilable/issue5116.d
+++ b/tests/compilable/issue5116.d
@@ -1,0 +1,19 @@
+// Regression test for issue #5116: defining a struct with a static array
+// field in a @compute module previously caused a spurious semantic error
+// ("can only call functions from other `@compute` modules") followed by a
+// null-pointer dereference crash in DComputeSemanticAnalyser::visit(CallExp*).
+// The crash happened because compiler-generated support functions (__xopEquals)
+// triggered instantiation of __equals templates from core.internal.array.equality,
+// whose body contains an indirect call through a function pointer (e->f == null).
+
+// REQUIRES: target_NVPTX
+// RUN: %ldc -mdcompute-targets=cuda-350 %s
+
+@compute(CompileFor.deviceOnly) module tests.compilable.issue5116;
+import ldc.dcompute;
+
+private enum N = 16u;
+
+struct S {
+    float[N] data;
+}

--- a/tests/compilable/issue5116.d
+++ b/tests/compilable/issue5116.d
@@ -1,8 +1,7 @@
-// Issue #5116: defining a struct with a static array field in a @compute
-// module caused DMD to generate __xopEquals, dragging in template
-// instantiations from core.internal.array.equality. The semantic walker
-// then either reported spurious errors on the nested __equals calls or
-// crashed on a null function pointer inside the instantiated body.
+// Without this patch, template instantiations from non-@compute modules (e.g.
+// __equals from core.internal.array.equality) were walked, producing spurious errors.
+// And indirect calls via function pointers inside those bodies additionally caused a
+// null-pointer dereference crash.
 
 // REQUIRES: target_NVPTX
 // RUN: %ldc -mdcompute-targets=cuda-350 %s


### PR DESCRIPTION
It is related to #5116 and #5100.

`Shared!(float[N]) tile;` is actually a struct with static array, DMD's semantic analysis automatically generates support functions for such structs, and those functions drag in template instantiations from `non-@compute` modules, which  triggers both the error message and the crash of compiler.
