### PR TITLE
Fix some missing IR-symbol visibilities

### DIFF
--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -1023,8 +1023,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
         (func->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage)) {
       // Fix linkage and visibility
       const auto lwc = lowerFuncLinkage(fd);
-      setLinkage(lwc, func);
-      setVisibility(fd, func);
+      setLinkageAndVisibility(fd, lwc, func);
     }
     return;
   }
@@ -1180,8 +1179,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
            lwc.first != llvm::GlobalValue::ExternalWeakLinkage &&
            lwc.first != llvm::GlobalValue::LinkOnceAnyLinkage);
   } else {
-    setLinkage(lwc, func);
-    setVisibility(fd, func);
+    setLinkageAndVisibility(fd, lwc, func);
   }
 
   // function attributes

--- a/gen/functions.cpp
+++ b/gen/functions.cpp
@@ -769,20 +769,6 @@ void DtoDeclareFunction(FuncDeclaration *fdecl) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static LinkageWithCOMDAT lowerFuncLinkage(FuncDeclaration *fdecl) {
-  // Intrinsics are always external.
-  if (DtoIsIntrinsic(fdecl)) {
-    return LinkageWithCOMDAT(LLGlobalValue::ExternalLinkage, false);
-  }
-
-  // A body-less declaration always needs to be marked as external in LLVM.
-  if (!fdecl->fbody) {
-    return LinkageWithCOMDAT(LLGlobalValue::ExternalLinkage, false);
-  }
-
-  return DtoLinkage(fdecl);
-}
-
 // LDC has the same problem with destructors of struct arguments in closures
 // as DMD, so we copy the failure detection
 void verifyScopedDestructionInClosure(FuncDeclaration *fd) {
@@ -1022,8 +1008,7 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
     if (!linkageAvailableExternally &&
         (func->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage)) {
       // Fix linkage and visibility
-      const auto lwc = lowerFuncLinkage(fd);
-      setLinkageAndVisibility(fd, lwc, func);
+      setLinkageAndVisibility(fd, func);
     }
     return;
   }
@@ -1170,16 +1155,17 @@ void DtoDefineFunction(FuncDeclaration *fd, bool linkageAvailableExternally) {
   const auto f = static_cast<TypeFunction *>(fd->type->toBasetype());
   IrFuncTy &irFty = irFunc->irFty;
 
-  const auto lwc = lowerFuncLinkage(fd);
   if (linkageAvailableExternally) {
     func->setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
     func->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
     // Assert that we are not overriding a linkage type that disallows inlining
+    const auto lwc = DtoLinkage(fd);
+    (void)lwc;
     assert(lwc.first != llvm::GlobalValue::WeakAnyLinkage &&
            lwc.first != llvm::GlobalValue::ExternalWeakLinkage &&
            lwc.first != llvm::GlobalValue::LinkOnceAnyLinkage);
   } else {
-    setLinkageAndVisibility(fd, lwc, func);
+    setLinkageAndVisibility(fd, func);
   }
 
   // function attributes

--- a/gen/linkage.h
+++ b/gen/linkage.h
@@ -17,6 +17,4 @@
 
 // Make it easier to test new linkage types
 
-#define TYPEINFO_LINKAGE_TYPE LLGlobalValue::LinkOnceODRLinkage
-
 extern LLGlobalValue::LinkageTypes templateLinkage;

--- a/gen/moduleinfo.cpp
+++ b/gen/moduleinfo.cpp
@@ -330,9 +330,17 @@ llvm::GlobalVariable *genModuleInfo(Module *m) {
   // Create a global symbol with the above initialiser.
   LLGlobalVariable *moduleInfoSym = getIrModule(m)->moduleInfoSymbol();
   b.finalize(moduleInfoSym);
+
+  // We don't use setLinkageAndVisibility() here, in order to handle the
+  // visibility manually - a module cannot be selectively exported, so the
+  // visibility of its ModuleInfo cannot be controlled in user code. Handle it
+  // by:
+  // * Posix: never hiding it (ignore `-fvisibility=hidden` for ModuleInfos)
+  // * Windows: DLL-exporting it with an explicit `-fvisibility=public`
   setLinkage({LLGlobalValue::ExternalLinkage, needsCOMDAT()}, moduleInfoSym);
   if (global.params.dllexport) {
     moduleInfoSym->setDLLStorageClass(LLGlobalValue::DLLExportStorageClass);
   }
+
   return moduleInfoSym;
 }

--- a/gen/ms-cxx-helper.cpp
+++ b/gen/ms-cxx-helper.cpp
@@ -200,11 +200,10 @@ llvm::GlobalVariable *getTypeDescriptor(IRState &irs, ClassDeclaration *cd) {
   llvm::StructType *TypeDescriptorType =
       getTypeDescriptorType(irs, TypeNameString);
 
-  const LinkageWithCOMDAT lwc = {LLGlobalVariable::LinkOnceODRLinkage, true};
   Var = defineGlobal(cd->loc, gIR->module, TypeDescName,
                      llvm::ConstantStruct::get(TypeDescriptorType, Fields),
-                     lwc.first, /*isConstant=*/true);
-  setLinkage(lwc, Var);
+                     LLGlobalValue::LinkOnceODRLinkage, /*isConstant=*/true);
+  setLinkOnceODRLinkageAndVisibility(Var);
 
   return Var;
 }

