### PR TITLE
Add DirectX dcompute target scaffold (DXIL triple + HLSL attrs).

### DIFF
--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -751,12 +751,14 @@ cl::opt<unsigned>
                    cl::desc("Warn for stack size bigger than the given number"),
                    cl::value_desc("threshold"));
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||       \
+    LDC_LLVM_SUPPORTED_TARGET_DirectX
 cl::list<std::string>
     dcomputeTargets("mdcompute-targets", cl::CommaSeparated,
                     cl::desc("Generates code for the specified DCompute target"
-                             " list. Use 'ocl-xy0' for OpenCL x.y, and "
-                             "'cuda-xy0' for CUDA CC x.y"),
+                             " list. Use 'ocl-xy0' for OpenCL x.y, "
+                             "'cuda-xy0' for CUDA CC x.y, and "
+                             "'directx-xy0' for DirectX Shader Model x.y"),
                      cl::value_desc("targets"));
 cl::opt<std::string>
     dcomputeFilePrefix("mdcompute-file-prefix",

--- a/driver/cl_options.h
+++ b/driver/cl_options.h
@@ -140,7 +140,8 @@ extern cl::opt<std::string> saveOptimizationRecord;
 
 extern cl::opt<unsigned> fWarnStackSize;
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||       \
+    LDC_LLVM_SUPPORTED_TARGET_DirectX || LDC_LLVM_SUPPORTED_TARGET_AArch64
 extern cl::list<std::string> dcomputeTargets;
 extern cl::opt<std::string> dcomputeFilePrefix;
 extern cl::opt<bool> fembedDCompute;

--- a/driver/dcomputecodegenerator.cpp
+++ b/driver/dcomputecodegenerator.cpp
@@ -17,7 +17,8 @@
 #include <string>
 #include <algorithm>
 
-#if !(LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX)
+#if !(LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||     \
+      LDC_LLVM_SUPPORTED_TARGET_DirectX)
 
 DComputeCodeGenManager::DComputeCodeGenManager(llvm::LLVMContext &c) : ctx(c) {}
 void DComputeCodeGenManager::emit(Module *) {}
@@ -59,17 +60,37 @@ DComputeCodeGenManager::createComputeTarget(const std::string &s) {
 #endif
   }
 
+  if (s.substr(0, 8) == "directx-") {
+#if LDC_LLVM_SUPPORTED_TARGET_DirectX
+    // Shader Model x.y encoded as x*100 + y*10 (e.g. directx-660 → SM 6.6)
+#define DIRECTX_VALID_VER_INIT 600, 610, 620, 630, 640, 650, 660, 670
+    const std::array<int, 8> valid_dx_versions = {{DIRECTX_VALID_VER_INIT}};
+
+    const int v = atoi(s.c_str() + 8);
+    if (std::find(valid_dx_versions.begin(), valid_dx_versions.end(), v) !=
+        valid_dx_versions.end()) {
+      return createDirectXTarget(ctx, v);
+    }
+#else
+    error(Loc(), "LDC was not built with DirectX DCompute support.");
+#endif
+  }
+
 #define STR(...) #__VA_ARGS__
 #define XSTR(x) STR(x)
 
   error(Loc(),
         "Unrecognised or invalid DCompute targets: the format is ocl-xy0 "
-        "for OpenCl x.y and cuda-xy0 for CUDA CC x.y."
+        "for OpenCl x.y, cuda-xy0 for CUDA CC x.y, and directx-xy0 for "
+        "DirectX Shader Model x.y."
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV
         " Valid version strings for OpenCl are ocl-{" XSTR(OCL_VALID_VER_INIT) "}."
 #endif
 #if LDC_LLVM_SUPPORTED_TARGET_NVPTX
         " Valid version strings for CUDA are cuda-{" XSTR(CUDA_VALID_VER_INIT) "}."
+#endif
+#if LDC_LLVM_SUPPORTED_TARGET_DirectX
+        " Valid version strings for DirectX are directx-{" XSTR(DIRECTX_VALID_VER_INIT) "}."
 #endif
   );
 
