### PR TITLE
CI: Fix filename of addon packages

### DIFF
--- a/.github/actions/extract-addon-packages/action.yml
+++ b/.github/actions/extract-addon-packages/action.yml
@@ -79,7 +79,7 @@ runs:
         set -eux
 
         mkdir -p newArtifacts
-        artifactID="$(echo artifacts/ldc2-*-android-aarch64.tar.xz | cut -d "-" -f 2)"
+        artifactID="$(echo artifacts/ldc2-*-android-aarch64.tar.xz | sed -E 's|artifacts/ldc2-(.+)-android-aarch64\.tar\.xz|\1|')"
 
         for dir in addon-*; do
           chmod -R go=rX $dir


### PR DESCRIPTION
The logic was too simplistic and broke for tags with dashes, like 1.43.0-beta1, only using `1.43.0`.