### PR TITLE
Fix/Emit array comparison/equality hooks for device code

### DIFF
--- a/dmd/id.d
+++ b/dmd/id.d
@@ -596,6 +596,10 @@ immutable Msgtable[] msgtable =
     { "dcompute" },
     { "dcPointer", "Pointer" },
     { "dcReflect", "__dcompute_reflect" },
+    // dcompute array comparison/equality lowering hooks
+    { "comparison" },
+    { "equality" },
+    { "dstrcmp" },
     { "RTInfoImpl" },
     { "opencl" },
 

--- a/dmd/id.h
+++ b/dmd/id.h
@@ -45,6 +45,9 @@ struct Id
     static Identifier *dcPointer;
     static Identifier *object;
     static Identifier *core;
+    static Identifier *internal;
+    static Identifier *array;
+    static Identifier *string;
     static Identifier *etc;
     static Identifier *std;
     static Identifier *ensure;
@@ -77,6 +80,10 @@ struct Id
     static Identifier *LDC_extern_weak;
     static Identifier *LDC_profile_instr;
     static Identifier *dcReflect;
+    // dcompute array comparison/equality hooks (see isDeviceArrayComparisonHook)
+    static Identifier *comparison;
+    static Identifier *equality;
+    static Identifier *dstrcmp;
     static Identifier *opencl;
     static Identifier *criticalenter;
     static Identifier *criticalexit;

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -363,7 +363,8 @@ public:
         return;
       }
       Module *m = decl->tempdecl->getModule();
