### PR TITLE
Fix nested this capture for traits(getMember, this, ...)

### DIFF
--- a/dmd/traits.d
+++ b/dmd/traits.d
@@ -1159,6 +1159,23 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                         return ErrorExp.get();
                 }
             }
+            version (IN_LLVM)
+            {
+                // getMember + wantsym does not keep a ThisExp; LDC needs vthis in
+                // closureVars for gen/nested (see getThisSkipNestedFuncs in expressionsem.d).
+                if (ex && !ex.isErrorExp())
+                {
+                    if (auto e0 = isExpression(o))
+                    {
+                        e0 = e0.expressionSemantic(sc);
+                        if (auto te = e0.isThisExp())
+                        {
+                            if (te.var && te.var.checkNestedReference(sc, e.loc))
+                                return ErrorExp.get();
+                        }
+                    }
+                }
+            }
             return ex;
         }
         else if (e.ident == Id.getVirtualFunctions ||

--- a/tests/dmd/runnable/issue5203.d
+++ b/tests/dmd/runnable/issue5203.d
@@ -1,0 +1,21 @@
+// https://github.com/ldc-developers/ldc/issues/5203
+
+void main()
+{
+    auto s = Struct();
+    auto dg = s.nestedThunk();
+    assert(dg() == 42);
+}
+
+struct Struct
+{
+    int field = 42;
+    auto nestedThunk()
+    {
+        int inner()
+        {
+            return __traits(getMember, this, "field");
+        }
+        return &inner;
+    }
+}


### PR DESCRIPTION
## Summary

Nested functions that only touch an instance field through `__traits(getMember, this, "member")` never registered a nested reference to the enclosing member `this`. LDC then omitted `vthis` from the closure frame, which showed up as a segfault when the nested function ran (#5203).

After semantic analysis of `getMember`, when the lookup object is `this`, call `checkNestedReference` on the member function's `vthis` so closure building matches a direct field access.

## Test plan

Added `tests/dmd/runnable/issue5203.d` covering a nested function returned as a delegate that reads a field via `getMember` on `this`.

Fixes ldc-developers/ldc#5203.
