### PR TITLE
Fix ABI break on MacOS Apple silicon for shm_open()

### DIFF
--- a/runtime/druntime/src/core/sys/posix/sys/mman.d
+++ b/runtime/druntime/src/core/sys/posix/sys/mman.d
@@ -859,7 +859,7 @@ version (CRuntime_Glibc)
 }
 else version (Darwin)
 {
-    int shm_open(const scope char*, int, mode_t);
+    int shm_open(const scope char*, int, ...);
     int shm_unlink(const scope char*);
 }
 else version (FreeBSD)


### PR DESCRIPTION
## Investigation into MacOS / D ABI issues

There seems to be an incompatibility with the declaration of `shm_open()` in `core.sys.posix.sys.mman` on Apple silicon

The MacOS man page shows the function as

```c
int shm_open(const char *name, int oflag, ...);
```

while the Darwin part of `core.sys.posix.sys.mman` declares it as

```d
int shm_open(const scope char*, int, mode_t);
```

## The Problem

If one process first opens a shared memory file with a given name, then another process (or the same) tries to open the same shared memory file, the second attempt will receive errno 13 (Permission denied).

The reason for this behaviour seems to be that the fixed third `mode_t` parameter will be marshalled differently than a variadic parameter on Apple silicon. See here:

https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code#Dont-Redeclare-a-Function-to-Have-Variable-Parameters

## The Solution

A temporary fix is to redeclare the function as

```d
extern (C) int shm_open(scope const char* name, int flags, ...) nothrow @nogc;
```

in one's own program.

This MR presents a permanent fix by correcting the declaration in `core.sys.posix.sys.mman`.

## Sample code which triggers the issue

See: https://github.com/sinisa-susnjar/macos_abi_investigation/blob/main/source/lib.d

Failed test-run: https://github.com/sinisa-susnjar/macos_abi_investigation/actions/runs/31896393080/job/95040250175