### PR TITLE
Make missed dynamic-cast lowerings for interfaces in the frontend a proper ICE

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -429,7 +429,11 @@ DValue *DtoDynamicCastInterface(Loc loc, DValue *val, Type *_to) {
     return new DImValue(_to, ret);
   }
 
-  llvm_unreachable("interface cast should have been lowered");
+  error(loc,
+        "Internal Compiler Error: dynamic cast to `%s` should have been "
+        "lowered by the frontend",
+        _to->toChars());
+  fatal();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Analogous to #5236, which missed interfaces.