### PR TITLE
GHA: Upload individual files as artifacts, unzipped

### DIFF
--- a/.github/actions/7-package/action.yml
+++ b/.github/actions/7-package/action.yml
@@ -169,7 +169,7 @@ runs:
 
         # export ARTIFACT_{ID,NAME}
         echo "ARTIFACT_ID=$artifactID" >> $GITHUB_ENV
-        echo "ARTIFACT_NAME=$artifactSuffix" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=$artifactName" >> $GITHUB_ENV
 
     - name: 'Linux x86_64: Pack source dir'
       if: runner.os == 'Linux' && inputs.os == '' && inputs.arch == 'x86_64'
@@ -190,9 +190,21 @@ runs:
       shell: bash  # don't run in VM, but host runner
       run: mv ../artifacts ./
 
-    - name: Upload artifact(s)
-      uses: actions/upload-artifact@v6
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v7
       with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: artifacts/
-        compression-level: 0
+        path: artifacts/${{ env.ARTIFACT_NAME }}.*
+        archive: false
+
+    - name: 'Linux x86_64: Upload source .tar.gz artifact'
+      if: runner.os == 'Linux' && inputs.os == '' && inputs.arch == 'x86_64'
+      uses: actions/upload-artifact@v7
+      with:
+        path: artifacts/*-src.tar.gz
+        archive: false
+    - name: 'Linux x86_64: Upload source .zip artifact'
+      if: runner.os == 'Linux' && inputs.os == '' && inputs.arch == 'x86_64'
+      uses: actions/upload-artifact@v7
+      with:
+        path: artifacts/*-src.zip
+        archive: false

--- a/.github/actions/extract-addon-packages/action.yml
+++ b/.github/actions/extract-addon-packages/action.yml
@@ -87,9 +87,14 @@ runs:
           cd ..
         done
 
-    - name: Upload addon artifacts
-      uses: actions/upload-artifact@v6
+    - name: Upload Windows addon artifact
+      uses: actions/upload-artifact@v7
       with:
-        name: extracted-addons
-        path: newArtifacts/
-        compression-level: 0
+        path: newArtifacts/*-addon-windows.tar.xz
+        archive: false
+
+    - name: Upload Android addon artifact
+      uses: actions/upload-artifact@v7
+      with:
+        path: newArtifacts/*-addon-android.tar.xz
+        archive: false

--- a/.github/actions/merge-macos/action.yml
+++ b/.github/actions/merge-macos/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Download x86_64 and arm64 artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: osx-*
+        pattern: '*-osx-*'
         path: artifacts/
         merge-multiple: true # place all files into artifacts/ directly
 
@@ -91,9 +91,8 @@ runs:
         sudo chown -R root:wheel $artifactName
         tar -cf - $artifactName | 7z a newArtifacts/$artifactName.tar.xz -si -txz -mx9
 
-    - name: Upload universal package
-      uses: actions/upload-artifact@v6
+    - name: Upload universal package artifact
+      uses: actions/upload-artifact@v7
       with:
-        name: osx-universal
-        path: newArtifacts/
-        compression-level: 0
+        path: newArtifacts/*-osx-universal.tar.xz
+        archive: false

--- a/.github/actions/merge-windows/action.yml
+++ b/.github/actions/merge-windows/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Download x64 and x86 artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: windows-*
+        pattern: '*-windows-*'
         path: artifacts/
         merge-multiple: true # place all files into artifacts/ directly
 
@@ -145,9 +145,14 @@ runs:
           "/DLDCDir=%CD%\%ARTIFACT_NAME%" ^
           packaging\windows_installer.iss
 
-    - name: Upload multilib package & installer
-      uses: actions/upload-artifact@v6
+    - name: Upload multilib package artifact
+      uses: actions/upload-artifact@v7
       with:
-        name: windows-multilib
-        path: newArtifacts/
-        compression-level: 0
+        path: newArtifacts/*-windows-multilib.7z
+        archive: false
+
+    - name: Upload multilib installer artifact
+      uses: actions/upload-artifact@v7
+      with:
+        path: newArtifacts/*-windows-multilib.exe
+        archive: false


### PR DESCRIPTION
Which is newly feasible with the latest upload-artifact version.