### PR TITLE
Fix build with LLVM 23 in `printLabelName`

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1365,7 +1365,7 @@ void printLabelName(std::ostream &target, const char *func_mangle,
   // note: quotes needed for Unicode
   target << '"'
 #if LLVM_VERSION_MAJOR >= 23
-         << gTargetMachine->getMCAsmInfo().getPrivateLabelPrefix().str()
+         << gTargetMachine->getMCAsmInfo().getInternalSymbolPrefix().str()
 #else
          << gTargetMachine->getMCAsmInfo()->getPrivateGlobalPrefix().str()
 #endif


### PR DESCRIPTION
Fixes building with LLVM 23 following llvm/llvm-project#200700