### PR TITLE
core/int128.d: udivmod: don't inline (fixes #4916)

### DIFF
--- a/runtime/druntime/src/core/int128.d
+++ b/runtime/druntime/src/core/int128.d
@@ -750,6 +750,11 @@ U udivmod(Cent c1, U c2, out U modulus)
     {
         version (GNU_OR_LDC_X86_64)
         {
+            // FIXME: https://github.com/ldc-developers/ldc/issues/4916
+            // An AMD CPU with -mattr=bmi2 fails std.int128 unittests.
+            // As a workaround, not inlining fixes it.
+            static if (__traits(targetHasFeature, "bmi2"))
+                pragma(inline, false);
             U ret = void;
             asm pure @trusted nothrow @nogc
             {


### PR DESCRIPTION
This works around an issue that makes the code produce seemingly bad results when all of the following condition are met:
1. The code is compiled with `-O1` (at least)
2. The code is compiled with `-mattr=bmi2`
3. The running processor is AMD (reproduced with *AMD Ryzen 7 5825U* and *AMD Ryzen 3960X*)

The `std.int128` unittests can be used to test if the code was misscompiled.