-      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly) {
+      if (m && hasComputeAttr(m) == DComputeCompileFor::hostOnly &&
+          !isDeviceArrayComparisonHook(decl->tempdecl)) {
         Logger::println("Skipping host-side template instantiations "
                         "in dcompute modules.");
         return;

--- a/gen/irstate.cpp
+++ b/gen/irstate.cpp
@@ -130,6 +130,12 @@ llvm::Instruction *IRState::CreateCallOrInvoke(LLFunction *Callee,
 }
 
 bool IRState::emitArrayBoundsChecks() {
+  // Bounds checks throw `RangeError`, which is illegal in `@compute` device code
+  // (and the `_d_arraybounds_index` handler has no device implementation), so
+  // never emit them for device code.
+  if (dcomputetarget)
+    return false;
+
   if (global.params.useArrayBounds != CHECKENABLEsafeonly) {
     return global.params.useArrayBounds == CHECKENABLEon;
   }

--- a/gen/semantic-dcompute.cpp
+++ b/gen/semantic-dcompute.cpp
@@ -42,6 +42,11 @@ struct DComputeSemanticAnalyser : public StoppableVisitor {
     FuncDeclaration *f = ce->f;
     if (f->ident == Id::dcReflect)
       return true;
+    // Calls into the comparison/equality hook modules (`__cmp`, `__equals`,
+    // their `isEqual`/`at` helpers) are the lowering for array `<`/`==` and are
+    // legal in device code even though those modules are host-only.
+    if (isDeviceArrayComparisonHook(f))
+      return true;
     if (currentFunction == nullptr)
       return false;
     TemplateInstance *inst = currentFunction->isInstantiated();

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -16,6 +16,7 @@
 #include "ir/irvar.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
+#include <cstring>
 #include <stdio.h>
 
 using namespace dmd;
@@ -642,6 +643,28 @@ extern "C" DComputeCompileFor hasComputeAttr(Dsymbol *sym) {
   checkStructElems(sle, {Type::tint32});
 
   return static_cast<DComputeCompileFor>(1 + (*sle->elements)[0]->toInteger());
+}
+
+bool isDeviceArrayComparisonHook(Dsymbol *sym) {
+  if (!sym)
+    return false;
+  Module *m = sym->getModule();
+  if (!m)
+    return false;
+  // These druntime modules are host-only, but their templates (`__cmp`,
+  // `__equals` and helpers like `isEqual`/`at`) are the lowering hooks emitted
+  // for array `<`/`==` in device code, so they must not be skipped.
+  const char *fqn = m->toPrettyChars();
+  if (!strcmp(fqn, "core.internal.array.comparison") ||
+      !strcmp(fqn, "core.internal.array.equality"))
+    return true;
+  // From core.internal.string only `dstrcmp` is a device-legal hook helper (the
+  // `char`/string `__cmp` specialization calls it). The rest of that module
+  // (e.g. signedToTempString) contains device-illegal code, so don't exempt the
+  // whole module.
+  if (!strcmp(fqn, "core.internal.string"))
+    return sym->ident && !strcmp(sym->ident->toChars(), "dstrcmp");
+  return false;
 }
 
 /// Returns whether `sym` has the `@ldc.dcompute._kernel()` UDA applied.

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -656,21 +656,17 @@ bool isDeviceArrayComparisonHook(Dsymbol *sym) {
   // These druntime modules are host-only, but their templates (`__cmp`,
   // `__equals` and helpers like `isEqual`/`at`) are the lowering hooks emitted
   // for array `<`/`==` in device code, so they must not be skipped.
-  Identifier *const internal = Identifier::idPool("internal");
   if (md->packages.length == 3 && md->packages.ptr[0] == Id::core &&
-      md->packages.ptr[1] == internal &&
-      md->packages.ptr[2] == Identifier::idPool("array") &&
-      (md->id == Identifier::idPool("comparison") ||
-       md->id == Identifier::idPool("equality")))
+      md->packages.ptr[1] == Id::internal && md->packages.ptr[2] == Id::array &&
+      (md->id == Id::comparison || md->id == Id::equality))
     return true;
   // From core.internal.string only `dstrcmp` is a device-legal hook helper (the
   // `char`/string `__cmp` specialization calls it). The rest of that module
   // (e.g. signedToTempString) contains device-illegal code, so don't exempt the
   // whole module.
   if (md->packages.length == 2 && md->packages.ptr[0] == Id::core &&
-      md->packages.ptr[1] == internal &&
-      md->id == Identifier::idPool("string"))
-    return sym->ident == Identifier::idPool("dstrcmp");
+      md->packages.ptr[1] == Id::internal && md->id == Id::string)
+    return sym->ident == Id::dstrcmp;
   return false;
 }
 

--- a/gen/uda.cpp
+++ b/gen/uda.cpp
@@ -16,7 +16,6 @@
 #include "ir/irvar.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
-#include <cstring>
 #include <stdio.h>
 
 using namespace dmd;
@@ -651,19 +650,27 @@ bool isDeviceArrayComparisonHook(Dsymbol *sym) {
   Module *m = sym->getModule();
   if (!m)
     return false;
+  const ModuleDeclaration *md = m->md;
+  if (!md)
+    return false;
   // These druntime modules are host-only, but their templates (`__cmp`,
   // `__equals` and helpers like `isEqual`/`at`) are the lowering hooks emitted
   // for array `<`/`==` in device code, so they must not be skipped.
-  const char *fqn = m->toPrettyChars();
-  if (!strcmp(fqn, "core.internal.array.comparison") ||
-      !strcmp(fqn, "core.internal.array.equality"))
+  Identifier *const internal = Identifier::idPool("internal");
+  if (md->packages.length == 3 && md->packages.ptr[0] == Id::core &&
+      md->packages.ptr[1] == internal &&
+      md->packages.ptr[2] == Identifier::idPool("array") &&
+      (md->id == Identifier::idPool("comparison") ||
+       md->id == Identifier::idPool("equality")))
     return true;
   // From core.internal.string only `dstrcmp` is a device-legal hook helper (the
   // `char`/string `__cmp` specialization calls it). The rest of that module
   // (e.g. signedToTempString) contains device-illegal code, so don't exempt the
   // whole module.
-  if (!strcmp(fqn, "core.internal.string"))
-    return sym->ident && !strcmp(sym->ident->toChars(), "dstrcmp");
+  if (md->packages.length == 2 && md->packages.ptr[0] == Id::core &&
+      md->packages.ptr[1] == internal &&
+      md->id == Identifier::idPool("string"))
+    return sym->ident == Identifier::idPool("dstrcmp");
   return false;
 }
 

--- a/gen/uda.h
+++ b/gen/uda.h
@@ -39,6 +39,16 @@ enum class DComputeCompileFor : int
   hostAndDevice = 2
 };
 extern "C" DComputeCompileFor hasComputeAttr(Dsymbol *sym);
+
+/// Returns whether `sym` is one of druntime's array comparison/equality
+/// lowering hooks: `__cmp`/`__equals` and their helpers `isEqual`/`at` (from
+/// core.internal.array.{comparison,equality}), plus `dstrcmp` (the char/string
+/// `__cmp` helper from core.internal.string). Array `<`/`==` in `@compute`
+/// device code lowers to these. They live in host-only modules but must still be
+/// validated and codegen'd for the device, so they are exempted from the
+/// host-only template skip.
+bool isDeviceArrayComparisonHook(Dsymbol *sym);
+
 bool hasNoSplitStackUDA(FuncDeclaration *fd);
 
 unsigned getMaskFromNoSanitizeUDA(FuncDeclaration &fd);

--- a/tests/codegen/dcompute_comparison_hooks.d
+++ b/tests/codegen/dcompute_comparison_hooks.d
@@ -1,0 +1,82 @@
+// Array `==` / `!=` / `<` / `>` / `<=` / `>=` in @compute device code lower to the
+// druntime hooks core.internal.array.equality.__equals and
+// core.internal.array.comparison.__cmp (plus helpers like isEqual/at). Those hooks
+// live in host-only druntime modules but are device-legal. Regression guard: they
+// used to be either rejected during dcompute semantic analysis or emitted as hollow
+// `declare`-only stubs. This test asserts the device IR contains real `define`d
+// bodies (never bare `declare`s) for every element type that actually instantiates
+// the templates.
+//
+// float / double / real / float[N] / struct-with-opEquals / struct-with-float-field
+// all bypass the int[] memcmp fast path, so the genuine __equals / __cmp templates
+// are instantiated and codegen'd for the device. (Plain POD structs and integral
+// element types take the inline-memcmp path instead -- see compilable/dcompute_comparison_hooks.d.)
+//
+// REQUIRES: target_NVPTX
+// RUN: %ldc -mdcompute-targets=cuda-700 -m64 -output-ll -output-o -c \
+// RUN:   -mdcompute-file-prefix=comparison_hooks -Iinputs %s
+// RUN: FileCheck %s < comparison_hooks_cuda700_64.ll
+
+@compute(CompileFor.deviceOnly) module dcompute_comparison_hooks;
+import ldc.dcompute;
+
+struct SEq    { int x; bool opEquals(ref const SEq o) const { return x == o.x; } }
+struct SFloat { float f; }
+struct SCmp   { int x; int opCmp(ref const SCmp o) const { return x < o.x ? -1 : (x > o.x ? 1 : 0); } }
+
+// ---- __equals (== / !=) ----------------------------------------------------
+
+// Dynamic float[] equality -> __equals!(float,float).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}__equalsTfTf
+@kernel void eq_float(float[] a, float[] b, bool* o)    { *o = (a == b); }
+
+// Dynamic double[] equality -> __equals!(double,double).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}__equalsTdTd
+@kernel void eq_double(double[] a, double[] b, bool* o) { *o = (a == b); }
+
+// Static float[4] equality -> __equals!(float,float, len, len).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}__equalsTfTfVmi4
+@kernel void eq_static(float[4] a, float[4] b, bool* o) { *o = (a == b); }
+
+// Struct with custom opEquals -> __equals!(SEq,SEq), element-wise via the user opEquals.
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}__equalsTS{{.*}}3SEq
+@kernel void eq_opequals(SEq[] a, SEq[] b, bool* o)     { *o = (a == b); }
+
+// Struct with a float field (forces element-wise compare, not memcmp) -> __equals!(SFloat,SFloat).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}__equalsTS{{.*}}6SFloat
+@kernel void eq_floatfield(SFloat[] a, SFloat[] b, bool* o) { *o = (a == b); }
+
+// `!=` lowers to the same __equals!(float,float) hook (negated). No NEW symbol needed
+// (shares eq_float's instantiation), but it must compile and stay defined.
+@kernel void ne_float(float[] a, float[] b, bool* o)    { *o = (a != b); }
+
+// The element comparator helper isEqual must also be defined (reached transitively
+// from __equals, lives in the same host-only equality module).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array8equality{{.*}}isEqual
+
+// ---- __cmp (< / > / <= / >=) -----------------------------------------------
+
+// float[] ordering -> __cmp!float. All four relational operators lower to the
+// same __cmp!float hook, so one define covers <, >, <=, >=.
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array10comparison{{.*}}__cmpTf
+@kernel void cmp_lt(float[] a, float[] b, bool* o) { *o = (a <  b); }
+@kernel void cmp_gt(float[] a, float[] b, bool* o) { *o = (a >  b); }
+@kernel void cmp_le(float[] a, float[] b, bool* o) { *o = (a <= b); }
+@kernel void cmp_ge(float[] a, float[] b, bool* o) { *o = (a >= b); }
+
+// double[] ordering -> __cmp!double.
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array10comparison{{.*}}__cmpTd
+@kernel void cmp_double(double[] a, double[] b, bool* o) { *o = (a < b); }
+
+// int[] ordering -> __cmp!int (ordering goes through __cmp, NOT the memcmp fast path
+// that int[] `==` uses).
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array10comparison{{.*}}__cmpTi
+@kernel void cmp_int(int[] a, int[] b, bool* o) { *o = (a < b); }
+
+// Struct with custom opCmp -> __cmp!(SCmp), element-wise via the user opCmp.
+// CHECK-DAG: define{{.*}}ptx_device{{.*}}@_D4core8internal5array10comparison{{.*}}__cmpTS{{.*}}4SCmp
+@kernel void cmp_opcmp(SCmp[] a, SCmp[] b, bool* o) { *o = (a < b); }
+
+// None of the hooks may be left as hollow `declare`-only stubs.
+// CHECK-NOT: declare{{.*}}__equals
+// CHECK-NOT: declare{{.*}}__cmp

