### PR TITLE
Make missed dynamic-cast lowerings in the frontend a proper ICE

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -384,7 +384,11 @@ DValue *DtoDynamicCastObject(Loc loc, DValue *val, Type *_to) {
     return new DImValue(_to, ret);
   }
 
-  llvm_unreachable("dynamic cast should have been lowered");
+  error(loc,
+        "Internal Compiler Error: dynamic cast to `%s` should have been "
+        "lowered by the frontend",
+        _to->toChars());
+  fatal();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Since we had multiple reports of related frontend regressions (IIRC, since D v2.112), so we cannot use an `llvm_unreachable` which gets optimized away and causes weird other error messages about Objective-C.