### PR TITLE
Fix #5192 - enable version(Apple) on iOS, tvOS, watchOS, and visionOS

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -897,18 +897,28 @@ void registerPredefinedTargetVersions() {
     break;
   case llvm::Triple::IOS:
     VersionCondition::addPredefinedGlobalIdent("iOS");
+    VersionCondition::addPredefinedGlobalIdent("Apple");
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_LLVM");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang"); // legacy
     break;
   case llvm::Triple::TvOS:
     VersionCondition::addPredefinedGlobalIdent("TVOS");
+    VersionCondition::addPredefinedGlobalIdent("Apple");
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_LLVM");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang"); // legacy
     break;
   case llvm::Triple::WatchOS:
     VersionCondition::addPredefinedGlobalIdent("WatchOS");
+    VersionCondition::addPredefinedGlobalIdent("Apple");
+    VersionCondition::addPredefinedGlobalIdent("Posix");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_LLVM");
+    VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang"); // legacy
+    break;
+  case llvm::Triple::XROS:
+    VersionCondition::addPredefinedGlobalIdent("VisionOS");
+    VersionCondition::addPredefinedGlobalIdent("Apple");
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_LLVM");
     VersionCondition::addPredefinedGlobalIdent("CppRuntime_Clang"); // legacy

--- a/tests/compilable/gh5192.d
+++ b/tests/compilable/gh5192.d
@@ -1,0 +1,7 @@
+// REQUIRES: target_AArch64
+// RUN: %ldc -mtriple=arm64-apple-ios -c -o- %s
+// RUN: %ldc -mtriple=arm64-apple-tvos -c -o- %s
+// RUN: %ldc -mtriple=arm64-apple-watchos -c -o- %s
+// RUN: %ldc -mtriple=arm64-apple-xros -c -o- %s
+
+version (Apple) {} else static assert(0, "version(Apple) missing");


### PR DESCRIPTION
## Summary
- Enables `version(Apple)` for `iOS`, `TvOS`, and `WatchOS` triples (same as `MacOSX`), matching the [spec](https://dlang.org/spec/version.html#predefined-versions).
- Adds `XROS` handling with `version(VisionOS)` and `version(Apple)`.
- Adds `tests/compilable/gh5192.d`.

Fixes https://github.com/ldc-developers/ldc/issues/5192

## Test plan
- [x] Code review against existing `MacOSX` / `iOS` version setup in `driver/main.cpp`.
- [x] New lit test (requires `target_AArch64`) compiles for ios/tvos/watchos/xros triples with `version(Apple)`.
- [ ] CI