### PR TITLE
Slightly revise default cross-CC candidates

### DIFF
--- a/driver/tool.cpp
+++ b/driver/tool.cpp
@@ -97,11 +97,10 @@ llvm::SmallVector<std::string, 2> findCCFallback() {
       break;
     }
   } else {
-    const auto tripleString = triple.getTriple();
     choices = {
-      { tripleString + "-gcc" },
-      { tripleString + "-clang" },
-      { "clang", "--target=" + tripleString },
+      { opts::mTargetTriple + "-gcc" },
+      { opts::mTargetTriple + "-clang" },
+      { "clang", "--target=" + triple.getTriple() },
     };
   }
 


### PR DESCRIPTION
By using the user-specified `-mtriple` value directly as `…-{gcc,clang}` prefix, not the normalized triple.

This e.g. means that `-mtriple=aarch64-linux-android30` will now prefer the NDK's dedicated `aarch64-linux-android30-clang` script, instead of `clang --target=aarch64-unknown-linux-android30`.