--- a/gen/rttibuilder.cpp
+++ b/gen/rttibuilder.cpp
@@ -80,11 +80,10 @@ void RTTIBuilder::push_void_array(llvm::Constant *CI, Type *valtype,
   mangleToBuffer(mangle_sym, initname);
   initname.writestring(".rtti.voidarr.data");
 
-  const LinkageWithCOMDAT lwc(TYPEINFO_LINKAGE_TYPE, needsCOMDAT());
-
-  auto G = new LLGlobalVariable(gIR->module, CI->getType(), true, lwc.first, CI,
+  auto G = new LLGlobalVariable(gIR->module, CI->getType(), true,
+                                LLGlobalValue::LinkOnceODRLinkage, CI,
                                 initname.peekChars());
-  setLinkage(lwc, G);
+  setLinkOnceODRLinkageAndVisibility(G);
   G->setAlignment(llvm::MaybeAlign(DtoAlignment(valtype)));
 
   push_void_array(getTypeAllocSize(CI->getType()), G);
@@ -106,11 +105,10 @@ void RTTIBuilder::push_array(llvm::Constant *CI, uint64_t dim, Type *valtype,
   initname.writestring(tmpStr.c_str());
   initname.writestring(".data");
 
-  const LinkageWithCOMDAT lwc(TYPEINFO_LINKAGE_TYPE, needsCOMDAT());
-
-  auto G = new LLGlobalVariable(gIR->module, CI->getType(), true, lwc.first, CI,
+  auto G = new LLGlobalVariable(gIR->module, CI->getType(), true,
+                                LLGlobalValue::LinkOnceODRLinkage, CI,
                                 initname.peekChars());
-  setLinkage(lwc, G);
+  setLinkOnceODRLinkageAndVisibility(G);
   G->setAlignment(llvm::MaybeAlign(DtoAlignment(valtype)));
 
   push_array(dim, G);

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -274,11 +274,6 @@ void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj) {
                             : nullptr);
 }
 
-void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
-  setLinkage(DtoLinkage(sym), obj);
-  setVisibility(sym, obj);
-}
-
 namespace {
 bool hasExportedLinkage(llvm::GlobalObject *obj) {
   const auto l = obj->getLinkage();
@@ -286,15 +281,16 @@ bool hasExportedLinkage(llvm::GlobalObject *obj) {
          l == LLGlobalValue::WeakODRLinkage ||
          l == LLGlobalValue::WeakAnyLinkage;
 }
-}
 
-void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
+void setVisibility(bool isExplicitlyExported, bool maybeInstantiatedAsWeakODR,
+                   llvm::GlobalObject *obj) {
   const auto &triple = *global.params.targetTriple;
 
   const bool hasHiddenUDA = obj->hasHiddenVisibility();
 
   if (triple.isOSWindows()) {
-    bool isExported = sym->isExport();
+    bool isExported = isExplicitlyExported;
+
     // Also export (non-linkonce_odr) symbols
     // * with -fvisibility=public without @hidden, or
     // * if declared with dllimport (so potentially imported from other object
@@ -312,7 +308,7 @@ void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
     obj->setDLLStorageClass(isExported ? LLGlobalValue::DLLExportStorageClass
                                        : LLGlobalValue::DefaultStorageClass);
   } else {
-    if (sym->isExport()) {
+    if (isExplicitlyExported) {
       obj->setVisibility(LLGlobalValue::DefaultVisibility); // overrides @hidden
     } else if (!obj->hasLocalLinkage() && !hasHiddenUDA) {
       // Hide with -fvisibility=hidden, or linkonce_odr etc.
@@ -325,11 +321,33 @@ void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
           (opts::symbolVisibility == opts::SymbolVisibility::default_ &&
            triple.isOSBinFormatWasm()) ||
           (!hasExportedLinkage(obj) &&
-           !(triple.isOSDarwin() && sym->isInstantiated()))) {
+           !(triple.isOSDarwin() && maybeInstantiatedAsWeakODR))) {
         obj->setVisibility(LLGlobalValue::HiddenVisibility);
       }
     }
   }
+}
+
+void setLinkageAndVisibility(LinkageWithCOMDAT lwc, bool isExplicitlyExported,
+                             bool maybeInstantiatedAsWeakODR,
+                             llvm::GlobalObject *obj) {
+  setLinkage(lwc, obj);
+  setVisibility(isExplicitlyExported, maybeInstantiatedAsWeakODR, obj);
+}
+}
+
+void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
+  setLinkageAndVisibility(sym, DtoLinkage(sym), obj);
+}
+
+void setLinkageAndVisibility(Dsymbol *sym, LinkageWithCOMDAT lwc,
+                             llvm::GlobalObject *obj) {
+  setLinkageAndVisibility(lwc, sym->isExport(), sym->isInstantiated(), obj);
+}
+
+void setLinkOnceODRLinkageAndVisibility(llvm::GlobalObject *obj) {
+  setLinkageAndVisibility({LLGlobalValue::LinkOnceODRLinkage, needsCOMDAT()},
+                          false, false, obj);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -247,6 +247,11 @@ LLGlobalValue::LinkageTypes DtoLinkageOnly(Dsymbol *sym) {
 }
 
 LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
+  // Intrinsics are always external.
+  if (auto fd = sym->isFuncDeclaration())
+    if (DtoIsIntrinsic(fd))
+      return LinkageWithCOMDAT(LLGlobalValue::ExternalLinkage, false);
+
   return {DtoLinkageOnly(sym), needsCOMDAT()};
 }
 
