### PR TITLE
Pass `LLVM_MAJOR_VERSION` through `ldc-build-runtime`

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -24,6 +24,9 @@ if(NOT LDC_EXE)
     if(NOT DEFINED DMDFE_MINOR_VERSION OR NOT DEFINED DMDFE_PATCH_VERSION)
         message(FATAL_ERROR "Please define the CMake variables DMDFE_MINOR_VERSION and DMDFE_PATCH_VERSION.")
     endif()
+    if(NOT DEFINED LLVM_VERSION_MAJOR)
+        message(FATAL_ERROR "Please define the CMake variable LLVM_VERSION_MAJOR.")
+    endif()
 endif()
 
 #

--- a/runtime/ldc-build-runtime.d.in
+++ b/runtime/ldc-build-runtime.d.in
@@ -159,6 +159,7 @@ void runCMake() {
         "-DLDMD_EXE_FULL=" ~ ldmdExecutable,
         "-DDMDFE_MINOR_VERSION=@DMDFE_MINOR_VERSION@",
         "-DDMDFE_PATCH_VERSION=@DMDFE_PATCH_VERSION@",
+        "-DLLVM_VERSION_MAJOR=@LLVM_VERSION_MAJOR@",
     ];
 
     if (config.targetSystem.length) args ~= "-DTARGET_SYSTEM=" ~ config.targetSystem.join(";");


### PR DESCRIPTION
Fixing a subtle issue with ldc-developers/ldc#5187 with it using `LLVM_VERSION_MAJOR` but is not being set (treated as 0 in comparisons?) and acting like an old version.