### PR TITLE
Compiler tweaks for Wasm & WASI

### DIFF
--- a/dmd/mangle/package.d
+++ b/dmd/mangle/package.d
@@ -726,6 +726,23 @@ public:
             buf.writestring(fd.ident.toString());
             return;
         }
+
+        version (IN_LLVM)
+        {
+            import gen.llvmhelpers : isTargetWasm;
+            bool isWasm = isTargetWasm();
+        }
+        else bool isWasm = false;
+
+        if (fd.isCMain() && isWasm)
+        {
+            if (fd.parameters)
+                buf.writestring("__main_argc_argv");
+            else
+                buf.writestring("__main_void");
+            return;
+        }
+
         visit(cast(Declaration)fd);
     }
 

--- a/dmd/mangle/package.d
+++ b/dmd/mangle/package.d
@@ -726,23 +726,6 @@ public:
             buf.writestring(fd.ident.toString());
             return;
         }
-
-        version (IN_LLVM)
-        {
-            import gen.llvmhelpers : isTargetWasm;
-            bool isWasm = isTargetWasm();
-        }
-        else bool isWasm = false;
-
-        if (fd.isCMain() && isWasm)
-        {
-            if (fd.parameters)
-                buf.writestring("__main_argc_argv");
-            else
-                buf.writestring("__main_void");
-            return;
-        }
-
         visit(cast(Declaration)fd);
     }
 