@@ -335,15 +340,11 @@ void setLinkageAndVisibility(LinkageWithCOMDAT lwc, bool isExplicitlyExported,
   setLinkage(lwc, obj);
   setVisibility(isExplicitlyExported, maybeInstantiatedAsWeakODR, obj);
 }
-}
+} // anonymous namespace
 
 void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj) {
-  setLinkageAndVisibility(sym, DtoLinkage(sym), obj);
-}
-
-void setLinkageAndVisibility(Dsymbol *sym, LinkageWithCOMDAT lwc,
-                             llvm::GlobalObject *obj) {
-  setLinkageAndVisibility(lwc, sym->isExport(), sym->isInstantiated(), obj);
+  setLinkageAndVisibility(DtoLinkage(sym), sym->isExport(),
+                          sym->isInstantiated(), obj);
 }
 
 void setLinkOnceODRLinkageAndVisibility(llvm::GlobalObject *obj) {

--- a/gen/tollvm.cpp
+++ b/gen/tollvm.cpp
@@ -247,13 +247,7 @@ LLGlobalValue::LinkageTypes DtoLinkageOnly(Dsymbol *sym) {
 }
 
 LinkageWithCOMDAT DtoLinkage(Dsymbol *sym) {
-  const auto linkage = DtoLinkageOnly(sym);
-  const bool inCOMDAT = needsCOMDAT() ||
-                        // ELF needs some help for ODR linkages:
-                        // https://github.com/ldc-developers/ldc/issues/3589
-                        (linkage == templateLinkage &&
-                         global.params.targetTriple->isOSBinFormatELF());
-  return {linkage, inCOMDAT};
+  return {DtoLinkageOnly(sym), needsCOMDAT()};
 }
 
 bool needsCOMDAT() {
@@ -270,8 +264,15 @@ bool needsCOMDAT() {
 
 void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj) {
   obj->setLinkage(lwc.first);
-  obj->setComdat(lwc.second ? gIR->module.getOrInsertComdat(obj->getName())
-                            : nullptr);
+
+  const bool inCOMDAT = lwc.second ||
+                        // ELF needs some help for ODR linkages:
+                        // https://github.com/ldc-developers/ldc/issues/3589
+                        (global.params.targetTriple->isOSBinFormatELF() &&
+                         (lwc.first == LLGlobalValue::LinkOnceODRLinkage ||
+                          lwc.first == LLGlobalValue::WeakODRLinkage));
+  obj->setComdat(inCOMDAT ? gIR->module.getOrInsertComdat(obj->getName())
+                          : nullptr);
 }
 
 namespace {

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -68,9 +68,6 @@ void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj);
 // Sets linkage and visibility of the specified IR symbol *definition*,
 // based on the specified D symbol (and -fvisibility).
 void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
-// Ditto, but enables overriding the default linkage-with-COMDAT.
-void setLinkageAndVisibility(Dsymbol *sym, LinkageWithCOMDAT lwc,
-                             llvm::GlobalObject *obj);
 // Helper variant for internal symbols only ever emitted as LinkOnceODR,
 // such as non-class TypeInfos (which are emitted into every referencing
 // object file).

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -65,8 +65,8 @@ LinkageWithCOMDAT DtoLinkage(Dsymbol *sym);
 bool needsCOMDAT();
 // Avoid this function and use setLinkageAndVisibility() instead.
 void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj);
-// Sets linkage and visibility of the specified IR symbol based on the specified
-// D symbol.
+// Sets linkage and visibility of the specified IR symbol *definition*,
+// based on the specified D symbol (and -fvisibility).
 void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
 // Ditto, but enables overriding the default linkage-with-COMDAT.
 void setLinkageAndVisibility(Dsymbol *sym, LinkageWithCOMDAT lwc,

--- a/gen/tollvm.h
+++ b/gen/tollvm.h
@@ -63,13 +63,18 @@ typedef std::pair<llvm::GlobalValue::LinkageTypes, bool> LinkageWithCOMDAT;
 LinkageWithCOMDAT DtoLinkage(Dsymbol *sym);
 
 bool needsCOMDAT();
+// Avoid this function and use setLinkageAndVisibility() instead.
 void setLinkage(LinkageWithCOMDAT lwc, llvm::GlobalObject *obj);
 // Sets linkage and visibility of the specified IR symbol based on the specified
 // D symbol.
 void setLinkageAndVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
-// Hides or exports the specified IR symbol depending on its linkage,
-// `-fvisibility` and the specified D symbol's visibility.
-void setVisibility(Dsymbol *sym, llvm::GlobalObject *obj);
+// Ditto, but enables overriding the default linkage-with-COMDAT.
+void setLinkageAndVisibility(Dsymbol *sym, LinkageWithCOMDAT lwc,
+                             llvm::GlobalObject *obj);
+// Helper variant for internal symbols only ever emitted as LinkOnceODR,
+// such as non-class TypeInfos (which are emitted into every referencing
+// object file).
+void setLinkOnceODRLinkageAndVisibility(llvm::GlobalObject *obj);
 
 // some types
 LLIntegerType *DtoSize_t();

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -480,7 +480,7 @@ void buildTypeInfo(TypeInfoDeclaration *decl) {
   // define the TypeInfo global
   DefineVisitor v(gvar);
   decl->accept(&v);
-  setLinkage({TYPEINFO_LINKAGE_TYPE, needsCOMDAT()}, gvar);
+  setLinkOnceODRLinkageAndVisibility(gvar);
 }
 
 /* ========================================================================= */
@@ -503,7 +503,7 @@ class DeclareOrDefineVisitor : public Visitor {
     }
 
     irstruct->getTypeInfoSymbol(/*define=*/true);
-    ti->setLinkage(TYPEINFO_LINKAGE_TYPE); // override
+    setLinkOnceODRLinkageAndVisibility(ti); // override
   }
 
   // Only declare class TypeInfos. They are defined once in their owning module

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -503,7 +503,8 @@ class DeclareOrDefineVisitor : public Visitor {
     }
 
     irstruct->getTypeInfoSymbol(/*define=*/true);
-    setLinkOnceODRLinkageAndVisibility(ti); // override
+    // override existing linkage and visibility (based on the struct)
+    setLinkOnceODRLinkageAndVisibility(ti);
   }
 
   // Only declare class TypeInfos. They are defined once in their owning module

