### PR TITLE
WinEH: Remove dummy _d_{enter,leave}_cleanup calls

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -727,12 +727,6 @@ static void buildRuntimeModule() {
   }
 
   if (useMSVCEH()) {
-    // _d_enter_cleanup(ptr frame)
-    createFwdDecl(LINK::c, boolTy, {"_d_enter_cleanup"}, {voidPtrTy});
-
-    // _d_leave_cleanup(ptr frame)
-    createFwdDecl(LINK::c, voidTy, {"_d_leave_cleanup"}, {voidPtrTy});
-
     // Throwable _d_eh_enter_catch(ptr exception, ClassInfo catchType)
     createFwdDecl(LINK::c, throwableTy, {"_d_eh_enter_catch"},
                   {voidPtrTy, classInfoTy}, {});

--- a/gen/trycatchfinally.cpp
+++ b/gen/trycatchfinally.cpp
@@ -845,15 +845,12 @@ TryCatchFinallyScopes::runCleanupPad(CleanupCursor scope,
   //
   // cleanuppad:
   //   %0 = cleanuppad within %funclet[]
-  //   %frame = nullptr
-  //   if (!_d_enter_cleanup(%frame)) br label %cleanupret
-  //                                  else br label %copy
+  //   br label %copy
   //
   // copy:
   //   invoke _dtor to %cleanupret unwind %unwindTo [ "funclet"(token %0) ]
   //
   // cleanupret:
-  //   _d_leave_cleanup(%frame)
   //   cleanupret %0 unwind %unwindTo
   //
   llvm::BasicBlock *cleanupbb = irs.insertBB("cleanuppad");
@@ -863,28 +860,14 @@ TryCatchFinallyScopes::runCleanupPad(CleanupCursor scope,
 
   llvm::BasicBlock *cleanupret = irs.insertBBAfter(cleanupbb, "cleanupret");
 
-  // preparation to allocate some space on the stack where _d_enter_cleanup
-  //  can place an exception frame (but not done here)
-  auto frame = getNullPtr();
-
   const auto savedInsertPoint = irs.saveInsertPoint();
 
-  auto endFn = getRuntimeFunction(Loc(), irs.module, "_d_leave_cleanup");
-  irs.ir->SetInsertPoint(cleanupret);
-  irs.DBuilder.EmitStopPoint(irs.func()->decl->loc);
-  irs.ir->CreateCall(endFn, frame,
-                     {llvm::OperandBundleDef("funclet", cleanuppad)}, "");
   llvm::CleanupReturnInst::Create(cleanuppad, unwindTo, cleanupret);
 
   auto copybb = cleanupScopes[scope].runCopying(irs, cleanupbb, cleanupret,
                                                 unwindTo, cleanuppad);
 
-  auto beginFn = getRuntimeFunction(Loc(), irs.module, "_d_enter_cleanup");
-  irs.ir->SetInsertPoint(cleanupbb);
-  irs.DBuilder.EmitStopPoint(irs.func()->decl->loc);
-  auto exec = irs.ir->CreateCall(
-      beginFn, frame, {llvm::OperandBundleDef("funclet", cleanuppad)}, "");
-  createBranch(exec, copybb, cleanupret, cleanupbb);
+  createBranch(copybb, cleanupbb);
 
   return cleanupbb;
 }

--- a/runtime/druntime/src/ldc/eh_msvc.d
+++ b/runtime/druntime/src/ldc/eh_msvc.d
@@ -626,22 +626,6 @@ static ~this()
 }
 
 ///////////////////////////////////////////////////////////////
-extern(C) bool _d_enter_cleanup(void* ptr)
-{
-    // currently just used to avoid that a cleanup handler that can
-    // be inferred to not return, is removed by the LLVM optimizer
-    //
-    // TODO: setup an exception handler here (ptr passes the address
-    // of a 40 byte stack area in a parent fuction scope) to deal with
-    // unhandled exceptions during unwinding.
-    return true;
-}
-
-extern(C) void _d_leave_cleanup(void* ptr)
-{
-}
-
-///////////////////////////////////////////////////////////////
 void msvc_eh_init()
 {
     throwInfoMutex = new Mutex;

--- a/tests/debuginfo/msvc_eh.d
+++ b/tests/debuginfo/msvc_eh.d
@@ -28,6 +28,4 @@ void foo_msvc()
         WithDtor swd_2 = { 48 };
     }
     // CHECK-DAG: call {{.*}}@_d_eh_enter_catch{{.*}} !dbg
-    // CHECK-DAG: call {{.*}}@_d_enter_cleanup{{.*}} !dbg
-    // CHECK-DAG: call {{.*}}@_d_leave_cleanup{{.*}} !dbg
 }


### PR DESCRIPTION
Wondering if we really need these - looking at the IR (for #3504) is quite tedious with these calls.