### PR TITLE
druntime: Use `@restrict` for array ops, enabling auto-vectorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - DMD-style inline assembly: `asm { naked; }` is now much less of a special case wrt. codegen - such naked functions are now emitted as if `asm { naked; }` was replaced with the `@naked` function UDA. IR-wise, they are not emitted as module-level asm blobs anymore, but regular IR functions. This should lift a few former `asm { naked; }`-specific restrictions and fixed at least one LTO issue. (#5041)
 - Predefined version `LDC_LLVM_*` now only contains the LLVM major version, i.e., former `version (LDC_LLVM_1801)` with LLVM v18.1 is now `version (LDC_LLVM_18)`. Use `ldc.intrinsics.LLVM_version` for backwards compatibility if really needed. (#5109)
 - **dcompute**: Added support for Native device code Embedding (PTX and SPIR-V) into the host executable's `.rodata` section. (#5140)
-- The `@ldc.attributes.restrict` UDA is now supported for dynamic-array parameters too. Builtin array ops (`c[] = a[] * b[]` etc.) use it, enabling auto-vectorization. (#5148, #5168, #5176)
+- The `@ldc.attributes.restrict` UDA is now supported for dynamic-array parameters too. Builtin array ops (`c[] = a[] * b[]` etc.) use it, enabling auto-vectorization. Note that for such array ops, the dlang spec prescribes that the slice on the left and any slices on the right must not overlap (https://dlang.org/spec/arrays.html#array-operations), and this knowledge is now used by the optimizer. (#5148, #5168, #5176)
 
 #### Platform support
 - Supports LLVM 18 - 22.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - DMD-style inline assembly: `asm { naked; }` is now much less of a special case wrt. codegen - such naked functions are now emitted as if `asm { naked; }` was replaced with the `@naked` function UDA. IR-wise, they are not emitted as module-level asm blobs anymore, but regular IR functions. This should lift a few former `asm { naked; }`-specific restrictions and fixed at least one LTO issue. (#5041)
 - Predefined version `LDC_LLVM_*` now only contains the LLVM major version, i.e., former `version (LDC_LLVM_1801)` with LLVM v18.1 is now `version (LDC_LLVM_18)`. Use `ldc.intrinsics.LLVM_version` for backwards compatibility if really needed. (#5109)
 - **dcompute**: Added support for Native device code Embedding (PTX and SPIR-V) into the host executable's `.rodata` section. (#5140)
+- The `@ldc.attributes.restrict` UDA is now supported for dynamic-array parameters too. Builtin array ops (`c[] = a[] * b[]` etc.) use it, enabling auto-vectorization. (#5148, #5168, #5176)
 
 #### Platform support
 - Supports LLVM 18 - 22.

--- a/runtime/druntime/src/core/internal/array/operations.d
+++ b/runtime/druntime/src/core/internal/array/operations.d
@@ -12,6 +12,8 @@ import core.internal.traits : Filter, staticMap, Unqual;
 version (GNU) version = GNU_OR_LDC;
 version (LDC) version = GNU_OR_LDC;
 
+version (LDC) import ldc.attributes : restrict;
+
 /**
  * Perform array (vector) operations and store the result in `res`.  Operand
  * types and operations are passed as template arguments in Reverse Polish
@@ -33,7 +35,7 @@ version (LDC) version = GNU_OR_LDC;
  *
  * Returns: the slice containing the result
  */
-T[] arrayOp(T : T[], Args...)(T[] res, Filter!(isType, Args) args) @trusted
+T[] arrayOp(T : T[], Args...)(@restrict T[] res, @restrict Filter!(isType, Args) args) @trusted
 {
     alias scalarizedExp = staticMap!(toElementType, Args);
     alias check = typeCheck!(true, T, scalarizedExp); // must support all scalar ops

--- a/tests/codegen/gh4991.d
+++ b/tests/codegen/gh4991.d
@@ -1,0 +1,23 @@
+// Make sure array ops are auto-vectorized with enabled optimizations.
+
+// REQUIRES: target_X86
+// RUN: %ldc -mtriple=x86_64-linux-gnu -O -mattr=+avx512vl -ffast-math -output-s -of=%t.s %s && FileCheck %s < %t.s
+
+// CHECK: _D6gh499113kernel_staticFKG16fKxG16fKxQgKxQkZv:
+void kernel_static(ref float[16] o, const ref float[16] a, const ref float[16] b, const ref float[16] c) {
+    // CHECK-NEXT: .cfi_startproc
+    // CHECK-NEXT: vmovups	(%rsi), %zmm0
+    // CHECK-NEXT: vmovups	(%rdx), %zmm1
+    // CHECK-NEXT: vfmadd213ps	(%rcx), %zmm0, %zmm1
+    // CHECK-NEXT: vmovups	%zmm1, (%rdi)
+    // CHECK-NEXT: vzeroupper
+    // CHECK-NEXT: retq
+    o[] = a[] * b[] + c[];
+}
+
+// CHECK: _D6gh499114kernel_dynamicFAfxAfxQdxQgZv:
+void kernel_dynamic(float[] o, const float[] a, const float[] b, const float[] c) {
+    // CHECK: vfmadd213ps
+    o[] = a[] * b[] + c[];
+    // CHECK: .size	_D6gh499114kernel_dynamicFAfxAfxQdxQgZv
+}

--- a/tests/dmd/runnable/arrayop.d
+++ b/tests/dmd/runnable/arrayop.d
@@ -751,7 +751,7 @@ void test11525()
 
     auto a = [Complex!double(2, 2)];
     assert(a.length == 1 && a[0].re == 2 && a[0].im == 2);
-    a[] *= a[];
+    a[] *= a.dup[];
     assert(a.length == 1 && a[0].re == 0 && a[0].im == 8);
 }
 


### PR DESCRIPTION
Resolves #4991.