### PR TITLE
CI: Install libclang-rt-dev on Ubuntu, not libclang-common-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commonSteps: &commonSteps
             sudo apt-get -q update
             sudo apt-get -yq install \
               git-core $gcc_pkg cmake \
-              llvm-$LLVM_MAJOR-dev libclang-common-$LLVM_MAJOR-dev zlib1g-dev \
+              llvm-$LLVM_MAJOR-dev libclang-rt-$LLVM_MAJOR-dev zlib1g-dev \
               $libcurl_pkg curl gdb python3 python3-pip tzdata unzip zip \
               ${EXTRA_APT_PACKAGES:-}
             # Download & extract Ninja

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -60,12 +60,12 @@ jobs:
             python3 -m pip install --user lit psutil
           fi
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
-      - name: 'Linux: Install gdb, lld, llvm-dev and libclang-common-dev'
+      - name: 'Linux: Install gdb, lld, llvm-dev and libclang-rt-dev'
         if: runner.os == 'Linux'
         run: |
           set -eux
           sudo apt-get update
-          sudo apt-get install gdb lld-${{ matrix.llvm_version }} llvm-${{ matrix.llvm_version }}-dev libclang-common-${{ matrix.llvm_version }}-dev ${{ matrix.llvm_version == '20' && 'libcurl4-openssl-dev' || '' }}
+          sudo apt-get install gdb lld-${{ matrix.llvm_version }} llvm-${{ matrix.llvm_version }}-dev libclang-rt-${{ matrix.llvm_version }}-dev ${{ matrix.llvm_version == '20' && 'libcurl4-openssl-dev' || '' }}
       - name: 'macOS: Install Homebrew llvm and a more recent GNU make'
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
Seems like this was wrong, and now causes trouble for CircleCI on Ubuntu 26.