### PR TITLE
Fix `config.maxIndividualTestTime` in `lit.site.cfg.in`

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -50,7 +50,7 @@ config.suffixes = ['.d', '.i', '.c']
 # Set individual test timeout to 60
 supported, errormsg = lit_config.maxIndividualTestTimeIsSupported
 if supported:
-    lit_config.maxIndividualTestTime = 60
+    config.maxIndividualTestTime = 60
 else:
     lit_config.warning(
         "Setting a timeout per test not supported: "


### PR DESCRIPTION
New failure. Assumed to be linked to the release of `lit` 23 yesterday.

Closes #5267