### PR TITLE
[regression] Restore `cold`/`noreturn` attributes on runtime error functions

### DIFF
--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -525,10 +525,21 @@ static void buildRuntimeModule() {
     auto addCold = [&](AttrSet& a) {
       llvm::AttrBuilder ab(context);
       ab.addAttribute(llvm::Attribute::Cold);
+      a.addToFunction(ab);
     };
     addCold(Attr_Cold);
     addCold(Attr_Cold_NoReturn);
     addCold(Attr_Cold_NoReturn_NoUnwind);
+  }
+  // `noreturn`
+  {
+    auto addNoReturn = [&](AttrSet& a) {
+      llvm::AttrBuilder ab(context);
+      ab.addAttribute(llvm::Attribute::NoReturn);
+      a.addToFunction(ab);
+    };
+    addNoReturn(Attr_Cold_NoReturn);
+    addNoReturn(Attr_Cold_NoReturn_NoUnwind);
   }
   // `nocapture`/ `captures(none)`
   {

--- a/tests/codegen/runtime_error_attrs.d
+++ b/tests/codegen/runtime_error_attrs.d
@@ -1,0 +1,9 @@
+// RUN: %ldc -O0 -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+// CHECK: declare {{.*}}@_d_assert({{.*}}) #[[ASSERT:[0-9]+]]
+void g(bool b)
+{
+    assert(b);
+}
+
+// CHECK: attributes #[[ASSERT]] ={{.*}} cold{{.*}}noreturn


### PR DESCRIPTION
The D runtime error functions (_d_assert, _d_arraybounds* etc.) lost their `cold` and `noreturn` attributes in https://github.com/ldc-developers/ldc/commit/705a60e8131b0e6c5c47fb0afa219c40deb5adc8, which rewrote the attribute table in gen/runtime.cpp to lambdas: the `cold` builder was never applied and the `noreturn` builder was missing. Restore both attributes and add a regression test.