### PR TITLE
GHA Main: Try bumping Ubuntu host image (24 => 26) for Alpine x86_64 container job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
             with_pgo: true
 
           - job_name: Alpine musl x86_64
-            os: ubuntu-latest
+            os: ubuntu-26.04
             container_image: alpine:3.24
             arch: x86_64
             base_cmake_flags: >-


### PR DESCRIPTION
There are signal-handler related unittest errors recently - for some CI runs only (then the same unittest fails for all 4 debug/release shared/static variants).

Might be container-related; try bumping to a newer kernel.