### PR TITLE
Implement native device code embedding for DCompute (PTX and SPIR-V)

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -763,6 +763,10 @@ cl::opt<std::string>
                        cl::desc("Prefix to prepend to the generated kernel files."),
                        cl::init("kernels"),
                        cl::value_desc("prefix"));
+cl::opt<bool>
+    fembedDCompute("fembed-dcompute",
+                   cl::desc("Embed DCompute target code into host module (default: true)"),
+                   cl::init(true));
 #endif
 
 #if defined(LDC_DYNAMIC_COMPILE)

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -144,6 +144,8 @@ extern cl::opt<unsigned> fWarnStackSize;
 extern cl::list<std::string> dcomputeTargets;
 extern cl::opt<std::string> dcomputeFilePrefix;
 extern cl::opt<bool> fembedDCompute;
+#else
+constexpr bool fembedDCompute = false;
 #endif
 
 #if defined(LDC_DYNAMIC_COMPILE)

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -143,6 +143,7 @@ extern cl::opt<unsigned> fWarnStackSize;
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
 extern cl::list<std::string> dcomputeTargets;
 extern cl::opt<std::string> dcomputeFilePrefix;
+extern cl::opt<bool> fembedDCompute;
 #endif
 
 #if defined(LDC_DYNAMIC_COMPILE)

