### PR TITLE
dcompute: Fix ref return dereferencing the address it should return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Platform support
 
 #### Bug fixes
+- dcompute: A `ref` return whose referent is reached through a `Pointer!(as, T)` does not emit an extra load anymore, so a `ref T opIndex()` accessor over a `GlobalPointer!T` no longer faults with `CUDA_ERROR_MISALIGNED_ADDRESS`. (#5284, #5285)
 
 # LDC 1.43.0 (2026-08-30)
 

--- a/gen/statements.cpp
+++ b/gen/statements.cpp
@@ -245,6 +245,31 @@ public:
         // do abi specific transformations on the return value
         returnValue = getIrFunc(fd)->irFty.putRet(dval);
 
+        // A `ref` return is a plain pointer in the LLVM function type, but in
+        // `@compute` code the referent may live in a non-generic address space
+        // (e.g. an element of a `GlobalPointer!T`). Convert the address space
+        // here; otherwise the mismatch falls through to the load-from-alloca
+        // fixup further down and the address gets dereferenced once too often.
+        if (irs->dcomputetarget && f->type->isRef() &&
+            returnValue->getType() != funcType->getReturnType()) {
+          LLPointerType *const src = isaPointer(returnValue);
+          LLPointerType *const dst = isaPointer(funcType->getReturnType());
+          if (src && dst) {
+            // DCompute nominal address spaces: Private = 0, Global = 1,
+            // Shared = 2, Constant = 3, Generic = 4. See gen/dcompute/target.h.
+            const int genericAS = irs->dcomputetarget->mapping[4];
+            if (dst->getAddressSpace() == static_cast<unsigned>(genericAS)) {
+              returnValue = irs->ir->CreateAddrSpaceCast(returnValue, dst);
+            } else {
+              error(stmt->loc,
+                    "cannot return a `ref` to a variable in address space %d, "
+                    "this `@compute` target has no generic address space to "
+                    "convert it to",
+                    static_cast<int>(src->getAddressSpace()));
+            }
+          }
+        }
+
         // Hack around LDC assuming structs and static arrays are in memory:
         // If the function returns a struct or a static array, and the return
         // value is a pointer to a struct or a static array, load from it

--- a/tests/codegen/dcompute_cu_addrspaces.d
+++ b/tests/codegen/dcompute_cu_addrspaces.d
@@ -34,3 +34,13 @@ void foo(GenericPointer!float f) {
     // PTX: ld.{{f|b}}32
     float g = *f;
 }
+
+// A `ref` return whose referent is reached through a non-generic pointer must
+// convert the address space; dereferencing it there yields the element value
+// instead of its address. See GH issue #5284.
+ref float refReturn(GlobalPointer!float f, size_t i) {
+    // LL: addrspacecast ptr addrspace(1) %{{[0-9]+}} to ptr
+    // LL-NEXT: ret ptr %
+    // PTX: cvta.global.u64
+    return f[i];
+}


### PR DESCRIPTION
Fixes #5284.

`putRet` for a `ref` return hands back the referent's pointer with its address space intact, but a `ref` return is plain `ptr` in the LLVM function type. The mismatch fell into the load-from-alloca fixup at the end of `visit(ReturnStatement *)`, so `return globalPtr[i]` loaded the element instead of returning its address.

Before, `-mdcompute-targets=cuda-800`:

```llvm
%4 = getelementptr inbounds float, ptr addrspace(1) %2, i64 %3
%5 = load ptr, ptr addrspace(1) %4, align 8
ret ptr %5
```

After:

```llvm
%4 = getelementptr inbounds float, ptr addrspace(1) %2, i64 %3
%5 = addrspacecast ptr addrspace(1) %4 to ptr
ret ptr %5
```

`ld.global.b64` at a 4-byte aligned `float` becomes `cvta.global.u64`.

On CUDA the plain pointer is the generic address space, so the conversion is exact. On SPIR-V it is Function, which cannot hold a global pointer, so that case is diagnosed instead of being miscompiled.

Test: `tests/codegen/dcompute_cu_addrspaces.d`, which fails without the patch.

Also checked on hardware (RTX 2050, CC 8.6, CUDA 12.0): a strided N-d view struct holding a `GlobalPointer!float` with `ref T opIndex`/`ref T at` accessors dies with `CUDA_ERROR_MISALIGNED_ADDRESS` before, and produces all 3072 correct elements after.

A `ref` parameter to such an element hits the same type mismatch and produces a broken module. That is loud rather than silent, and is left alone here.
