### PR TITLE
Fix missing D_HardFloat/D_SoftFloat on RISC-V, wasm, MSP430, Xtensa

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -706,12 +706,18 @@ void registerPredefinedTargetVersions() {
     break;
   case llvm::Triple::msp430:
     VersionCondition::addPredefinedGlobalIdent("MSP430");
+    // No hardware FPU; match AVR.
+    VersionCondition::addPredefinedGlobalIdent("D_SoftFloat");
     break;
   case llvm::Triple::riscv32:
     VersionCondition::addPredefinedGlobalIdent("RISCV32");
+    VersionCondition::addPredefinedGlobalIdent(
+        floatABI == FloatABI::Soft ? "D_SoftFloat" : "D_HardFloat");
     break;
   case llvm::Triple::riscv64:
     VersionCondition::addPredefinedGlobalIdent("RISCV64");
+    VersionCondition::addPredefinedGlobalIdent(
+        floatABI == FloatABI::Soft ? "D_SoftFloat" : "D_HardFloat");
     break;
   case llvm::Triple::sparc:
     // FIXME: Detect SPARC v8+ (SPARC_V8Plus).
@@ -739,6 +745,7 @@ void registerPredefinedTargetVersions() {
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:
     VersionCondition::addPredefinedGlobalIdent("WebAssembly");
+    VersionCondition::addPredefinedGlobalIdent("D_HardFloat");
     break;
   case llvm::Triple::loongarch32:
     VersionCondition::addPredefinedGlobalIdent("LoongArch32");
@@ -750,6 +757,8 @@ void registerPredefinedTargetVersions() {
     break;
   case llvm::Triple::xtensa:
     VersionCondition::addPredefinedGlobalIdent("Xtensa");
+    VersionCondition::addPredefinedGlobalIdent(
+        floatABI == FloatABI::Soft ? "D_SoftFloat" : "D_HardFloat");
     break;
   default:
     warning(Loc(), "unknown target CPU architecture: %s",

--- a/tests/driver/msp430_float_versions.d
+++ b/tests/driver/msp430_float_versions.d
@@ -1,0 +1,6 @@
+// REQUIRES: target_MSP430
+
+// RUN: %ldc -c -o- %s -mtriple=msp430-unknown-elf
+
+version (D_SoftFloat) {} else static assert(0);
+version (D_HardFloat) static assert(0);

--- a/tests/driver/msp430_float_versions.d
+++ b/tests/driver/msp430_float_versions.d
@@ -1,5 +1,3 @@
-// REQUIRES: target_MSP430
-
 // RUN: %ldc -c -o- %s -mtriple=msp430-unknown-elf
 
 version (D_SoftFloat) {} else static assert(0);

--- a/tests/driver/riscv64_float_versions.d
+++ b/tests/driver/riscv64_float_versions.d
@@ -1,5 +1,3 @@
-// REQUIRES: target_RISCV
-
 // Default float ABI is hard (lp64d-style).
 // RUN: %ldc -c -o- %s -mtriple=riscv64-unknown-linux-gnu -d-version=HARD
 // RUN: %ldc -c -o- %s -mtriple=riscv64-unknown-linux-gnu -float-abi=soft -d-version=SOFT

--- a/tests/driver/riscv64_float_versions.d
+++ b/tests/driver/riscv64_float_versions.d
@@ -1,0 +1,18 @@
+// REQUIRES: target_RISCV
+
+// Default float ABI is hard (lp64d-style).
+// RUN: %ldc -c -o- %s -mtriple=riscv64-unknown-linux-gnu -d-version=HARD
+// RUN: %ldc -c -o- %s -mtriple=riscv64-unknown-linux-gnu -float-abi=soft -d-version=SOFT
+
+version (HARD)
+{
+    version (D_HardFloat) {} else static assert(0);
+    version (D_SoftFloat) static assert(0);
+}
+else version (SOFT)
+{
+    version (D_SoftFloat) {} else static assert(0);
+    version (D_HardFloat) static assert(0);
+}
+else
+    static assert(0);

--- a/tests/driver/wasm_float_versions.d
+++ b/tests/driver/wasm_float_versions.d
@@ -1,0 +1,6 @@
+// REQUIRES: target_WebAssembly
+
+// RUN: %ldc -c -o- %s -mtriple=wasm32-unknown-unknown-wasm
+
+version (D_HardFloat) {} else static assert(0);
+version (D_SoftFloat) static assert(0);

--- a/tests/driver/wasm_float_versions.d
+++ b/tests/driver/wasm_float_versions.d
@@ -1,5 +1,3 @@
-// REQUIRES: target_WebAssembly
-
 // RUN: %ldc -c -o- %s -mtriple=wasm32-unknown-unknown-wasm
 
 version (D_HardFloat) {} else static assert(0);


### PR DESCRIPTION
## Summary

`registerPredefinedTargetVersions()` did not set `D_HardFloat` / `D_SoftFloat` for RISC-V, WebAssembly, MSP430, or Xtensa.

- MSP430 → `D_SoftFloat` (same as AVR; no hardware FPU)
- WebAssembly → `D_HardFloat` (f32/f64)
- RISC-V / Xtensa → follow `-float-abi` (default hard → `D_HardFloat`)

Adds lit tests for riscv64, wasm32, and msp430.

Fixes #5200

## Test plan

- [ ] CI lit: `tests/driver/riscv64_float_versions.d`, `wasm_float_versions.d`, `msp430_float_versions.d`
- [ ] Manual: `version (D_HardFloat)` / `version (D_SoftFloat)` with the triples from #5200