### PR TITLE
Undo TLS hack on Wasm

### DIFF
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1722,11 +1722,10 @@ llvm::GlobalVariable *declareGlobal(Loc loc, llvm::Module &module,
                                     llvm::StringRef mangledName,
                                     bool isConstant, bool isThreadLocal,
                                     bool useDLLImport) {
-  // No TLS support for WebAssembly and AVR; spare users from having to add
+  // No TLS support for AVR; spare users from having to add
   // __gshared everywhere.
   const auto arch = global.params.targetTriple->getArch();
-  if (arch == llvm::Triple::wasm32 || arch == llvm::Triple::wasm64 ||
-      arch == llvm::Triple::avr)
+  if (arch == llvm::Triple::avr)
     isThreadLocal = false;
 
   llvm::GlobalVariable *existing =

--- a/tests/codegen/wasm.d
+++ b/tests/codegen/wasm.d
@@ -12,9 +12,9 @@
 version (WebAssembly) {} else static assert(0);
 
 
-// make sure TLS globals are emitted as regular __gshared globals:
+// make sure TLS globals are emitted properly:
 
-// CHECK: @_D4wasm13definedGlobali = hidden global i32 123
+// CHECK: @_D4wasm13definedGlobali = hidden thread_local global i32 123
 int definedGlobal = 123;
 
 


### PR DESCRIPTION
In preparation for WASIp3.

This hack has not been required since LLVM 9 (this behavior of demoting to standard globals has been integrated into LLVM for some time now).