### PR TITLE
druntime: Fix `getStackBottom` on Wasm

### DIFF
--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -1894,10 +1894,10 @@ version (LDC_Windows)
 }
 else version (WebAssembly)
 {
-    private extern(C) extern void* __stack_low;
+    private extern(C) extern ubyte __stack_high;
     private extern(D) void* getStackBottom() nothrow @nogc
     {
-        return __stack_low;
+        return &__stack_high;
     }
 }
 else


### PR DESCRIPTION
Stack grows down on Wasm, not up.

Also, it's the address of `__stack_high` that marks the location, not the value.