### PR TITLE
CI: Work around curl.se having dropped official 32-bit Windows builds

### DIFF
--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -173,10 +173,6 @@ runs:
         cd ..
 
         url='https://curl.se/windows/latest.cgi?p=win64-mingw.zip'
-        if [[ '${{ inputs.arch }}' == x86 ]]; then
-          # this is the latest *official* 32-bit build
-          url='https://curl.se/windows/dl-8.15.0_5/curl-8.15.0_5-win32-mingw.zip'
-        fi
 
         curl -fL --retry 3 --max-time 60 -o libcurl.zip "$url"
         mkdir libcurl
@@ -184,10 +180,17 @@ runs:
         7z x ../libcurl.zip >/dev/null
         rm ../libcurl.zip
         mkdir ldc2
-        cp curl-*/bin/{libcurl*.dll,curl-ca-bundle.crt} ldc2/
-        if [[ '${{ inputs.arch }}' != x86 ]]; then
-          mv ldc2/libcurl*.dll ldc2/libcurl.dll
+        if [[ '${{ inputs.arch }}' == x86 ]]; then
+          # The official 32-bit builds were dropped at one point in 2026.
+          # Resort to the 32-bit DLL bundled with LDC v1.42.0.
+          curl -fL --retry 3 --max-time 120 -o ldc32.7z https://github.com/ldc-developers/ldc/releases/download/v1.42.0/ldc2-1.42.0-windows-x86.7z
+          7z x ldc32.7z >/dev/null
+          cp ldc2-1.42.0-windows-x86/bin/libcurl.dll ldc2/
+          rm -rf ldc2-1.42.0-windows-x86 ldc32.7z
+        else
+          cp curl-*/bin/libcurl*.dll ldc2/libcurl.dll
         fi
+        cp curl-*/bin/curl-ca-bundle.crt ldc2/
         ls -lh ldc2/
 
     - name: 'Windows: Set LDC_VSDIR env variable' # to somewhat speed-up MSVC auto-detection

--- a/tests/dmd/runnable/test21757.d
+++ b/tests/dmd/runnable/test21757.d
@@ -1,5 +1,8 @@
 // https://github.com/dlang/dmd/issues/21757
 
+// LDC: ignore MS linker warnings for 32-bit Windows
+// TRANSFORM_OUTPUT(windows32): remove_lines("warning LNK4318: Very long symbol name encountered while producing debug information")
+
 struct S
 {
     void*[300_000] arr; // generates stupidly large symbols for RTImfoImpl!() that crash MS link.exe


### PR DESCRIPTION
They've apparently removed all published 32-bit packages too, not just stopped putting out new 32-bit builds.

Resort to the latest 32-bit DLL bundled with LDC v1.42.0, but use the latest `curl-ca-bundle.crt` from the official x86_64 build.