### PR TITLE
Add predefined global dcompute versions for cuda, ocl, metal

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -751,7 +751,7 @@ cl::opt<unsigned>
                    cl::desc("Warn for stack size bigger than the given number"),
                    cl::value_desc("threshold"));
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
 cl::list<std::string>
     dcomputeTargets("mdcompute-targets", cl::CommaSeparated,
                     cl::desc("Generates code for the specified DCompute target"

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -140,7 +140,7 @@ extern cl::opt<std::string> saveOptimizationRecord;
 
 extern cl::opt<unsigned> fWarnStackSize;
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
 extern cl::list<std::string> dcomputeTargets;
 extern cl::opt<std::string> dcomputeFilePrefix;
 extern cl::opt<bool> fembedDCompute;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -993,7 +993,7 @@ void registerPredefinedVersions() {
 
     #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
       if (targetInfo.starts_with("metal")) {
-          VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_METAL");
+          VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_Metal");
       }
     #endif
   }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -52,6 +52,7 @@
 #include "gen/passes/Passes.h"
 #include "gen/runtime.h"
 #include "gen/uda.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/IR/LLVMContext.h"
@@ -974,6 +975,28 @@ void registerPredefinedVersions() {
     VersionCondition::addPredefinedGlobalIdent("LDC_DCompute");
   }
 #endif
+
+  for(auto& dcomputeTarget: dcomputeTargets) {
+    auto targetInfo = llvm::StringRef(dcomputeTarget);
+    
+    #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
+      if (targetInfo.starts_with("cuda")) {
+            VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_CUDA");
+      }
+    #endif
+
+    #if LDC_LLVM_SUPPORTED_TARGET_SPIRV
+      if (targetInfo.starts_with("ocl")) {
+            VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_OCL");
+      }
+    #endif
+
+    #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
+      if (targetInfo.starts_with("metal")) {
+          VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_METAL");
+      }
+    #endif
+  }
 
   if (global.params.ddoc.doOutput) {
     VersionCondition::addPredefinedGlobalIdent("D_Ddoc");

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -970,33 +970,27 @@ void registerPredefinedVersions() {
   VersionCondition::addPredefinedGlobalIdent("all");
   VersionCondition::addPredefinedGlobalIdent("D_Version2");
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
+  for(auto& dcomputeTarget: dcomputeTargets) {
+    auto targetInfo = llvm::StringRef(dcomputeTarget);
+    
+    if (targetInfo.starts_with("cuda")) {
+      VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_CUDA");
+    }
+
+    if (targetInfo.starts_with("ocl")) {
+      VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_OCL");
+    }
+
+    if (targetInfo.starts_with("metal")) {
+      VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_Metal");
+    }
+  }
+
   if (dcomputeTargets.size() != 0) {
     VersionCondition::addPredefinedGlobalIdent("LDC_DCompute");
   }
 #endif
-
-  for(auto& dcomputeTarget: dcomputeTargets) {
-    auto targetInfo = llvm::StringRef(dcomputeTarget);
-    
-    #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
-      if (targetInfo.starts_with("cuda")) {
-            VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_CUDA");
-      }
-    #endif
-
-    #if LDC_LLVM_SUPPORTED_TARGET_SPIRV
-      if (targetInfo.starts_with("ocl")) {
-            VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_OCL");
-      }
-    #endif
-
-    #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
-      if (targetInfo.starts_with("metal")) {
-          VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_Metal");
-      }
-    #endif
-  }
 
   if (global.params.ddoc.doOutput) {
     VersionCondition::addPredefinedGlobalIdent("D_Ddoc");


### PR DESCRIPTION
Hello, This PR adds `LDC_DCompute_CUDA`, `LDC_DCompute_OCL`, `LDC_DCompute_Metal` corresponding to what users specifies for `mdcompute-targets` command line option.