### PR TITLE
fix issue 5134 windows response files with spaces in paths

### DIFF
--- a/tests/driver/gh5134_rsp_spaces.d
+++ b/tests/driver/gh5134_rsp_spaces.d
@@ -1,0 +1,13 @@
+// https://github.com/ldc-developers/ldc/issues/5134
+// Dub writes LF-only response files on Windows; LLVM's Windows tokenizer
+// expects CRLF, which used to glue the next flag onto a quoted .lib path
+// (Error: unrecognized file extension lib).
+//
+// REQUIRES: Windows
+// RUN: mkdir "%t dir with spaces"
+// RUN: echo void main(){} > "%t dir with spaces/t.d"
+// RUN: python %S/inputs/write_lf_rsp.py %t.rsp "\"%t dir with spaces/t.d\"" -c -o- -vcolumns
+// RUN: %ldc @%t.rsp
+// RUN: python %S/inputs/write_lf_rsp.py %t2.rsp "\"%t dir with spaces/dummy.lib\"" -vcolumns
+// RUN: not %ldc @%t2.rsp 2>&1 | FileCheck %s
+// CHECK-NOT: unrecognized file extension

--- a/tests/driver/inputs/write_lf_rsp.py
+++ b/tests/driver/inputs/write_lf_rsp.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Write a response file with LF-only line endings (dub-style on Windows)."""
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write("usage: write_lf_rsp.py <path> <line>...\n")
+        return 1
+    path = sys.argv[1]
+    content = "\n".join(sys.argv[2:]) + "\n"
+    with open(path, "wb") as f:
+        f.write(content.encode("utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
fixes the windows bug where dub builds fail if the user profile path has spaces.

dub writes each compiler flag on its own line and quotes paths that contain spaces. llvm response file parsing could stick that quoted path to the next line so a .lib argument became something like lib plus vcolumns. ldc then reported unrecognized file extension lib.

ldc2 now expands response files with the same dmd compatible parser ldmd already uses.

fixes #5134