### PR TITLE
Default to -fno-moduleinfo-localclasses for all wasm targets

### DIFF
--- a/.github/actions/5a-wasi/action.yml
+++ b/.github/actions/5a-wasi/action.yml
@@ -27,7 +27,7 @@ runs:
 
         bootstrap-ldc/bin/ldc-build-runtime \
           --ninja \
-          --dFlags="-mtriple=$triple;-fno-moduleinfo-localclasses" \
+          --dFlags="-mtriple=$triple" \
           --ldcSrcDir="$PWD/ldc" \
           --buildDir="ldc-build-runtime.$os-$arch" \
           --installWithSuffix="-$os-$arch" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - WebAssembly: In order to allow D's GC to function correctly, a new pass is run after optimizations, to spill potential pointers onto the "stack" (#5178).
   Wasm operates an infinite (practically: large) number of locals (~registers), as well as an opaque value stack. To compensate for the fact that these locations can't be easily scanned, any intermediate value detected as pointer, or as contributing to one, is forcibly spilled onto the normal stack (which lies in linear memory) as needed. The stack is then scanned in the usual conservative manner.
   This pass is enabled by default on all Wasm targets, but can be disabled with `-betterC` or the new `-disable-wasm-ptrs-spill`.
-- A new `-fno-moduleinfo-localclasses` switch has been added. This disables populating `ModuleInfo.localClasses` for each module. This can help eliminate/strip more dead-code (thus decreasing binary sizes), but breaks `Object.factory` and any other code relying on iterating over said `localClasses` (#5224).
+- A new `-fno-moduleinfo-localclasses` switch has been added. This disables populating `ModuleInfo.localClasses` for each module. This can help eliminate/strip more dead-code (thus decreasing binary sizes), but breaks `Object.factory` and any other code relying on iterating over said `localClasses`. Enabled by default for Wasm targets. (#5224)
 
 #### Platform support
 - Supports LLVM 18 - 22.

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -612,11 +612,11 @@ cl::opt<bool> fNoModuleInfo("fno-moduleinfo", cl::ZeroOrMore,
 cl::opt<bool> fNoRTTI("fno-rtti", cl::ZeroOrMore,
                       cl::desc("Disable generation of TypeInfos"));
 
-cl::opt<bool>
-    fNoModuleInfoLocalClasses("fno-moduleinfo-localclasses", cl::ZeroOrMore,
-                        cl::desc("Disable population of `localClasses`"
-                                 "in ModuleInfos. Allows better DCE, but"
-                                 "breaks e.g. `Object.factory`."));
+cl::opt<bool> fNoModuleInfoLocalClasses(
+    "fno-moduleinfo-localclasses", cl::ZeroOrMore,
+    cl::desc("Disable population of `localClasses` in ModuleInfos. Allows "
+             "better DCE, but breaks e.g. `Object.factory`. Enabled by default "
+             "for wasm targets."));
 
 cl::opt<bool>
     fSplitStack("fsplit-stack", cl::ZeroOrMore,

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -1267,6 +1267,12 @@ int cppmain() {
 
   global.preprocess = &runCPreprocessor;
 
+  // wasm: default to -fno-moduleinfo-localclasses
+  if (opts::fNoModuleInfoLocalClasses.getNumOccurrences() == 0 &&
+      triple->isWasm()) {
+    opts::fNoModuleInfoLocalClasses = true;
+  }
+
   // allocate the target abi
   gABI = TargetABI::getTarget();
 


### PR DESCRIPTION
Don't just compile WASI druntime (and Phobos in the future) with it, but default to dropping the `ModuleInfo.localClasses` baggage for all wasm targets.