### PR TITLE
Carry the D type alignment on struct copy/init memcpy and memset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Platform support
 
 #### Bug fixes
+- Struct assignments and struct-literal initialisations now carry the D type's alignment on the emitted `llvm.memcpy`/`llvm.memset` instead of alignment 1. This matters on targets with strict alignment (e.g. `-mattr=+strict-align`), where an alignment-1 memcpy is lowered to byte-wise loads and stores. (#5279)
 
 # LDC 1.43.0 (2026-08-30)
 

--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -401,7 +401,8 @@ void DtoAssign(Loc loc, DValue *lhs, DValue *rhs, EXP op,
       // time as to not emit an invalid (overlapping) memcpy on trivial
       // struct self-assignments like 'A a; a = a;'.
       if (src != dst)
-        DtoMemCpy(DtoType(lhs->type), dst, src);
+        DtoMemCpy(DtoType(lhs->type), dst, src, false,
+                  DtoAlignment(lhs->type));
     }
   } else if (t->ty == TY::Tarray || t->ty == TY::Tsarray) {
     DtoArrayAssign(loc, lhs, rhs, op, canSkipPostblit);

--- a/gen/toir.cpp
+++ b/gen/toir.cpp
@@ -574,7 +574,7 @@ public:
       Logger::println("performing aggregate zero initialization");
       assert(toInteger(e->e2) == 0);
       LLValue *lval = DtoLVal(lhs);
-      DtoMemSetZero(DtoType(lhs->type), lval);
+      DtoMemSetZero(DtoType(lhs->type), lval, DtoAlignment(lhs->type));
       TypeStruct *ts = static_cast<TypeStruct *>(e->e1->type);
       if (ts->sym->isNested() && ts->sym->vthis)
         DtoResolveNestedContext(e->loc, ts->sym, lval);
@@ -2487,11 +2487,12 @@ public:
         dstMem = DtoAlloca(e->type, ".structliteral");
 
       if (sd->zeroInit()) {
-        DtoMemSetZero(DtoType(e->type), dstMem);
+        DtoMemSetZero(DtoType(e->type), dstMem, DtoAlignment(e->type));
       } else {
         LLValue *initsym = getIrAggr(sd)->getInitSymbol();
         assert(dstMem->getType() == initsym->getType());
-        DtoMemCpy(DtoType(e->type), dstMem, initsym);
+        DtoMemCpy(DtoType(e->type), dstMem, initsym, false,
+                  DtoAlignment(e->type));
       }
 
       return new DLValue(e->type, dstMem);
@@ -2862,7 +2863,8 @@ bool toInPlaceConstruction(DLValue *lhs, Expression *rhs) {
         DtoResolveStruct(sd);
         if (sd->zeroInit()) {
           Logger::println("success, zeroing out");
-          DtoMemSetZero(DtoType(lhs->type) ,DtoLVal(lhs));
+          DtoMemSetZero(DtoType(lhs->type), DtoLVal(lhs),
+                        DtoAlignment(lhs->type));
           return true;
         }
       }

--- a/tests/codegen/struct_copy_alignment.d
+++ b/tests/codegen/struct_copy_alignment.d
@@ -1,0 +1,34 @@
+// Struct copies and initialisations carry the D type alignment on the memcpy/memset.
+// RUN: %ldc -c -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+
+struct S8 { long a; int b; }
+align(1) struct P4 { int a; ubyte b; }
+align(16) struct A16 { int a; }
+
+// CHECK-LABEL: define {{.*}}_D{{.*}}copy8
+void copy8(ref S8 dst, ref S8 src)
+{
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 8 %{{.*}}, ptr align 8 %{{.*}}, i{{32|64}} 16
+    dst = src;
+}
+
+// CHECK-LABEL: define {{.*}}_D{{.*}}copy1
+void copy1(ref P4 dst, ref P4 src)
+{
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 1 %{{.*}}, ptr align 1 %{{.*}}, i{{32|64}} 5
+    dst = src;
+}
+
+// CHECK-LABEL: define {{.*}}_D{{.*}}copy16
+void copy16(ref A16 dst, ref A16 src)
+{
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 16 %{{.*}}, ptr align 16 %{{.*}}, i{{32|64}} 16
+    dst = src;
+}
+
+// CHECK-LABEL: define {{.*}}_D{{.*}}init8
+void init8(ref S8 dst)
+{
+    // CHECK: call void @llvm.memcpy.{{.*}}(ptr align 8 %{{.*}}, ptr align 8 %{{.*}}, i{{32|64}} 16
+    dst = S8.init;
+}


### PR DESCRIPTION
`DtoAssign` copies structs through `DtoMemCpy(DtoType(lhs->type), dst, src)`, which uses the helper's default alignment of 1. Struct literal initialisation (`getInitSymbol()` copy and the zero-init path) and struct zero-assignment do the same. Every struct copy therefore reaches LLVM as an `llvm.memcpy` / `llvm.memset` with `align 1`, and LLVM has to treat it as potentially unaligned.

On targets that can't do unaligned access this is costly: with `-mtriple=armv5te-none-eabi -mattr=+strict-align`, each small struct copy is lowered to a run of `ldrb`/`strb` (or `store i64 ..., align 1` after SROA, which lowers the same way). Example, appending a plain `struct { uint; long; delegate }` to an array:

```
strb r6, [r0, r1, lsl #3]!
lsr  r2, r1, #8
strb r2, [r0, #21]
lsr  r2, r3, #8
strb r2, [r0, #17]
... (30 more)
```

versus five `str`s with the alignment known. On a ~1 MB embedded image (OpenWatt, LDC 1.43.0, `-Oz`) this accounted for roughly 12 KB of text, about 60% of the whole strict-align penalty.

This PR passes `DtoAlignment(type)` at those sites. That is the same alignment LDC already uses for the type's allocas and globals, so no new assumption is introduced: an `align(1)` struct still copies with alignment 1, and an `align(16)` struct now says 16.

Before / after for the added test:

```
call void @llvm.memcpy.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 16, i1 false)
call void @llvm.memcpy.p0.p0.i64(ptr align 8 %dst, ptr align 8 %src, i64 16, i1 false)
```

Not touched here: array slice copies (`arrays.cpp`), tuple element copies and `va_copy`, which go through the untyped helper or don't have the D type at hand.
