### PR TITLE
CI: Increase timeout for druntime integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commonSteps: &commonSteps
           # FIXME: https://github.com/dlang/phobos/issues/10730
           excludes+='|^std.experimental.allocator.building_blocks.allocator_list'
           cd ../build
-          ctest -j$PARALLELISM --output-on-failure -E "$excludes" --timeout 120
+          ctest -j$PARALLELISM --output-on-failure -E "$excludes" --timeout 180
 
 version: 2
 jobs:

--- a/.github/actions/4d-test-libs/action.yml
+++ b/.github/actions/4d-test-libs/action.yml
@@ -38,7 +38,7 @@ runs:
           fi
         fi
 
-        ctest -j$N --output-on-failure -E "$excludes" --timeout 120
+        ctest -j$N --output-on-failure -E "$excludes" --timeout 180
 
     - name: 'Windows: Run defaultlib unittests & druntime integration tests'
       if: runner.os == 'Windows'
@@ -55,4 +55,4 @@ runs:
         echo on
         cd build || exit /b
         # FIXME: https://github.com/dlang/phobos/issues/10730
-        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^std.experimental.allocator.building_blocks.allocator_list" --timeout 120 || exit /b
+        ctest -j4 --output-on-failure -E "dmd-testsuite|lit-tests|ldc2-unittest|^std.experimental.allocator.building_blocks.allocator_list" --timeout 180 || exit /b

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -128,4 +128,4 @@ jobs:
           else
             N=$(nproc)
           fi
-          ctest -j$N --output-on-failure -E "$excludes" --timeout 120
+          ctest -j$N --output-on-failure -E "$excludes" --timeout 180


### PR DESCRIPTION
As `druntime-test-gc-release` can take quite a while, especially on the sometimes-very-slow macOS GHA runners, taking close to 100 secs and sometimes longer, causing spurious CI failures. So increase the timeout from 2 to 3 mins.