### PR TITLE
GHA Main: Revert to Ubuntu 24 host for Alpine x86_64 job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
             with_pgo: true
 
           - job_name: Alpine musl x86_64
-            os: ubuntu-26.04
+            os: ubuntu-24.04
             container_image: alpine:3.24
             arch: x86_64
             base_cmake_flags: >-


### PR DESCRIPTION
To avoid sanitizer lit-test regressions wrt. 'cannot disable ASLR'.