### PR TITLE
FreeBSD: add powerpc64 support

### DIFF
--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -143,7 +143,7 @@ const char *getABI(const llvm::Triple &triple, const llvm::SmallVectorImpl<llvm:
   case llvm::Triple::mips64el:
     return "n32";
   case llvm::Triple::ppc64:
-    return "elfv1";
+    return triple.isOSFreeBSD() ? "elfv2" : "elfv1";
   case llvm::Triple::ppc64le:
     return "elfv2";
   case llvm::Triple::riscv64:

--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -269,8 +269,12 @@ TargetABI *TargetABI::getTarget() {
   case llvm::Triple::riscv64:
     return getRISCV64TargetABI();
   case llvm::Triple::ppc:
+    return getPPCTargetABI(false);
   case llvm::Triple::ppc64:
-    return getPPCTargetABI(global.params.targetTriple->isArch64Bit());
+    // FreeBSD powerpc64 is big-endian but uses the ELFv2 ABI, like ppc64le
+    if (global.params.targetTriple->isOSFreeBSD())
+      return getPPC64LETargetABI();
+    return getPPCTargetABI(true);
   case llvm::Triple::ppc64le:
     return getPPC64LETargetABI();
   case llvm::Triple::aarch64:


### PR DESCRIPTION
Use ELFv2 on powerpc64 - FreeBSD switched to ELFv2 in 13.0-RELEASE.