### PR TITLE
druntime: Update to `wasi-sdk` 34

### DIFF
--- a/.github/actions/1a-setup-wasi/action.yml
+++ b/.github/actions/1a-setup-wasi/action.yml
@@ -2,30 +2,20 @@ name: "WASI: Install additional prerequisites"
 inputs:
   wasi_sdk_version:
     required: false
-    default: 33
+    default: 34
   wasmtime_version:
     required: false
-    default: 46.0.1
+    default: 48.0.1
 runs:
   using: composite
   steps:
-    - name: "Install wasi-sdk" # into ../wasi-sdk
-      shell: bash
-      run: |
-        set -eux
-        cd ..
+    - name: "Install wasi-sdk"
+      uses: bytecodealliance/setup-wasi-sdk-action@v1
+      with:
+        add-to-path: false
+        version: ${{ inputs.wasi_sdk_version }}
 
-        WASI_SDK_VERSION='${{ inputs.wasi_sdk_version }}'
-        curl -fOL --retry 3 --max-time 120 https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-arm64-linux.tar.gz
-        tar -xzf wasi-sdk-${WASI_SDK_VERSION}.0-arm64-linux.tar.gz
-        mv wasi-sdk-${WASI_SDK_VERSION}.0-arm64-linux wasi-sdk
-    - name: "Install wasmtime" # into ../wasmtime
-      shell: bash
-      run: |
-        set -eux
-        cd ..
-
-        WASMTIME_VERSION='${{ inputs.wasmtime_version }}'
-        curl -fOL --retry 3 --max-time 60 https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-aarch64-linux.tar.xz
-        tar -xf wasmtime-v${WASMTIME_VERSION}-aarch64-linux.tar.xz
-        mv wasmtime-v${WASMTIME_VERSION}-aarch64-linux wasmtime
+    - name: "Install wasmtime"
+      uses: bytecodealliance/actions/wasmtime/setup@v1
+      with:
+        version: ${{ inputs.wasmtime_version }}

--- a/.github/actions/5a-wasi/action.yml
+++ b/.github/actions/5a-wasi/action.yml
@@ -34,7 +34,7 @@ runs:
           --testrunners \
           CMAKE_INSTALL_PREFIX="$PWD/install" \
           RT_CONF_TRIPLE_REGEX="$arch-.*-$os" \
-          CMAKE_TOOLCHAIN_FILE="$PWD/wasi-sdk/share/cmake/wasi-sdk${toolchain_suffix}.cmake" \
+          CMAKE_TOOLCHAIN_FILE="$WASI_SDK_PATH/share/cmake/wasi-sdk${toolchain_suffix}.cmake" \
           BUILD_LTO_LIBS=ON
 
     - name: Run druntime unittests
@@ -44,8 +44,8 @@ runs:
         cd ../ldc-build-runtime.${{ inputs.os }}-${{ inputs.arch }}
 
         export WASMTIME_BACKTRACE_DETAILS=1
-        ../wasmtime/wasmtime -W exceptions ./druntime-test-runner-debug
-        ../wasmtime/wasmtime -W exceptions ./druntime-test-runner
+        wasmtime ./druntime-test-runner-debug
+        wasmtime ./druntime-test-runner
 
     - name: Run phobos unittests
       shell: bash
@@ -58,7 +58,7 @@ runs:
         export WASMTIME_BACKTRACE_DETAILS=1
 
         for testrunner in ./phobos2-test-runner*; do
-          ../wasmtime/wasmtime -W exceptions \
+          wasmtime \
             --dir testrunner_tmpdir::/ \
             --dir /usr/share/zoneinfo::/tz \
             --env TZDIR=/tz/ \
@@ -80,7 +80,7 @@ runs:
         # wasm-enable-sjlj only used so `setjmp.h` doesn't error out
         bootstrap-ldc/bin/ldc2 \
           -defaultlib=druntime-ldc -L-Linstall/lib-$os-$arch \
-          -gcc=wasi-sdk/bin/$arch-$os-clang \
+          -gcc=$WASI_SDK_PATH/bin/$arch-$os-clang \
           --mtriple=$triple \
           -P=-mllvm -P=-wasm-enable-sjlj \
           -P=-D_WASI_EMULATED_SIGNAL --d-version=WASI_EMULATED_SIGNAL \
