### PR TITLE
pass typeid(T) when extending struct arrays so they finalize as structs

### DIFF
--- a/runtime/druntime/src/core/internal/array/capacity.d
+++ b/runtime/druntime/src/core/internal/array/capacity.d
@@ -279,7 +279,10 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
     if (!arr.ptr)
     {
         assert(arr.length == 0);
-        void* ptr = GC.malloc(newsize, gcAttrs);
+        version (D_TypeInfo)
+            void* ptr = GC.malloc(newsize, gcAttrs, typeid(T));
+        else
+            void* ptr = GC.malloc(newsize, gcAttrs, null);
         if (!ptr)
         {
             onOutOfMemoryError();
@@ -315,7 +318,10 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
 
     if (!gc_expandArrayUsed(newdata[0 .. oldsize], newsize, isShared))
     {
-        newdata = GC.malloc(newsize, gcAttrs);
+        version (D_TypeInfo)
+            newdata = GC.malloc(newsize, gcAttrs, typeid(T));
+        else
+            newdata = GC.malloc(newsize, gcAttrs, null);
         if (!newdata)
         {
             onOutOfMemoryError();


### PR DESCRIPTION
  Fixes #5150. Extending an array of structs that have a destructor (e.g. arr.length = n) lowers to _d_arraysetlengthT_ in core/internal/array/capacity.d, which sets BlkAttr.FINALIZE on the allocated block but never passes typeid(T) to GC.malloc. Without the TypeInfo, the conservative GC's adjustAttrs cannot promote the block to BlkAttr.STRUCTFINAL, so when the block is later collected the GC finalizes it as a class ,  reading a vtable/ClassInfo pointer out of what is really struct data — and segfaults in rt_finalize2 during the sweep typically reached from gc_term at shutdown).

  This passes typeid(T) to both GC.malloc calls in _d_arraysetlengthT_ (the initial allocation and the reallocation path), guarded by version (D_TypeInfo) to match the existing pattern already used in construction.d and utils.d. With the TypeInfo present, adjustAttrs sets STRUCTFINAL and the block is finalized correctly as a struct. This is a direct port of the upstream DMD fix dlang/dmd#22990 (original  report dlang/dmd#22884); LDC 1.42 ships the pre-fix druntime, which is why the regression surfaced there.

  Verified with the module from the issue (ddn.adam, built with ldc2 -unittest -main): it segfaults in rt_finalize2 on every run before this change and exits cleanly after, using an otherwise identical toolchain  that differs only by this patch.
