### PR TITLE
Enable @restrict to slices via llvm.assume["separate_storage"] (#5145)

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -54,6 +54,7 @@
 #include "ir/irfunction.h"
 #include "ir/irmodule.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
@@ -858,6 +859,44 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
   }
 }
 
+// For @restrict slice parameters, emit llvm.assume["separate_storage"]
+// to indicate the slice data pointers do not alias.
+void emitRestrictSeparateStorage(FuncDeclaration *fd, IrFuncTy &irFty) {
+  std::vector<LLValue *> restrictPtrs;
+
+  auto &args = irFty.args;
+  for (auto *arg : args) {
+    if (!arg->isRestrictSlice)
+      continue;
+
+    auto paramIdx = arg->parametersIdx;
+    if (paramIdx >= fd->parameters->length)
+      continue;
+    auto param = (*fd->parameters)[paramIdx];
+
+    auto *irparam = getIrParameter(param);
+    LLValue *allocaVal = irparam->value;
+    LLValue *ptrGEP = DtoGEP(DtoType(param->type->toBasetype()),
+                             allocaVal, 0, 1, ".restrict.ptr.gep");
+    LLValue *ptr = DtoLoad(getOpaquePtrType(), ptrGEP, ".restrict.ptr");
+    restrictPtrs.push_back(ptr);
+  }
+
+  if (restrictPtrs.size() < 2)
+    return;
+
+  auto *assumeFn = GET_INTRINSIC_DECL(assume, {});
+  auto *trueVal = llvm::ConstantInt::getTrue(gIR->context());
+
+  for (size_t i = 0; i < restrictPtrs.size(); i++) {
+    for (size_t j = i + 1; j < restrictPtrs.size(); j++) {
+      LLValue *ptrs[] = {restrictPtrs[i], restrictPtrs[j]};
+      llvm::OperandBundleDef ob("separate_storage", ptrs);
+      gIR->ir->CreateCall(assumeFn, {trueVal}, {ob});
+    }
+  }
+}
+
 void emitDMDStyleFunctionTrace(IRState &irs, FuncDeclaration *fd,
                                FuncGenState &funcGen) {
   /* DMD-style profiling: wrap the entire function body in:
@@ -1243,6 +1282,9 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   // define all explicit parameters
   if (!isNaked && fd->parameters)
     defineParameters(irFty, *fd->parameters);
+
+  // Emit separate_storage assumes for @restrict slice params
+  emitRestrictSeparateStorage(fd, irFty);
 
   // Initialize PGO state for this function
   funcGen.pgo.assignRegionCounters(fd, func);

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -862,7 +862,7 @@ void defineParameters(IrFuncTy &irFty, VarDeclarations &parameters) {
 // For @restrict slice parameters, emit llvm.assume["separate_storage"]
 // to indicate the slice data pointers do not alias.
 void emitRestrictSeparateStorage(FuncDeclaration *fd, IrFuncTy &irFty) {
-  std::vector<LLValue *> restrictPtrs;
+  llvm::SmallVector<LLValue *, 4> restrictPtrs;
 
   auto &args = irFty.args;
   for (auto *arg : args) {

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -586,7 +586,16 @@ void applyFuncDeclUDAs(FuncDeclaration *decl, IrFunction *irFunc) {
 
       auto ident = sle->sd->ident;
       if (ident == Id::udaLLVMAttr) {
-        applyAttrLLVMAttr(sle, arg->attrs);
+        // noalias is only valid for pointer-type params. For non-pointer
+        // types (slices, static arrays, structs, scalars), skip the LLVM
+        // attribute. Slice params get separate_storage assumes instead.
+        if (getStringElem(sle, 0) == "noalias" &&
+            !arg->ltype->isPointerTy()) {
+          if (param->type->toBasetype()->ty == TY::Tarray)
+            arg->isRestrictSlice = true;
+        } else {
+          applyAttrLLVMAttr(sle, arg->attrs);
+        }
       } else {
         warning(sle->loc,
                 "ignoring unrecognized special parameter attribute "

--- a/ir/irfuncty.h
+++ b/ir/irfuncty.h
@@ -65,6 +65,9 @@ struct IrFuncTyArg {
    *  return values */
   ABIRewrite *rewrite = nullptr;
 
+  /// True if this param is a @restrict slice, needing separate_storage
+  bool isRestrictSlice = false;
+
   /// Helper to check if the 'inreg' attribute is set
   bool isInReg() const;
   /// Helper to check if the 'sret' attribute is set

--- a/tests/codegen/restrict_slice.d
+++ b/tests/codegen/restrict_slice.d
@@ -22,10 +22,19 @@ void threeSlices(@restrict int[] a, @restrict int[] b, @restrict int[] c) { }
 // CHECK-NOT: separate_storage
 void singleSlice(@restrict int[] a) { }
 
-// Mix: restrict pointer (noalias attr) + restrict slice (separate_storage)
+// Mix: restrict pointer (noalias attr) + restrict slices (separate_storage)
 // CHECK-LABEL: define {{.*}}@{{.*}}mixed
 // CHECK-SAME: ptr noalias %p_arg
+// CHECK-NOT: noalias %a_arg
+// CHECK-NOT: noalias %b_arg
 // CHECK: separate_storage
-void mixed(@restrict int[] a, @restrict int* p) {
+void mixed(@restrict int[] a, @restrict int[] b, @restrict int* p) {
     a[0] = *p;
+    b[0] = *p;
 }
+
+// Restrict on static array (non-pointer type) → should not crash
+// CHECK-LABEL: define {{.*}}@{{.*}}staticArray
+// CHECK-NOT: noalias
+// CHECK-NOT: separate_storage
+void staticArray(@restrict int[4] arr) {}

--- a/tests/codegen/restrict_slice.d
+++ b/tests/codegen/restrict_slice.d
@@ -2,11 +2,13 @@
 
 import ldc.attributes;
 
-// Two restrict slices → one assume with separate_storage
+// Two restrict slices → one pairwise assume with separate_storage
 // CHECK-LABEL: define {{.*}}@{{.*}}twoSlices
 // CHECK: getelementptr inbounds {{.*}} i32 0, i32 1
+// CHECK: [[A:%.restrict.ptr[0-9]*]] = load ptr, ptr
 // CHECK: getelementptr inbounds {{.*}} i32 0, i32 1
-// CHECK: separate_storage
+// CHECK: [[B:%.restrict.ptr[0-9]*]] = load ptr, ptr
+// CHECK: separate_storage{{.*}}ptr [[A]], ptr [[B]]
 void twoSlices(@restrict int[] a, @restrict int[] b) {
     a[0] = 1;
     b[0] = 2;
@@ -22,9 +24,16 @@ void threeSlices(@restrict int[] a, @restrict int[] b, @restrict int[] c) { }
 // CHECK-NOT: separate_storage
 void singleSlice(@restrict int[] a) { }
 
+// One restrict slice + one non-restrict slice → no assume
+// CHECK-LABEL: define {{.*}}@{{.*}}oneRestrictOneNormal
+// CHECK-NOT: separate_storage
+void oneRestrictOneNormal(@restrict int[] a, int[] b) { }
+
 // Mix: restrict pointer (noalias attr) + restrict slices (separate_storage)
 // CHECK-LABEL: define {{.*}}@{{.*}}mixed
-// CHECK-SAME: ptr noalias %p_arg
+// CHECK-NOT: noalias %a_arg
+// CHECK-NOT: noalias %b_arg
+// CHECK: ptr noalias %p_arg
 // CHECK-NOT: noalias %a_arg
 // CHECK-NOT: noalias %b_arg
 // CHECK: separate_storage

--- a/tests/codegen/restrict_slice.d
+++ b/tests/codegen/restrict_slice.d
@@ -1,0 +1,31 @@
+// RUN: %ldc -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import ldc.attributes;
+
+// Two restrict slices → one assume with separate_storage
+// CHECK-LABEL: define {{.*}}@{{.*}}twoSlices
+// CHECK: getelementptr inbounds {{.*}} i32 0, i32 1
+// CHECK: getelementptr inbounds {{.*}} i32 0, i32 1
+// CHECK: separate_storage
+void twoSlices(@restrict int[] a, @restrict int[] b) {
+    a[0] = 1;
+    b[0] = 2;
+}
+
+// Three slices → three pairwise assumes
+// CHECK-LABEL: define {{.*}}@{{.*}}threeSlices
+// CHECK: separate_storage
+void threeSlices(@restrict int[] a, @restrict int[] b, @restrict int[] c) { }
+
+// Single restrict slice → no assume generated
+// CHECK-LABEL: define {{.*}}@{{.*}}singleSlice
+// CHECK-NOT: separate_storage
+void singleSlice(@restrict int[] a) { }
+
+// Mix: restrict pointer (noalias attr) + restrict slice (separate_storage)
+// CHECK-LABEL: define {{.*}}@{{.*}}mixed
+// CHECK-SAME: ptr noalias %p_arg
+// CHECK: separate_storage
+void mixed(@restrict int[] a, @restrict int* p) {
+    a[0] = *p;
+}

--- a/tests/codegen/restrict_slice.d
+++ b/tests/codegen/restrict_slice.d
@@ -32,9 +32,3 @@ void mixed(@restrict int[] a, @restrict int[] b, @restrict int* p) {
     a[0] = *p;
     b[0] = *p;
 }
-
-// Restrict on static array (non-pointer type) → should not crash
-// CHECK-LABEL: define {{.*}}@{{.*}}staticArray
-// CHECK-NOT: noalias
-// CHECK-NOT: separate_storage
-void staticArray(@restrict int[4] arr) {}

--- a/tests/codegen/restrict_slice_opt.d
+++ b/tests/codegen/restrict_slice_opt.d
@@ -1,0 +1,19 @@
+// RUN: %ldc -O3 -boundscheck=off -ffast-math -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+import ldc.attributes;
+
+// Without restrict: LLVM must assume slices may overlap → scalar code path
+// CHECK-LABEL: define {{.*}}@{{.*}}noRestrict
+// CHECK-NOT: load <4 x float>
+void noRestrict(float[] o, const float[] a,
+                const float[] b, const float[] c) {
+    foreach (i; 0..16) o[i] = b[i] * a[i] + c[i];
+}
+
+// With restrict: LLVM knows slices don't overlap → auto-vectorized
+// CHECK-LABEL: define {{.*}}@{{.*}}withRestrict
+// CHECK: load <4 x float>
+void withRestrict(@restrict float[] o, @restrict const float[] a,
+                  @restrict const float[] b, @restrict const float[] c) {
+    foreach (i; 0..16) o[i] = b[i] * a[i] + c[i];
+}


### PR DESCRIPTION
Try to implement #5145: For slice params marked `@restrict`, emit pairwise llvm.assume calls with "separate_storage" operand bundles in the function prologue.  Also prevent the invalid noalias attribute from being applied to non-pointer
parameter types (slices, static arrays, structs, scalars).