### PR TITLE
druntime: Allow thread resume/suspend to work on WASI

### DIFF
--- a/.github/actions/5a-wasi/action.yml
+++ b/.github/actions/5a-wasi/action.yml
@@ -45,6 +45,5 @@ runs:
         cd ../ldc-build-runtime.${{ inputs.os }}-${{ inputs.arch }}
 
         export WASMTIME_BACKTRACE_DETAILS=1
+        ../wasmtime/wasmtime -W exceptions ./druntime-test-runner-debug
         ../wasmtime/wasmtime -W exceptions ./druntime-test-runner
-        # FIXME: hangs at one point after core.internal.container.treap
-        #../wasmtime/wasmtime -W exceptions ./druntime-test-runner-debug

--- a/runtime/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/runtime/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3341,9 +3341,7 @@ Lmark:
                 rangesLock.unlock();
                 rootsLock.unlock();
             }
-
-            version (WASI) {} // WASI is single-threaded
-            else thread_suspendAll();
+            thread_suspendAll();
 
             prepare();
 

--- a/runtime/druntime/src/core/thread/osthread.d
+++ b/runtime/druntime/src/core/thread/osthread.d
@@ -2501,7 +2501,14 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
     }
     else version (WASI)
     {
-        onThreadError( "Unable to suspend thread" );
+        if ( t.m_addr != 1 ) // dummy main thread
+        {
+            onThreadError( "Unable to suspend thread" );
+        }
+        else if ( !t.m_lock )
+        {
+            t.m_curr.tstack = getStackTop();
+        }
     }
     return true;
 }
@@ -2524,8 +2531,6 @@ extern (C) void thread_preStopTheWorld() nothrow {
  */
 extern (C) void thread_suspendAll() nothrow
 {
-    version (WASI) onThreadError( "Unable to suspend all threads" );
-
     // NOTE: We've got an odd chicken & egg problem here, because while the GC
     //       is required to call thread_init before calling any other thread
     //       routines, thread_init may allocate memory which could in turn
@@ -2680,7 +2685,14 @@ private extern (D) void resume(ThreadBase _t) nothrow @nogc
     }
     else version (WASI)
     {
-        onThreadError( "Unable to resume thread" );
+        if ( t.m_addr != 1 ) // dummy main thread
+        {
+            onThreadError( "Unable to resume thread" );
+        }
+        else if ( !t.m_lock )
+        {
+            t.m_curr.tstack = t.m_curr.bstack;
+        }
     }
     else
         static assert(false, "Platform not supported.");


### PR DESCRIPTION
Rather than erroring out always, allows "suspending" and "resuming" the main thread (which on POSIX, and now WASI, just marks the stack top).

Prevents issues with code expecting `thread_suspendAll` to be called before hand.