### PR TITLE
ImportC: Define `__IMPORTC_LDC__` in `importc.h` to make it possible to detect LDC via the C preprocessor.

### DIFF
--- a/runtime/druntime/src/importc.h
+++ b/runtime/druntime/src/importc.h
@@ -19,6 +19,7 @@
  * For special casing ImportC code.
  */
 #define __IMPORTC__ 1
+#define __IMPORTC_LDC__ 1
 
 /********************
  * Some compilers define `__restrict` instead of `restrict` as C++ compilers don't


### PR DESCRIPTION
Does what it says on the tin.

Please see https://github.com/dlang/dmd/pull/16372#issuecomment-4878525526 for the motivation behind this PR.