--- a/tests/compilable/dcompute_comparison_hooks.d
+++ b/tests/compilable/dcompute_comparison_hooks.d
@@ -1,0 +1,53 @@
+// Companion to codegen/dcompute_comparison_hooks.d. That test proves the array
+// comparison/equality hooks emit defined device bodies; this one proves the
+// surrounding compile-ok matrix:
+//   * the hooks compile in a deviceOnly @compute module, used directly in a
+//     @kernel AND in a called non-kernel @compute helper,
+//   * the hooks also compile in a hostAndDevice @compute module
+//     (inputs/comparison_hooks_had.d),
+//   * the Cat-2 "controls": integral element `==` takes the inline memcmp fast
+//     path and never instantiates __equals at all.
+//
+// REQUIRES: target_NVPTX
+
+// deviceOnly: hooks in a kernel and in a called @compute helper must compile.
+// RUN: %ldc -c -mdcompute-targets=cuda-700 %s
+
+// hostAndDevice: the same hooks must compile when the module targets both.
+// RUN: %ldc -c -mdcompute-targets=cuda-700 -I%S %S/inputs/comparison_hooks_had.d
+
+// Cat-2 control: int[]/int[4]/byte[] `==` lower to an inline memcmp; the __equals
+// template is NEVER instantiated. Assert the device IR has no __equals symbol but
+// does contain memcmp, documenting the bypass so future readers aren't surprised.
+// RUN: %ldc -mdcompute-targets=cuda-700 -m64 -output-ll -output-o -c \
+// RUN:   -mdcompute-file-prefix=cmphooks_ctrl -d-version=Controls %s
+// RUN: FileCheck %s --check-prefix=CTRL < cmphooks_ctrl_cuda700_64.ll
+
+@compute(CompileFor.deviceOnly) module dcompute_comparison_hooks;
+import ldc.dcompute;
+
+struct SEq { int x; bool opEquals(ref const SEq o) const { return x == o.x; } }
+
+version (Controls)
+{
+    // CTRL-NOT: __equals
+    // CTRL: memcmp
+    @kernel void c_int (int[]  a, int[]  b, bool* o) { *o = (a == b); }
+    @kernel void c_int4(int[4] a, int[4] b, bool* o) { *o = (a == b); }
+    @kernel void c_byte(byte[] a, byte[] b, bool* o) { *o = (a == b); }
+}
+else
+{
+    // Hook used in a non-kernel @compute helper that the kernel calls.
+    bool eqHelper(float[] a, float[] b) { return a == b; }
+    int  cmpHelper(double[] a, double[] b) { return a < b ? -1 : 1; }
+
+    // Hook used directly in a kernel, across element types.
+    @kernel void k_float (float[]  a, float[]  b, bool* o) { *o = (a == b); }
+    @kernel void k_double(double[] a, double[] b, bool* o) { *o = (a <  b); }
+    @kernel void k_struct(SEq[]    a, SEq[]    b, bool* o) { *o = (a == b); }
+    @kernel void k_helper(float[]  a, float[]  b, double[] c, double[] d, bool* o)
+    {
+        *o = eqHelper(a, b) && (cmpHelper(c, d) < 0);
+    }
+}

