### PR TITLE
GHA Main: Disable etc.linux.memoryerror unittests on Alpine x86_64

### DIFF
--- a/.github/actions/4d-test-libs/action.yml
+++ b/.github/actions/4d-test-libs/action.yml
@@ -31,6 +31,12 @@ runs:
           # FIXME: regressed with image bump from macos-13 to macos-15-intel, apparently wrt. getpwnam_r() setting unexpected errno
           excludes+='|^std.path'
         fi
+        if [[ '${{ runner.os }}-${{ inputs.arch }}' == Linux-x86_64 ]]; then
+          if type -P apk &>/dev/null; then
+            # fails on some runners (all 4 test variants), works on others
+            excludes+='|^etc.linux.memoryerror'
+          fi
+        fi
 
         ctest -j$N --output-on-failure -E "$excludes" --timeout 120
 


### PR DESCRIPTION
As they have become flaky recently; maybe after the bump to Alpine v3.24, or because something changed on the host runners. The 4 test variants either all work, or all fail.