### PR TITLE
cmake: link libzstd when LLD is built against a shared libLLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,11 +574,21 @@ if(LDC_WITH_LLD)
     else()
         set(LDC_LINKERFLAG_LIST -llldMinGW -llldCOFF -llldELF -llldMachO -llldWasm -llldCommon -lLLVMSymbolize ${LDC_LINKERFLAG_LIST})
     endif()
-    if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-        # FreeBSD LLVM port links to zstd, but does not convey this information via CMake
-        # Workaround it here until it is fixed in the port
-        find_package(zstd)
-        list(APPEND LDC_LINKERFLAG_LIST "$<TARGET_LINKER_FILE:zstd::libzstd_shared>")
+    if(LLVM_IS_SHARED)
+        # LLD's ELF backend references zstd (OutputSection::maybeCompress). A shared
+        # libLLVM only loads libzstd privately -- it does not re-export those symbols --
+        # and `llvm-config --system-libs` reports nothing in shared mode, so the
+        # statically-linked lld archives are left with unresolved ZSTD_* symbols.
+        # Link libzstd explicitly here; the full path from find_package also covers
+        # installs outside the default linker search path (e.g. Homebrew's
+        # /opt/homebrew/opt/zstd). This subsumes the former FreeBSD-only workaround
+        # (that port ships a shared LLVM with the exact same gap).
+        find_package(zstd QUIET)
+        if(TARGET zstd::libzstd_shared)
+            list(APPEND LDC_LINKERFLAG_LIST "$<TARGET_LINKER_FILE:zstd::libzstd_shared>")
+        elseif(TARGET zstd::libzstd_static)
+            list(APPEND LDC_LINKERFLAG_LIST "$<TARGET_LINKER_FILE:zstd::libzstd_static>")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
LLD's ELF backend references zstd (OutputSection::maybeCompress, for compressed output sections). When LLVM is a shared library, libLLVM only loads libzstd privately -- it does not re-export those symbols -- and `llvm-config --system-libs` reports nothing in shared mode. The statically-linked lld archives are therefore left with unresolved ZSTD_* symbols at final link (seen with Homebrew's shared llvm@16 on macOS).

Link libzstd explicitly whenever LLVM is shared. Using the full path from find_package(zstd) also covers installs outside the default linker search path (e.g. Homebrew's /opt/homebrew/opt/zstd). This generalizes and subsumes the previous FreeBSD-only workaround, which addressed the exact same gap (its LLVM port also ships a shared libLLVM).

By @ljmf00 