--- a/tests/compilable/dcompute_ctfe_host_templates.d
+++ b/tests/compilable/dcompute_ctfe_host_templates.d
@@ -1,0 +1,37 @@
+// No-regression guard (Cat 4): the comparison/equality-hook allowance must NOT
+// drag CTFE-only host templates into device legality checking.
+//
+// std.traits.fullyQualifiedName / moduleName are host-only templates whose
+// implementations use array concatenation (`~`) -- lowered to host runtime
+// helpers in core.internal.array.concatenation / .utils that do GC.malloc/memcpy
+// and are genuinely device-illegal. Used purely at compile time (here: to derive
+// CT lengths) they must not trip any device error, because the concat helpers run
+// only during CTFE and never reach device codegen. The hook allowance is scoped to
+// core.internal.array.comparison / .equality, so it must leave these alone.
+//
+// This is the exact case that regressed under an over-broad "any instantiated
+// template is device-legal" predicate; it must compile cleanly (exit 0).
+//
+// REQUIRES: target_NVPTX
+// RUN: %ldc -c -mdcompute-targets=cuda-700 %s
+
+@compute(CompileFor.deviceOnly) module dcompute_ctfe_host_templates;
+import ldc.dcompute;
+import std.traits : fullyQualifiedName, moduleName;
+
+struct SomeType { int x; }
+
+@kernel void k(GlobalPointer!int o)
+{
+    // CT-only consumption of the host template results -- never materializes the
+    // string at runtime, so no host array machinery reaches device codegen.
+    enum nFqnInt   = fullyQualifiedName!int.length;
+    enum nFqnType  = fullyQualifiedName!SomeType.length;
+    enum nModName  = moduleName!SomeType.length;
+
+    int acc = 0;
+    static foreach (i; 0 .. nFqnInt)
+        acc += i;
+
+    *o = acc + cast(int)(nFqnType + nModName);
+}

