### PR TITLE
DCompute: Skip host-side template instantiations during semantic analysis

### DIFF
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -15,6 +15,7 @@
 #include "dmd/id.h"
 #include "dmd/import.h"
 #include "dmd/init.h"
+#include "dmd/module.h"
 #include "dmd/nspace.h"
 #include "dmd/root/rmem.h"
 #include "dmd/target.h"
@@ -353,13 +354,20 @@ public:
       return;
     }
 
-    if (irs->dcomputetarget && (decl->tempdecl == Type::rtinfo ||
-                                decl->tempdecl == Type::rtinfoImpl)) {
-      // Emitting object.RTInfo(Impl) template instantiations in dcompute
-      // modules would require dcompute support for global variables.
-      Logger::println("Skipping object.RTInfo(Impl) template instantiations "
-                      "in dcompute modules.");
-      return;
+    if (irs->dcomputetarget && decl->tempdecl) {
+      if (decl->tempdecl == Type::rtinfo || decl->tempdecl == Type::rtinfoImpl) {
+        // Emitting object.RTInfo(Impl) template instantiations in dcompute
+        // modules would require dcompute support for global variables.
+        Logger::println("Skipping object.RTInfo(Impl) template instantiations "
+                        "in dcompute modules.");
+        return;
+      }
+      Module *m = decl->tempdecl->getModule();
+      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly) {
+        Logger::println("Skipping host-side template instantiations "
+                        "in dcompute modules.");
+        return;
+      }
     }
 
     for (auto &m : *decl->members) {

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -260,6 +260,16 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     // as they contain unsupported global variables.
     if (ti->tempdecl == Type::rtinfo || ti->tempdecl == Type::rtinfoImpl) {
       stop = true;
+      return;
+    }
+    
+    // Skip host-side template instantiations (like TypeInfo or std.stdio)
+    if (ti->tempdecl) {
+      Module *m = ti->tempdecl->getModule();
+      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly) {
+        stop = true;
+        return;
+      }
     }
   }
 

--- a/tests/compilable/dcompute_host_template_test.d
+++ b/tests/compilable/dcompute_host_template_test.d
@@ -1,4 +1,6 @@
 // RUN: %ldc -c -mdcompute-targets=cuda-350 -I%S %s
+// RUN: not %ldc -o- -mdcompute-targets=cuda-350 -verrors=0 -I%S -d-version=Fail %s 2>&1 | FileCheck %s
+
 @compute(CompileFor.deviceOnly) module dcompute_host_template_test;
 import ldc.dcompute;
 import inputs.host_template_module;
@@ -8,4 +10,9 @@ void kernel() {
     // This should compile successfully because DCompute semantic analysis
     // should skip over host-only template instantiations.
     alias X = HostTemplate!int;
+
+    version(Fail) {
+        // CHECK: dcompute_host_template_test.d([[@LINE+1]]): Error: can only call functions from other `@compute` modules in `@compute` code
+        X.doHostThings();
+    }
 }

--- a/tests/compilable/dcompute_host_template_test.d
+++ b/tests/compilable/dcompute_host_template_test.d
@@ -1,0 +1,11 @@
+// RUN: %ldc -c -mdcompute-targets=cuda-350 -I%S %s
+@compute(CompileFor.deviceOnly) module dcompute_host_template_test;
+import ldc.dcompute;
+import inputs.host_template_module;
+
+void kernel() {
+    // Instantiate a template that resides in a hostOnly module.
+    // This should compile successfully because DCompute semantic analysis
+    // should skip over host-only template instantiations.
+    alias X = HostTemplate!int;
+}

--- a/tests/compilable/dcompute_host_template_test.d
+++ b/tests/compilable/dcompute_host_template_test.d
@@ -1,5 +1,5 @@
 // RUN: %ldc -c -mdcompute-targets=cuda-350 -I%S %s
-// RUN: not %ldc -o- -mdcompute-targets=cuda-350 -verrors=0 -I%S -d-version=Fail %s 2>&1 | FileCheck %s
+// RUN: not %ldc -o- -mdcompute-targets=cuda-350 -verrors=0 -I%S -d-version=Fail %s 2>&1 | FileCheck %s --check-prefix=FAIL
 
 @compute(CompileFor.deviceOnly) module dcompute_host_template_test;
 import ldc.dcompute;
@@ -12,7 +12,7 @@ void kernel() {
     alias X = HostTemplate!int;
 
     version(Fail) {
-        // CHECK: dcompute_host_template_test.d([[@LINE+1]]): Error: can only call functions from other `@compute` modules in `@compute` code
+        // FAIL: dcompute_host_template_test.d([[@LINE+1]]): Error: can only call functions from other `@compute` modules in `@compute` code
         X.doHostThings();
     }
 }

--- a/tests/compilable/inputs/host_template_module.d
+++ b/tests/compilable/inputs/host_template_module.d
@@ -1,0 +1,10 @@
+module inputs.host_template_module;
+
+template HostTemplate(T) {
+    // Global variables are not allowed in @compute device code!
+    // Without the fix, DCompute semantic analysis will process this
+    // instantiation and erroneously emit an error for the global variable.
+    int unsupportedGlobalVar = 42;
+    
+    void doHostThings() { }
+}


### PR DESCRIPTION
   When a `@compute` device module instantiates a template that resides in a normal, host-only module (like `std.stdio` or internal runtime `TypeInfo` templates), the DCompute semantic  visitor previously attempted to fully analyze those instantiations. Because host-side templates frequently contain constructs that are explicitly banned in `@compute` code (such as global variables, classes, or unsupported function calls), this resulted in spurious compilation errors that prevented otherwise valid code from compiling.
  
 **Fix**
    We now check the module where the template is declared (`ti->tempdecl->getModule()`). If the declaring module does not have a `@compute` attribute (meaning it resolves to `CompileFor.
  hostOnly`), we explicitly skip DCompute semantic analysis for that specific instantiation. 
  **Tests**
    - Added a new compilable test case (`tests/compilable/dcompute_host_template_test.d`) which imports a mock host-only module and instantiates a template containing an unsupported      
  global variable.
    - Verified that it correctly bypasses semantic analysis and compiles successfully.

 
