### PR TITLE
Fix Wasm `getStackTop` on older LLVM

### DIFF
--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -1688,7 +1688,7 @@ in (fn)
             }}
             asm pure nothrow @nogc {
                 ("sd $gp, %0") : "=m" (regs[8]);
-                ("sd $fp, %0") : "=m" (regs[9]);
+                ("sd $fp, %0") : "=m" (regs[9]); 
                 ("sd $ra, %0") : "=m" (sp);
             }
         }
@@ -1848,22 +1848,7 @@ version (LDC)
             import ldc.intrinsics;
 
             static if (LLVM_major >= 22) return llvm_stackaddress();
-            else static if (LLVM_major >= 18) return llvm_stacksave();
-            else {
-                // Inline assembly to workaround issue solved by
-                // https://github.com/llvm/llvm-project/pull/68133
-                //
-                // Which wasn't merged/fixed until LLVM 18
-
-                import ldc.llvmasm;
-
-                enum string isize = size_t.sizeof == 8 ? "i64" : "i32";
-                return __asm!(void*)(`
-                    .globaltype __stack_pointer, `~isize~`
-                    global.get __stack_pointer
-                    local.set $0
-                `, "=r");
-            }
+            else return llvm_stacksave();
         }
     }
     else

--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -1846,7 +1846,24 @@ version (LDC)
         private extern(D) void* getStackTop() nothrow @nogc
         {
             import ldc.intrinsics;
-            return llvm_stackaddress();
+
+            static if (LLVM_atleast!22) return llvm_stackaddress();
+            else static if (LLVM_atleast!18) return llvm_stacksave();
+            else {
+                // Inline assembly to workaround issue solved by
+                // https://github.com/llvm/llvm-project/pull/68133
+                //
+                // Which wasn't merged/fixed until LLVM 18
+
+                import ldc.llvmasm;
+
+                enum string isize = size_t.sizeof == 8 ? "i64" : "i32";
+                return __asm!(void*)(`
+                    .globaltype __stack_pointer, `~isize~`
+                    global.get __stack_pointer
+                    local.set $0
+                `, "=r");
+            }
         }
     }
     else

--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -1688,7 +1688,7 @@ in (fn)
             }}
             asm pure nothrow @nogc {
                 ("sd $gp, %0") : "=m" (regs[8]);
-                ("sd $fp, %0") : "=m" (regs[9]); 
+                ("sd $fp, %0") : "=m" (regs[9]);
                 ("sd $ra, %0") : "=m" (sp);
             }
         }
@@ -1847,8 +1847,8 @@ version (LDC)
         {
             import ldc.intrinsics;
 
-            static if (LLVM_atleast!22) return llvm_stackaddress();
-            else static if (LLVM_atleast!18) return llvm_stacksave();
+            static if (LLVM_major >= 22) return llvm_stackaddress();
+            else static if (LLVM_major >= 18) return llvm_stacksave();
             else {
                 // Inline assembly to workaround issue solved by
                 // https://github.com/llvm/llvm-project/pull/68133

--- a/runtime/druntime/src/ldc/intrinsics.di
+++ b/runtime/druntime/src/ldc/intrinsics.di
@@ -63,14 +63,14 @@ pragma(LDC_intrinsic, "llvm.stackaddress.p0")
 /// function stack, for use with llvm.stackrestore. This is useful for
 /// implementing language features like scoped automatic variable sized arrays
 /// in C99.
-pragma(LDC_intrinsic, "llvm.stacksave")
+pragma(LDC_intrinsic, LLVM_atleast!18 ? "llvm.stacksave.p0" : "llvm.stacksave")
     void* llvm_stacksave();
 
 /// The 'llvm.stackrestore' intrinsic is used to restore the state of the
 /// function stack to the state it was in when the corresponding llvm.stacksave
 /// intrinsic executed. This is useful for implementing language features like
 /// scoped automatic variable sized arrays in C99.
-pragma(LDC_intrinsic, "llvm.stackrestore")
+pragma(LDC_intrinsic, LLVM_atleast!18 ? "llvm.stackrestore.p0" : "llvm.stackrestore")
     void llvm_stackrestore(void* ptr);
 
 /// The 'llvm.prefetch' intrinsic is a hint to the code generator to insert a

--- a/runtime/druntime/src/ldc/intrinsics.di
+++ b/runtime/druntime/src/ldc/intrinsics.di
@@ -63,14 +63,14 @@ pragma(LDC_intrinsic, "llvm.stackaddress.p0")
 /// function stack, for use with llvm.stackrestore. This is useful for
 /// implementing language features like scoped automatic variable sized arrays
 /// in C99.
-pragma(LDC_intrinsic, (LLVM_major >= 18) ? "llvm.stacksave.p0" : "llvm.stacksave")
+pragma(LDC_intrinsic, "llvm.stacksave.p0")
     void* llvm_stacksave();
 
 /// The 'llvm.stackrestore' intrinsic is used to restore the state of the
 /// function stack to the state it was in when the corresponding llvm.stacksave
 /// intrinsic executed. This is useful for implementing language features like
 /// scoped automatic variable sized arrays in C99.
-pragma(LDC_intrinsic, (LLVM_major >= 18) ? "llvm.stackrestore.p0" : "llvm.stackrestore")
+pragma(LDC_intrinsic, "llvm.stackrestore.p0")
     void llvm_stackrestore(void* ptr);
 
 /// The 'llvm.prefetch' intrinsic is a hint to the code generator to insert a

--- a/runtime/druntime/src/ldc/intrinsics.di
+++ b/runtime/druntime/src/ldc/intrinsics.di
@@ -63,14 +63,14 @@ pragma(LDC_intrinsic, "llvm.stackaddress.p0")
 /// function stack, for use with llvm.stackrestore. This is useful for
 /// implementing language features like scoped automatic variable sized arrays
 /// in C99.
-pragma(LDC_intrinsic, LLVM_atleast!18 ? "llvm.stacksave.p0" : "llvm.stacksave")
+pragma(LDC_intrinsic, (LLVM_major >= 18) ? "llvm.stacksave.p0" : "llvm.stacksave")
     void* llvm_stacksave();
 
 /// The 'llvm.stackrestore' intrinsic is used to restore the state of the
 /// function stack to the state it was in when the corresponding llvm.stacksave
 /// intrinsic executed. This is useful for implementing language features like
 /// scoped automatic variable sized arrays in C99.
-pragma(LDC_intrinsic, LLVM_atleast!18 ? "llvm.stackrestore.p0" : "llvm.stackrestore")
+pragma(LDC_intrinsic, (LLVM_major >= 18) ? "llvm.stackrestore.p0" : "llvm.stackrestore")
     void llvm_stackrestore(void* ptr);
 
 /// The 'llvm.prefetch' intrinsic is a hint to the code generator to insert a


### PR DESCRIPTION
Fixes `getStackTop` to work on older versions of LLVM.

`llvm_stackaddress` was introduced in LLVM 22. Use `llvm_stacksave` instead when needed.

This also fixes the intrinsic names/mangling of `llvm_stacksave` and `llvm_stackrestore` after their adjustment in LLVM 18.