### PR TITLE
Fix loop-vectorizations being enabled by default with -Oz and -O1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 #### Bug fixes
 - Posix: Don't export non-class TypeInfos from binaries. (#5217)
 - Apple: Pre-define `version(Apple)` on iOS, tvOS, watchOS, and visionOS. (#5192, #5195)
+- Don't enable loop-vectorization by default with `-Oz` and `-O1`. (#5233, #5253)
 
 # LDC 1.42.0 (2026-03-01)
 

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -1049,16 +1049,11 @@ void hideLLVMOptions() {
       "function-sections"};
 
   // pulled in from shared LLVM headers, but unused or not desired in LDC
-  static const char *const removedOptions[] = {"disable-tail-calls",
-                                               "fatal-warnings",
-                                               "filetype",
-                                               "no-deprecated-warn",
-                                               "no-warn",
-                                               "stackrealign",
-                                               "start-after",
-                                               "stop-after",
-                                               "trap-func",
-                                               "W"};
+  static const char *const removedOptions[] = {
+      "disable-tail-calls", "fatal-warnings", "filetype",
+      "no-deprecated-warn", "no-warn",        "stackrealign",
+      "start-after",        "stop-after",     "trap-func",
+      "vectorize-loops",    "vectorize-slp",  "W"};
 
   auto &map = cl::getRegisteredOptions();
 

--- a/gen/optimizer.cpp
+++ b/gen/optimizer.cpp
@@ -406,23 +406,12 @@ static std::optional<PGOOptions> getPGOOptions() {
 static PipelineTuningOptions getPipelineTuningOptions(unsigned optLevelVal, unsigned sizeLevelVal) {
   PipelineTuningOptions pto;
 
-  pto.LoopUnrolling = optLevelVal > 0;
-
-  pto.LoopUnrolling = !((disableLoopUnrolling.getNumOccurrences() > 0)
-                                   ? disableLoopUnrolling
-                                   : optLevelVal == 0);
-
-  // This is final, unless there is a #pragma vectorize enable
-  if (disableLoopVectorization) {
-    pto.LoopVectorization = false;
-    // If option wasn't forced via cmd line (-vectorize-loops, -loop-vectorize)
-  } else if (!pto.LoopVectorization) {
-    pto.LoopVectorization = optLevelVal > 1 && sizeLevelVal < 2;
-  }
-
-  // When #pragma vectorize is on for SLP, do the same as above
-  pto.SLPVectorization =
-      disableSLPVectorization ? false : optLevelVal > 1 && sizeLevelVal < 2;
+  pto.LoopUnrolling = !disableLoopUnrolling && optLevelVal > 0;
+  // loop vectorizer disabled with -Oz
+  pto.LoopVectorization =
+      !disableLoopVectorization && optLevelVal > 1 && sizeLevelVal < 2;
+  // SLP vectorizer enabled with -Oz
+  pto.SLPVectorization = !disableSLPVectorization && optLevelVal > 1;
 
   return pto;
 }

--- a/tests/driver/disable_vectorization.d
+++ b/tests/driver/disable_vectorization.d
@@ -1,0 +1,47 @@
+// https://github.com/ldc-developers/ldc/issues/5233
+
+// REQUIRES: target_X86
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-s -of=%t.s -O %s
+// RUN: FileCheck %s --check-prefix=ALL --check-prefix=ENABLED < %t.s
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-s -of=%t.s -O -disable-loop-vectorization %s
+// RUN: FileCheck %s --check-prefix=ALL --check-prefix=NOLOOP < %t.s
+
+// `-Oz` is equivalent to `-O -disable-loop-vectorization` wrt. vectorization defaults
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-s -of=%t.s -Oz %s
+// RUN: FileCheck %s --check-prefix=ALL --check-prefix=NOLOOP < %t.s
+
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-s -of=%t.s -O -disable-loop-vectorization -disable-slp-vectorization %s
+// RUN: FileCheck %s --check-prefix=ALL --check-prefix=DISABLED < %t.s
+
+// `-O1` disables both
+// RUN: %ldc -mtriple=x86_64-linux-gnu -output-s -of=%t.s -O1 %s
+// RUN: FileCheck %s --check-prefix=ALL --check-prefix=DISABLED < %t.s
+
+
+import ldc.attributes : restrict;
+
+
+// loop test:
+// ALL: _D21disable_vectorization11add_dynamicFAfxAfxQdZv:
+void add_dynamic(@restrict float[] a, @restrict const float[] b, @restrict const float[] c) {
+    // ENABLED: addps
+    // NOLOOP-NOT: addps
+    // DISABLED-NOT: addps
+    foreach (i; 0 .. a.length)
+        a[i] = b[i] + c[i];
+    // ALL: .size	_D21disable_vectorization11add_dynamicFAfxAfxQdZv
+}
+
+
+// SLP test:
+// ALL: _D21disable_vectorization10add_staticFKG4fKxG4fKxQfZv:
+void add_static(@restrict ref float[4] a, @restrict const ref float[4] b, @restrict const ref float[4] c) {
+    // ENABLED: addps
+    // NOLOOP: addps
+    // DISABLED-NOT: addps
+    foreach (i; 0 .. a.length)
+        a[i] = b[i] + c[i];
+    // ALL: .size	_D21disable_vectorization10add_staticFKG4fKxG4fKxQfZv
+}

--- a/tests/linking/ir2obj_caching_flags1.d
+++ b/tests/linking/ir2obj_caching_flags1.d
@@ -23,7 +23,6 @@
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-loop-unrolling          -vv | FileCheck --check-prefix=NO_HIT %s
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-loop-vectorization      -vv | FileCheck --check-prefix=NO_HIT %s
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -disable-slp-vectorization       -vv | FileCheck --check-prefix=NO_HIT %s
-// RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -vectorize-loops                 -vv | FileCheck --check-prefix=NO_HIT %s
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -v -wi -d                        -vv | FileCheck --check-prefix=MUST_HIT %s
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -D -H -I. -J.                    -vv | FileCheck --check-prefix=MUST_HIT %s
 // RUN: %ldc %s -c -of=%t%obj -cache=%t-dir -d-version=Irrelevant            -vv | FileCheck --check-prefix=MUST_HIT %s


### PR DESCRIPTION
And enable the SLP vectorizations with -Oz. Resolves #5233.

Also drop `-vectorize-{loops,slp}` inherited from LLVM, which conflict with our dedicated switches.