### PR TITLE
MSVC++ interop: Fix private-fields special case for struct PODness

### DIFF
--- a/gen/abi/abi.cpp
+++ b/gen/abi/abi.cpp
@@ -116,12 +116,24 @@ bool TargetABI::isAggregate(Type *t) {
          /*ty == TY::Tarray ||*/ ty == TY::Tdelegate || t->isComplex();
 }
 
-bool TargetABI::isPOD(Type *t, bool excludeStructsWithCtor) {
+bool TargetABI::isPOD(Type *t, bool msvcSemantics) {
   t = t->baseElemOf();
   if (t->ty != TY::Tstruct)
     return true;
   StructDeclaration *sd = static_cast<TypeStruct *>(t)->sym;
-  return dmd::isPOD(sd) && !(excludeStructsWithCtor && sd->ctor);
+  if (!dmd::isPOD(sd))
+    return false;
+  if (msvcSemantics) {
+    // any ctor makes the struct a non-POD
+    if (sd->ctor)
+      return false;
+    // any non-public field makes it a non-POD
+    for (auto vd : sd->fields) {
+      if (vd->visible().kind < Visibility::public_)
+        return false;
+    }
+  }
+  return true;
 }
 
 bool TargetABI::canRewriteAsInt(Type *t, bool include64bit) {

--- a/gen/abi/abi.h
+++ b/gen/abi/abi.h
@@ -208,9 +208,9 @@ protected:
   /// * complex number
   static bool isAggregate(Type *t);
 
-  /// Returns true if the D type is a Plain-Old-Datatype, optionally excluding
-  /// structs with constructors from that definition.
-  static bool isPOD(Type *t, bool excludeStructsWithCtor = false);
+  /// Returns true if the D type is a Plain-Old-Datatype, optionally using
+  /// MSVC++ semantics.
+  static bool isPOD(Type *t, bool msvcSemantics = false);
 
   /// Returns true if the D type can be bit-cast to an integer of the same size.
   static bool canRewriteAsInt(Type *t, bool include64bit = true);

--- a/gen/abi/win64.cpp
+++ b/gen/abi/win64.cpp
@@ -59,7 +59,8 @@ private:
     // Handle non-PODs:
     if (isReturnValue) {
       // Enforce sret for non-PODs.
-      // MSVC++ additionally enforces it for all structs with ctors.
+      // MSVC++ additionally enforces it for all structs with ctors (or
+      // non-public fields).
       if (!isPOD(t, isMSVCpp))
         return true;
     } else {

--- a/gen/abi/x86.cpp
+++ b/gen/abi/x86.cpp
@@ -135,8 +135,7 @@ struct X86TargetABI : TargetABI {
     }
 
     // force sret for non-POD structs
-    const bool excludeStructsWithCtor = isMSVCpp;
-    if (!isPOD(rt, excludeStructsWithCtor))
+    if (!isPOD(rt, isMSVCpp))
       return true;
 
     // return aggregates of a power-of-2 size <= 8 bytes in register(s),

--- a/tests/dmd/runnable_cxx/extra-files/cpp_nonpod_byval.cpp
+++ b/tests/dmd/runnable_cxx/extra-files/cpp_nonpod_byval.cpp
@@ -72,3 +72,16 @@ struct MemberWithCtor
     CtorOnly m;
 };
 Foo(MemberWithCtor);
+
+struct PrivateField
+{
+private:
+    int a;
+
+    // just to be able to access and construct it in the C++ function
+    // (the MSVC++ special case of private fields breaking PODness
+    // doesn't require a constructor):
+    PrivateField(int a) : a(a) {}
+    friend PrivateField fooCpp(PrivateField param);
+};
+Foo(PrivateField);

--- a/tests/dmd/runnable_cxx/nonpod_byval.d
+++ b/tests/dmd/runnable_cxx/nonpod_byval.d
@@ -105,6 +105,12 @@ struct MemberWithCtor
 }
 mixin Foo!MemberWithCtor;
 
+struct PrivateField
+{
+    private int a;
+}
+mixin Foo!PrivateField;
+
 void main()
 {
     test!POD();
@@ -115,4 +121,5 @@ void main()
     test!CopyAndMove();
     test!MoveOnly();
     test!MemberWithCtor();
+    test!PrivateField();
 }


### PR DESCRIPTION
Resolves #5139.