--- a/driver/codegenerator.cpp
+++ b/driver/codegenerator.cpp
@@ -272,6 +272,11 @@ void CodeGenerator::writeAndFreeLLModule(const char *filename) {
   llvm::LLVMRemarkFileHandle diagnosticsOutputFile =
       createAndSetDiagnosticsOutputFile(*ir_, context_, filename);
 
+  if (dcomputeHook_) {
+    dcomputeHook_(&ir_->module);
+    dcomputeHook_ = nullptr;
+  }
+
   writeModule(&ir_->module, filename);
 
   if (diagnosticsOutputFile)

--- a/driver/codegenerator.h
+++ b/driver/codegenerator.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "gen/irstate.h"
+#include <functional>
 
 #if LDC_MLIR_ENABLED
 namespace mlir {
@@ -45,7 +46,12 @@ public:
   void emitMLIR(Module *m);
 #endif
 
+  void setDComputeHook(std::function<void(llvm::Module *)> hook) {
+    dcomputeHook_ = std::move(hook);
+  }
+
 private:
+  std::function<void(llvm::Module *)> dcomputeHook_;
   void prepareLLModule(Module *m);
   void finishLLModule(Module *m);
   void writeAndFreeLLModule(const char *filename);

--- a/driver/dcomputecodegenerator.cpp
+++ b/driver/dcomputecodegenerator.cpp
@@ -21,7 +21,7 @@
 
 DComputeCodeGenManager::DComputeCodeGenManager(llvm::LLVMContext &c) : ctx(c) {}
 void DComputeCodeGenManager::emit(Module *) {}
-void DComputeCodeGenManager::writeModules() {}
+void DComputeCodeGenManager::writeModules(llvm::Module *) {}
 DComputeCodeGenManager::~DComputeCodeGenManager() {}
 
 #else
@@ -86,6 +86,7 @@ DComputeCodeGenManager::DComputeCodeGenManager(llvm::LLVMContext &c) : ctx(c) {
   }
   oldGIR = gIR;
   oldGTargetMachine = gTargetMachine;
+  oldGABI = gABI;
 }
 
 void DComputeCodeGenManager::emit(Module *m) {
@@ -93,17 +94,26 @@ void DComputeCodeGenManager::emit(Module *m) {
     target->emit(m);
     IrDsymbol::resetAll();
   }
+  gIR = oldGIR;
+  gTargetMachine = oldGTargetMachine;
+  gABI = oldGABI;
 }
 
-void DComputeCodeGenManager::writeModules() {
+void DComputeCodeGenManager::writeModules(llvm::Module *hostModule) {
   for (auto &target : targets) {
-    target->writeModule();
+    // Set target machine before writing the module, since writeModule uses it
+    gTargetMachine = target->targetMachine;
+    target->writeModule(hostModule);
   }
+  gIR = oldGIR;
+  gTargetMachine = oldGTargetMachine;
+  gABI = oldGABI;
 }
 
 DComputeCodeGenManager::~DComputeCodeGenManager() {
   gIR = oldGIR;
   gTargetMachine = oldGTargetMachine;
+  gABI = oldGABI;
 }
 
 #endif // LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX

--- a/driver/dcomputecodegenerator.cpp
+++ b/driver/dcomputecodegenerator.cpp
@@ -111,6 +111,9 @@ void DComputeCodeGenManager::writeModules(llvm::Module *hostModule) {
 }
 
 DComputeCodeGenManager::~DComputeCodeGenManager() {
+  for (auto t : targets) {
+    delete t;
+  }
   gIR = oldGIR;
   gTargetMachine = oldGTargetMachine;
   gABI = oldGABI;

--- a/driver/dcomputecodegenerator.h
+++ b/driver/dcomputecodegenerator.h
@@ -16,6 +16,9 @@ namespace llvm {
   class TargetMachine;
 }
 
+class DComputeTarget;
+class TargetABI;
+
 // gets run on modules marked @compute
 // All @compute D modules are emitted into one LLVM module once per target.
 class DComputeCodeGenManager {
@@ -25,9 +28,10 @@ class DComputeCodeGenManager {
   DComputeTarget *createComputeTarget(const std::string &s);
   IRState *oldGIR = nullptr;
   llvm::TargetMachine *oldGTargetMachine = nullptr;
+  TargetABI *oldGABI = nullptr;
 public:
   void emit(Module *m);
-  void writeModules();
+  void writeModules(llvm::Module *hostModule);
 
   DComputeCodeGenManager(llvm::LLVMContext &c);
   ~DComputeCodeGenManager();

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1283,7 +1283,7 @@ void codegenModules(Modules &modules) {
     for (d_size_t i = modules.length; i-- > 0;) {
       Module *const m = modules[i];
 
-      if (m->filetype == FileType::dhdr)
+      if (m->filetype != FileType::d)
         continue;
 
       if (global.params.v.verbose)

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1283,7 +1283,7 @@ void codegenModules(Modules &modules) {
     for (d_size_t i = modules.length; i-- > 0;) {
       Module *const m = modules[i];
 
-      if (m->filetype != FileType::d)
+      if (m->filetype != FileType::d && m->filetype != FileType::c)
         continue;
 
       if (global.params.v.verbose)

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1218,6 +1218,7 @@ void codegenModules(Modules &modules) {
   if (global.params.obj && !modules.empty()) {
     dmd::TimeTraceScope timeScope(TimeTraceEventType::codegenGlobal);
 
+    DComputeCodeGenManager dccg(getGlobalContext());
 #if LDC_MLIR_ENABLED
     mlir::MLIRContext mlircontext;
     ldc::CodeGenerator cg(getGlobalContext(), mlircontext,
@@ -1225,7 +1226,6 @@ void codegenModules(Modules &modules) {
 #else
     ldc::CodeGenerator cg(getGlobalContext(), global.params.oneobj);
 #endif
-    DComputeCodeGenManager dccg(getGlobalContext());
     std::vector<Module *> computeModules;
     // When inlining is enabled, we are calling semantic3 on function
     // declarations, which may _add_ members to the first module in the modules
@@ -1241,23 +1241,7 @@ void codegenModules(Modules &modules) {
       if (m->filetype == FileType::dhdr)
         continue;
 
-      if (global.params.v.verbose)
-        message("code      %s", m->toChars());
-
       const auto atCompute = hasComputeAttr(m);
-      if (atCompute == DComputeCompileFor::hostOnly ||
-          atCompute == DComputeCompileFor::hostAndDevice) {
-        dmd::TimeTraceScope timeScope(
-            TimeTraceEventType::codegenModule,
-            (llvm::Twine("Codegen: module ") + m->toChars()).str().c_str(),
-            m->toChars(), m->loc);
-#if LDC_MLIR_ENABLED
-        if (global.params.output_mlir == OUTPUTFLAGset)
-          cg.emitMLIR(m);
-        else
-#endif
-          cg.emit(m);
-      }
       if (atCompute != DComputeCompileFor::hostOnly) {
         computeModules.push_back(m);
         if (atCompute == DComputeCompileFor::deviceOnly) {
@@ -1271,10 +1255,9 @@ void codegenModules(Modules &modules) {
           }
         }
       }
-      if (global.errors)
-        fatal();
     }
 
+    bool dcomputeWritten = false;
     if (!computeModules.empty()) {
       dmd::TimeTraceScope timeScope("Codegen DCompute device modules");
       for (auto &mod : computeModules) {
@@ -1286,8 +1269,46 @@ void codegenModules(Modules &modules) {
             mod->toChars(), mod->loc);
         dccg.emit(mod);
       }
+      cg.setDComputeHook([&](llvm::Module *m) {
+        if (!dcomputeWritten) {
+          dccg.writeModules(m);
+          dcomputeWritten = true;
+        }
+      });
     }
-    dccg.writeModules();
+
+    bool hasHostModules = false;
+    for (d_size_t i = modules.length; i-- > 0;) {
+      Module *const m = modules[i];
+
+      if (m->filetype == FileType::dhdr)
+        continue;
+
+      if (global.params.v.verbose)
+        message("code      %s", m->toChars());
+
+      const auto atCompute = hasComputeAttr(m);
+      if (atCompute == DComputeCompileFor::hostOnly ||
+          atCompute == DComputeCompileFor::hostAndDevice) {
+        hasHostModules = true;
+        dmd::TimeTraceScope timeScope(
+            TimeTraceEventType::codegenModule,
+            (llvm::Twine("Codegen: module ") + m->toChars()).str().c_str(),
+            m->toChars(), m->loc);
+#if LDC_MLIR_ENABLED
+        if (global.params.output_mlir == OUTPUTFLAGset)
+          cg.emitMLIR(m);
+        else
+#endif
+          cg.emit(m);
+      }
+      if (global.errors)
+        fatal();
+    }
+
+    if (!computeModules.empty() && !hasHostModules) {
+      dccg.writeModules(nullptr);
+    }
 
     // We may have removed all object files, if so don't link.
     if (global.params.objfiles.length == 0)

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1272,7 +1272,7 @@ void codegenModules(Modules &modules) {
       }
       cg.setDComputeHook([&](llvm::Module *m) {
         if (!dcomputeWritten) {
-          dccg.writeModules(m);
+          dccg.writeModules(opts::fembedDCompute ? m : nullptr);
           dcomputeWritten = true;
         }
       });

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -38,6 +38,7 @@
 #include "driver/plugins.h"
 #include "driver/targetmachine.h"
 #include "gen/abi/abi.h"
+#include "ir/irtypestruct.h"
 #include "gen/irstate.h"
 #include "gen/ldctraits.h"
 #include "gen/linkage.h"
@@ -1275,6 +1276,7 @@ void codegenModules(Modules &modules) {
           dcomputeWritten = true;
         }
       });
+      IrTypeStruct::resetDComputeTypes();
     }
 
     bool hasHostModules = false;

--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -20,6 +20,12 @@
 #include "gen/llvmhelpers.h"
 #include "gen/runtime.h"
 #include "ir/irtypestruct.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/GlobalAlias.h"
+#include "llvm/IR/Module.h"
+#include <algorithm>
 
 
 void DComputeTarget::doCodeGen(Module *m) {
@@ -47,10 +53,11 @@ void DComputeTarget::emit(Module *m) {
   gABI = abi;
   gIR = _ir;
   gTargetMachine = targetMachine;
+  modules.push_back(m);
   doCodeGen(m);
 }
 
-void DComputeTarget::writeModule() {
+void DComputeTarget::writeModule(llvm::Module *hostModule) {
   addMetadata();
 
   std::string filename;
@@ -63,6 +70,47 @@ void DComputeTarget::writeModule() {
       FileName::combine(global.params.objdir.ptr, os.str().c_str());
 
   ::writeModule(&_ir->module, path);
+
+  if (hostModule) {
+    auto bufferOrErr = llvm::MemoryBuffer::getFile(path);
+    if (bufferOrErr) {
+      llvm::StringRef ptxString = bufferOrErr.get()->getBuffer();
+      llvm::Constant *ptxConst = llvm::ConstantDataArray::getString(
+          ctx, ptxString, true);
+
+      std::string internalName = "__dcompute_ptx_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
+      
+      auto *gv = new llvm::GlobalVariable(
+          *hostModule,
+          ptxConst->getType(),
+          true, // isConstant
+          llvm::GlobalValue::PrivateLinkage,
+          ptxConst,
+          internalName);
+
+      for (auto *m : modules) {
+        std::string modName = m->toPrettyChars();
+        std::replace(modName.begin(), modName.end(), '.', '_');
+        std::string symName = "__dcompute_ptx_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
+
+        auto *alias = llvm::GlobalAlias::create(
+            ptxConst->getType(),
+            0, // address space
+            llvm::GlobalValue::ExternalLinkage,
+            symName,
+            gv,
+            hostModule);
+
+        if (alias->getName() != symName) {
+          if (auto *existing = hostModule->getNamedValue(symName)) {
+            existing->replaceAllUsesWith(alias);
+            existing->eraseFromParent();
+          }
+          alias->setName(symName);
+        }
+      }
+    }
+  }
 
   delete _ir;
   _ir = nullptr;

--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -70,50 +70,52 @@ void DComputeTarget::writeModule(llvm::Module *hostModule) {
       FileName::combine(global.params.objdir.ptr, os.str().c_str());
 
   ::writeModule(&_ir->module, path);
-
-  if (hostModule) {
-    auto bufferOrErr = llvm::MemoryBuffer::getFile(path);
-    if (bufferOrErr) {
-      llvm::StringRef ptxString = bufferOrErr.get()->getBuffer();
-      llvm::Constant *ptxConst = llvm::ConstantDataArray::getString(
-          ctx, ptxString, true);
-
-      std::string internalName = "__dcompute_ptx_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
-      
-      auto *gv = new llvm::GlobalVariable(
-          *hostModule,
-          ptxConst->getType(),
-          true, // isConstant
-          llvm::GlobalValue::PrivateLinkage,
-          ptxConst,
-          internalName);
-
-      for (auto *m : modules) {
-        std::string modName = m->toPrettyChars();
-        std::replace(modName.begin(), modName.end(), '.', '_');
-        std::string symName = "__dcompute_ptx_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
-
-        auto *alias = llvm::GlobalAlias::create(
-            ptxConst->getType(),
-            0, // address space
-            llvm::GlobalValue::ExternalLinkage,
-            symName,
-            gv,
-            hostModule);
-
-        if (alias->getName() != symName) {
-          if (auto *existing = hostModule->getNamedValue(symName)) {
-            existing->replaceAllUsesWith(alias);
-            existing->eraseFromParent();
-          }
-          alias->setName(symName);
-        }
-      }
-    }
-  }
-
+  
   delete _ir;
   _ir = nullptr;
+
+  if (!hostModule)
+    return;
+
+  auto bufferOrErr = llvm::MemoryBuffer::getFile(path);
+  if (!bufferOrErr)
+    return;
+
+  llvm::StringRef ptxString = bufferOrErr.get()->getBuffer();
+  llvm::Constant *ptxConst = llvm::ConstantDataArray::getString(
+      ctx, ptxString, true);
+
+  std::string internalName = "__dcompute_ptx_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
+  
+  auto *gv = new llvm::GlobalVariable(
+      *hostModule,
+      ptxConst->getType(),
+      true, // isConstant
+      llvm::GlobalValue::PrivateLinkage,
+      ptxConst,
+      internalName);
+
+  for (auto *m : modules) {
+    std::string modName = m->toPrettyChars();
+    std::replace(modName.begin(), modName.end(), '.', '_');
+    std::string symName = "__dcompute_ptx_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
+
+    auto *alias = llvm::GlobalAlias::create(
+        ptxConst->getType(),
+        0, // address space
+        llvm::GlobalValue::ExternalLinkage,
+        symName,
+        gv,
+        hostModule);
+
+    if (alias->getName() != symName) {
+      if (auto *existing = hostModule->getNamedValue(symName)) {
+        existing->replaceAllUsesWith(alias);
+        existing->eraseFromParent();
+      }
+      alias->setName(symName);
+    }
+  }
 }
 
 #endif

--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -81,28 +81,30 @@ void DComputeTarget::writeModule(llvm::Module *hostModule) {
   if (!bufferOrErr)
     return;
 
-  llvm::StringRef ptxString = bufferOrErr.get()->getBuffer();
-  llvm::Constant *ptxConst = llvm::ConstantDataArray::getString(
-      ctx, ptxString, true);
+  llvm::StringRef deviceString = bufferOrErr.get()->getBuffer();
+  llvm::Constant *deviceConst = llvm::ConstantDataArray::getString(
+      ctx, deviceString, true);
 
-  std::string internalName = "__dcompute_" + std::string(binSuffix) + "_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
+  std::string prefix = "__dcompute_" + std::string(binSuffix) + "_" +
+                       std::string(short_name) + std::to_string(tversion);
+  std::string internalName = prefix + "_internal_" + opts::dcomputeFilePrefix;
   
   auto *gv = new llvm::GlobalVariable(
       *hostModule,
-      ptxConst->getType(),
+      deviceConst->getType(),
       true, // isConstant
       llvm::GlobalValue::PrivateLinkage,
-      ptxConst,
+      deviceConst,
       internalName);
   gv->setAlignment(llvm::Align(4));
 
   for (auto *m : modules) {
     std::string modName = m->toPrettyChars();
     std::replace(modName.begin(), modName.end(), '.', '_');
-    std::string symName = "__dcompute_" + std::string(binSuffix) + "_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
+    std::string symName = prefix + "_" + modName;
 
     auto *alias = llvm::GlobalAlias::create(
-        ptxConst->getType(),
+        deviceConst->getType(),
         0, // address space
         llvm::GlobalValue::ExternalLinkage,
         symName,

--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -85,7 +85,7 @@ void DComputeTarget::writeModule(llvm::Module *hostModule) {
   llvm::Constant *ptxConst = llvm::ConstantDataArray::getString(
       ctx, ptxString, true);
 
-  std::string internalName = "__dcompute_ptx_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
+  std::string internalName = "__dcompute_" + std::string(binSuffix) + "_internal_" + std::string(short_name) + std::to_string(tversion) + "_" + opts::dcomputeFilePrefix;
   
   auto *gv = new llvm::GlobalVariable(
       *hostModule,
@@ -94,11 +94,12 @@ void DComputeTarget::writeModule(llvm::Module *hostModule) {
       llvm::GlobalValue::PrivateLinkage,
       ptxConst,
       internalName);
+  gv->setAlignment(llvm::Align(4));
 
   for (auto *m : modules) {
     std::string modName = m->toPrettyChars();
     std::replace(modName.begin(), modName.end(), '.', '_');
-    std::string symName = "__dcompute_ptx_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
+    std::string symName = "__dcompute_" + std::string(binSuffix) + "_" + std::string(short_name) + std::to_string(tversion) + "_" + modName;
 
     auto *alias = llvm::GlobalAlias::create(
         ptxConst->getType(),

--- a/gen/dcompute/target.h
+++ b/gen/dcompute/target.h
@@ -13,6 +13,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Function.h"
 #include <array>
+#include <vector>
 
 namespace llvm {
 class Module;
@@ -38,6 +39,7 @@ public:
   std::array<int, 5> mapping;
 
   IRState *_ir;
+  std::vector<::Module *> modules;
 
   DComputeTarget(llvm::LLVMContext &c, int v, ID id, const char *_short_name,
                  const char *suffix, TargetABI *a, std::array<int, 5> map)
@@ -46,7 +48,7 @@ public:
 
   void emit(Module *m);
   void doCodeGen(Module *m);
-  void writeModule();
+  void writeModule(llvm::Module *hostModule);
 
   virtual void addMetadata() = 0;
   virtual void addKernelMetadata(FuncDeclaration *df,

--- a/gen/dcompute/target.h
+++ b/gen/dcompute/target.h
@@ -46,6 +46,10 @@ public:
       : ctx(c), tversion(v), target(id), short_name(_short_name),
         binSuffix(suffix), abi(a), mapping(map), _ir(nullptr) {}
 
+  virtual ~DComputeTarget() {
+    delete _ir;
+  }
+
   void emit(Module *m);
   void doCodeGen(Module *m);
   void writeModule(llvm::Module *hostModule);

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -16,6 +16,7 @@
 #include "ir/irvar.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
+#include <stdio.h>
 
 using namespace dmd;
 
@@ -84,22 +85,32 @@ void checkStructElems(StructLiteralExp *sle, ArrayParam<Type *> elemTypes) {
 }
 
 /// Returns the StructLiteralExp magic attribute with identifier `id` from
-/// the ldc magic module with identifier `from` (attributes or dcompute)
+/// the ldc magic module with identifier `module_id` (attributes or dcompute)
 /// if it is applied to `sym`, otherwise returns nullptr.
 StructLiteralExp *getMagicAttribute(Dsymbol *sym, const Identifier *id,
-                                    const Identifier *from) {
+                                    const Identifier *module_id) {
   if (!sym->userAttribDecl())
     return nullptr;
-
-  // Loop over all UDAs and early return the expression if a match was found.
+  
   Expressions *attrs = getAttributes(sym->userAttribDecl());
   expandTuples(attrs);
-  for (auto attr : *attrs) {
-    if (auto sle = attr->isStructLiteralExp())
-      if (isFromMagicModule(sle, from) && id == sle->sd->ident)
-        return sle;
-  }
 
+  if (!attrs)
+    return nullptr;
+  for (auto exp : *attrs) {
+    unsigned prevErrors = global.startGagging();
+    auto e = ctfeInterpret(exp);
+    if (global.endGagging(prevErrors))
+      continue;
+
+    if (e->op == EXP::structLiteral) {
+      auto sle = e->isStructLiteralExp();
+      
+      if (sle->sd->ident == id && isFromMagicModule(sle, module_id)) {
+        return sle;
+      }
+    }
+  }
   return nullptr;
 }
 

--- a/tests/codegen/dcompute_dual_targets.d
+++ b/tests/codegen/dcompute_dual_targets.d
@@ -16,10 +16,10 @@ void main(string[] args)
     foo(global_x);
 }
 
-// LL-DAG: __dcompute_ptx_internal_{{.*}} align 4
+// LL-DAG: __dcompute_ptx_{{.*}}_internal_{{.*}} align 4
 // LL-DAG: __dcompute_ptx_{{.*}} ={{.*}}alias
 
-// LL-DAG: __dcompute_spv_internal_{{.*}} align 4
+// LL-DAG: __dcompute_spv_{{.*}}_internal_{{.*}} align 4
 // LL-DAG: __dcompute_spv_{{.*}} ={{.*}}alias
 
 void foo(GlobalPointer!float x_in) {

--- a/tests/codegen/dcompute_dual_targets.d
+++ b/tests/codegen/dcompute_dual_targets.d
@@ -1,0 +1,28 @@
+// Check that we can generate code for both the host and multiple devices in one compiler invocation
+// REQUIRES: target_NVPTX
+// REQUIRES: target_SPIRV
+// RUN: %ldc -c -mdcompute-targets=cuda-350,ocl-220 -m64 -output-ll -mdcompute-file-prefix=dual -I%S/inputs -output-o %s %S/inputs/kernel.d
+// RUN: FileCheck %s --check-prefix=LL < dcompute_dual_targets.ll
+
+import inputs.kernel : k_foo;
+import ldc.dcompute;
+
+void main(string[] args)
+{
+    string s = foo.mangleof;
+    string k_s = k_foo.mangleof;
+
+    GlobalPointer!float global_x;
+    foo(global_x);
+}
+
+// LL: __dcompute_ptx_internal_{{.*}} align 4
+// LL: __dcompute_ptx_{{.*}} ={{.*}}alias
+
+// LL: __dcompute_spv_internal_{{.*}} align 4
+// LL: __dcompute_spv_{{.*}} ={{.*}}alias
+
+void foo(GlobalPointer!float x_in) {
+    SharedPointer!float shared_x;
+    *shared_x = *x_in;
+}

--- a/tests/codegen/dcompute_dual_targets.d
+++ b/tests/codegen/dcompute_dual_targets.d
@@ -16,11 +16,11 @@ void main(string[] args)
     foo(global_x);
 }
 
-// LL: __dcompute_ptx_internal_{{.*}} align 4
-// LL: __dcompute_ptx_{{.*}} ={{.*}}alias
+// LL-DAG: __dcompute_ptx_internal_{{.*}} align 4
+// LL-DAG: __dcompute_ptx_{{.*}} ={{.*}}alias
 
-// LL: __dcompute_spv_internal_{{.*}} align 4
-// LL: __dcompute_spv_{{.*}} ={{.*}}alias
+// LL-DAG: __dcompute_spv_internal_{{.*}} align 4
+// LL-DAG: __dcompute_spv_{{.*}} ={{.*}}alias
 
 void foo(GlobalPointer!float x_in) {
     SharedPointer!float shared_x;

--- a/tests/codegen/dcompute_host_and_device.d
+++ b/tests/codegen/dcompute_host_and_device.d
@@ -22,7 +22,7 @@ void main(string[] args)
     foo(global_x);
 }
 
-// LL: __dcompute_ptx_internal_
+// LL: __dcompute_ptx_{{.*}}_internal_
 // LL: __dcompute_ptx_{{.*}} ={{.*}}alias
 
 void foo(GlobalPointer!float x_in) {

--- a/tests/codegen/dcompute_host_and_device.d
+++ b/tests/codegen/dcompute_host_and_device.d
@@ -22,40 +22,43 @@ void main(string[] args)
     foo(global_x);
 }
 
+// LL: __dcompute_ptx_internal_
+// LL: __dcompute_ptx_{{.*}} ={{.*}}alias
+
 void foo(GlobalPointer!float x_in) {
-    // LL-LABEL: foo
+    // LL-LABEL: define {{.*}}@{{.*}}foo
     SharedPointer!float shared_x;
 	PrivatePointer!float private_x;
 	ConstantPointer!float const_x;
 
-    // LL: [[s_load_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[s_addr_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[s_store_reg:%[0-9]*]] = load float, ptr [[s_addr_reg]]
-    // LL: store float [[s_store_reg]], ptr [[s_load_reg]]
+    // LL: [[s_load_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[s_addr_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[s_store_reg:%[0-9]*]] = load float, ptr{{.*}} [[s_addr_reg]]
+    // LL: store float [[s_store_reg]], ptr{{.*}} [[s_load_reg]]
 	*shared_x = *x_in;
   
-    // LL: [[p_load_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[p_addr_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[p_store_reg:%[0-9]*]] = load float, ptr [[p_addr_reg]]
-    // LL: store float [[p_store_reg]], ptr [[p_load_reg]]
+    // LL: [[p_load_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[p_addr_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[p_store_reg:%[0-9]*]] = load float, ptr{{.*}} [[p_addr_reg]]
+    // LL: store float [[p_store_reg]], ptr{{.*}} [[p_load_reg]]
 	*private_x = *x_in;
   
-    // LL: [[c_load_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[c_addr_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[c_store_reg:%[0-9]*]] = load float, ptr [[c_addr_reg]]
-    // LL: store float [[c_store_reg]], ptr [[c_load_reg]]
+    // LL: [[c_load_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[c_addr_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[c_store_reg:%[0-9]*]] = load float, ptr{{.*}} [[c_addr_reg]]
+    // LL: store float [[c_store_reg]], ptr{{.*}} [[c_load_reg]]
 	*x_in = *const_x;
 
-    // LL: [[g1_load_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[g1_addr_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[g1_store_reg:%[0-9]*]] = load float, ptr [[g1_addr_reg]]
-    // LL: store float [[g1_store_reg]], ptr [[g1_load_reg]]
+    // LL: [[g1_load_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[g1_addr_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[g1_store_reg:%[0-9]*]] = load float, ptr{{.*}} [[g1_addr_reg]]
+    // LL: store float [[g1_store_reg]], ptr{{.*}} [[g1_load_reg]]
     *x_in = *shared_x;
 
-    // LL: [[g2_load_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[g2_addr_reg:%[0-9]*]] = load ptr, ptr {{%[0-9]*}}
-    // LL: [[g2_store_reg:%[0-9]*]] = load float, ptr [[g2_addr_reg]]
-    // LL: store float [[g2_store_reg]], ptr [[g2_load_reg]]
+    // LL: [[g2_load_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[g2_addr_reg:%[0-9]*]] = load ptr{{.*}}, ptr {{%[0-9]*}}
+    // LL: [[g2_store_reg:%[0-9]*]] = load float, ptr{{.*}} [[g2_addr_reg]]
+    // LL: store float [[g2_store_reg]], ptr{{.*}} [[g2_load_reg]]
 	*x_in = *private_x;
 }
 

--- a/tests/codegen/dcompute_no_embed.d
+++ b/tests/codegen/dcompute_no_embed.d
@@ -1,0 +1,23 @@
+// Check that we can disable embedding of device code
+// REQUIRES: target_NVPTX
+// RUN: %ldc -c -mdcompute-targets=cuda-350 -m64 -output-ll -mdcompute-file-prefix=no_embed -fembed-dcompute=false -I%S/inputs -output-o %s %S/inputs/kernel.d
+// RUN: FileCheck %s --check-prefix=LL < dcompute_no_embed.ll
+
+import inputs.kernel : k_foo;
+import ldc.dcompute;
+
+void main(string[] args)
+{
+    string s = foo.mangleof;
+    string k_s = k_foo.mangleof;
+
+    GlobalPointer!float global_x;
+    foo(global_x);
+}
+
+// LL-NOT: __dcompute_ptx_internal_
+
+void foo(GlobalPointer!float x_in) {
+    SharedPointer!float shared_x;
+    *shared_x = *x_in;
+}


### PR DESCRIPTION
                                                                                                                                                                    
  ## Overview                                                                                                                                                                            
  This PR introduces Native device code Embedding for DCompute, enabling device kernels to be natively baked directly into the host executable's `.rodata` section.                                                                                          
                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                         
  ## Key Changes                                                                                                                                                                         
                                                                                                                                                                                         
 ### 1. Native device code Injection (`target.cpp`, `main.cpp`, `codegenerator.cpp`)                                                                                                            
  - Implemented a callback hook (`dcomputeHook_`) in `CodeGenerator` that triggers right before `writeAndFreeLLModule`.                                                                  
  - Used `llvm::GlobalAlias` to intercept and resolve `extern(C)` payload references in the host module, seamlessly pointing them to the actual PTX binary string embedded as an LLVM    
`GlobalVariable`.   
- OpenCL SPIR-V embedding now dynamically assigns the correct `spv` identifier instead of hardcoding `ptx` to prevent naming collisions.Additionally, explicitly enforces a 4-byte memory alignment (`align 4`) on the embedded SPIR-V payload to prevent unaligned memory access crashes on OpenCL drivers.                                                                                                                                                                

 ### 2. ABI Resolution & Codegen Execution Reordering (`main.cpp`)
  - **Bug Fixed:** Previously, if host modules were emitted before device modules, `DtoResolveFunction` would erroneously resolve the kernel function using the host ABI instead of the  
target's `PTX_Kernel` calling convention.
  - **Solution:** Reordered the generation pipeline to ensure `dccg.emit(mod)` executes strictly *before* `cg.emit(m)`, guaranteeing kernels are resolved with the correct device ABI.   
   - **File Type Filtering:** Whitelisted `FileType::c` so that ImportC source modules are safely permitted through the codegen phase alongside standard `.d` files.                      
   
  ### 3. Global State Restoration (`dcomputecodegenerator.cpp`)
  - **Bug Fixed:** Device compilation overrode critical global state (`gIR`, `gTargetMachine`, and `gABI`) with device targets, which subsequently poisoned the host compilation and     
triggered LLVM Verifier failures.
  - **Solution:** `DComputeCodeGenManager::emit` now securely caches `oldGIR`, `oldGTargetMachine`, and `oldGABI` before generating device code, and seamlessly restores the host state  before handing execution back.
### 4. LLVM Context & Type Leakage Fixes
 - **Double Free Fix:** Resolved a double-free bug that occurred during LLVM context teardown by ensuring DCompute targets are always flushed correctly.
  - **Host Codegen Isolation:** Fixed an issue where DCompute types were leaking into host codegen, ensuring device-specific types do not accidentally pollute host IR generation.
  ### 5. CLI Toggles
  
 - **-fembed-dcompute** : Added a new command-line option (defaults to  true ). Users can pass  -fembed-dcompute=false  to bypass the new embedding behavior and fall back exclusively to  emitting standalone  .ptx  /  .spv  files to the disk. (Safeguarded for LLVM builds lacking DCompute support like Android).
  

  ## Testing
  -  Added  tests/codegen/dcompute_dual_targets.d  to verify safe injection and prevent naming collisions when simultaneously generating  -mdcompute-targets=cuda-350,ocl-220 .             
  - Added  tests/codegen/dcompute_no_embed.d  to strictly verify the  -fembed-dcompute=false  fallback logic using  FileCheck .