@@ -119,4 +140,4 @@ DComputeCodeGenManager::~DComputeCodeGenManager() {
   gABI = oldGABI;
 }
 
-#endif // LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#endif // SPIRV || NVPTX || DirectX

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -970,7 +970,8 @@ void registerPredefinedVersions() {
   VersionCondition::addPredefinedGlobalIdent("all");
   VersionCondition::addPredefinedGlobalIdent("D_Version2");
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX || LDC_LLVM_SUPPORTED_TARGET_AArch64
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||       \
+    LDC_LLVM_SUPPORTED_TARGET_DirectX || LDC_LLVM_SUPPORTED_TARGET_AArch64
   for(auto& dcomputeTarget: dcomputeTargets) {
     auto targetInfo = llvm::StringRef(dcomputeTarget);
     
@@ -984,6 +985,10 @@ void registerPredefinedVersions() {
 
     if (targetInfo.starts_with("metal")) {
       VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_Metal");
+    }
+
+    if (targetInfo.starts_with("directx")) {
+      VersionCondition::addPredefinedGlobalIdent("LDC_DCompute_DirectX");
     }
   }
 

--- a/gen/abi/directx.cpp
+++ b/gen/abi/directx.cpp
@@ -1,0 +1,57 @@
+//===-- gen/abi/directx.cpp -------------------------------------*- C++ -*-===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gen/abi/abi.h"
+#include "gen/dcompute/druntime.h"
+#include "gen/uda.h"
+#include "dmd/declaration.h"
+#include "gen/tollvm.h"
+#include "gen/dcompute/abi-rewrites.h"
+
+using namespace dmd;
+
+/// ABI for DirectX / DXIL dcompute kernels.
+/// Calling convention stays C; kernel marking is via HLSL function attributes
+/// (see targetDirectX.cpp), not a special LLVM CC.
+struct DirectXTargetABI : TargetABI {
+  DComputePointerRewrite pointerRewite;
+
+  llvm::CallingConv::ID callingConv(LINK l) override {
+    assert(l == LINK::c);
+    return llvm::CallingConv::C;
+  }
+
+  llvm::CallingConv::ID callingConv(FuncDeclaration *fdecl) override {
+    (void)fdecl;
+    return llvm::CallingConv::C;
+  }
+
+  bool passByVal(TypeFunction *, Type *t) override {
+    return DtoIsInMemoryOnly(t) && isPOD(t) && size(t) > 64;
+  }
+
+  bool returnInArg(TypeFunction *tf, bool) override {
+    return DtoIsInMemoryOnly(tf->next);
+  }
+
+  void rewriteArgument(IrFuncTy &fty, IrFuncTyArg &arg) override {
+    TargetABI::rewriteArgument(fty, arg);
+    if (arg.rewrite)
+      return;
+
+    Type *ty = arg.type->toBasetype();
+    std::optional<DcomputePointer> ptr;
+    if (ty->ty == TY::Tstruct &&
+        (ptr = toDcomputePointer(static_cast<TypeStruct *>(ty)->sym))) {
+      pointerRewite.applyTo(arg);
+    }
+  }
+};
+
+TargetABI *createDirectXABI() { return new DirectXTargetABI(); }

--- a/gen/abi/targets.h
+++ b/gen/abi/targets.h
@@ -31,6 +31,8 @@ TargetABI *getRISCV64TargetABI();
 
 TargetABI *createSPIRVABI();
 
+TargetABI *createDirectXABI();
+
 TargetABI *getWin64TargetABI();
 
 TargetABI *getX86_64TargetABI();

--- a/gen/dcompute/target.cpp
+++ b/gen/dcompute/target.cpp
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||       \
+    LDC_LLVM_SUPPORTED_TARGET_DirectX
 
 #include "dmd/dsymbol.h"
 #include "dmd/errors.h"

--- a/gen/dcompute/target.h
+++ b/gen/dcompute/target.h
@@ -27,8 +27,10 @@ class FuncDeclaration;
 class DComputeTarget {
 public:
   llvm::LLVMContext &ctx;
-  int tversion; // OpenCL or CUDA CC version:major*100 + minor*10
-  enum class ID { Host = 0, OpenCL = 1, CUDA = 2 };
+  int tversion; // OpenCL / CUDA CC / DirectX SM: major*100 + minor*10
+  // MUST stay in sync with ldc.dcompute.ReflectTarget.
+  // DirectX = 4 leaves 3 free for Vulkan (GSoC / PR) without renumbering.
+  enum class ID { Host = 0, OpenCL = 1, CUDA = 2, Vulkan = 3, DirectX = 4 };
   ID target;    // ID for codegen time conditional compilation.
   const char *short_name;
   const char *binSuffix;
@@ -66,4 +68,8 @@ DComputeTarget *createCUDATarget(llvm::LLVMContext &c, int sm);
 
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV
 DComputeTarget *createOCLTarget(llvm::LLVMContext &c, int oclver);
+#endif
+
+#if LDC_LLVM_SUPPORTED_TARGET_DirectX
+DComputeTarget *createDirectXTarget(llvm::LLVMContext &c, int smVersion);
 #endif

--- a/gen/dcompute/targetDirectX.cpp
+++ b/gen/dcompute/targetDirectX.cpp
@@ -1,0 +1,109 @@
+//===-- gen/dcompute/targetDirectX.cpp ------------------------------------===//
+//
+//                         LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license. See the LICENSE
+// file for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// DirectX / DXIL dcompute backend scaffold.
+// Metadata style mirrors Vulkan (HLSL function attrs) + DXIL compute triple,
+// per Clang CodeGenHLSL / llvm/test/CodeGen/DirectX requirements.
+//
+//===----------------------------------------------------------------------===//
+
+#if LDC_LLVM_SUPPORTED_TARGET_DirectX
+
+#include "dmd/expression.h"
+#include "gen/abi/targets.h"
+#include "gen/dcompute/druntime.h"
+#include "gen/dcompute/target.h"
+#include "gen/logger.h"
+#include "gen/optimizer.h"
+#include "gen/to_string.h"
+#include "driver/targetmachine.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/Target/TargetMachine.h"
+#include <string>
+
+using namespace dmd;
+
+namespace {
+
+class TargetDirectX : public DComputeTarget {
+public:
+  TargetDirectX(llvm::LLVMContext &c, int smVersion)
+      : DComputeTarget(c, smVersion, ID::DirectX, "directx", "ll",
+                       createDirectXABI(),
+                       // Private, Global, Shared, Constant, Generic
+                       // Shared → addrspace(3) (Clang group_shared / DXIL)
+                       {{0, 1, 3, 2, 0}}) {
+
+    const int major = tversion / 100;
+    const int minor = (tversion % 100) / 10;
+    std::string tripleString =
+        "dxil-pc-shadermodel" + ldc::to_string(major) + "." +
+        ldc::to_string(minor) + "-compute";
+
+    auto floatABI = ::FloatABI::Hard;
+    targetMachine = createTargetMachine(
+        tripleString, "dxil", "", {}, ExplicitBitness::None, floatABI,
+        llvm::Reloc::Static, llvm::CodeModel::Medium, codeGenOptLevel(), false);
+
+    _ir = new IRState("dcomputeTargetDirectX", ctx);
+#if LLVM_VERSION_MAJOR >= 21
+    _ir->module.setTargetTriple(llvm::Triple(tripleString));
+#else
+    _ir->module.setTargetTriple(tripleString);
+#endif
+    _ir->module.setDataLayout(targetMachine->createDataLayout());
+    _ir->dcomputetarget = this;
+  }
+
+  void addMetadata() override {
+    // Module-level MD left empty initially (same as CUDA/Vulkan).
+    // dxil-translate-metadata derives !dx.shaderModel from triple + fn attrs.
+  }
+
+  llvm::AttrBuilder buildKernAttrs(StructLiteralExp *kernAttr) {
+    auto b = llvm::AttrBuilder(ctx);
+    b.addAttribute("hlsl.shader", "compute");
+
+    // @kernel(size_t[3] bounds) — first struct field is the array literal.
+    std::string numthreads = "1,1,1";
+    if (kernAttr && kernAttr->elements && kernAttr->elements->length > 0) {
+      if (auto *ale = (*kernAttr->elements)[0]->isArrayLiteralExp()) {
+        if (ale->elements && ale->elements->length >= 3) {
+          numthreads.clear();
+          numthreads += ldc::to_string((*ale->elements)[0]->toInteger());
+          numthreads += ",";
+          numthreads += ldc::to_string((*ale->elements)[1]->toInteger());
+          numthreads += ",";
+          numthreads += ldc::to_string((*ale->elements)[2]->toInteger());
+        }
+      }
+    }
+    b.addAttribute("hlsl.numthreads", numthreads);
+
+    // Present in LLVM DirectX fixtures before dxil-prepare; harmless for IR
+    // inspection. Passes may strip it later.
+    b.addAttribute("exp-shader", "cs");
+    return b;
+  }
+
+  void addKernelMetadata(FuncDeclaration *df, llvm::Function *llf,
+                         StructLiteralExp *kernAttr) override {
+    (void)df;
+    // Same HLSL-shaped attrs as Vulkan's buildKernAttrs — required by DXIL.
+    llf->addFnAttrs(buildKernAttrs(kernAttr));
+  }
+};
+
+} // namespace
+
+DComputeTarget *createDirectXTarget(llvm::LLVMContext &c, int smVersion) {
+  return new TargetDirectX(c, smVersion);
+}
+
+#endif // LDC_LLVM_SUPPORTED_TARGET_DirectX

--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -401,7 +401,8 @@ Expression *Target::getTargetInfo(const char *name_, Loc loc) {
     return IntegerExp::create(loc, static_cast<unsigned>(cet), Type::tint32);
   }
 
-#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
+#if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX ||       \
+    LDC_LLVM_SUPPORTED_TARGET_DirectX
   if (name == "dcomputeTargets") {
     Expressions* exps = createExpressions();
     for (auto &targ : opts::dcomputeTargets) {

--- a/runtime/druntime/src/ldc/dcompute.d
+++ b/runtime/druntime/src/ldc/dcompute.d
@@ -10,10 +10,12 @@ module ldc.dcompute;
 
 enum ReflectTarget : uint
 {
-    // These numbers MUST match DcomputeTarget::target in LDC.
+    // These numbers MUST match DComputeTarget::ID in LDC gen/dcompute/target.h.
     Host = 0,
     OpenCL = 1,
     CUDA = 2,
+    Vulkan = 3,   // reserved (GSoC / upstream PR); not required for DirectX
+    DirectX = 4,
 }
 /**
  * The pseudo conditional compilation function.
@@ -42,8 +44,8 @@ enum CompileFor : int
 
 /++
 + When applied to a module, specifies that the module should be compiled for
-+ dcompute (-mdcompute-targets=<...>) using the NVPTX and/or SPIRV backends of
-+ LLVM.
++ dcompute (-mdcompute-targets=<...>) using the NVPTX, SPIRV, and/or DirectX
++ backends of LLVM.
 +
 + Examples:
 + ---


### PR DESCRIPTION
Mirror Vulkan-style hlsl.shader/numthreads metadata with dxil-pc-shadermodel*-compute triple and -mdcompute-targets=directx-XY0 CLI. ReflectTarget.DirectX=4 leaves Vulkan=3 free.