### PR TITLE
Enable EH for all wasm targets, not just WASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,13 @@ makeConfSection(NAME "30-compiler" SECTION "default"
     POST_SWITCHES "-I${INCLUDE_INSTALL_DIR}"
 )
 
-# Add a base config for all wasm targets, setting some linker defaults.
+# Add a base config for all wasm targets, setting some linker defaults and enabling EH.
+set(wasm_eh_switches --wasm-enable-eh)
+if(LLVM_VERSION_MAJOR GREATER_EQUAL 20)
+    list(APPEND wasm_eh_switches --wasm-use-legacy-eh=false)
+elseif(LLVM_VERSION_MAJOR GREATER_EQUAL 19)
+    list(APPEND wasm_eh_switches --wasm-enable-exnref)
+endif()
 makeConfSection(NAME "51-target-wasm-base"
     SECTION "^wasm(32|64)-"
     SWITCHES
@@ -933,26 +939,7 @@ makeConfSection(NAME "51-target-wasm-base"
         -L-z -Lstack-size=1048576
         # Protect from stack overflow overwriting global memory
         -L--stack-first
-)
-
-# Add a base config for all WASI targets.
-set(wasi_eh_switches --wasm-enable-eh --mattr=+exception-handling)
-if(LLVM_VERSION_MAJOR GREATER_EQUAL 20)
-    list(APPEND wasi_eh_switches --wasm-use-legacy-eh=false)
-elseif(LLVM_VERSION_MAJOR GREATER_EQUAL 19)
-    list(APPEND wasi_eh_switches --wasm-enable-exnref)
-endif()
-# A hack to make sure EH actually gets enabled, even though
-# the EH model should be implied by `--wasm-enable-eh`
-# 
-# I don't know what broke it for 21, but this fixes it for 23:
-# https://github.com/llvm/llvm-project/pull/177542
-if((LLVM_VERSION_MAJOR EQUAL 21) OR (LLVM_VERSION_MAJOR EQUAL 22))
-    list(APPEND wasi_eh_switches --exception-model=wasm)
-endif()
-makeConfSection(NAME "52-target-wasi-base"
-    SECTION "^wasm(32|64)-.*-wasi"
-    SWITCHES ${wasi_eh_switches}
+        ${wasm_eh_switches}
 )
 
 # Add a convenience config for *naked* wasm targets, omitting druntime/Phobos

--- a/driver/targetmachine.cpp
+++ b/driver/targetmachine.cpp
@@ -627,6 +627,19 @@ createTargetMachine(const std::string targetTriple, const std::string arch,
     targetOptions.EmulatedTLS = false;
   }
 
+  // wasm: enable EH (with the help of 51-target-wasm-base.conf)
+  if (triple.isWasm()) {
+    if (!hasFeature("exception-handling")) {
+      features.push_back("+exception-handling");
+    }
+
+#if LLVM_VERSION_MAJOR >= 21 && LLVM_VERSION_MAJOR <= 22
+    // we need to enforce `--exception-model=wasm`, although it should be
+    // implied by `--wasm-enable-eh`
+    targetOptions.ExceptionModel = llvm::ExceptionHandling::Wasm;
+#endif
+  }
+
   const std::string finalFeaturesString =
       llvm::join(features.begin(), features.end(), ",");
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -93,8 +93,8 @@ if("${TARGET_SYSTEM}" MATCHES "UNIX|WASI")
     ENABLE_LANGUAGE(ASM)
 endif()
 
-# Enable switches needed on Wasm/WASI (normally inherited from etc/ldc2.conf/{51-target-wasm-base,52-target-wasi-base}.conf)
-if("${TARGET_SYSTEM}" MATCHES "WASI")
+# Enable switches needed on Wasm (normally inherited from etc/ldc2.conf/51-target-wasm-base.conf)
+if("${TARGET_SYSTEM}" MATCHES "WASI|Emscripten")
     # Make sure LLVM_VERSION_MAJOR is defined
     # (particularly if this CMake project is NOT
     # embedded in the LDC CMake project)
@@ -105,21 +105,10 @@ if("${TARGET_SYSTEM}" MATCHES "WASI")
     append("-Wl,-z,stack-size=1048576 -Wl,--stack-first" LD_FLAGS)
 
     list(APPEND D_FLAGS --wasm-enable-eh)
-    list(APPEND D_FLAGS --mattr=+exception-handling)
-
     if(LLVM_VERSION_MAJOR GREATER_EQUAL 20)
-        list (APPEND D_FLAGS --wasm-use-legacy-eh=false)
+        list(APPEND D_FLAGS --wasm-use-legacy-eh=false)
     elseif(LLVM_VERSION_MAJOR GREATER_EQUAL 19)
-        list (APPEND D_FLAGS --wasm-enable-exnref)
-    endif()
-
-    # A hack to make sure EH actually gets enabled, even though
-    # the EH model should be implied by `--wasm-enable-eh`
-    # 
-    # I don't know what broke it for 21, but this fixes it for 23:
-    # https://github.com/llvm/llvm-project/pull/177542
-    if((LLVM_VERSION_MAJOR EQUAL 21) OR (LLVM_VERSION_MAJOR EQUAL 22))
-      list(APPEND D_FLAGS --exception-model=wasm)
+        list(APPEND D_FLAGS --wasm-enable-exnref)
     endif()
 endif()
 

--- a/tests/baremetal/lit.local.cfg
+++ b/tests/baremetal/lit.local.cfg
@@ -1,6 +1,6 @@
 import subprocess
 
 # Define `%baremetal_args` as LDC args making sure
-# * no ldc2.conf file is used (=> no implicit command-line args), and
+# * druntime/Phobos aren't linked
 # * the empty object.d in ./inputs is imported (=> no TypeInfo, ModuleInfo, Object...).
-config.substitutions.append( ('%baremetal_args', '-conf= -I' + config.test_source_root + '/baremetal/inputs') )
+config.substitutions.append( ('%baremetal_args', '-defaultlib= -I' + config.test_source_root + '/baremetal/inputs') )

--- a/tests/baremetal/wasm.d
+++ b/tests/baremetal/wasm.d
@@ -1,10 +1,10 @@
-// Compile and link directly to WebAssembly.
+// Compile and link directly to naked WebAssembly.
 
 // REQUIRES: target_WebAssembly
-// REQUIRES: internal_lld
-// RUN: %ldc -mtriple=wasm32-unknown-unknown-wasm -w -link-internally %s %baremetal_args
+// REQUIRES: link_WebAssembly
+// RUN: %ldc -mtriple=wasm32-unknown-unknown -w %s
 
-extern(C): // no mangling, no arguments order reversal
+extern(C): // no mangling
 
 void _start() {}
 

--- a/tests/baremetal/wasm2.d
+++ b/tests/baremetal/wasm2.d
@@ -1,9 +1,9 @@
-// A more complex wasm example using Phobos templates (=> -betterC to keep it simple).
+// A more complex naked wasm example using Phobos templates.
 
 // REQUIRES: target_WebAssembly
 // REQUIRES: link_WebAssembly
 
-// RUN: %ldc -mtriple=wasm32-unknown-unknown-wasm -betterC -w -L--export-dynamic %s -of=%t.wasm
+// RUN: %ldc -mtriple=wasm32-unknown-unknown -w -L--export-dynamic %s -of=%t.wasm
 
 // make sure the .wasm file contains `myExportedFoo` (https://github.com/ldc-developers/ldc/issues/3023)
 // RUN: grep myExportedFoo %t.wasm
@@ -12,7 +12,7 @@ extern(C):
 
 void _start() {}
 
-void __assert(const(char)* msg, const(char)* file, uint line) {}
+void _d_assert_msg(string msg, string file, uint line) {}
 
 export int myExportedFoo()
 {


### PR DESCRIPTION
And handle the `--exception-model=wasm` required with LLVM 21-22 directly in the compiler.