@@ -90,4 +90,4 @@ runs:
           $PWD/ldc/runtime/druntime/test/importc_compare/src/importc_compare.d
 
         export WASMTIME_BACKTRACE_DETAILS=1
-        wasmtime/wasmtime -W exceptions ./importc_compare.wasm
+        wasmtime ./importc_compare.wasm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,14 +434,14 @@ jobs:
           # generate hello.d
           echo 'void main() { import std.stdio; writefln!"Hello world, %d bits"(size_t.sizeof * 8); }' > hello.d
           # put WASI-SDK clang onto PATH
-          export PATH="$PWD/../wasi-sdk/bin:$PATH"
+          export PATH="$WASI_SDK_PATH/bin:$PATH"
           # build & run hello-world
           for os in wasip1 wasip2; do
             # test LTO too
             for args in "" "-O -flto=full -defaultlib=druntime-ldc-lto,phobos2-ldc-lto"; do
               bin/ldc2 -mtriple=${{ matrix.arch }}-unknown-$os $args hello.d
               ls -l hello.wasm
-              ../wasmtime/wasmtime -W exceptions ./hello.wasm
+              wasmtime ./hello.wasm
             done
           done
 

--- a/runtime/druntime/src/core/stdc/stdint.d
+++ b/runtime/druntime/src/core/stdc/stdint.d
@@ -400,8 +400,8 @@ else version (WASI)
 
     alias int_fast8_t   = byte;   ///
     alias uint_fast8_t  = ubyte;  ///
-    alias int_fast16_t  = short;  ///
-    alias uint_fast16_t = ushort; ///
+    alias int_fast16_t  = int;    ///
+    alias uint_fast16_t = uint;   ///
     alias int_fast32_t  = int;    ///
     alias uint_fast32_t = uint;   ///
 

--- a/runtime/druntime/src/core/sync/event.d
+++ b/runtime/druntime/src/core/sync/event.d
@@ -280,7 +280,10 @@ nothrow @nogc:
                     timespec t = void;
                     mktspec(t, tmout);
 
-                    result = pthread_cond_timedwait(&m_cond, &m_mutex, &t);
+                    version (WASI)   // wasi-libc traps for single-thread futex
+                        result = -1;
+                    else
+                        result = pthread_cond_timedwait(&m_cond, &m_mutex, &t);
                 }
             }
             if (result == 0 && !m_manualReset)

--- a/runtime/druntime/src/core/sys/posix/stdio.d
+++ b/runtime/druntime/src/core/sys/posix/stdio.d
@@ -551,13 +551,9 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_WASI)
 {
-    // TODO: once WebAssembly/wasi-libc#851 makes its way to wasi-sdk release
-    version (none)
-    {
-        void   flockfile(FILE*);
-        int    ftrylockfile(FILE*);
-        void   funlockfile(FILE*);
-    }
+    void   flockfile(FILE*);
+    int    ftrylockfile(FILE*);
+    void   funlockfile(FILE*);
     int    getc_unlocked(FILE*);
     int    getchar_unlocked();
     int    putc_unlocked(int, FILE*);

--- a/runtime/druntime/src/core/sys/posix/sys/socket.d
+++ b/runtime/druntime/src/core/sys/posix/sys/socket.d
@@ -1715,9 +1715,9 @@ else version (CRuntime_WASI)
 
     enum
     {
-        SHUT_RD,
-        SHUT_WR,
-        SHUT_RDWR
+        SHUT_RD = 1,
+        SHUT_WR = 2,
+        SHUT_RDWR = 3
     }
 }
 else


### PR DESCRIPTION
Updates the supported version of `wasi-libc` to the one distributed by `wasi-sdk` 34.

Also updates the version of Wasmtime used by CI to 48.0.1

The diff is smaller than it normally would be, as I incorporated some changes between 33 and 34 when I initially implemented (inadvertently).

Phobos is not yet updated to make use of `flockfile`. This will be done alongside other changes needed for WASIp3 later on (i.e. once it actually matters).