### PR TITLE
GHA: Add a few missing step names

### DIFF
--- a/.github/actions/4a-test-ldc2/action.yml
+++ b/.github/actions/4a-test-ldc2/action.yml
@@ -2,5 +2,6 @@ name: Run LDC D unittests
 runs:
   using: composite
   steps:
-    - run: cd ../build && ctest --output-on-failure -R "ldc2-unittest"
+    - name: Run ldc2-unittest runner
+      run: cd ../build && ctest --output-on-failure -R "ldc2-unittest"
       shell: ${{ env.GHA_BASH_SHELL }}

--- a/.github/actions/5a-android-x86/action.yml
+++ b/.github/actions/5a-android-x86/action.yml
@@ -5,7 +5,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
+    - name: Cross-compile Android x86 libraries & copy to install dir
+      shell: bash
       run: |
         set -eux
         cd ..

--- a/.github/actions/5a-ios/action.yml
+++ b/.github/actions/5a-ios/action.yml
@@ -8,7 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
+    - name: Cross-compile iOS libraries, copy to install dir & extend ldc2.conf
+      shell: bash
       run: |
         set -eux
         cd ..

--- a/.github/actions/helper-build-gdb/action.yml
+++ b/.github/actions/helper-build-gdb/action.yml
@@ -20,7 +20,8 @@ runs:
           /usr/local/share/gdb
         key: gdb-${{ inputs.arch }}
 
-    - shell: bash
+    - name: Build gdb if needed
+      shell: bash
       run: |
         set -eux
 

--- a/.github/actions/helper-build-ldc/action.yml
+++ b/.github/actions/helper-build-ldc/action.yml
@@ -22,7 +22,8 @@ runs:
   using: composite
   steps:
 
-    - if: runner.os != 'Windows'
+    - name: 'Posix: Build LDC'
+      if: runner.os != 'Windows'
       shell: ${{ env.GHA_BASH_SHELL }}
       run: |
         set -eux
@@ -43,7 +44,8 @@ runs:
         ninja obj/ldc2.o ${{ inputs.build_targets }}
 
     # Windows: invoke CMake & ninja in MSVC env
-    - if: runner.os == 'Windows'
+    - name: 'Windows: Build LDC'
+      if: runner.os == 'Windows'
       shell: cmd
       run: |
         call "%LDC_VSDIR%\Common7\Tools\VsDevCmd.bat" -arch=${{ inputs.arch }} || exit /b

--- a/.github/actions/helper-mimalloc/action.yml
+++ b/.github/actions/helper-mimalloc/action.yml
@@ -6,7 +6,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: ${{ env.GHA_BASH_SHELL }}
+    - name: Build mimalloc
+      shell: ${{ env.GHA_BASH_SHELL }}
       run: |
         set -eux
         cd ..


### PR DESCRIPTION
As these step names of composite actions are now finally shown in the CI logs (as collapsible sections), incl. nesting - I thought I'd never see that happen. :)

So the names are now more than just documenting comments, and a few were missing. Very bad are anonymous multiline run steps, as the displayed section name is the first line then (`Run set -eux`).