--- a/tests/compilable/inputs/comparison_hooks_had.d
+++ b/tests/compilable/inputs/comparison_hooks_had.d
@@ -1,0 +1,11 @@
+// hostAndDevice companion for compilable/dcompute_comparison_hooks.d.
+// The array comparison/equality hooks (__equals/__cmp) must also compile when the
+// @compute module targets both host and device, not just deviceOnly.
+@compute(CompileFor.hostAndDevice) module inputs.comparison_hooks_had;
+import ldc.dcompute;
+
+struct SEq { int x; bool opEquals(ref const SEq o) const { return x == o.x; } }
+
+@kernel void had_eq    (float[] a, float[] b, bool* o) { *o = (a == b); }
+@kernel void had_cmp   (float[] a, float[] b, bool* o) { *o = (a <  b); }
+@kernel void had_struct(SEq[]   a, SEq[]   b, bool* o) { *o = (a == b); }


### PR DESCRIPTION
                                                                                                                                                                                                                     
Array comparison/equality (`==` `!=` `<` `>` `<=` `>=`) on arrays/slices in `@compute` device code lowers to the druntime hooks `core.internal.array.comparison.__cmp` and `core.internal.array.equality.__equals`
  (plus helpers `isEqual`/`at`, and `core.internal.string.dstrcmp` for `char`). These live in host-only modules and were dropped during dcompute semantic analysis and codegen, ending up as hollow `declare`-only
  stubs — unresolved at device link/JIT (and a compiler crash before #5142). This makes them emit real `ptx_device`/SPIR-V bodies.
  ## Background ##
  - Before , the dcompute semantic walk descended into these host-only templates and segfaulted.
  - #5142 stopped the crash by skipping *all* host-side template instantiations — but that also skipped the comparison/equality hooks, which are device-legal and meant to work, leaving them as hollow stubs.  
## FIX ##
  Adds `isDeviceArrayComparisonHook()` in  (`gen/uda`) recognizing the hooks(`__cmp`/`__equals`/`isEqual`/`at` by module, `dstrcmp` by symbol), and:
 - allows the kernel's call into them during dcompute semantic analysis (`gen/semantic-dcompute.cpp`), and
  - exempts them from the codegen host-only-template skip so their real device bodies are emitted (`gen/declarations.cpp`).
  -  ` _d_arraybounds_index`  its illegal (on device) because it throws RangeError. so never emit in device code.


  The semantic walk still doesn't descend into the hook bodies; codegen emits the device-reachable instances . Compiler-only — no druntime changes.

 ## Further  Required Fix
.The memcmp-able fast path (`int[]`/`char[] ==` lowers to an inline `memcmp`,  and `char[] <` reaches `memcmp` via `dstrcmp` But still references a device `memcmp`, which druntime/dcompute doesn't provide (`core.stdc.string.memcmp` is  only an `extern(C)` libc binding with no body). That's a separate  gap and is not addressed here.

The tests are generated with Claude code ( Opus 4.8 - xhigh) 