--- a/gen/typinf.cpp
+++ b/gen/typinf.cpp
@@ -503,8 +503,6 @@ class DeclareOrDefineVisitor : public Visitor {
     }
 
     irstruct->getTypeInfoSymbol(/*define=*/true);
-    // override existing linkage and visibility (based on the struct)
-    setLinkOnceODRLinkageAndVisibility(ti);
   }
 
   // Only declare class TypeInfos. They are defined once in their owning module

--- a/ir/irclass.cpp
+++ b/ir/irclass.cpp
@@ -591,13 +591,11 @@ LLConstant *IrClass::getInterfaceVtblInit(BaseClass *b,
 
     llvm::Function *thunk = gIR->module.getFunction(thunkIRMangle);
     if (!thunk) {
-      const LinkageWithCOMDAT lwc(LLGlobalValue::LinkOnceODRLinkage,
-                                  needsCOMDAT());
       const auto callee = irFunc->getLLVMCallee();
-      thunk = LLFunction::Create(
-          callee->getFunctionType(), lwc.first,
-          thunkIRMangle, &gIR->module);
-      setLinkage(lwc, thunk);
+      thunk = LLFunction::Create(callee->getFunctionType(),
+                                 LLGlobalValue::LinkOnceODRLinkage,
+                                 thunkIRMangle, &gIR->module);
+      setLinkOnceODRLinkageAndVisibility(thunk);
       thunk->copyAttributesFrom(callee);
 
       // Thunks themselves don't have an identity, only the target function has.

--- a/ir/irstruct.cpp
+++ b/ir/irstruct.cpp
@@ -65,8 +65,10 @@ LLGlobalVariable* IrStruct::getTypeInfoSymbol(bool define) {
 
   if (define) {
     auto init = getTypeInfoInit();
-    if (!typeInfo->hasInitializer())
-      defineGlobal(typeInfo, init, aggrdecl);
+    if (!typeInfo->hasInitializer()) {
+      defineGlobal(typeInfo, init, /*symbolForLinkageAndVisibility=*/nullptr);
+      setLinkOnceODRLinkageAndVisibility(typeInfo);
+    }
   }
 
   return typeInfo;

--- a/tests/codegen/export_aggregate_symbols.d
+++ b/tests/codegen/export_aggregate_symbols.d
@@ -49,9 +49,8 @@ export struct ExportedS { int nonZero = 1; }
 
 // struct TypeInfos:
 
-// DEFAULT:    _D45TypeInfo_S24export_aggregate_symbols8DefaultS6__initZ
-// HIDDEN-NOT: _D45TypeInfo_S24export_aggregate_symbols8DefaultS6__initZ
+// BOTH-NOT: _D45TypeInfo_S24export_aggregate_symbols8DefaultS6__initZ
 auto ti_defaultS = typeid(DefaultS);
 
-// BOTH: _D46TypeInfo_S24export_aggregate_symbols9ExportedS6__initZ
+// BOTH-NOT: _D46TypeInfo_S24export_aggregate_symbols9ExportedS6__initZ
 auto ti_exportedS = typeid(ExportedS);

--- a/tests/codegen/pragma_no_typeinfo.d
+++ b/tests/codegen/pragma_no_typeinfo.d
@@ -5,7 +5,8 @@
 pragma(LDC_no_moduleinfo); // prevent ModuleInfo from referencing class TypeInfos
 
 
-// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = linkonce_odr global %object.TypeInfo_Struct
+// note: no `hidden` on Windows (DLL storage classes instead)
+// CHECK: _D50TypeInfo_S18pragma_no_typeinfo18StructWithTypeInfo6__initZ = linkonce_odr{{( hidden)?}} global %object.TypeInfo_Struct
 struct StructWithTypeInfo {}
 // force emission
 auto ti = typeid(StructWithTypeInfo);

--- a/tests/codegen/static_typeid_gh1540.d
+++ b/tests/codegen/static_typeid_gh1540.d
@@ -19,10 +19,11 @@ struct S
 // CHECK-DAG: _D{{.*}}classvarC14TypeInfo_Class{{\"?}} = thread_local global ptr {{.*}}1C7__ClassZ
 auto classvar = typeid(C);
 
-// CHECK-DAG: _D{{.*}}TypeInfo_C{{.*}}1I6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Interface
+// note: no `hidden` on Windows (DLL storage classes instead)
+// CHECK-DAG: _D{{.*}}TypeInfo_C{{.*}}1I6__initZ{{\"?}} = linkonce_odr{{( hidden)?}} global %object.TypeInfo_Interface
 // CHECK-DAG: _D{{.*}}interfacevarC18TypeInfo_Interface{{\"?}} = thread_local global ptr {{.*}}TypeInfo_C{{.*}}1I6__initZ
 auto interfacevar = typeid(I);
 
-// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = linkonce_odr global %object.TypeInfo_Struct
+// CHECK-DAG: _D{{.*}}TypeInfo_S{{.*}}1S6__initZ{{\"?}} = linkonce_odr{{( hidden)?}} global %object.TypeInfo_Struct
 // CHECK-DAG: _D{{.*}}structvarC15TypeInfo_Struct{{\"?}} = thread_local global ptr {{.*}}TypeInfo_S{{.*}}1S6__initZ
 auto structvar = typeid(S);


### PR DESCRIPTION
Mainly for non-class TypeInfos, by consistently using the `setLinkageAndVisibility()` helper.