### PR TITLE
Fix build on recent FreeBSD/powerpc64le

### DIFF
--- a/gen/target.cpp
+++ b/gen/target.cpp
@@ -315,7 +315,8 @@ const char *TargetCPP::typeMangle(Type *t) {
     if (triple.getArch() == llvm::Triple::ppc64 ||
         triple.getArch() == llvm::Triple::ppc64le) {
       if (target.RealProperties.mant_dig == 113 &&
-          triple.getEnvironment() == llvm::Triple::GNU) {
+          (triple.getEnvironment() == llvm::Triple::GNU ||
+           triple.isOSFreeBSD())) {
         return "u9__ieee128";
       }
       if (target.RealProperties.mant_dig == 106) {

--- a/runtime/druntime/src/core/stdc/config.d
+++ b/runtime/druntime/src/core/stdc/config.d
@@ -658,6 +658,11 @@ package(core) template muslRedirTime64Mangle(string name, string redirectedName)
 }
 
 version (PPC64)
-    enum PPCUseIEEE128 = real.mant_dig == 113;
+{
+    version (CRuntime_Glibc)
+        enum PPCUseIEEE128 = real.mant_dig == 113;
+    else
+        enum PPCUseIEEE128 = false;
+}
 else
     enum PPCUseIEEE128 = false;

--- a/runtime/druntime/src/core/stdc/config.d
+++ b/runtime/druntime/src/core/stdc/config.d
@@ -662,7 +662,7 @@ version (PPC64)
     version (CRuntime_Glibc)
         enum PPCUseIEEE128 = real.mant_dig == 113;
     else
-        enum PPCUseIEEE128 = false;
+        enum PPCUseIEEE128 = false; // no dual-ABI mangling for e.g. FreeBSD
 }
 else
     enum PPCUseIEEE128 = false;


### PR DESCRIPTION
FreeBSD on powerpc64le has recently switched to IEEE 128b long double.
Use proper mangling for that. Since we don't support IBM long double -
we switched from 64-bit long double - don't use glibc's double ABI
mechanism.
