### PR TITLE
Fixes for `WasmSpillPointers`

### DIFF
--- a/gen/passes/WasmPointersSpill.cpp
+++ b/gen/passes/WasmPointersSpill.cpp
@@ -144,7 +144,9 @@ bool WasmPointersSpill::run(Function &F) {
           continue;
 
         if (TypeContainsPointers(I.getType())) {
-          PotentialPointers.insert(&I);
+          if (!isa<PHINode>(&I) || !isa<CatchSwitchInst>(BB.getTerminator()))
+            PotentialPointers.insert(&I);
+
           if (IntToPtrInst *IntToPtr = dyn_cast<IntToPtrInst>(&I)) {
             // if we have `inttoptr` it's transitive uses are themselves
             // potential pointers
@@ -197,7 +199,9 @@ bool WasmPointersSpill::run(Function &F) {
           I->getType()->getScalarSizeInBits() <= 16)
         continue;
 
-      PotentialPointers.insert(I);
+      if (!isa<PHINode>(I) ||
+          !isa<CatchSwitchInst>(I->getParent()->getTerminator()))
+        PotentialPointers.insert(I);
 
       // trace `alloca` loads back through stores to the same
       if (auto *Load = dyn_cast<LoadInst>(I)) {
@@ -557,8 +561,17 @@ bool WasmPointersSpill::run(Function &F) {
           for (Instruction &IterI : make_range(BB.rbegin(), BB.rend())) {
             if (isa<CallBase>(&IterI)) {
               if (auto *Invoke = dyn_cast<InvokeInst>(&IterI)) {
-                Builder.SetInsertPoint(
-                    Invoke->getNormalDest()->getFirstInsertionPt());
+                BasicBlock *NormalDest = Invoke->getNormalDest();
+                if (NormalDest->getUniquePredecessor()) {
+                  Builder.SetInsertPoint(NormalDest->getFirstInsertionPt());
+                } else {
+                  BasicBlock *Split =
+                      SplitEdge(&BB, NormalDest, nullptr, nullptr, nullptr,
+                                ai->getName() + ".lifetimeEnd.bb");
+                  NewBlocks.insert(Split);
+                  Invoke->replaceSuccessorWith(NormalDest, Split);
+                  Builder.SetInsertPoint(Split->begin());
+                }
 
                 // This doesn't place a lifetime.end down the unwind path,
                 // as there is no guaranteed spot to put it. Can't split the
@@ -588,8 +601,23 @@ bool WasmPointersSpill::run(Function &F) {
 
             if (Found && isa<CallBase>(&IterI)) {
               if (auto *Invoke = dyn_cast<InvokeInst>(&IterI)) {
-                Builder.SetInsertPoint(
-                    Invoke->getNormalDest()->getFirstInsertionPt());
+                BasicBlock *NormalDest = Invoke->getNormalDest();
+                if (NormalDest->getUniquePredecessor()) {
+                  Builder.SetInsertPoint(NormalDest->getFirstInsertionPt());
+                } else {
+                  BasicBlock *Split =
+                      SplitEdge(&BB, NormalDest, nullptr, nullptr, nullptr,
+                                ai->getName() + ".lifetimeEnd.bb");
+                  NewBlocks.insert(Split);
+                  Invoke->replaceSuccessorWith(NormalDest, Split);
+                  Builder.SetInsertPoint(Split->begin());
+                }
+
+                // This doesn't place a lifetime.end down the unwind path,
+                // as there is no guaranteed spot to put it. Can't split the
+                // unwind edge, and catchswitch (and the downstream catchpad)
+                // may have multiple predecessors. Have to accept the lifetime
+                // leak.
               } else {
                 assert(!IterI.isTerminator());
                 Builder.SetInsertPoint(std::next(IterI.getIterator()));
@@ -639,17 +667,18 @@ bool WasmPointersSpill::run(Function &F) {
       SpillInsertPoint = Invoke->getNormalDest()->getFirstInsertionPt();
     } else if (isa<PHINode>(I)) {
       if (isa<CatchSwitchInst>(BB->getTerminator())) {
-        // Having a catchswitch for a terminator means no instructions other
-        // than PHI can be here. And since all successors must be catchpad
-        // we can't split the edge either.
+        // There is no place we can reliably insert a spill for the PHI
+        // without having to clone entire EH pad/funclets.
         //
-        // However, Wasm EH associates each catchswitch with a single catchpad.
-        // So spill at the start of that single successor.
+        // However part of WinEHPrepare (which also runs for Wasm) is
+        // explicitly converting these PHIs to alloca load/stores.
+        // (see WinEHPrepareImpl::demotePHIsOnFunclets)
+        //
+        // Since it will already be in a stack slot (and won't be optimized
+        // back into a PHI), we don't bother trying to respill it.
 
-        BasicBlock *Succ = BB->getSingleSuccessor();
-        assert(Succ && "catchswitch with multiple catchpads?");
-
-        SpillInsertPoint = Succ->getFirstInsertionPt();
+        assert(0 && "Trying to spill PHI in a `catchswitch` block?");
+        continue;
       } else {
         // After all the PHI
         SpillInsertPoint = BB->getFirstInsertionPt();

--- a/tests/codegen/wasm_spill_pointers_pass.d
+++ b/tests/codegen/wasm_spill_pointers_pass.d
@@ -405,11 +405,11 @@ void test14()
 }
 
 // CHECK-LABEL: define {{.*}}_D24wasm_spill_pointers_pass6test15FZPv
-// Spills are placed correctly when PHIs occur in a catchswitch
+// No errors and no spills when PHIs occur in a catchswitch. We simply ignore
+// since a later pass turns the PHI into an alloca anyway.
 void* test15() {
     // CHECK-NEXT: [[spill1:%stackSpill\..+]] = alloca ptr
     // CHECK-NEXT: [[spill2:%stackSpill\..+]] = alloca ptr
-    // CHECK-NEXT: [[spill3:%stackSpill\..+]] = alloca ptr
 
     void* ptr;
     try {
@@ -424,38 +424,37 @@ void* test15() {
         // CHECK-NEXT: to label %[[try_success:.+]] unwind label %[[catch_dispatch]]
         blackbox();
     }
+    // CHECK: [[try_success]]:
+    // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill1]])
+    // CHECK-NEXT: br label %[[after_try_catch:.+]]
+
     // CHECK: [[catch_dispatch]]:
     // CHECK-NEXT: [[ptr_phi:%.+]] = phi ptr [ [[ptr0]], %[[postinvoke]] ], [ null, %0 ]
     // CHECK-NEXT: [[catchswitch:%.+]] = catchswitch within none [label %[[catch_start:.+]]] unwind to caller
 
     // CHECK: [[catch_start]]:
     // CHECK-NEXT: [[catchpad:%.+]] = catchpad within [[catchswitch]] [ptr @_D9Exception7__ClassZ]
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0(ptr [[spill2]])
-    // CHECK-NEXT: store volatile ptr [[ptr_phi]], ptr [[spill2]]
     // CHECK-NEXT: [[eh_obj:%.+]] = tail call ptr @llvm.wasm.get.exception(token [[catchpad]])
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0(ptr [[spill3]])
-    // CHECK-NEXT: store volatile ptr [[eh_obj]], ptr [[spill3]]
+    // CHECK-NEXT: call void @llvm.lifetime.start.p0(ptr [[spill2]])
+    // CHECK-NEXT: store volatile ptr [[eh_obj]], ptr [[spill2]]
     // CHECK-NEXT: [[selector:%.+]] = tail call i32 @llvm.wasm.get.ehselector(token [[catchpad]])
     // CHECK-NEXT: [[typeid:%.+]] = tail call i32 @llvm.eh.typeid.for.p0(ptr nonnull @_D9Exception7__ClassZ)
     // CHECK-NEXT: [[is_match:%.+]] = icmp eq i32 [[selector]], [[typeid]]
     // CHECK-NEXT: br i1 [[is_match]], label %[[catch_match:.+]], label %[[catch_mismatch:.+]]
 
     // CHECK: [[catch_mismatch]]:
-    // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill3]])
     // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill2]])
     // CHECK-NEXT: call void @llvm.wasm.rethrow() [ "funclet"(token [[catchpad]]) ]
     // CHECK-NEXT: unreachable
     catch (Exception e) {
         // CHECK: [[catch_match]]:
         // CHECK-NEXT: {{%.+}} = call ptr @_d_eh_enter_catch(ptr [[eh_obj]]) [ "funclet"(token [[catchpad]]) ]
-        // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill3]])
         // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill2]])
-        // CHECK-NEXT: catchret from [[catchpad]] to label %[[try_success]]
+        // CHECK-NEXT: catchret from [[catchpad]] to label %[[after_try_catch]]
     }
 
-    // CHECK: [[try_success]]:
-    // CHECK-NEXT: [[ret_phi:%.+]] = phi ptr [ [[ptr0]], %[[postinvoke]] ], [ [[ptr_phi]], %[[catch_match]] ]
-    // CHECK-NEXT: call void @llvm.lifetime.end.p0(ptr [[spill1]])
+    // CHECK: [[after_try_catch]]:
+    // CHECK-NEXT: [[ret_phi:%.+]] = phi ptr [ [[ptr0]], %[[try_success]] ], [ [[ptr_phi]], %[[catch_match]] ]
     // CHECK-NEXT: ret ptr [[ret_phi]]
     return ptr;
 }
@@ -513,4 +512,26 @@ void* test16() {
 
     // CHECK-NEXT: br label %[[common_ret]]
     return null;
+}
+
+// CHECK-LABEL: define {{.*}}_D24wasm_spill_pointers_pass6test17FZv()
+// Regression test for when `catchswitch` block has a PHI and a unwind target
+// (make sure it doesn't crash)
+void test17()
+{
+    // CHECK: catch.dispatch:
+    // CHECK-NEXT: {{%.+}} = phi ptr
+    // CHECK-NEXT: {{%.+}} = catchswitch within none [label %catch.start] unwind label %cleanuppad
+
+    void* result = getPtr();
+
+    scope(exit) blackbox();
+    scope(failure) usePtr(result);
+
+    blackbox();
+
+    while (getBool())
+    {
+        result = getPtr();
+    }
 }


### PR DESCRIPTION
Fixes a couple of issues with `WasmSpillPointers` and its interaction with EH I found while getting Phobos to compile.

- `catchswitch` does NOT always have one successor. The unwind destination is another. However [`WinEHPrepare::demotePHIsOnFunclets`](https://github.com/llvm/llvm-project/blob/f99ee4f26d51091b805fc12affd19b4497081525/llvm/lib/CodeGen/WinEHPrepare.cpp#L864) converts applicable PHIs into stack slots anyway, so we don't actually need to spill!
- We now correctly split the `Invoke->getNormalDest()` edge to place the `lifetime.end` if the target has multiple predecessors.