### PR TITLE
Fix #5135: Prevent CondExp from dropping address spaces

### DIFF
--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2173,7 +2173,7 @@ public:
       llvm::Type *ptrType = nullptr;
       if (u_val) ptrType = u_val->getType();
       else if (v_val) ptrType = v_val->getType();
-      else ptrType = DtoPtrToType(dtype);
+      else ptrType = getOpaquePtrType();
 
       if (u_bb && v_bb) {
         llvm::PHINode *phi = p->ir->CreatePHI(ptrType, 2, "condtmp");

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2179,6 +2179,8 @@ public:
         ptrType = v_val->getType();
       }
 
+      LLValue *val = nullptr;
+
       if (u_bb && v_bb) {
         llvm::PHINode *phi = p->ir->CreatePHI(ptrType, 2, "condtmp");
         
@@ -2194,21 +2196,29 @@ public:
         }
         phi->addIncoming(v_inc, v_bb);
         
-        result = new DLValue(e->type, phi);
+        val = phi;
       } else if (u_bb) {
         LLValue *u_inc = u_val ? u_val : llvm::UndefValue::get(ptrType);
         if (u_inc->getType() != ptrType) {
           u_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(u_inc, ptrType);
         }
-        result = new DLValue(e->type, u_inc);
+        val = u_inc;
       } else if (v_bb) {
         LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
         if (v_inc->getType() != ptrType) {
           v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
         }
-        result = new DLValue(e->type, v_inc);
+        val = v_inc;
       } else {
-        result = new DLValue(e->type, llvm::UndefValue::get(ptrType));
+        val = llvm::UndefValue::get(ptrType);
+      }
+
+      if (auto du = u ? u->isDDcomputeLVal() : nullptr) {
+        result = new DDcomputeLValue(e->type, du->lltype, val);
+      } else if (auto dv = v ? v->isDDcomputeLVal() : nullptr) {
+        result = new DDcomputeLValue(e->type, dv->lltype, val);
+      } else {
+        result = new DLValue(e->type, val);
       }
     } else if (retPtr) {
       result = new DLValue(e->type, retPtr);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2170,19 +2170,26 @@ public:
 
     p->ir->SetInsertPoint(condend);
     if (isLvalue) {
-      if (u_bb && v_bb && u_val && v_val) {
-        llvm::Type *phiType = u_val->getType();
-        llvm::PHINode *phi = p->ir->CreatePHI(phiType, 2, "condtmp");
-        phi->addIncoming(u_val, u_bb);
-        if (v_val->getType() != phiType) {
-          v_val = DtoBitCast(v_val, phiType);
+      llvm::Type *ptrType = nullptr;
+      if (u_val) ptrType = u_val->getType();
+      else if (v_val) ptrType = v_val->getType();
+      else ptrType = DtoPtrToType(dtype);
+
+      if (u_bb && v_bb) {
+        llvm::PHINode *phi = p->ir->CreatePHI(ptrType, 2, "condtmp");
+        phi->addIncoming(u_val ? u_val : llvm::UndefValue::get(ptrType), u_bb);
+        LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
+        if (v_inc->getType() != ptrType) {
+          v_inc = DtoBitCast(v_inc, ptrType);
         }
-        phi->addIncoming(v_val, v_bb);
+        phi->addIncoming(v_inc, v_bb);
         result = new DLValue(e->type, phi);
-      } else if (u_bb && u_val) {
-        result = new DLValue(e->type, u_val);
-      } else if (v_bb && v_val) {
-        result = new DLValue(e->type, v_val);
+      } else if (u_bb) {
+        result = new DLValue(e->type, u_val ? u_val : llvm::UndefValue::get(ptrType));
+      } else if (v_bb) {
+        result = new DLValue(e->type, v_val ? v_val : llvm::UndefValue::get(ptrType));
+      } else {
+        result = new DLValue(e->type, llvm::UndefValue::get(ptrType));
       }
     } else if (retPtr) {
       result = new DLValue(e->type, retPtr);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2179,36 +2179,27 @@ public:
         ptrType = v_val->getType();
       }
 
+      // Coerce a branch value to ptrType, substituting undef for a missing
+      // branch. Bitcast/addrspacecast keeps the address space intact.
+      auto incomingFor = [&](LLValue *branchVal) {
+        LLValue *inc = branchVal ? branchVal : llvm::UndefValue::get(ptrType);
+        if (inc->getType() != ptrType) {
+          inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(inc, ptrType);
+        }
+        return inc;
+      };
+
       LLValue *val = nullptr;
 
       if (u_bb && v_bb) {
         llvm::PHINode *phi = p->ir->CreatePHI(ptrType, 2, "condtmp");
-        
-        LLValue *u_inc = u_val ? u_val : llvm::UndefValue::get(ptrType);
-        if (u_inc->getType() != ptrType) {
-          u_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(u_inc, ptrType);
-        }
-        phi->addIncoming(u_inc, u_bb);
-        
-        LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
-        if (v_inc->getType() != ptrType) {
-          v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
-        }
-        phi->addIncoming(v_inc, v_bb);
-        
+        phi->addIncoming(incomingFor(u_val), u_bb);
+        phi->addIncoming(incomingFor(v_val), v_bb);
         val = phi;
       } else if (u_bb) {
-        LLValue *u_inc = u_val ? u_val : llvm::UndefValue::get(ptrType);
-        if (u_inc->getType() != ptrType) {
-          u_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(u_inc, ptrType);
-        }
-        val = u_inc;
+        val = incomingFor(u_val);
       } else if (v_bb) {
-        LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
-        if (v_inc->getType() != ptrType) {
-          v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
-        }
-        val = v_inc;
+        val = incomingFor(v_val);
       } else {
         val = llvm::UndefValue::get(ptrType);
       }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2113,10 +2113,12 @@ public:
     PGO.setCurrentStmt(e);
 
     Type *dtype = e->type->toBasetype();
+    const bool isLvalue = e->isLvalue();
     LLValue *retPtr = nullptr;
     if (!(dtype->ty == TY::Tvoid || dtype->ty == TY::Tnoreturn)) {
-      // allocate a temporary for pointer to the final result.
-      retPtr = DtoAlloca(pointerTo(dtype), "condtmp");
+      if (!isLvalue) {
+        retPtr = DtoAlloca(dtype, "condtmp");
+      }
     }
 
     llvm::BasicBlock *condtrue = p->insertBB("condtrue");
@@ -2131,26 +2133,60 @@ public:
     auto branchweights = PGO.createProfileWeights(truecount, falsecount);
     p->ir->CreateCondBr(cond_val, condtrue, condfalse, branchweights);
 
+    LLValue *u_val = nullptr;
+    llvm::BasicBlock *u_bb = nullptr;
     p->ir->SetInsertPoint(condtrue);
     PGO.emitCounterIncrement(e);
     DValue *u = toElem(e->e1);
-    if (retPtr && u->type->toBasetype()->ty != TY::Tnoreturn) {
-      LLValue *lval = makeLValue(e->loc, u);
-      DtoStore(lval, retPtr);
+    if (u->type->toBasetype()->ty != TY::Tnoreturn) {
+      if (isLvalue) {
+        u_val = makeLValue(e->loc, u);
+      } else if (retPtr) {
+        LLValue *rval = DtoRVal(u);
+        DtoStoreZextI8(rval, retPtr);
+      }
+    }
+    if (!p->scopebb()->getTerminator()) {
+      u_bb = p->scopebb();
     }
     createBranch(condend, p->scopebb());
 
+    LLValue *v_val = nullptr;
+    llvm::BasicBlock *v_bb = nullptr;
     p->ir->SetInsertPoint(condfalse);
     DValue *v = toElem(e->e2);
-    if (retPtr && v->type->toBasetype()->ty != TY::Tnoreturn) {
-      LLValue *lval = makeLValue(e->loc, v);
-      DtoStore(lval, retPtr);
+    if (v->type->toBasetype()->ty != TY::Tnoreturn) {
+      if (isLvalue) {
+        v_val = makeLValue(e->loc, v);
+      } else if (retPtr) {
+        LLValue *rval = DtoRVal(v);
+        DtoStoreZextI8(rval, retPtr);
+      }
+    }
+    if (!p->scopebb()->getTerminator()) {
+      v_bb = p->scopebb();
     }
     createBranch(condend, p->scopebb());
 
     p->ir->SetInsertPoint(condend);
-    if (retPtr)
-      result = new DSpecialRefValue(e->type, retPtr);
+    if (isLvalue) {
+      if (u_bb && v_bb && u_val && v_val) {
+        llvm::Type *phiType = u_val->getType();
+        llvm::PHINode *phi = p->ir->CreatePHI(phiType, 2, "condtmp");
+        phi->addIncoming(u_val, u_bb);
+        if (v_val->getType() != phiType) {
+          v_val = DtoBitCast(v_val, phiType);
+        }
+        phi->addIncoming(v_val, v_bb);
+        result = new DLValue(e->type, phi);
+      } else if (u_bb && u_val) {
+        result = new DLValue(e->type, u_val);
+      } else if (v_bb && v_val) {
+        result = new DLValue(e->type, v_val);
+      }
+    } else if (retPtr) {
+      result = new DLValue(e->type, retPtr);
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2138,7 +2138,7 @@ public:
     p->ir->SetInsertPoint(condtrue);
     PGO.emitCounterIncrement(e);
     DValue *u = toElem(e->e1);
-    if (u->type->toBasetype()->ty != TY::Tnoreturn) {
+    if (u && u->type->toBasetype()->ty != TY::Tnoreturn) {
       if (isLvalue) {
         u_val = makeLValue(e->loc, u);
       } else if (retPtr) {
@@ -2155,7 +2155,7 @@ public:
     llvm::BasicBlock *v_bb = nullptr;
     p->ir->SetInsertPoint(condfalse);
     DValue *v = toElem(e->e2);
-    if (v->type->toBasetype()->ty != TY::Tnoreturn) {
+    if (v && v->type->toBasetype()->ty != TY::Tnoreturn) {
       if (isLvalue) {
         v_val = makeLValue(e->loc, v);
       } else if (retPtr) {
@@ -2180,7 +2180,7 @@ public:
         phi->addIncoming(u_val ? u_val : llvm::UndefValue::get(ptrType), u_bb);
         LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
         if (v_inc->getType() != ptrType) {
-          v_inc = DtoBitCast(v_inc, ptrType);
+          v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
         }
         phi->addIncoming(v_inc, v_bb);
         result = new DLValue(e->type, phi);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2170,24 +2170,43 @@ public:
 
     p->ir->SetInsertPoint(condend);
     if (isLvalue) {
-      llvm::Type *ptrType = nullptr;
-      if (u_val) ptrType = u_val->getType();
-      else if (v_val) ptrType = v_val->getType();
-      else ptrType = getOpaquePtrType();
+      llvm::Type *ptrType = getOpaquePtrType();
+      if (u_val && v_val && u_val->getType() == v_val->getType()) {
+        ptrType = u_val->getType();
+      } else if (u_val && !v_val) {
+        ptrType = u_val->getType();
+      } else if (v_val && !u_val) {
+        ptrType = v_val->getType();
+      }
 
       if (u_bb && v_bb) {
         llvm::PHINode *phi = p->ir->CreatePHI(ptrType, 2, "condtmp");
-        phi->addIncoming(u_val ? u_val : llvm::UndefValue::get(ptrType), u_bb);
+        
+        LLValue *u_inc = u_val ? u_val : llvm::UndefValue::get(ptrType);
+        if (u_inc->getType() != ptrType) {
+          u_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(u_inc, ptrType);
+        }
+        phi->addIncoming(u_inc, u_bb);
+        
         LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
         if (v_inc->getType() != ptrType) {
           v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
         }
         phi->addIncoming(v_inc, v_bb);
+        
         result = new DLValue(e->type, phi);
       } else if (u_bb) {
-        result = new DLValue(e->type, u_val ? u_val : llvm::UndefValue::get(ptrType));
+        LLValue *u_inc = u_val ? u_val : llvm::UndefValue::get(ptrType);
+        if (u_inc->getType() != ptrType) {
+          u_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(u_inc, ptrType);
+        }
+        result = new DLValue(e->type, u_inc);
       } else if (v_bb) {
-        result = new DLValue(e->type, v_val ? v_val : llvm::UndefValue::get(ptrType));
+        LLValue *v_inc = v_val ? v_val : llvm::UndefValue::get(ptrType);
+        if (v_inc->getType() != ptrType) {
+          v_inc = p->ir->CreatePointerBitCastOrAddrSpaceCast(v_inc, ptrType);
+        }
+        result = new DLValue(e->type, v_inc);
       } else {
         result = new DLValue(e->type, llvm::UndefValue::get(ptrType));
       }

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -2142,8 +2142,8 @@ public:
       if (isLvalue) {
         u_val = makeLValue(e->loc, u);
       } else if (retPtr) {
-        LLValue *rval = DtoRVal(u);
-        DtoStoreZextI8(rval, retPtr);
+        DLValue dst(dtype, retPtr);
+        DtoAssign(e->loc, &dst, u, EXP::blit);
       }
     }
     if (!p->scopebb()->getTerminator()) {
@@ -2159,8 +2159,8 @@ public:
       if (isLvalue) {
         v_val = makeLValue(e->loc, v);
       } else if (retPtr) {
-        LLValue *rval = DtoRVal(v);
-        DtoStoreZextI8(rval, retPtr);
+        DLValue dst(dtype, retPtr);
+        DtoAssign(e->loc, &dst, v, EXP::blit);
       }
     }
     if (!p->scopebb()->getTerminator()) {

--- a/tests/codegen/dcompute_cl_addrspaces.d
+++ b/tests/codegen/dcompute_cl_addrspaces.d
@@ -50,3 +50,21 @@ void foo(GenericPointer!float f) {
     // LL: load float, ptr addrspace(4)
     float g = *f;
 }
+
+void ternary_rval(GlobalPointer!float f, bool c) {
+    // LL-LABEL: define{{.*}} @{{.*}}ternary_rval
+    // LL: load float, ptr addrspace(1)
+    float g = c ? *f : 0.0f;
+}
+
+void ternary_lval(GlobalPointer!float f, GlobalPointer!float g, bool c) {
+    // LL-LABEL: define{{.*}} @{{.*}}ternary_lval
+    // LL: load float, ptr addrspace(1)
+    float h = c ? *f : *g;
+}
+
+void ternary_lval_assign(GlobalPointer!float f, GlobalPointer!float g, bool c) {
+    // LL-LABEL: define{{.*}} @{{.*}}ternary_lval_assign
+    // LL: store float 1.000000e+00, ptr addrspace(1)
+    (c ? *f : *g) = 1.0f;
+}


### PR DESCRIPTION
This fixes an issue in the DCompute backend where ternary condition expressions dropped device address spaces. R-values now use local allocas for the value, and L-values natively preserve pointer types through LLVM PHI nodes.


Fixes #5135.

This PR fixes a bug in the DCompute backend where ternary condition expressions `(c) ? e1 : e2` stripped device address spaces (e.g., `addrspace(1)`) from `GlobalPointer` memory references. 

**Root Cause:**
Previously, `visit(CondExp)` indiscriminately wrapped the branches inside a generic address space temporary (`condtmp` pointer), which forced `DSpecialRefValue::getRVal()` to reload the branches using `getOpaquePtrType()`. This stripped out the inner device address space.

**Solution:**
The code has been updated to distinctly handle ternary expressions depending on their evaluation context:
1. **L-value context (`e->isLvalue()`):** Entirely bypasses intermediate allocation wrappers and `DSpecialRefValue`. Instead, it fetches the actual device pointers using `makeLValue` and naturally preserves their exact LLVM type (including `addrspace`) by linking them into an LLVM `PHINode` at the branch merge point. 
2. **R-value context (`!e->isLvalue()`):** Creates a standard `alloca` for the target value type (rather than an `alloca` of a pointer), evaluates the condition branches as standard R-values, and stores them appropriately. This prevents any inner structs (like `GlobalPointer`) from having their address spaces stripped from memory.

This fully resolves `val = (c) ? input[i] : 0` as well as the related `val = (c) ? input[i] : input[j]` bug.