--- a/driver/linker-gcc.cpp
+++ b/driver/linker-gcc.cpp
@@ -810,7 +810,7 @@ int linkObjToBinaryGcc(llvm::StringRef outputPath,
   // exception: invoke (ld-compatible) linker directly for WebAssembly targets
   std::string tool;
   std::unique_ptr<ArgsBuilder> argsBuilder;
-  if (global.params.targetTriple->isOSBinFormatWasm()) {
+  if (global.params.targetTriple->isOSBinFormatWasm() && !global.params.targetTriple->isOSWASI()) {
     argsBuilder = std::make_unique<LdArgsBuilder>();
     tool = getProgram("wasm-ld", &opts::linker);
   } else {

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -908,8 +908,26 @@ void registerPredefinedTargetVersions() {
     break;
   case llvm::Triple::WASI:
     VersionCondition::addPredefinedGlobalIdent("WASI");
+    VersionCondition::addPredefinedGlobalIdent("WASIp1");
     VersionCondition::addPredefinedGlobalIdent("CRuntime_WASI");
     break;
+#if LLVM_VERSION_MAJOR >= 22
+  case llvm::Triple::WASIp1:
+    VersionCondition::addPredefinedGlobalIdent("WASI");
+    VersionCondition::addPredefinedGlobalIdent("WASIp1");
+    VersionCondition::addPredefinedGlobalIdent("CRuntime_WASI");
+    break;
+  case llvm::Triple::WASIp2:
+    VersionCondition::addPredefinedGlobalIdent("WASI");
+    VersionCondition::addPredefinedGlobalIdent("WASIp2");
+    VersionCondition::addPredefinedGlobalIdent("CRuntime_WASI");
+    break;
+  case llvm::Triple::WASIp3:
+    VersionCondition::addPredefinedGlobalIdent("WASI");
+    VersionCondition::addPredefinedGlobalIdent("WASIp3");
+    VersionCondition::addPredefinedGlobalIdent("CRuntime_WASI");
+    break;
+#endif
   case llvm::Triple::Emscripten:
     VersionCondition::addPredefinedGlobalIdent("Emscripten");
     // Emscripten uses musl and libc++, so mimic a musl Linux platform:

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -71,6 +71,10 @@ llvm::cl::opt<llvm::GlobalVariable::ThreadLocalMode> clThreadModel(
 bool isTargetWindowsMSVC() {
   return global.params.targetTriple->isWindowsMSVCEnvironment();
 }
+bool isTargetWasm() {
+  return global.params.targetTriple->isWasm();
+}
+
 
 /******************************************************************************
  * Global context
@@ -289,7 +293,7 @@ void DtoCAssert(Module *M, Loc loc, LLValue *msg) {
     args.push_back(file);
     args.push_back(line);
     args.push_back(msg);
-  } else if (triple.isOSSolaris() || triple.isMusl() ||
+  } else if (triple.isOSSolaris() || triple.isMusl() || triple.isOSWASI() ||
              global.params.isUClibcEnvironment ||
              triple.isGNUEnvironment()) {
     const auto irFunc = gIR->func();

--- a/gen/llvmhelpers.d
+++ b/gen/llvmhelpers.d
@@ -20,3 +20,4 @@ import dmd.dtemplate;
 extern (C++) void DtoSetFuncDeclIntrinsicName(TemplateInstance ti, TemplateDeclaration td, FuncDeclaration fd);
 
 extern (C++) bool isTargetWindowsMSVC();
+extern (C++) bool isTargetWasm();

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -358,7 +358,7 @@ static const char *getCAssertFunctionName() {
     return "_assert";
   } else if (triple.isOSSolaris()) {
     return "__assert_c99";
-  } else if (triple.isMusl() || triple.isGNUEnvironment()) {
+  } else if (triple.isMusl() || triple.isGNUEnvironment() || triple.isOSWASI()) {
     return "__assert_fail";
   } else if (global.params.isNewlibEnvironment) {
     return "__assert_func";
@@ -372,7 +372,7 @@ static std::vector<PotentiallyLazyType> getCAssertFunctionParamTypes() {
   const auto uint = Type::tuns32;
 
   if (triple.isOSDarwin() || triple.isOSFreeBSD() || triple.isOSSolaris() ||
-      triple.isMusl() || global.params.isUClibcEnvironment ||
+      triple.isMusl() || triple.isOSWASI() || global.params.isUClibcEnvironment ||
       triple.isGNUEnvironment()) {
     return {voidPtr, voidPtr, uint, voidPtr};
   }

--- a/tests/codegen/wasi.d
+++ b/tests/codegen/wasi.d
@@ -1,8 +1,14 @@
 // REQUIRES: target_WebAssembly, link_WebAssembly
 
 // emit textual IR *and* compile & link
-// RUN: %ldc -mtriple=wasm32-unknown-wasi -output-ll -output-o -of=%t.wasm %s
+// RUN: %ldc -mtriple=wasm32-unknown-wasi -Xcc=-nostdlib -output-ll -output-o -of=%t.wasm %s
 // RUN: FileCheck %s < %t.ll
+//
+// RUN: %ldc -mtriple=wasm32-unknown-wasip1 -Xcc=-nostdlib -output-ll -output-o -of=%t_p1.wasm %s
+// RUN: FileCheck %s < %t_p1.ll
+//
+// RUN: %ldc -mtriple=wasm32-unknown-wasip2 -Xcc=-nostdlib -output-ll -output-o -of=%t_p2.wasm %s
+// RUN: FileCheck %s < %t_p2.ll
 
 
 // test predefined versions:

--- a/tests/codegen/wasi.d
+++ b/tests/codegen/wasi.d
@@ -1,13 +1,13 @@
 // REQUIRES: target_WebAssembly, link_WebAssembly
 
 // emit textual IR *and* compile & link
-// RUN: %ldc -mtriple=wasm32-unknown-wasi -Xcc=-nostdlib -output-ll -output-o -of=%t.wasm %s
+// RUN: %ldc -mtriple=wasm32-unknown-wasi --linker=lld -Xcc=-nostdlib -output-ll -output-o -of=%t.wasm %s
 // RUN: FileCheck %s < %t.ll
 //
-// RUN: %ldc -mtriple=wasm32-unknown-wasip1 -Xcc=-nostdlib -output-ll -output-o -of=%t_p1.wasm %s
+// RUN: %ldc -mtriple=wasm32-unknown-wasip1 --linker=lld -Xcc=-nostdlib -output-ll -output-o -of=%t_p1.wasm %s
 // RUN: FileCheck %s < %t_p1.ll
 //
-// RUN: %ldc -mtriple=wasm32-unknown-wasip2 -Xcc=-nostdlib -output-ll -output-o -of=%t_p2.wasm %s
+// RUN: %ldc -mtriple=wasm32-unknown-wasip2 --linker=lld -Xcc=-nostdlib -output-ll -output-o -of=%t_p2.wasm %s
 // RUN: FileCheck %s < %t_p2.ll
 
 


### PR DESCRIPTION
- On Wasm, do as Clang does and mangle C `main` as either `__main_void` or `__main_argc_argv` as appropriate
- Don't force use of direct `wasm-ld` for WASI targets. Allows `clang` to be set as the link driver (via `-gcc`).
- Define appropriate versions for the new `wasm32-unknown-wasip1`, `-wasip2`, and `-wasip3` targets, and account for the fact that the legacy `-wasi` triple aliases to `p1` at the moment.
- Emit musl-style `__assert_failed` on WASI.

Split from #5152