### PR TITLE
Fix WASI builds on LLVM 21 & 22 (EH)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -969,6 +969,15 @@ elseif(LLVM_VERSION_MAJOR GREATER_EQUAL 19)
   list (APPEND wasi_switches --wasm-enable-exnref)
 endif()
 
+# A hack to make sure EH actually gets enabled, even though
+# the EH model should be implied by `--wasm-enable-eh`
+# 
+# I don't know what broke it for 21, but this fixes it for 23:
+# https://github.com/llvm/llvm-project/pull/177542
+if((LLVM_VERSION_MAJOR EQUAL 21) OR (LLVM_VERSION_MAJOR EQUAL 22))
+  list(APPEND wasi_switches --exception-model=wasm)
+endif()
+
 makeConfSection(NAME "60-target-any-wasi"
     SECTION "^wasm32-.*-wasi"
     SWITCHES ${wasi_switches}

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -110,6 +110,15 @@ if("${TARGET_SYSTEM}" MATCHES "WASI")
     elseif(LLVM_VERSION_MAJOR GREATER_EQUAL 19)
         list (APPEND D_FLAGS --wasm-enable-exnref)
     endif()
+    
+    # A hack to make sure EH actually gets enabled, even though
+    # the EH model should be implied by `--wasm-enable-eh`
+    # 
+    # I don't know what broke it for 21, but this fixes it for 23:
+    # https://github.com/llvm/llvm-project/pull/177542
+    if((LLVM_VERSION_MAJOR EQUAL 21) OR (LLVM_VERSION_MAJOR EQUAL 22))
+      list(APPEND D_FLAGS --exception-model=wasm)
+    endif()
 endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
Works around an LLVM bug where EH would silently not properly enable.

Somehow introduced for LLVM 21, present for LLVM 22, but fixed for (what will be) 23 by llvm/llvm-project#177542